### PR TITLE
Add support for starting account balance

### DIFF
--- a/backend/app/routes/account.py
+++ b/backend/app/routes/account.py
@@ -12,10 +12,12 @@ from sqlalchemy.orm import selectinload
 from app.database import get_db
 from app.dependencies import get_current_user
 from app.models.account import Account, AccountBalanceSnapshot, AccountPermission, TaxAdvantagedPlan
-from app.models.base import ACCOUNT_KIND_BY_TYPE, AccountKind, AccountType, PermissionLevel, TaxTreatment
+from app.models.base import ACCOUNT_KIND_BY_TYPE, AccountKind, AccountType, CategoryKind, PermissionLevel, TaxTreatment
+from app.models.category import Category
 from app.models.currency import Currency
 from app.models.group import Group, GroupMember
 from app.models.institution import Institution
+from app.models.transaction import Transaction
 from app.models.user import User
 from app.permissions import check_account_access
 from app.schemas.account import (
@@ -32,7 +34,7 @@ from app.services.accounts import (
     get_account_cash_flow_history,
     get_account_spending_breakdown,
 )
-from app.services.snapshots import attach_current_balances
+from app.services.snapshots import attach_current_balances, recompute_snapshots_from
 
 router = APIRouter(prefix="/accounts", tags=["accounts"])
 
@@ -42,6 +44,24 @@ _VALID_ACCOUNT_TYPES = {e.value for e in AccountType}
 
 # UpdateAccountRequest fields that map to NOT NULL columns — explicit null on these is rejected with 422.
 _UPDATE_ACCOUNT_NOT_NULL_FIELDS = frozenset({"name", "is_hidden"})
+_BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
+_STARTING_BALANCE_NOTE = "Starting balance"
+
+
+async def _get_system_balance_adjustment_category_id(db: AsyncSession) -> uuid.UUID:
+    category_id = await db.scalar(
+        select(Category.id).where(
+            Category.is_system.is_(True),
+            Category.kind == CategoryKind.TRANSFER,
+            Category.name == _BALANCE_ADJUSTMENT_CATEGORY_NAME,
+        ),
+    )
+    if category_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Balance adjustment category is not configured",
+        )
+    return category_id
 
 
 async def _validate_tax_advantaged_plan_link(
@@ -344,11 +364,26 @@ async def create_account(
     # This gives the frontend a stable starting point for charts without needing
     # to join against account.created_at. Recompute restores this anchor when
     # transaction history is emptied.
+    anchor_dt = account.created_at.astimezone(ZoneInfo(anchor_tz)).date()
     db.add(AccountBalanceSnapshot(
         account_id=account.id,
-        dt=account.created_at.astimezone(ZoneInfo(anchor_tz)).date(),
+        dt=anchor_dt,
         balance=0,
     ))
+
+    if data.starting_balance:
+        db.add(Transaction(
+            created_by_user_id=user.id,
+            account_id=account.id,
+            dt=anchor_dt,
+            category_id=await _get_system_balance_adjustment_category_id(db),
+            amount=data.starting_balance,
+            currency=account.currency,
+            fx_rate=None,
+            notes=_STARTING_BALANCE_NOTE,
+        ))
+        await db.flush()
+        await recompute_snapshots_from(db, account.id, anchor_dt)
 
     await db.commit()
     # Re-fetch with eager loading so the institution relationship is populated for serialization

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -61,6 +61,7 @@ class CreateAccountRequest(BaseModel):
     institution_id: uuid.UUID | None = None
     currency: str = Field(min_length=3, max_length=3)
     credit_limit: int | None = None  # Only valid on liability accounts
+    starting_balance: int | None = None  # Signed initial balance adjustment in minor units
     is_hidden: bool = False
     group_id: uuid.UUID | None = None
 

--- a/backend/tests/routes/test_account.py
+++ b/backend/tests/routes/test_account.py
@@ -1,9 +1,17 @@
-from datetime import date
+from datetime import date, datetime
+from uuid import UUID
+from zoneinfo import ZoneInfo
 
-from app.models.base import InstitutionStatus
+import pytest
+from sqlalchemy import delete, func, select
+
+from app.models.account import Account, AccountBalanceSnapshot
+from app.models.base import CategoryKind, InstitutionStatus
+from app.models.category import Category
 from app.models.institution import Institution
+from app.models.transaction import Transaction
 from tests.conftest import TestSession
-from tests.routes.conftest import ACCOUNT_PAYLOAD, _create_account, _create_user, _get_auth_header
+from tests.routes.conftest import ACCOUNT_PAYLOAD, _create_account, _create_user, _get_auth_header, _seed_currency
 
 # --- Helpers ---
 
@@ -49,6 +57,20 @@ async def _create_second_user(client):
         "tz": "America/Toronto",
         "base_currency": "CAD",
     })
+
+
+async def _signup_user(client, *, email: str, first_name: str, tz: str):
+    return await client.post("/auth/signup", json={
+        "email": email,
+        "password": "securepassword123",
+        "first_name": first_name,
+        "tz": tz,
+        "base_currency": "CAD",
+    })
+
+
+def _created_at_in_tz(account_data: dict, tz: str) -> date:
+    return datetime.fromisoformat(account_data["created_at"]).astimezone(ZoneInfo(tz)).date()
 
 
 # --- GET /accounts ---
@@ -178,6 +200,194 @@ async def test_create_account_returns_current_balance(client):
 
     assert resp.status_code == 201
     assert resp.json()["current_balance"] == 0
+
+
+async def test_create_account_with_starting_balance_creates_adjustment(client):
+    """Non-zero starting_balance creates a Balance Adjustment transaction."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+
+    resp = await _create_account(client, headers, starting_balance=123_45)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["current_balance"] == 123_45
+    account_id = UUID(data["id"])
+    expected_dt = _created_at_in_tz(data, "America/Toronto")
+
+    async with TestSession() as session:
+        result = await session.execute(
+            select(Transaction, Category)
+            .join(Category, Transaction.category_id == Category.id)
+            .where(Transaction.account_id == account_id)
+            .order_by(Transaction.dt, Transaction.created_at, Transaction.id),
+        )
+        rows = result.all()
+        snapshots_result = await session.execute(
+            select(AccountBalanceSnapshot).where(AccountBalanceSnapshot.account_id == account_id),
+        )
+        snapshots = snapshots_result.scalars().all()
+
+    assert len(rows) == 1
+    txn, category = rows[0]
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert txn.created_by_user_id == user_id
+    assert txn.account_id == account_id
+    assert txn.dt == expected_dt
+    assert txn.merchant_id is None
+    assert txn.fx_rate is None
+    assert txn.amount == 123_45
+    assert txn.currency == data["currency"]
+    assert txn.notes == "Starting balance"
+    assert category.name == "Balance Adjustment"
+    assert category.kind == CategoryKind.TRANSFER
+    assert category.is_system is True
+    assert category.owner_id is None
+    assert category.group_id is None
+    assert snapshot.account_id == account_id
+    assert snapshot.dt == expected_dt
+    assert snapshot.balance == 123_45
+
+    detail_resp = await client.get(f"/accounts/{account_id}", headers=headers)
+    list_resp = await client.get("/accounts", headers=headers)
+
+    assert detail_resp.status_code == 200
+    assert detail_resp.json()["current_balance"] == 123_45
+    assert list_resp.status_code == 200
+    assert list_resp.json()[0]["current_balance"] == 123_45
+
+
+async def test_create_group_account_starting_balance_uses_group_owner_creation_day(client):
+    """Group-account starting balances are dated in the group owner's timezone."""
+    await _seed_currency()
+    owner_resp = await _signup_user(
+        client,
+        email="owner@example.com",
+        first_name="Owner",
+        tz="Pacific/Kiritimati",
+    )
+    member_resp = await _signup_user(
+        client,
+        email="member@example.com",
+        first_name="Member",
+        tz="America/Adak",
+    )
+    owner_headers = _get_auth_header(owner_resp)
+    member_headers = _get_auth_header(member_resp)
+    member_user_id = member_resp.json()["user"]["id"]
+
+    group_resp = await client.post("/groups", json={"name": "Global Household"}, headers=owner_headers)
+    assert group_resp.status_code == 201
+    group_id = group_resp.json()["id"]
+    add_member_resp = await client.post(f"/groups/{group_id}/members", json={"user_id": member_user_id}, headers=owner_headers)
+    assert add_member_resp.status_code == 201
+    promote_resp = await client.patch(f"/groups/{group_id}/members/{member_user_id}", json={"is_admin": True}, headers=owner_headers)
+    assert promote_resp.status_code == 200
+
+    resp = await _create_account(client, member_headers, group_id=group_id, starting_balance=50_00)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    account_id = UUID(data["id"])
+    owner_local_dt = _created_at_in_tz(data, "Pacific/Kiritimati")
+    acting_user_local_dt = _created_at_in_tz(data, "America/Adak")
+    assert owner_local_dt != acting_user_local_dt
+
+    async with TestSession() as session:
+        txn = await session.scalar(select(Transaction).where(Transaction.account_id == account_id))
+        snapshot = await session.scalar(select(AccountBalanceSnapshot).where(AccountBalanceSnapshot.account_id == account_id))
+
+    assert txn is not None
+    assert snapshot is not None
+    assert txn.dt == owner_local_dt
+    assert snapshot.dt == owner_local_dt
+    assert txn.dt != acting_user_local_dt
+    assert snapshot.balance == 50_00
+
+
+async def test_create_account_starting_balance_rolls_back_if_balance_adjustment_category_missing(client):
+    """Missing Balance Adjustment configuration does not leave partial account rows."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    async with TestSession() as session:
+        await session.execute(delete(Category).where(Category.name == "Balance Adjustment", Category.is_system.is_(True)))
+        await session.commit()
+
+    resp = await _create_account(client, headers, starting_balance=100_00)
+
+    assert resp.status_code == 500
+    assert resp.json()["detail"] == "Balance adjustment category is not configured"
+
+    async with TestSession() as session:
+        account_count = await session.scalar(select(func.count(Account.id)))
+        transaction_count = await session.scalar(select(func.count(Transaction.id)))
+        snapshot_count = await session.scalar(select(func.count(AccountBalanceSnapshot.account_id)))
+
+    assert account_count == 0
+    assert transaction_count == 0
+    assert snapshot_count == 0
+
+
+async def test_create_revolving_account_with_signed_starting_balance(client):
+    """Liability starting balances are accepted as signed debt values."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    resp = await _create_account(
+        client,
+        headers,
+        account_kind="revolving",
+        account_type="credit_card",
+        name="Visa",
+        starting_balance=-42_42,
+    )
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["current_balance"] == -42_42
+    account_id = UUID(data["id"])
+    expected_dt = _created_at_in_tz(data, "America/Toronto")
+
+    async with TestSession() as session:
+        txn = await session.scalar(select(Transaction).where(Transaction.account_id == account_id))
+        snapshot = await session.scalar(select(AccountBalanceSnapshot).where(AccountBalanceSnapshot.account_id == account_id))
+
+    assert txn is not None
+    assert snapshot is not None
+    assert txn.dt == expected_dt
+    assert txn.amount == -42_42
+    assert txn.notes == "Starting balance"
+    assert snapshot.dt == expected_dt
+    assert snapshot.balance == -42_42
+
+
+@pytest.mark.parametrize("starting_balance", [None, 0])
+async def test_create_account_without_nonzero_starting_balance_creates_no_adjustment(client, starting_balance):
+    """Null and zero starting balances keep the zero anchor and skip a transaction row."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    resp = await _create_account(client, headers, starting_balance=starting_balance)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["current_balance"] == 0
+    account_id = UUID(data["id"])
+    expected_dt = _created_at_in_tz(data, "America/Toronto")
+
+    async with TestSession() as session:
+        transaction_id = await session.scalar(select(Transaction.id).where(Transaction.account_id == account_id))
+        snapshot = await session.scalar(
+            select(AccountBalanceSnapshot).where(AccountBalanceSnapshot.account_id == account_id),
+        )
+
+    assert transaction_id is None
+    assert snapshot is not None
+    assert snapshot.dt == expected_dt
+    assert snapshot.balance == 0
 
 
 async def test_list_accounts_without_auth_returns_401(client):

--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -93,6 +93,7 @@ export interface CreateAccountPayload {
   institution_id: string | null;
   currency: string;
   credit_limit: number | null;
+  starting_balance: number | null;
   is_hidden: boolean;
 }
 

--- a/frontend/src/components/CreateAccountModal.tsx
+++ b/frontend/src/components/CreateAccountModal.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'motion/react';
 import { Landmark, X } from 'lucide-react';
 import Dropdown from '@/components/Dropdown';
+import IconTooltip from '@/components/IconTooltip';
 import { useCurrencies } from '@/api/currency';
 import { useInstitutions } from '@/api/institutions';
 import { useTaxAdvantagedPlans } from '@/api/taxAdvantagedPlans';
@@ -40,6 +41,7 @@ const INITIAL_FORM = {
   institution_id: '',
   tax_advantaged_plan_id: '',
   credit_limit: '',
+  starting_balance: '',
 };
 
 // Shared animation for conditional fields sliding in/out
@@ -74,20 +76,25 @@ interface FieldErrors {
   name?: string;
   currency?: string;
   credit_limit?: string;
+  starting_balance?: string;
 }
 
 interface FieldLabelRowProps {
   label: React.ReactNode;
   htmlFor?: string;
   error?: string;
+  accessory?: React.ReactNode;
 }
 
-function FieldLabelRow({ label, htmlFor, error }: FieldLabelRowProps) {
+function FieldLabelRow({ label, htmlFor, error, accessory }: FieldLabelRowProps) {
   return (
     <div className="mb-1.5 flex items-start justify-between gap-3">
-      <label htmlFor={htmlFor} className="app-label block shrink-0 text-[0.9375rem] leading-5">
-        {label}
-      </label>
+      <div className="flex min-w-0 items-center gap-1.5">
+        <label htmlFor={htmlFor} className="app-label block shrink-0 text-[0.9375rem] leading-5">
+          {label}
+        </label>
+        {accessory}
+      </div>
       <AnimatePresence initial={false}>
         {error && (
           <motion.p
@@ -117,6 +124,10 @@ function validate(form: typeof INITIAL_FORM): FieldErrors {
   if (form.credit_limit) {
     const n = Number(form.credit_limit.replace(/,/g, ''));
     if (isNaN(n) || n < 0) errors.credit_limit = 'Must be a positive number';
+  }
+  if (form.starting_balance) {
+    const n = Number(form.starting_balance.replace(/,/g, ''));
+    if (isNaN(n) || n < 0) errors.starting_balance = 'Must be zero or higher';
   }
   return errors;
 }
@@ -150,10 +161,12 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
   // credit_limit applies only to revolving-credit products (credit cards,
   // LOCs, HELOCs). Amortizing debt has a fixed principal schedule, not a limit.
   const isRevolving = accountKind === 'revolving';
+  const isLiability = accountKind === 'revolving' || accountKind === 'amortizing';
   const canLinkTaxPlan = accountKind === 'asset' && !!form.currency;
   const conditionalAccountField = canLinkTaxPlan ? 'tax-plan' : isRevolving ? 'credit-limit' : null;
   const selectedAccountType = ACCOUNT_TYPE_OPTIONS.find((option) => option.value === form.account_type);
   const selectedCurrencySymbol = currencies.find((currency) => currency.id === form.currency)?.symbol ?? '';
+  const startingBalanceLabel = isLiability ? 'Starting Amount Owed' : 'Starting Balance';
 
   // Dropdown options
   const currencyOptions = useMemo(
@@ -239,7 +252,7 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
 
     const errors = validate(form);
     setFieldErrors(errors);
-    setTouched({ account_type: true, name: true, currency: true, credit_limit: true });
+    setTouched({ account_type: true, name: true, currency: true, credit_limit: true, starting_balance: true });
     if (Object.keys(errors).length > 0) return;
 
     // Convert user-entered major units (e.g. dollars) to minor units (e.g. cents)
@@ -261,6 +274,11 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
       institution_id: form.institution_id || null,
       currency: form.currency,
       credit_limit: isRevolving ? toMinor(form.credit_limit) : null,
+      starting_balance: (() => {
+        const amount = toMinor(form.starting_balance);
+        if (amount === null) return null;
+        return isLiability ? -amount : amount;
+      })(),
       is_hidden: false,
     };
 
@@ -456,6 +474,47 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                                 onCreateNew={handleCreateInstitution}
                                 createNewLabel={(query) => query ? `Create institution "${query}"` : 'Create institution'}
                               />
+                            </div>
+
+                            <div>
+                              <FieldLabelRow
+                                htmlFor="starting-balance"
+                                label={startingBalanceLabel}
+                                error={showError('starting_balance') || undefined}
+                                accessory={(
+                                  <IconTooltip
+                                    label={`${startingBalanceLabel} info`}
+                                    placement="top"
+                                    widthClassName="w-56"
+                                    size={14}
+                                  >
+                                    If provided, this account will be created with a balance adjustment transaction for this amount.
+                                  </IconTooltip>
+                                )}
+                              />
+                              <div className="relative">
+                                {selectedCurrencySymbol && (
+                                  <span
+                                    className="pointer-events-none absolute left-4 top-1/2 -translate-y-1/2"
+                                    style={{ color: 'var(--app-text-subtle)' }}
+                                    aria-hidden
+                                  >
+                                    {selectedCurrencySymbol}
+                                  </span>
+                                )}
+                                <input
+                                  id="starting-balance"
+                                  className={`app-input ${selectedCurrencySymbol ? 'pl-8' : ''} ${showError('starting_balance') ? 'app-input-error' : ''}`}
+                                  inputMode="decimal"
+                                  placeholder="Optional"
+                                  value={form.starting_balance}
+                                  onChange={(e) => handleChange(
+                                    'starting_balance',
+                                    formatMoneyInputLive(sanitizeMoneyInput(e.target.value)),
+                                  )}
+                                  onBlur={() => handleBlur('starting_balance')}
+                                />
+                              </div>
                             </div>
 
                             <AnimatePresence initial={false} mode="wait">


### PR DESCRIPTION
## Features

- Add optional starting balance/starting amount owed support to account creation modal
- Create a Balance Adjustment transaction with the provided amount and with a note "Starting balance"
- Recompute snapshots so account balances update immediately after creation
- Add an info tooltip explaining the behaviour of specifying account starting balance

This resolves #6 