### PR TITLE
Fix inconsistent income and expense totals across widgets

### DIFF
--- a/backend/app/routes/transaction.py
+++ b/backend/app/routes/transaction.py
@@ -220,7 +220,7 @@ async def get_transactions_overview(
     ).where(base_where)
     flow = (await db.execute(flow_query)).one()
 
-    # Top 5 expense categories by total spend
+    # Top 5 expense-side categories by net category outflow.
     cat_query = (
         select(
             Transaction.category_id,
@@ -229,9 +229,9 @@ async def get_transactions_overview(
         )
         .join(Category, Transaction.category_id == Category.id)
         .where(base_where)
-        .where(Category.kind == CategoryKind.EXPENSE)
-        .where(Transaction.amount < 0)
+        .where(Category.kind.in_([CategoryKind.EXPENSE, CategoryKind.INCOME]))
         .group_by(Transaction.category_id, Category.name)
+        .having(sa.func.sum(Transaction.amount) < 0)
         .order_by(sa.func.sum(Transaction.amount).asc())
         .limit(5)
     )
@@ -250,7 +250,25 @@ async def get_transactions_overview(
     )
     daily_rows = (await db.execute(daily_query)).all()
 
-    # Top 3 largest expense transactions
+    expense_side_category_query = (
+        select(
+            Transaction.category_id,
+            sa.func.sum(Transaction.amount).label("total"),
+        )
+        .join(Category, Transaction.category_id == Category.id)
+        .where(base_where)
+        .where(Category.kind.in_([CategoryKind.EXPENSE, CategoryKind.INCOME]))
+        .group_by(Transaction.category_id)
+        .having(sa.func.sum(Transaction.amount) < 0)
+    )
+    expense_side_category_rows = (await db.execute(expense_side_category_query)).all()
+    remaining_by_category = {
+        row.category_id: -int(row.total)
+        for row in expense_side_category_rows
+    }
+
+    # Top 3 largest expense-side transaction contributors after category-level
+    # refunds/income offsets have been netted for the selected period.
     outlier_query = (
         select(
             Transaction.id,
@@ -258,16 +276,30 @@ async def get_transactions_overview(
             Transaction.notes,
             Transaction.amount,
             Transaction.dt,
+            Transaction.category_id,
         )
         .outerjoin(Merchant, Transaction.merchant_id == Merchant.id)
         .join(Category, Transaction.category_id == Category.id)
         .where(base_where)
-        .where(Category.kind == CategoryKind.EXPENSE)
+        .where(Category.kind.in_([CategoryKind.EXPENSE, CategoryKind.INCOME]))
         .where(Transaction.amount < 0)
         .order_by(Transaction.amount.asc())
-        .limit(3)
     )
-    outlier_rows = (await db.execute(outlier_query)).all()
+    outlier_candidates = []
+    for row in (await db.execute(outlier_query)).all():
+        remaining = remaining_by_category.get(row.category_id, 0)
+        if remaining <= 0:
+            continue
+        amount = -min(-int(row.amount), remaining)
+        remaining_by_category[row.category_id] = remaining + amount
+        outlier_candidates.append(OutlierTransaction(
+            id=row.id,
+            merchant_name=row.merchant_name,
+            notes=row.notes,
+            amount=amount,
+            dt=row.dt,
+        ))
+    outliers = sorted(outlier_candidates, key=lambda row: row.amount)[:3]
 
     return TransactionsOverview(
         total_inflow=flow.inflow,
@@ -280,10 +312,7 @@ async def get_transactions_overview(
             DailyCashFlow(date=r.date, inflow=r.inflow, outflow=r.outflow)
             for r in daily_rows
         ],
-        outliers=[
-            OutlierTransaction(id=r.id, merchant_name=r.merchant_name, notes=r.notes, amount=r.amount, dt=r.dt)
-            for r in outlier_rows
-        ],
+        outliers=outliers,
     )
 
 

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -201,9 +201,9 @@ async def get_runway(
     """Compute the user's cash runway in months.
 
     Runway = (sum of current balance across selected runway accounts) divided
-    by the average monthly expense over the last 12 completed months. Transfer-category
-    transactions are excluded from the denominator so inter-account moves and
-    debt payments (which the app models as transfers) don't shorten runway.
+    by the average monthly net expense over the last 12 completed months.
+    Expense refunds reduce expenses, while income and transfer-category
+    transactions are excluded.
     """
     accessible_ids = {a.id for a in await get_accessible_accounts(db, user)}
     stored = await db.execute(
@@ -225,22 +225,34 @@ async def get_runway(
     today = datetime.now(ZoneInfo(user.tz)).date()
     window_end = date(today.year, today.month, 1)
     window_start = _add_months_anchored(window_end, -_RUNWAY_WINDOW_MONTHS)
-    expense_filter = (Transaction.amount < 0) & (Category.kind == CategoryKind.EXPENSE)
-    # COUNT(DISTINCT … FILTER …) only counts completed month buckets that
-    # actually contain expenses, so missing history is not treated as zero spend.
-    agg = (await db.execute(
+    month_bucket = sa.func.date_trunc("month", Transaction.dt).label("month")
+    category_month_totals = (
         select(
-            sa.func.count(sa.distinct(sa.func.date_trunc("month", Transaction.dt)))
-                .filter(expense_filter).label("months_covered"),
-            sa.func.coalesce(
-                sa.func.sum(sa.case((expense_filter, Transaction.amount), else_=0)), 0,
-            ).label("expense_outflow"),
+            month_bucket,
+            Category.id.label("category_id"),
+            sa.func.sum(Transaction.amount).label("total"),
         )
         .select_from(Transaction)
         .join(Category, Category.id == Transaction.category_id)
         .where(Transaction.account_id.in_(accessible_ids))
         .where(Transaction.dt >= window_start)
-        .where(Transaction.dt < window_end),
+        .where(Transaction.dt < window_end)
+        .where(Category.kind == CategoryKind.EXPENSE)
+        .group_by(month_bucket, Category.id)
+        .cte("category_month_totals")
+    )
+    outflow_filter = category_month_totals.c.total < 0
+    # Negative expense category-month totals count toward runway. Refunds reduce
+    # expenses; over-refunded categories, income, and transfers are ignored.
+    agg = (await db.execute(
+        select(
+            sa.func.count(sa.distinct(category_month_totals.c.month))
+                .filter(outflow_filter).label("months_covered"),
+            sa.func.coalesce(
+                sa.func.sum(sa.case((outflow_filter, category_month_totals.c.total), else_=0)), 0,
+            ).label("expense_outflow"),
+        )
+        .select_from(category_month_totals),
     )).one()
 
     months_covered = int(agg.months_covered)

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -30,11 +30,15 @@ class SpendingBreakdownResponse(BaseModel):
     period (WTD / MTD / QTD / YTD) — the boundaries match the spending
     comparison endpoint's current-period slots. Entries are sorted largest-
     first and compacted with an Other slice for the dashboard widget.
+    ``expense_total`` and ``income_total`` are authoritative center totals
+    after flipped refund/loss categories are netted against their original side.
     """
 
     range: RangeKind
     expense: list[CategoryBreakdownEntry]
     income: list[CategoryBreakdownEntry]
+    expense_total: int
+    income_total: int
 
 
 class SpendingComparisonResponse(BaseModel):

--- a/backend/app/schemas/insights.py
+++ b/backend/app/schemas/insights.py
@@ -34,10 +34,14 @@ class InsightsIncomeExpenseBreakdownResponse(BaseModel):
     """Payload for the insights income/expense breakdown card.
 
     Pie rows are ``(id, name, original_category_kind, amount)``.
+    ``expense_total`` and ``income_total`` are authoritative center totals
+    after flipped refund/loss categories are netted against their original side.
     """
 
     expense: list[tuple[str, str, str, int]]
     income: list[tuple[str, str, str, int]]
+    expense_total: int
+    income_total: int
     expense_increases: list[tuple[str, str, int, int, int | None, int]]
     expense_decreases: list[tuple[str, str, int, int, int | None, int]]
     income_increases: list[tuple[str, str, int, int, int | None, int]]

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -21,7 +21,7 @@ class DailyCashFlow(BaseModel):
 
 
 class OutlierTransaction(BaseModel):
-    """A single large-spend transaction surfaced as unusual."""
+    """A large expense-side transaction contribution surfaced as unusual."""
 
     id: uuid.UUID
     merchant_name: str | None

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -91,7 +91,7 @@ class RunwayResponse(BaseModel):
     """Runway projection in months.
 
     How many months the user's selected visible liquid balance covers at their
-    trailing 12-month average monthly expense across readable non-hidden accounts.
+    trailing 12-month average monthly net expense across readable non-hidden accounts.
     """
 
     months: float | None

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -551,7 +551,13 @@ async def get_spending_breakdown(
     """
     start, end = _current_period_bounds(range_, now.date())
     if not base_currency_account_ids:
-        return SpendingBreakdownResponse(range=range_, expense=[], income=[])
+        return SpendingBreakdownResponse(
+            range=range_,
+            expense=[],
+            income=[],
+            expense_total=0,
+            income_total=0,
+        )
 
     result = await db.execute(
         select(
@@ -593,10 +599,14 @@ async def get_spending_breakdown(
 
     expense.sort(key=lambda e: (-e.amount, e.name))
     income.sort(key=lambda e: (-e.amount, e.name))
+    expense_refunds = sum(entry.amount for entry in income if entry.category_kind == CategoryKind.EXPENSE)
+    income_losses = sum(entry.amount for entry in expense if entry.category_kind == CategoryKind.INCOME)
     return SpendingBreakdownResponse(
         range=range_,
         expense=_dashboard_breakdown_entries(expense, CategoryKind.EXPENSE),
         income=_dashboard_breakdown_entries(income, CategoryKind.INCOME),
+        expense_total=max(sum(entry.amount for entry in expense) - expense_refunds, 0),
+        income_total=max(sum(entry.amount for entry in income) - income_losses, 0),
     )
 
 

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -264,8 +264,9 @@ async def get_savings_rate_history(
     The series covers ``DASHBOARD_SAVINGS_HISTORY_MONTHS`` calendar months
     ending with the current (in-progress) month, ordered oldest-first. Months
     with no activity are emitted as zeros so every chart slot has a value.
-    Expenses are stored as negative amounts; the returned ``expenses`` field
-    is the absolute value so the frontend can compute the rate directly.
+    Income/expense categories are netted per category within each month, then
+    positive category totals count as income and negative category totals count
+    as expenses. Transfers are excluded.
     """
     months_count = DASHBOARD_SAVINGS_HISTORY_MONTHS
     first_month = _months_before(now, months_count - 1)
@@ -287,7 +288,7 @@ async def get_savings_rate_history(
 
     month_start_expr = func.date_trunc("month", Transaction.dt).label("month_start")
     result = await db.execute(
-        select(month_start_expr, Category.kind, func.sum(Transaction.amount).label("total"))
+        select(month_start_expr, Category.id.label("category_id"), func.sum(Transaction.amount).label("total"))
         .join(Category, Transaction.category_id == Category.id)
         .where(
             Transaction.account_id.in_(base_currency_account_ids),
@@ -295,22 +296,24 @@ async def get_savings_rate_history(
             Transaction.dt >= first_month,
             Transaction.dt < window_end,
         )
-        .group_by(month_start_expr, Category.kind),
+        .group_by(month_start_expr, Category.id),
     )
 
-    # Collect row totals keyed by first-of-month, keeping income and expense
-    # buckets separate so we can emit one MonthlyIncomeExpense per month below.
-    totals: dict[date, dict[CategoryKind, int]] = {m: {} for m in months}
+    totals = {m: {"income": 0, "expenses": 0} for m in months}
     for row in result:
         # date_trunc returns a timestamp; coerce to a plain date for the key.
         key = row.month_start.date() if hasattr(row.month_start, "date") else row.month_start
-        totals[key][row.kind] = int(row.total)
+        total = int(row.total or 0)
+        if total > 0:
+            totals[key]["income"] += total
+        elif total < 0:
+            totals[key]["expenses"] += -total
 
     return [
         MonthlyIncomeExpense(
             month=m,
-            income=totals[m].get(CategoryKind.INCOME, 0),
-            expenses=abs(totals[m].get(CategoryKind.EXPENSE, 0)),
+            income=totals[m]["income"],
+            expenses=totals[m]["expenses"],
         )
         for m in months
     ]

--- a/backend/app/services/insights/income_expense_breakdown.py
+++ b/backend/app/services/insights/income_expense_breakdown.py
@@ -151,6 +151,10 @@ def _breakdown_entries(
     ]
 
 
+def _breakdown_total(stats_by_id: BreakdownCategoryStatsById) -> int:
+    return sum(stats.amount for stats in stats_by_id.values())
+
+
 def _change_pct(current_amount: int, previous_amount: int) -> int | None:
     if previous_amount <= 0:
         return None
@@ -220,6 +224,8 @@ async def get_income_expense_breakdown(
         return InsightsIncomeExpenseBreakdownResponse(
             expense=[],
             income=[],
+            expense_total=0,
+            income_total=0,
             expense_increases=[],
             expense_decreases=[],
             income_increases=[],
@@ -263,10 +269,22 @@ async def get_income_expense_breakdown(
 
     expense_increases, expense_decreases = _category_trends(current_expense_stats, previous_expense_stats)
     income_increases, income_decreases = _category_trends(current_income_stats, previous_income_stats)
+    expense_refunds = sum(
+        stats.amount
+        for stats in current_income_breakdown.values()
+        if stats.category_kind == CategoryKind.EXPENSE
+    )
+    income_losses = sum(
+        stats.amount
+        for stats in current_expense_breakdown.values()
+        if stats.category_kind == CategoryKind.INCOME
+    )
 
     return InsightsIncomeExpenseBreakdownResponse(
         expense=_breakdown_entries(current_expense_breakdown),
         income=_breakdown_entries(current_income_breakdown),
+        expense_total=max(_breakdown_total(current_expense_breakdown) - expense_refunds, 0),
+        income_total=max(_breakdown_total(current_income_breakdown) - income_losses, 0),
         expense_increases=expense_increases,
         expense_decreases=expense_decreases,
         income_increases=income_increases,

--- a/backend/app/services/insights/period_glance.py
+++ b/backend/app/services/insights/period_glance.py
@@ -14,6 +14,8 @@ from app.models.user import User
 from app.schemas.insights import InsightsPeriodGlanceResponse
 from app.services.insights.common import get_base_currency_accounts, previous_period_bounds
 
+CategoryNetTotals = dict[uuid.UUID, tuple[str, CategoryKind, int]]
+
 
 async def _query_period_totals(
     db: AsyncSession,
@@ -77,6 +79,38 @@ async def _query_expense_category_totals(
     return totals
 
 
+async def _query_category_net_totals(
+    db: AsyncSession,
+    account_ids: list[uuid.UUID],
+    from_date: date,
+    to_date: date,
+) -> CategoryNetTotals:
+    """Return signed category totals keyed by category id for an inclusive period."""
+    result = await db.execute(
+        select(
+            Category.id,
+            Category.name,
+            Category.kind,
+            func.sum(Transaction.amount).label("total"),
+        )
+        .join(Category, Transaction.category_id == Category.id)
+        .where(
+            Transaction.account_id.in_(account_ids),
+            Category.kind.in_([CategoryKind.INCOME, CategoryKind.EXPENSE]),
+            Transaction.dt >= from_date,
+            Transaction.dt <= to_date,
+        )
+        .group_by(Category.id, Category.name, Category.kind),
+    )
+
+    totals: CategoryNetTotals = {}
+    for row in result:
+        amount = int(row.total or 0)
+        if amount:
+            totals[row.id] = (row.name, row.kind, amount)
+    return totals
+
+
 def _top_category(
     current_totals: dict[uuid.UUID, tuple[str, int]],
 ) -> tuple[str, int | None] | None:
@@ -89,26 +123,72 @@ def _top_category(
 
 
 def _biggest_category_change(
-    current_totals: dict[uuid.UUID, tuple[str, int]],
-    previous_totals: dict[uuid.UUID, tuple[str, int]],
+    current_totals: CategoryNetTotals,
+    previous_totals: CategoryNetTotals,
 ) -> tuple[str, int, int | None] | None:
-    """Return the expense category with the largest absolute dollar change."""
-    category_ids = set(current_totals) | set(previous_totals)
+    """Return the tracked category with the largest comparable dollar change."""
+    category_ids = [
+        category_id
+        for category_id in set(current_totals) | set(previous_totals)
+        if _is_change_candidate(category_id, current_totals, previous_totals)
+    ]
     if not category_ids:
         return None
 
     def change_sort_key(candidate: uuid.UUID) -> tuple[int, str]:
-        current_name, current_amount = current_totals.get(candidate, ("", 0))
-        previous_name, previous_amount = previous_totals.get(candidate, ("", 0))
-        return -abs(current_amount - previous_amount), current_name or previous_name
+        name, kind = _category_identity(candidate, current_totals, previous_totals)
+        current_amount = current_totals.get(candidate, ("", kind, 0))[2]
+        previous_amount = previous_totals.get(candidate, ("", kind, 0))[2]
+        return -abs(_category_change_amount(kind, current_amount, previous_amount)), name
 
     category_id = sorted(category_ids, key=change_sort_key)[0]
-    name = current_totals.get(category_id, previous_totals.get(category_id, ("", 0)))[0]
-    current_amount = current_totals.get(category_id, ("", 0))[1]
-    previous_amount = previous_totals.get(category_id, ("", 0))[1]
-    change_amount = current_amount - previous_amount
-    change_pct = round((change_amount / previous_amount) * 100) if previous_amount > 0 else None
+    name, kind = _category_identity(category_id, current_totals, previous_totals)
+    current_amount = current_totals.get(category_id, ("", kind, 0))[2]
+    previous_amount = previous_totals.get(category_id, ("", kind, 0))[2]
+    change_amount = _category_change_amount(kind, current_amount, previous_amount)
+    previous_basis = _category_change_basis(kind, current_amount, previous_amount)
+    change_pct = round((change_amount / previous_basis) * 100) if previous_basis > 0 else None
     return name, change_amount, change_pct
+
+
+def _category_identity(
+    category_id: uuid.UUID,
+    current_totals: CategoryNetTotals,
+    previous_totals: CategoryNetTotals,
+) -> tuple[str, CategoryKind]:
+    name, kind, _amount = current_totals.get(
+        category_id,
+        previous_totals.get(category_id, ("", CategoryKind.EXPENSE, 0)),
+    )
+    return name, kind
+
+
+def _is_change_candidate(
+    category_id: uuid.UUID,
+    current_totals: CategoryNetTotals,
+    previous_totals: CategoryNetTotals,
+) -> bool:
+    _name, kind = _category_identity(category_id, current_totals, previous_totals)
+    current_amount = current_totals.get(category_id, ("", kind, 0))[2]
+    previous_amount = previous_totals.get(category_id, ("", kind, 0))[2]
+
+    if kind == CategoryKind.INCOME:
+        return current_amount < 0
+    return current_amount != 0 or previous_amount != 0
+
+
+def _category_change_amount(kind: CategoryKind, current_amount: int, previous_amount: int) -> int:
+    if kind == CategoryKind.EXPENSE and current_amount <= 0 and previous_amount <= 0:
+        return (-current_amount) - (-previous_amount)
+    return current_amount - previous_amount
+
+
+def _category_change_basis(kind: CategoryKind, current_amount: int, previous_amount: int) -> int:
+    if previous_amount == 0:
+        return 0
+    if kind == CategoryKind.EXPENSE and current_amount <= 0 and previous_amount <= 0:
+        return -previous_amount
+    return abs(previous_amount)
 
 
 async def _net_worth_at(
@@ -168,7 +248,13 @@ async def get_period_glance(
         from_date,
         to_date,
     )
-    previous_category_totals = await _query_expense_category_totals(
+    current_category_net_totals = await _query_category_net_totals(
+        db,
+        account_ids,
+        from_date,
+        to_date,
+    )
+    previous_category_net_totals = await _query_category_net_totals(
         db,
         account_ids,
         previous_from_date,
@@ -177,7 +263,7 @@ async def get_period_glance(
     start_net_worth = await _net_worth_at(db, base_currency_accounts, from_date)
     end_net_worth = await _net_worth_at(db, base_currency_accounts, to_date)
     top_category = _top_category(current_category_totals)
-    biggest_change = _biggest_category_change(current_category_totals, previous_category_totals)
+    biggest_change = _biggest_category_change(current_category_net_totals, previous_category_net_totals)
 
     return InsightsPeriodGlanceResponse(
         income=income,

--- a/backend/app/services/insights/period_glance.py
+++ b/backend/app/services/insights/period_glance.py
@@ -21,9 +21,9 @@ async def _query_period_totals(
     from_date: date,
     to_date: date,
 ) -> tuple[int, int]:
-    """Return kind-aware net income and expense totals for the period."""
+    """Return sign-directed net income and expense totals for the period."""
     result = await db.execute(
-        select(Category.kind, func.sum(Transaction.amount).label("total"))
+        select(Category.id, func.sum(Transaction.amount).label("total"))
         .join(Category, Transaction.category_id == Category.id)
         .where(
             Transaction.account_id.in_(account_ids),
@@ -31,19 +31,19 @@ async def _query_period_totals(
             Transaction.dt >= from_date,
             Transaction.dt <= to_date,
         )
-        .group_by(Category.kind),
+        .group_by(Category.id),
     )
 
     income = 0
     expenses = 0
     for row in result:
         total = int(row.total or 0)
-        if row.kind == CategoryKind.INCOME:
+        if total > 0:
             income += total
-        else:
-            expenses += total
+        elif total < 0:
+            expenses += -total
 
-    return income, max(-expenses, 0)
+    return income, expenses
 
 
 async def _query_expense_category_totals(
@@ -52,7 +52,7 @@ async def _query_expense_category_totals(
     from_date: date,
     to_date: date,
 ) -> dict[uuid.UUID, tuple[str, int]]:
-    """Return positive expense-kind totals keyed by category id for an inclusive period."""
+    """Return positive expense-side totals keyed by category id for an inclusive period."""
     result = await db.execute(
         select(
             Category.id,
@@ -62,7 +62,7 @@ async def _query_expense_category_totals(
         .join(Category, Transaction.category_id == Category.id)
         .where(
             Transaction.account_id.in_(account_ids),
-            Category.kind == CategoryKind.EXPENSE,
+            Category.kind.in_([CategoryKind.INCOME, CategoryKind.EXPENSE]),
             Transaction.dt >= from_date,
             Transaction.dt <= to_date,
         )

--- a/backend/app/services/insights/savings_rate_trend.py
+++ b/backend/app/services/insights/savings_rate_trend.py
@@ -57,7 +57,7 @@ async def get_savings_rate_trend(
     user: User,
     now: datetime,
 ) -> InsightsSavingsRateTrendResponse:
-    """Return latest available monthly income and expense totals for savings-rate trend."""
+    """Return latest available sign-directed monthly totals for savings-rate trend."""
     accounts = await get_base_currency_accounts(db, user)
     account_ids = [account.id for account in accounts]
     if not account_ids:
@@ -72,11 +72,11 @@ async def get_savings_rate_trend(
     earliest_visible_month = _add_months(current_month, -(SAVINGS_RATE_TREND_MONTHS - 1))
     start_month = max(first_activity_month, earliest_visible_month)
     months = _build_months(start_month, current_month)
-    totals: dict[date, dict[CategoryKind, int]] = {month: {} for month in months}
+    totals = {month: {"income": 0, "expenses": 0} for month in months}
 
     month_start_expr = func.date_trunc("month", Transaction.dt).label("month_start")
     result = await db.execute(
-        select(month_start_expr, Category.kind, func.sum(Transaction.amount).label("total"))
+        select(month_start_expr, func.sum(Transaction.amount).label("total"))
         .join(Category, Transaction.category_id == Category.id)
         .where(
             Transaction.account_id.in_(account_ids),
@@ -84,19 +84,23 @@ async def get_savings_rate_trend(
             Transaction.dt >= start_month,
             Transaction.dt < window_end,
         )
-        .group_by(month_start_expr, Category.kind),
+        .group_by(month_start_expr, Category.id),
     )
 
     for row in result:
         month = row.month_start.date() if hasattr(row.month_start, "date") else row.month_start
-        totals[month][row.kind] = int(row.total or 0)
+        total = int(row.total or 0)
+        if total > 0:
+            totals[month]["income"] += total
+        elif total < 0:
+            totals[month]["expenses"] += -total
 
     return InsightsSavingsRateTrendResponse(
         points=[
             (
                 month,
-                totals[month].get(CategoryKind.INCOME, 0),
-                max(-totals[month].get(CategoryKind.EXPENSE, 0), 0),
+                totals[month]["income"],
+                totals[month]["expenses"],
             )
             for month in months
         ],

--- a/backend/tests/routes/test_dashboard_timezone.py
+++ b/backend/tests/routes/test_dashboard_timezone.py
@@ -292,6 +292,42 @@ async def test_dashboard_savings_rate_excludes_transfers(client, monkeypatch):
     }
 
 
+async def test_dashboard_savings_rate_routes_flipped_categories_by_monthly_net(client, monkeypatch):
+    """Savings rate nets each monthly category before assigning income or expense."""
+    from app.routes import dashboard as dashboard_routes
+
+    monkeypatch.setattr(dashboard_routes, "datetime", _FixedClock(datetime(2026, 4, 20, 16, 0, tzinfo=UTC)))
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    account_id = (await _create_account(client, headers, name="Main Cash")).json()["id"]
+    salary_id = (await _create_category(client, headers, name="Test Salary", kind="income")).json()["id"]
+    capital_loss_id = (await _create_category(client, headers, name="Test Capital Gains", kind="income")).json()["id"]
+    groceries_id = (await _create_category(client, headers, name="Test Groceries Net", kind="expense")).json()["id"]
+    over_refund_id = (await _create_category(client, headers, name="Test Over-refunded", kind="expense")).json()["id"]
+    transfer_id = (await _create_category(client, headers, name="Test Transfer", kind="transfer")).json()["id"]
+
+    await _create_transaction(client, headers, account_id, salary_id, dt="2026-04-02", amount=360_000)
+    await _create_transaction(client, headers, account_id, salary_id, dt="2026-04-03", amount=-60_000)
+    await _create_transaction(client, headers, account_id, capital_loss_id, dt="2026-04-04", amount=20_000)
+    await _create_transaction(client, headers, account_id, capital_loss_id, dt="2026-04-05", amount=-100_000)
+    await _create_transaction(client, headers, account_id, groceries_id, dt="2026-04-06", amount=-100_000)
+    await _create_transaction(client, headers, account_id, groceries_id, dt="2026-04-07", amount=40_000)
+    await _create_transaction(client, headers, account_id, over_refund_id, dt="2026-04-08", amount=-30_000)
+    await _create_transaction(client, headers, account_id, over_refund_id, dt="2026-04-09", amount=50_000)
+    await _create_transaction(client, headers, account_id, transfer_id, dt="2026-04-10", amount=999_999)
+    await _create_transaction(client, headers, account_id, transfer_id, dt="2026-04-11", amount=-999_999)
+
+    resp = await client.get("/dashboard/savings-rate", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["savings_rate_history"][-1] == {
+        "month": "2026-04-01",
+        "income": 320_000,
+        "expenses": 140_000,
+    }
+
+
 async def test_dashboard_excludes_hidden_accounts_from_net_worth_and_credit(client, monkeypatch):
     """Dashboard balance aggregates use visible accounts only."""
     from app.routes import dashboard as dashboard_routes

--- a/backend/tests/routes/test_dashboard_timezone.py
+++ b/backend/tests/routes/test_dashboard_timezone.py
@@ -60,7 +60,10 @@ async def test_dashboard_spending_breakdown_uses_viewer_timezone_at_utc_boundary
     resp = await client.get("/dashboard/spending-breakdown", params={"range": "MTD"}, headers=headers)
 
     assert resp.status_code == 200
-    assert resp.json()["expense"][0]["amount"] == 4100
+    data = resp.json()
+    assert data["expense"][0]["amount"] == 4100
+    assert data["expense_total"] == 4100
+    assert data["income_total"] == 0
 
 
 async def test_dashboard_spending_breakdown_counts_category_crossovers_by_sign(client, monkeypatch):
@@ -115,6 +118,8 @@ async def test_dashboard_spending_breakdown_counts_category_crossovers_by_sign(c
             "amount": 20_000,
         },
     ]
+    assert data["expense_total"] == 120_000
+    assert data["income_total"] == 240_000
 
 
 async def test_dashboard_spending_breakdown_uses_other_for_tiny_slices(client, monkeypatch):
@@ -157,6 +162,8 @@ async def test_dashboard_spending_breakdown_uses_other_for_tiny_slices(client, m
     assert data["expense"][-1]["name"] == "Other"
     assert data["expense"][-1]["category_kind"] == "expense"
     assert data["expense"][-1]["amount"] == 10_000
+    assert data["expense_total"] == 280_000
+    assert data["income_total"] == 0
 
 
 async def test_dashboard_spending_breakdown_keeps_hidden_flipped_categories_out_of_other(client, monkeypatch):
@@ -253,6 +260,8 @@ async def test_dashboard_spending_breakdown_keeps_hidden_flipped_categories_out_
     }
     assert data["income"][-1]["category_kind"] == "income"
     assert data["income"][-1]["amount"] == 1_000
+    assert data["expense_total"] == 391_000
+    assert data["income_total"] == 391_000
 
 
 async def test_dashboard_savings_rate_excludes_transfers(client, monkeypatch):

--- a/backend/tests/routes/test_insights_income_expense_breakdown.py
+++ b/backend/tests/routes/test_insights_income_expense_breakdown.py
@@ -132,6 +132,8 @@ async def test_income_expense_breakdown_returns_limited_period_payload(client):
             [str(freelance_id), "Freelance", "income", 100_000],
             [str(bonus_id), "Bonus", "income", 80_000],
         ],
+        "expense_total": 620_000,
+        "income_total": 680_000,
         "expense_increases": [
             [str(shopping_id), "Shopping", 70_000, 0, None, 1],
             [str(groceries_id), "Groceries", 90_000, 30_000, 200, 1],
@@ -169,11 +171,14 @@ async def test_income_expense_breakdown_counts_category_crossovers_by_sign(clien
             capital_gains,
             groceries,
             over_refund,
-            _transaction(user_id, account_id, salary_id, date(2026, 4, 2), 300_000),
-            _transaction(user_id, account_id, capital_gains_id, date(2026, 4, 3), -80_000),
+            _transaction(user_id, account_id, salary_id, date(2026, 4, 2), 360_000),
+            _transaction(user_id, account_id, salary_id, date(2026, 4, 3), -60_000),
+            _transaction(user_id, account_id, capital_gains_id, date(2026, 4, 3), 20_000),
+            _transaction(user_id, account_id, capital_gains_id, date(2026, 4, 4), -100_000),
             _transaction(user_id, account_id, groceries_id, date(2026, 4, 4), -100_000),
             _transaction(user_id, account_id, groceries_id, date(2026, 4, 5), 40_000),
-            _transaction(user_id, account_id, over_refund_id, date(2026, 4, 6), 20_000),
+            _transaction(user_id, account_id, over_refund_id, date(2026, 4, 6), -30_000),
+            _transaction(user_id, account_id, over_refund_id, date(2026, 4, 7), 50_000),
             _transaction(user_id, account_id, salary_id, date(2026, 3, 5), 300_000),
             _transaction(user_id, account_id, capital_gains_id, date(2026, 3, 6), 20_000),
             _transaction(user_id, account_id, over_refund_id, date(2026, 3, 7), -30_000),
@@ -196,9 +201,11 @@ async def test_income_expense_breakdown_counts_category_crossovers_by_sign(clien
         [str(capital_gains_id), "Capital Gains", "income", 80_000],
         [str(groceries_id), "Groceries", "expense", 60_000],
     ]
-    assert data["income_decreases"] == [[str(capital_gains_id), "Capital Gains", 0, 20_000, -100, 1]]
+    assert data["expense_total"] == 120_000
+    assert data["income_total"] == 240_000
+    assert data["income_decreases"] == [[str(capital_gains_id), "Capital Gains", 0, 20_000, -100, 2]]
     assert data["expense_increases"] == [[str(groceries_id), "Groceries", 60_000, 0, None, 2]]
-    assert data["expense_decreases"] == [[str(over_refund_id), "Over-refunded", 0, 30_000, -100, 1]]
+    assert data["expense_decreases"] == [[str(over_refund_id), "Over-refunded", 0, 30_000, -100, 2]]
 
 
 async def test_income_expense_breakdown_does_not_emit_other_for_exact_limit(client):
@@ -298,6 +305,8 @@ async def test_income_expense_breakdown_omits_zero_net_current_categories(client
     assert resp.json() == {
         "expense": [],
         "income": [],
+        "expense_total": 0,
+        "income_total": 0,
         "expense_increases": [],
         "expense_decreases": [],
         "income_increases": [],
@@ -320,6 +329,8 @@ async def test_income_expense_breakdown_returns_empty_payload_without_accounts(c
     assert resp.json() == {
         "expense": [],
         "income": [],
+        "expense_total": 0,
+        "income_total": 0,
         "expense_increases": [],
         "expense_decreases": [],
         "income_increases": [],

--- a/backend/tests/routes/test_insights_period_glance.py
+++ b/backend/tests/routes/test_insights_period_glance.py
@@ -225,8 +225,8 @@ async def test_period_glance_nets_expense_refunds(client):
     assert data["top_category_share_pct"] == 100
 
 
-async def test_period_glance_nets_refunds_for_savings_rate_but_not_category_share(client):
-    """Expense refunds affect the total expense figure without distorting top-category share."""
+async def test_period_glance_routes_flipped_categories_to_opposite_side(client):
+    """Refunds and income losses are netted per category, then routed by sign."""
     signup_resp = await _create_user(client)
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
@@ -258,17 +258,17 @@ async def test_period_glance_nets_refunds_for_savings_rate_but_not_category_shar
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["income"] == 195_000
-    assert data["expenses"] == 40_000
+    assert data["income"] == 220_000
+    assert data["expenses"] == 65_000
     assert data["top_category_name"] == "Groceries"
-    assert data["top_category_share_pct"] == 100
+    assert data["top_category_share_pct"] == 92
     assert data["biggest_change_name"] == "Groceries"
     assert data["biggest_change_amount"] == 60_000
     assert "biggest_change_pct" not in data
 
 
-async def test_period_glance_keeps_negative_capital_gains_in_income(client):
-    """Negative income-kind totals reduce income instead of becoming expenses."""
+async def test_period_glance_counts_net_negative_income_categories_as_expenses(client):
+    """Income-kind categories become expenses when their period net is negative."""
     signup_resp = await _create_user(client)
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
@@ -293,12 +293,12 @@ async def test_period_glance_keeps_negative_capital_gains_in_income(client):
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["income"] == 220_000
-    assert data["expenses"] == 0
-    assert "top_category_name" not in data
-    assert "top_category_share_pct" not in data
-    assert "biggest_change_name" not in data
-    assert "biggest_change_amount" not in data
+    assert data["income"] == 300_000
+    assert data["expenses"] == 80_000
+    assert data["top_category_name"] == "Capital Gains"
+    assert data["top_category_share_pct"] == 100
+    assert data["biggest_change_name"] == "Capital Gains"
+    assert data["biggest_change_amount"] == 80_000
     assert "biggest_change_pct" not in data
 
 

--- a/backend/tests/routes/test_insights_period_glance.py
+++ b/backend/tests/routes/test_insights_period_glance.py
@@ -298,8 +298,68 @@ async def test_period_glance_counts_net_negative_income_categories_as_expenses(c
     assert data["top_category_name"] == "Capital Gains"
     assert data["top_category_share_pct"] == 100
     assert data["biggest_change_name"] == "Capital Gains"
-    assert data["biggest_change_amount"] == 80_000
+    assert data["biggest_change_amount"] == -80_000
     assert "biggest_change_pct" not in data
+
+
+async def test_period_glance_excludes_resolved_income_loss(client):
+    """An income-kind category moving from loss to zero is not a current-period change driver."""
+    signup_resp = await _create_user(client)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Investment Cash")).json()["id"])
+    capital_gains_id, capital_gains = _category(user_id, "Capital Gains", CategoryKind.INCOME)
+
+    async with TestSession() as session:
+        session.add_all([
+            capital_gains,
+            _transaction(user_id, account_id, capital_gains_id, date(2026, 1, 4), -466_541),
+        ])
+        await session.commit()
+
+    resp = await client.get(
+        "/insights/period-glance",
+        params={"from_date": "2026-01-08", "to_date": "2026-01-14"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["income"] == 0
+    assert data["expenses"] == 0
+    assert "biggest_change_name" not in data
+    assert "biggest_change_amount" not in data
+    assert "biggest_change_pct" not in data
+
+
+async def test_period_glance_reports_vanished_over_refund_as_negative_change(client):
+    """An expense-kind category moving from over-refund to zero is negative movement."""
+    signup_resp = await _create_user(client)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
+    shopping_id, shopping = _category(user_id, "Shopping", CategoryKind.EXPENSE)
+
+    async with TestSession() as session:
+        session.add_all([
+            shopping,
+            _transaction(user_id, account_id, shopping_id, date(2026, 2, 4), 25_000),
+        ])
+        await session.commit()
+
+    resp = await client.get(
+        "/insights/period-glance",
+        params={"from_date": "2026-02-08", "to_date": "2026-02-14"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["income"] == 0
+    assert data["expenses"] == 0
+    assert data["biggest_change_name"] == "Shopping"
+    assert data["biggest_change_amount"] == -25_000
+    assert data["biggest_change_pct"] == -100
 
 
 async def test_period_glance_uses_stable_tie_breakers(client):

--- a/backend/tests/routes/test_insights_savings_rate_trend.py
+++ b/backend/tests/routes/test_insights_savings_rate_trend.py
@@ -190,8 +190,8 @@ async def test_savings_rate_trend_uses_user_timezone_for_current_month(client, m
     }
 
 
-async def test_savings_rate_trend_keeps_monthly_totals_kind_aware(client, monkeypatch):
-    """Income reversals and expense refunds net only within their own category kind."""
+async def test_savings_rate_trend_routes_flipped_categories_by_monthly_net(client, monkeypatch):
+    """Savings trend nets each monthly category before assigning income or expense."""
     from app.routes import insights as insights_routes
 
     monkeypatch.setattr(insights_routes, "datetime", _FixedClock(datetime(2026, 5, 19, 16, 0, tzinfo=UTC)))
@@ -223,7 +223,7 @@ async def test_savings_rate_trend_keeps_monthly_totals_kind_aware(client, monkey
     assert resp.status_code == 200
     assert resp.json() == {
         "points": [
-            ["2026-05-01", 220_000, 40_000],
+            ["2026-05-01", 320_000, 140_000],
         ],
     }
 

--- a/backend/tests/routes/test_transaction.py
+++ b/backend/tests/routes/test_transaction.py
@@ -702,34 +702,45 @@ async def test_transactions_overview_explicit_hidden_account_is_allowed(client):
     assert data["total_outflow"] == -30_000
 
 
-async def test_transactions_overview_top_categories_only_include_expense_categories(client):
-    """Top categories exclude negative income and transfer rows."""
+async def test_transactions_overview_top_categories_use_net_expense_side_categories(client):
+    """Top categories net refunds and include net-negative income categories."""
     headers, account_id, expense_category_id = await _setup_user_with_deps(client)
     transfer_category_id = (await _create_category(client, headers, name="Main Transfer", kind="transfer")).json()["id"]
     income_category_id = (await _create_category(client, headers, name="Main Income", kind="income")).json()["id"]
+    over_refund_category_id = (await _create_category(client, headers, name="Over Refund", kind="expense")).json()["id"]
 
     await _create_transaction(client, headers, account_id, transfer_category_id, amount=-20_000)
     await _create_transaction(client, headers, account_id, income_category_id, amount=-15_000)
     await _create_transaction(client, headers, account_id, expense_category_id, amount=-4_000)
     await _create_transaction(client, headers, account_id, expense_category_id, amount=-3_000)
+    await _create_transaction(client, headers, account_id, expense_category_id, amount=2_000)
+    await _create_transaction(client, headers, account_id, over_refund_category_id, amount=-1_000)
+    await _create_transaction(client, headers, account_id, over_refund_category_id, amount=1_500)
 
     resp = await client.get("/transactions/overview", headers=headers)
 
     assert resp.status_code == 200
     data = resp.json()
     assert [(row["category_id"], row["total"]) for row in data["top_categories"]] == [
-        (expense_category_id, -7_000),
+        (income_category_id, -15_000),
+        (expense_category_id, -5_000),
     ]
 
 
-async def test_transactions_overview_outliers_only_include_expense_categories(client):
-    """Most expensive transactions exclude negative income and transfer rows."""
+async def test_transactions_overview_outliers_include_income_loss_transactions(client):
+    """Most expensive transactions include income losses but exclude transfers."""
     headers, account_id, expense_category_id = await _setup_user_with_deps(client)
     transfer_category_id = (await _create_category(client, headers, name="Main Transfer", kind="transfer")).json()["id"]
     income_category_id = (await _create_category(client, headers, name="Main Income", kind="income")).json()["id"]
+    refunded_category_id = (await _create_category(client, headers, name="Refunded Expense", kind="expense")).json()["id"]
+    over_refund_category_id = (await _create_category(client, headers, name="Over-refunded Expense", kind="expense")).json()["id"]
 
     await _create_transaction(client, headers, account_id, transfer_category_id, amount=-20_000)
     await _create_transaction(client, headers, account_id, income_category_id, amount=-15_000)
+    await _create_transaction(client, headers, account_id, refunded_category_id, amount=-10_000)
+    await _create_transaction(client, headers, account_id, refunded_category_id, amount=4_000)
+    await _create_transaction(client, headers, account_id, over_refund_category_id, amount=-9_000)
+    await _create_transaction(client, headers, account_id, over_refund_category_id, amount=9_500)
     await _create_transaction(client, headers, account_id, expense_category_id, amount=-4_000)
     await _create_transaction(client, headers, account_id, expense_category_id, amount=-3_000)
 
@@ -737,7 +748,7 @@ async def test_transactions_overview_outliers_only_include_expense_categories(cl
 
     assert resp.status_code == 200
     data = resp.json()
-    assert [row["amount"] for row in data["outliers"]] == [-4_000, -3_000]
+    assert [row["amount"] for row in data["outliers"]] == [-15_000, -6_000, -4_000]
 
 
 # --- Sorting ---

--- a/backend/tests/routes/test_user.py
+++ b/backend/tests/routes/test_user.py
@@ -671,6 +671,111 @@ async def test_get_runway_excludes_current_partial_month_from_average(client, mo
     assert data["thresholds"] == thresholds
 
 
+async def test_get_runway_handles_refunds_and_excludes_income_losses_and_transfers(client, monkeypatch):
+    """Runway uses net expense category totals and excludes income/transfers."""
+    from app.routes import user as user_routes
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            instant = datetime(2026, 4, 15, 16, 0, tzinfo=UTC)
+            return instant.astimezone(tz) if tz else instant
+
+    monkeypatch.setattr(user_routes, "datetime", FixedDateTime)
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = signup_resp.json()["user"]["id"]
+    account_id = (await _create_account(client, headers)).json()["id"]
+
+    async with TestSession() as session:
+        expense_category = Category(owner_id=user_id, name="Groceries", kind=CategoryKind.EXPENSE)
+        over_refunded_category = Category(owner_id=user_id, name="Shopping", kind=CategoryKind.EXPENSE)
+        income_category = Category(owner_id=user_id, name="Capital Gains", kind=CategoryKind.INCOME)
+        transfer_category = Category(owner_id=user_id, name="Transfer", kind=CategoryKind.TRANSFER)
+        session.add_all([expense_category, over_refunded_category, income_category, transfer_category])
+        await session.flush()
+        session.add_all([
+            Transaction(
+                created_by_user_id=user_id,
+                account_id=account_id,
+                category_id=expense_category.id,
+                dt=date(2026, 3, 1),
+                amount=-12_000,
+                currency="CAD",
+            ),
+            Transaction(
+                created_by_user_id=user_id,
+                account_id=account_id,
+                category_id=income_category.id,
+                dt=date(2026, 3, 2),
+                amount=-6_000,
+                currency="CAD",
+            ),
+            Transaction(
+                created_by_user_id=user_id,
+                account_id=account_id,
+                category_id=expense_category.id,
+                dt=date(2026, 3, 3),
+                amount=4_000,
+                currency="CAD",
+            ),
+            Transaction(
+                created_by_user_id=user_id,
+                account_id=account_id,
+                category_id=income_category.id,
+                dt=date(2026, 3, 3),
+                amount=1_000,
+                currency="CAD",
+            ),
+            Transaction(
+                created_by_user_id=user_id,
+                account_id=account_id,
+                category_id=over_refunded_category.id,
+                dt=date(2026, 3, 3),
+                amount=-5_000,
+                currency="CAD",
+            ),
+            Transaction(
+                created_by_user_id=user_id,
+                account_id=account_id,
+                category_id=over_refunded_category.id,
+                dt=date(2026, 3, 3),
+                amount=7_000,
+                currency="CAD",
+            ),
+            Transaction(
+                created_by_user_id=user_id,
+                account_id=account_id,
+                category_id=transfer_category.id,
+                dt=date(2026, 3, 4),
+                amount=-99_000,
+                currency="CAD",
+            ),
+            Transaction(
+                created_by_user_id=user_id,
+                account_id=account_id,
+                category_id=expense_category.id,
+                dt=date(2026, 4, 1),
+                amount=-48_000,
+                currency="CAD",
+            ),
+        ])
+        session.add(AccountBalanceSnapshot(account_id=account_id, dt=date(2026, 4, 15), balance=180_000))
+        await session.commit()
+
+    await client.put("/me/runway-accounts", json={"account_ids": [account_id]}, headers=headers)
+    resp = await client.get("/me/runway", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["months_covered"] == 1
+    # Groceries net to $80.00. Capital Gains, transfers, over-refunded Shopping,
+    # and the current partial month are excluded.
+    assert data["avg_monthly_expense"] == 8_000
+    assert data["reason"] is None
+
+
 async def test_get_runway_uses_viewer_timezone_for_window_start(client, monkeypatch):
     """A Toronto viewer still treats Jan 1 01:00 UTC as Dec 31 for runway history."""
     from app.routes import user as user_routes

--- a/frontend/src/accounts/hooks/useAccountsMetrics.ts
+++ b/frontend/src/accounts/hooks/useAccountsMetrics.ts
@@ -77,7 +77,7 @@ export function useAccountsMetrics(
       : runway.reason === 'no_accounts'
         ? 'Choose accounts in Settings'
         : runway.reason === 'insufficient_history'
-          ? 'Need 1+ month of expense data'
+          ? 'Need 1+ month of net expense data'
           : `${formatCurrency(runway.avg_monthly_expense, displayCurrency)}/mth · ${formatRunwayBasis(runway.months_covered)}`
 
   const savingsRatePeriod = dashboardSavingsRate?.savings_rate_history.at(-1)

--- a/frontend/src/api/dashboard.ts
+++ b/frontend/src/api/dashboard.ts
@@ -49,6 +49,8 @@ export interface SpendingBreakdownResponse {
   range: SpendingRange;
   expense: CategoryBreakdownEntry[];
   income: CategoryBreakdownEntry[];
+  expense_total: number;
+  income_total: number;
 }
 
 export interface SpendingComparisonResponse {

--- a/frontend/src/api/insights.ts
+++ b/frontend/src/api/insights.ts
@@ -32,6 +32,8 @@ export type InsightsCategoryTrendEntry = [string, string, number, number, number
 export interface InsightsIncomeExpenseBreakdownResponse {
   expense: InsightsBreakdownEntry[];
   income: InsightsBreakdownEntry[];
+  expense_total: number;
+  income_total: number;
   expense_increases: InsightsCategoryTrendEntry[];
   expense_decreases: InsightsCategoryTrendEntry[];
   income_increases: InsightsCategoryTrendEntry[];

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -47,11 +47,9 @@ export const transactionKeys = {
   ] as const,
 };
 
-const TRANSACTION_OVERVIEW_VERSION = 'category-net-v2';
-
 export const transactionOverviewKeys = {
   all: ['transactions-overview'] as const,
-  detail: (filters: Record<string, unknown>) => ['transactions-overview', TRANSACTION_OVERVIEW_VERSION, filters] as const,
+  detail: (filters: Record<string, unknown>) => ['transactions-overview', filters] as const,
 };
 
 export const taxAdvantagedPlanKeys = {
@@ -61,15 +59,11 @@ export const taxAdvantagedPlanKeys = {
   limits: (planId: string | undefined) => ['tax-advantaged-plans', planId, 'limits'] as const,
 };
 
-const DASHBOARD_SAVINGS_RATE_VERSION = 'category-net-v2';
-const INSIGHTS_PERIOD_GLANCE_VERSION = 'category-change-v3';
-const INSIGHTS_SAVINGS_RATE_TREND_VERSION = 'category-net-v2';
-
 export const dashboardKeys = {
   credit: () => ['dashboard-credit'] as const,
   netWorth: (windowDays: number) => ['dashboard-net-worth', windowDays] as const,
   netWorthAll: ['dashboard-net-worth'] as const,
-  savingsRate: () => ['dashboard-savings-rate', DASHBOARD_SAVINGS_RATE_VERSION] as const,
+  savingsRate: () => ['dashboard-savings-rate'] as const,
   savingsRateAll: ['dashboard-savings-rate'] as const,
   recentActivity: (windowDays: number) => ['dashboard-recent-activity', windowDays] as const,
   recentActivityAll: ['dashboard-recent-activity'] as const,
@@ -80,12 +74,12 @@ export const dashboardKeys = {
 };
 
 export const insightsKeys = {
-  periodGlance: (fromDate: string, toDate: string) => ['insights-period-glance', INSIGHTS_PERIOD_GLANCE_VERSION, fromDate, toDate] as const,
+  periodGlance: (fromDate: string, toDate: string) => ['insights-period-glance', fromDate, toDate] as const,
   fundFlow: (fromDate: string, toDate: string) => ['insights-fund-flow', fromDate, toDate] as const,
   incomeExpenseBreakdown: (fromDate: string, toDate: string) => ['insights-income-expense-breakdown', fromDate, toDate] as const,
   cashFlow: (fromDate: string, toDate: string) => ['insights-cash-flow', fromDate, toDate] as const,
-  netWorth: (fromDate: string, toDate: string) => ['insights-net-worth', 'groups-v1', fromDate, toDate] as const,
-  savingsRateTrend: () => ['insights-savings-rate-trend', INSIGHTS_SAVINGS_RATE_TREND_VERSION] as const,
+  netWorth: (fromDate: string, toDate: string) => ['insights-net-worth', fromDate, toDate] as const,
+  savingsRateTrend: () => ['insights-savings-rate-trend'] as const,
   merchantDistribution: (fromDate: string, toDate: string) => ['insights-merchant-distribution', fromDate, toDate] as const,
   merchantRanking: (fromDate: string, toDate: string) => ['insights-merchant-ranking', fromDate, toDate] as const,
 };

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -47,9 +47,11 @@ export const transactionKeys = {
   ] as const,
 };
 
+const TRANSACTION_OVERVIEW_VERSION = 'category-net-v2';
+
 export const transactionOverviewKeys = {
   all: ['transactions-overview'] as const,
-  detail: (filters: Record<string, unknown>) => ['transactions-overview', filters] as const,
+  detail: (filters: Record<string, unknown>) => ['transactions-overview', TRANSACTION_OVERVIEW_VERSION, filters] as const,
 };
 
 export const taxAdvantagedPlanKeys = {

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -60,6 +60,7 @@ export const taxAdvantagedPlanKeys = {
 };
 
 const DASHBOARD_SAVINGS_RATE_VERSION = 'category-net-v2';
+const INSIGHTS_SAVINGS_RATE_TREND_VERSION = 'category-net-v2';
 
 export const dashboardKeys = {
   credit: () => ['dashboard-credit'] as const,
@@ -81,7 +82,7 @@ export const insightsKeys = {
   incomeExpenseBreakdown: (fromDate: string, toDate: string) => ['insights-income-expense-breakdown', fromDate, toDate] as const,
   cashFlow: (fromDate: string, toDate: string) => ['insights-cash-flow', fromDate, toDate] as const,
   netWorth: (fromDate: string, toDate: string) => ['insights-net-worth', 'groups-v1', fromDate, toDate] as const,
-  savingsRateTrend: () => ['insights-savings-rate-trend'] as const,
+  savingsRateTrend: () => ['insights-savings-rate-trend', INSIGHTS_SAVINGS_RATE_TREND_VERSION] as const,
   merchantDistribution: (fromDate: string, toDate: string) => ['insights-merchant-distribution', fromDate, toDate] as const,
   merchantRanking: (fromDate: string, toDate: string) => ['insights-merchant-ranking', fromDate, toDate] as const,
 };

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -62,6 +62,7 @@ export const taxAdvantagedPlanKeys = {
 };
 
 const DASHBOARD_SAVINGS_RATE_VERSION = 'category-net-v2';
+const INSIGHTS_PERIOD_GLANCE_VERSION = 'category-change-v3';
 const INSIGHTS_SAVINGS_RATE_TREND_VERSION = 'category-net-v2';
 
 export const dashboardKeys = {
@@ -79,7 +80,7 @@ export const dashboardKeys = {
 };
 
 export const insightsKeys = {
-  periodGlance: (fromDate: string, toDate: string) => ['insights-period-glance', fromDate, toDate] as const,
+  periodGlance: (fromDate: string, toDate: string) => ['insights-period-glance', INSIGHTS_PERIOD_GLANCE_VERSION, fromDate, toDate] as const,
   fundFlow: (fromDate: string, toDate: string) => ['insights-fund-flow', fromDate, toDate] as const,
   incomeExpenseBreakdown: (fromDate: string, toDate: string) => ['insights-income-expense-breakdown', fromDate, toDate] as const,
   cashFlow: (fromDate: string, toDate: string) => ['insights-cash-flow', fromDate, toDate] as const,

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -59,11 +59,13 @@ export const taxAdvantagedPlanKeys = {
   limits: (planId: string | undefined) => ['tax-advantaged-plans', planId, 'limits'] as const,
 };
 
+const DASHBOARD_SAVINGS_RATE_VERSION = 'category-net-v2';
+
 export const dashboardKeys = {
   credit: () => ['dashboard-credit'] as const,
   netWorth: (windowDays: number) => ['dashboard-net-worth', windowDays] as const,
   netWorthAll: ['dashboard-net-worth'] as const,
-  savingsRate: () => ['dashboard-savings-rate'] as const,
+  savingsRate: () => ['dashboard-savings-rate', DASHBOARD_SAVINGS_RATE_VERSION] as const,
   savingsRateAll: ['dashboard-savings-rate'] as const,
   recentActivity: (windowDays: number) => ['dashboard-recent-activity', windowDays] as const,
   recentActivityAll: ['dashboard-recent-activity'] as const,

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -148,7 +148,7 @@ interface RunwayResultResponse {
 }
 
 // Mirrors backend RunwayResponse. `months` is null when `reason` is set —
-// either the user hasn't chosen accounts or there's not enough expense data.
+// either the user hasn't chosen accounts or there's not enough net expense data.
 export interface RunwayResult {
   months: number | null;
   reason: 'no_accounts' | 'insufficient_history' | null;

--- a/frontend/src/dashboard/widgets/RunwayWidget.tsx
+++ b/frontend/src/dashboard/widgets/RunwayWidget.tsx
@@ -25,7 +25,7 @@ function getRunwayCaption(
   if (!runway) return ''
 
   if (runway.reason === 'no_accounts') return 'Choose accounts in Settings'
-  if (runway.reason === 'insufficient_history') return 'Need 1+ month of expense data'
+  if (runway.reason === 'insufficient_history') return 'Need 1+ month of net expense data'
 
   return `${formatCurrency(runway.avg_monthly_expense, displayCurrency)}/mth \u00B7 ${formatRunwayBasis(runway.months_covered)}`
 }
@@ -64,7 +64,7 @@ export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
           widthClassName="w-64"
         >
           <span className="block">
-            Runway estimates how long selected asset accounts can cover spending, using completed months with recorded expenses.
+            Runway estimates how long selected asset accounts can cover net expenses, using completed months with recorded expenses.
           </span>
           <Link
             to="/settings#runway"

--- a/frontend/src/dashboard/widgets/SpendingBreakdownWidget.tsx
+++ b/frontend/src/dashboard/widgets/SpendingBreakdownWidget.tsx
@@ -53,6 +53,10 @@ function getBreakdownCategoryColorId(
     : entry.category_id
 }
 
+function getEntryTotal(entries: CategoryBreakdownEntry[]) {
+  return entries.reduce((sum, entry) => sum + entry.amount, 0)
+}
+
 export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWidgetProps) {
   const shouldReduceMotion = useReducedMotion()
   const {
@@ -67,7 +71,12 @@ export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWi
     if (!spendingBreakdown) return []
     return breakdownMode === 'spending' ? spendingBreakdown.expense : spendingBreakdown.income
   }, [spendingBreakdown, breakdownMode])
-  const breakdownTotal = breakdownEntries.reduce((sum, entry) => sum + entry.amount, 0)
+  const fallbackBreakdownTotal = getEntryTotal(breakdownEntries)
+  const breakdownTotal = spendingBreakdown
+    ? breakdownMode === 'spending'
+      ? spendingBreakdown.expense_total
+      : spendingBreakdown.income_total
+    : fallbackBreakdownTotal
   const breakdownChartKey = `${breakdownMode}-${breakdownRange}`
   const breakdownLoadingText = formatDashboardMoney(88888800, displayCurrency, 'breakdown')
   const breakdownCategoryKind = breakdownMode === 'spending' ? 'expense' : 'income'

--- a/frontend/src/insights/InsightsPage.tsx
+++ b/frontend/src/insights/InsightsPage.tsx
@@ -18,6 +18,7 @@ import { useInsightsRange } from './hooks/useInsightsRange'
 import { getCashFlowBarData } from './utils/cashFlow'
 import {
   getBreakdownEntriesForMode,
+  getBreakdownTotalForMode,
   getCategoryTrendSections,
 } from './utils/incomeExpenseBreakdown'
 import { getFundFlowCardData } from './utils/fundFlow'
@@ -58,6 +59,10 @@ export default function InsightsPage() {
   const displayCurrency = user?.base_currency ?? 'CAD'
   const selectedBreakdown = useMemo(
     () => getBreakdownEntriesForMode(queries.incomeExpenseBreakdown.data, breakdownMode),
+    [breakdownMode, queries.incomeExpenseBreakdown.data],
+  )
+  const selectedBreakdownTotal = useMemo(
+    () => getBreakdownTotalForMode(queries.incomeExpenseBreakdown.data, breakdownMode),
     [breakdownMode, queries.incomeExpenseBreakdown.data],
   )
   const selectedCategoryTrendSections = useMemo(
@@ -156,6 +161,7 @@ export default function InsightsPage() {
             mode={breakdownMode}
             onModeToggle={() => setBreakdownMode((mode) => (mode === 'expense' ? 'income' : 'expense'))}
             entries={selectedBreakdown}
+            total={selectedBreakdownTotal}
             trendSections={selectedCategoryTrendSections}
             displayCurrency={displayCurrency}
             animationKey={`${breakdownMode}-${range.cardTransitionKey}`}

--- a/frontend/src/insights/components/IncomeExpenseBreakdownCard.tsx
+++ b/frontend/src/insights/components/IncomeExpenseBreakdownCard.tsx
@@ -48,6 +48,7 @@ type IncomeExpenseBreakdownCardProps = {
   mode: BreakdownMode
   onModeToggle: () => void
   entries: BreakdownEntry[]
+  total: number
   trendSections: CategoryTrendSection[]
   displayCurrency: string
   animationKey: string
@@ -58,6 +59,7 @@ type IncomeExpenseBreakdownCardProps = {
 type IncomeExpenseBreakdownSnapshot = {
   mode: BreakdownMode
   entries: BreakdownEntry[]
+  total: number
   trendSections: CategoryTrendSection[]
   displayCurrency: string
   animationKey: string
@@ -150,6 +152,7 @@ export function IncomeExpenseBreakdownCard({
   mode,
   onModeToggle,
   entries,
+  total,
   trendSections,
   displayCurrency,
   animationKey,
@@ -159,10 +162,11 @@ export function IncomeExpenseBreakdownCard({
   const incomingSnapshot = useMemo<IncomeExpenseBreakdownSnapshot>(() => ({
     mode,
     entries,
+    total,
     trendSections,
     displayCurrency,
     animationKey,
-  }), [animationKey, displayCurrency, entries, mode, trendSections])
+  }), [animationKey, displayCurrency, entries, mode, total, trendSections])
   const {
     displaySnapshot,
     contentConcealed,
@@ -173,7 +177,7 @@ export function IncomeExpenseBreakdownCard({
     loading,
     transitionKey,
   })
-  const total = getTotal(displaySnapshot.entries)
+  const sliceTotal = getTotal(displaySnapshot.entries)
   const breakdownColors = useMemo(() => getCategoryColorMap(displaySnapshot.entries.map((entry) => ({
     id: entry.id,
     name: entry.name,
@@ -222,7 +226,7 @@ export function IncomeExpenseBreakdownCard({
                     Total {displaySnapshot.mode === 'expense' ? 'Expense' : 'Income'}
                   </span>
                   <span className="font-financial text-3xl leading-none tracking-tight">
-                    {formatCurrency(total, displaySnapshot.displayCurrency)}
+                    {formatCurrency(displaySnapshot.total, displaySnapshot.displayCurrency)}
                   </span>
                 </div>
                 <ResponsiveContainer width="100%" height="100%">
@@ -297,7 +301,7 @@ export function IncomeExpenseBreakdownCard({
                           {renderCrossoverBadge(entry, displaySnapshot.mode)}
                         </span>
                         <span className="font-financial">
-                          {getPct(entry.amount, total)}%
+                          {getPct(entry.amount, sliceTotal)}%
                         </span>
                       </motion.div>
                     ))}

--- a/frontend/src/insights/components/MerchantDistributionCard.tsx
+++ b/frontend/src/insights/components/MerchantDistributionCard.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { Store } from 'lucide-react'
+import IconTooltip from '@/components/IconTooltip'
 import { formatCurrency } from '@/utils/formatCurrency'
 import {
   InsightLoadingContent,
@@ -378,7 +379,21 @@ export function MerchantDistributionCard({
 
   return (
     <div className="app-card flex h-[560px] flex-col min-[1300px]:h-full">
-      <SectionHeader icon={Store} label="Spending Distribution by Merchant" />
+      <SectionHeader
+        icon={Store}
+        label={(
+          <span className="inline-flex items-center gap-2">
+            Spending Distribution by Merchant
+            <IconTooltip
+              label="How merchant distribution is calculated"
+              placement="bottom"
+              widthClassName="w-64"
+            >
+              Shows merchant spending after refunds. Income losses are not included.
+            </IconTooltip>
+          </span>
+        )}
+      />
       <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
         <InsightLoadingContent
           className="flex min-h-0 flex-1 flex-col"

--- a/frontend/src/insights/components/MerchantRankingCard.tsx
+++ b/frontend/src/insights/components/MerchantRankingCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { ListChecks } from 'lucide-react'
+import IconTooltip from '@/components/IconTooltip'
 import { formatCurrency } from '@/utils/formatCurrency'
 import {
   InsightLoadingContent,
@@ -66,7 +67,21 @@ export function MerchantRankingCard({
 
   return (
     <div className="app-card min-[1300px]:h-[560px]">
-      <SectionHeader icon={ListChecks} label="Merchant Ranking" />
+      <SectionHeader
+        icon={ListChecks}
+        label={(
+          <span className="inline-flex items-center gap-2">
+            Merchant Ranking
+            <IconTooltip
+              label="How merchant ranking is calculated"
+              placement="bottom"
+              widthClassName="w-64"
+            >
+              Ranks merchants by spending after refunds. Income losses are not included.
+            </IconTooltip>
+          </span>
+        )}
+      />
       <div className="relative overflow-hidden">
         <InsightLoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           {displaySnapshot.merchants.length > 0 ? (

--- a/frontend/src/insights/utils/incomeExpenseBreakdown.ts
+++ b/frontend/src/insights/utils/incomeExpenseBreakdown.ts
@@ -37,6 +37,18 @@ export function getBreakdownEntriesForMode(
   return getBreakdownEntries(mode === 'expense' ? data?.expense : data?.income)
 }
 
+export function getBreakdownTotalForMode(
+  data: InsightsIncomeExpenseBreakdownResponse | undefined,
+  mode: BreakdownMode,
+): number {
+  if (!data) return 0
+  const total = mode === 'expense' ? data.expense_total : data.income_total
+  if (Number.isFinite(total)) return total
+
+  return getBreakdownEntries(mode === 'expense' ? data.expense : data.income)
+    .reduce((sum, entry) => sum + entry.amount, 0)
+}
+
 export function getCategoryTrendSections(
   data: InsightsIncomeExpenseBreakdownResponse | undefined,
   mode: BreakdownMode,

--- a/frontend/src/settings/components/RunwaySection.tsx
+++ b/frontend/src/settings/components/RunwaySection.tsx
@@ -55,10 +55,10 @@ export default function RunwaySection({
         description={
           <>
             <p>
-              Pick which accounts should count toward calculating your runway — how long the total balance in the selected accounts will last if your average monthly spend doesn't change. The average uses up to the last 12 completed months with recorded expenses; the current partial month and months with no expense data are excluded. Only open asset accounts are eligible; liabilities like credit cards or loans can't be counted.
+              Pick which accounts should count toward calculating your runway — how long the total balance in the selected accounts will last if your average monthly net expenses don't change. The average uses up to the last 12 completed months with recorded expenses; the current partial month and months with no net expense data are excluded. Only open asset accounts are eligible; liabilities like credit cards or loans can't be counted.
             </p>
             <p>
-              For example, if your selected accounts hold $30,000 and you've averaged $5,000 a month in spending, that's a 6-month runway.
+              For example, if your selected accounts hold $30,000 and you've averaged $5,000 a month in net expenses, that's a 6-month runway.
             </p>
           </>
         }

--- a/frontend/src/transactions/components/topBand/MostExpensiveTransactionsPanel.tsx
+++ b/frontend/src/transactions/components/topBand/MostExpensiveTransactionsPanel.tsx
@@ -41,7 +41,7 @@ export default function MostExpensiveTransactionsPanel({
           placement="bottom"
           widthClassName="w-64"
         >
-          Shows the three largest expense transactions in the selected period
+          Shows the three largest net expense-side transaction contributors in the selected period
         </IconTooltip>
       </p>
       <div className="mt-2 flex flex-col gap-2.5">

--- a/frontend/src/transactions/components/topBand/TopCategoriesChart.tsx
+++ b/frontend/src/transactions/components/topBand/TopCategoriesChart.tsx
@@ -83,7 +83,7 @@ export default function TopCategoriesChart({
           placement="bottom"
           widthClassName="w-64"
         >
-          The top 5 categories as ranked by total amount spent in the selected period. The progress bar is relative to the highest-spend category, not an absolute scale.
+          The top 5 categories ranked by net expense-side total in the selected period. The progress bar is relative to the highest-spend category, not an absolute scale.
         </IconTooltip>
       </p>
       <div className="mt-2">


### PR DESCRIPTION
## Summary

This PR standardizes how income, expenses, refunds, and flipped category totals are calculated across the dashboard, insights, runway, and transaction overview surfaces. The goal is that the same period shows the same totals wherever the app is summarizing expenses and incomes.

## Bug Fixes

- Fixed runway using raw expense outflows instead of net expense totals after refunds
- Fixed dashboard spending breakdown so expense-category refunds reduce both the donut total and the affected category slice
- Fixed dashboard and insights savings rate, and insights savings rate trend, showing incorrect savings when refunds or income losses changed category totals
- Uniformed all expense calculation logic for spending/income breakdown charts and values
- Fixed transaction overview top categories to count refunded expense categories
- Fixed transaction overview most expensive transactions showing categories whose net expense had been reduced or eliminated by refunds
- Added merchant insight tooltip text to clarify merchant spending excludes income losses

## Adjustments
- Period-at-a-glance biggest-change won't show income losses if it generate neither income nor losses in the current period