### PR TITLE
Fix budget modal invocation issue

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -123,7 +123,16 @@ function AnimatedRoutes() {
 
   // Keep rendering the previous protected route until its exit fade completes.
   useEffect(() => {
-    if (location.pathname === displayLocation.pathname) return;
+    if (location.pathname === displayLocation.pathname) {
+      if (location.search !== displayLocation.search || location.hash !== displayLocation.hash) {
+        const syncTimer = window.setTimeout(() => {
+          setDisplayLocation(location);
+        }, 0);
+
+        return () => window.clearTimeout(syncTimer);
+      }
+      return;
+    }
 
     let exitTimer: number | undefined;
 
@@ -147,7 +156,7 @@ function AnimatedRoutes() {
       window.clearTimeout(transitionTimer);
       if (exitTimer !== undefined) window.clearTimeout(exitTimer);
     };
-  }, [displayLocation.pathname, location]);
+  }, [displayLocation.hash, displayLocation.pathname, displayLocation.search, location]);
 
   // Hold the route-level loading state until queries settle and the minimum
   // transition duration has elapsed.

--- a/frontend/src/budgets/components/budget-details-modal/BudgetDetailsModal.tsx
+++ b/frontend/src/budgets/components/budget-details-modal/BudgetDetailsModal.tsx
@@ -31,6 +31,8 @@ function utilizationPercent(spent: number, limit: number) {
   return (spent / limit) * 100
 }
 
+const CHART_INITIAL_DIMENSION = { width: 1, height: 192 }
+
 export default function BudgetDetailsModal({
   baseBudget,
   periods,
@@ -455,7 +457,7 @@ export default function BudgetDetailsModal({
                       Utilization history could not load.
                     </div>
                   ) : chartData.length > 0 ? (
-                    <ResponsiveContainer width="100%" height="100%">
+                    <ResponsiveContainer width="100%" height="100%" initialDimension={CHART_INITIAL_DIMENSION}>
                       <BarChart data={chartData} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
                         <CartesianGrid stroke="var(--app-border)" vertical={false} />
                         <XAxis


### PR DESCRIPTION
This is a hot fix to fix an issue where the budget modal is not being invoked when the budget is clicked. 

The route shell rendered from a cached `displayLocation` that only changed on path name updates. Clicking a budget changed `/budgets` to `/budgets?budget=<id>`, but the rendered route still received the old location, so the budgets page never saw the budget search param and the modal stayed closed.