### PR TITLE
Fix insights net worth change to use value one day prior to range start

### DIFF
--- a/backend/app/schemas/insights.py
+++ b/backend/app/schemas/insights.py
@@ -67,6 +67,7 @@ class InsightsNetWorthResponse(BaseModel):
     """Payload for the insights net-worth card."""
 
     groups: list[tuple[str, str, NetWorthGroupKind]]
+    baseline: list[int] = Field(default_factory=list)
     points: list[tuple[date, date, list[int]]]
     fx_status: FxStatus = Field(default_factory=FxStatus)
 

--- a/backend/app/services/insights/net_worth.py
+++ b/backend/app/services/insights/net_worth.py
@@ -1,5 +1,6 @@
 """Net worth service for the insights page."""
 
+import uuid
 from dataclasses import dataclass
 from datetime import date, timedelta
 from typing import Literal
@@ -106,18 +107,18 @@ async def _query_net_worth_points(
     base_currency: str,
     from_date: date,
     to_date: date,
-) -> tuple[list[tuple[date, date, list[int]]], FxStatus]:
+) -> tuple[list[int], list[tuple[date, date, list[int]]], FxStatus]:
     """Return signed grouped balances converted to base currency for each chart bucket."""
     buckets = _build_buckets(from_date, to_date)
     if not accounts or not buckets:
-        return [], FxStatus()
+        return [], [], FxStatus()
 
     account_ids = [account.id for account in accounts]
-    account_by_id = {account.id: account for account in accounts}
     group_index_by_account_id = {
         account.id: GROUP_INDEX_BY_ID[_group_id_for_account(account)]
         for account in accounts
     }
+    baseline_date = from_date - timedelta(days=1)
     converter = FxConverter(
         currency_exponents=await _get_currency_exponents(
             db,
@@ -129,6 +130,16 @@ async def _query_net_worth_points(
         accounts=accounts,
         buckets=buckets,
         base_currency=base_currency,
+        baseline_date=baseline_date,
+    )
+    baseline_balances = await _balances_at(db, account_ids, baseline_date)
+    baseline_values = await _grouped_values_from_balances(
+        accounts,
+        group_index_by_account_id,
+        baseline_balances,
+        base_currency=base_currency,
+        rate_date=baseline_date,
+        converter=converter,
     )
     first_bucket_start = buckets[0][0]
     anchor_result = await db.execute(
@@ -167,23 +178,63 @@ async def _query_net_worth_points(
             running[snapshot.account_id] = int(snapshot.balance)
             snapshot_index += 1
 
-        values = [0] * len(NET_WORTH_GROUPS)
-        for account_id in account_ids:
-            account = account_by_id[account_id]
-            converted_balance = await converter.convert_minor_units(
-                running[account_id],
-                base=account.currency,
-                quote=base_currency,
-                rate_date=value_date,
-            )
-            if converted_balance is None:
-                continue
-
-            group_index = group_index_by_account_id[account_id]
-            values[group_index] += converted_balance
+        values = await _grouped_values_from_balances(
+            accounts,
+            group_index_by_account_id,
+            running,
+            base_currency=base_currency,
+            rate_date=value_date,
+            converter=converter,
+        )
         points.append((label_date, value_date, values))
 
-    return points, converter.get_status()
+    return baseline_values, points, converter.get_status()
+
+
+async def _balances_at(
+    db: AsyncSession,
+    account_ids: list[uuid.UUID],
+    target_date: date,
+) -> dict[uuid.UUID, int]:
+    """Return latest balances on or before target_date keyed by account id."""
+    if not account_ids:
+        return {}
+
+    result = await db.execute(
+        select(AccountBalanceSnapshot.account_id, AccountBalanceSnapshot.balance)
+        .where(
+            AccountBalanceSnapshot.account_id.in_(account_ids),
+            AccountBalanceSnapshot.dt <= target_date,
+        )
+        .order_by(AccountBalanceSnapshot.account_id, AccountBalanceSnapshot.dt.desc())
+        .distinct(AccountBalanceSnapshot.account_id),
+    )
+    return {row.account_id: int(row.balance) for row in result}
+
+
+async def _grouped_values_from_balances(
+    accounts: list[Account],
+    group_index_by_account_id: dict[uuid.UUID, int],
+    balances: dict[uuid.UUID, int],
+    *,
+    base_currency: str,
+    rate_date: date,
+    converter: FxConverter,
+) -> list[int]:
+    values = [0] * len(NET_WORTH_GROUPS)
+    for account in accounts:
+        converted_balance = await converter.convert_minor_units(
+            int(balances.get(account.id, 0)),
+            base=account.currency,
+            quote=base_currency,
+            rate_date=rate_date,
+        )
+        if converted_balance is None:
+            continue
+
+        group_index = group_index_by_account_id[account.id]
+        values[group_index] += converted_balance
+    return values
 
 
 async def _get_currency_exponents(db: AsyncSession, currencies: set[str]) -> dict[str, int]:
@@ -199,11 +250,12 @@ async def _prefetch_net_worth_rates(
     accounts: list[Account],
     buckets: list[tuple[date, date]],
     base_currency: str,
+    baseline_date: date,
 ) -> None:
     if not buckets:
         return
 
-    start_date = min(value_date for _label_date, value_date in buckets)
+    start_date = min(baseline_date, *(value_date for _label_date, value_date in buckets))
     end_date = max(value_date for _label_date, value_date in buckets)
     for currency in sorted({account.currency for account in accounts if account.currency != base_currency}):
         await converter.prefetch_rates(
@@ -225,11 +277,11 @@ async def get_net_worth(
     if not accounts:
         return InsightsNetWorthResponse(groups=[], points=[])
 
-    points, fx_status = await _query_net_worth_points(db, accounts, user.base_currency, from_date, to_date)
+    baseline, points, fx_status = await _query_net_worth_points(db, accounts, user.base_currency, from_date, to_date)
     active_group_indexes = [
         index
         for index in range(len(NET_WORTH_GROUPS))
-        if any(point_values[index] != 0 for _label_date, _value_date, point_values in points)
+        if baseline[index] != 0 or any(point_values[index] != 0 for _label_date, _value_date, point_values in points)
     ]
     if not active_group_indexes:
         return InsightsNetWorthResponse(groups=[], points=[], fx_status=fx_status)
@@ -239,6 +291,7 @@ async def get_net_worth(
             (NET_WORTH_GROUPS[index].id, NET_WORTH_GROUPS[index].name, NET_WORTH_GROUPS[index].kind)
             for index in active_group_indexes
         ],
+        baseline=[baseline[index] for index in active_group_indexes],
         points=[
             (
                 label_date,

--- a/backend/app/services/insights/period_glance.py
+++ b/backend/app/services/insights/period_glance.py
@@ -1,13 +1,13 @@
 """Period glance service for the insights page."""
 
 import uuid
-from datetime import date
+from datetime import date, timedelta
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account, AccountBalanceSnapshot
-from app.models.base import AccountKind, CategoryKind
+from app.models.base import CategoryKind
 from app.models.category import Category
 from app.models.currency import Currency
 from app.models.transaction import Transaction
@@ -297,12 +297,13 @@ async def _query_net_worth_change(
     from_date: date,
     to_date: date,
 ) -> tuple[int, FxStatus]:
-    """Return converted net-worth movement between the two valuation dates."""
+    """Return converted net-worth movement over the inclusive selected period."""
     if not accounts:
         return 0, FxStatus()
 
     account_ids = [account.id for account in accounts]
-    start_balances = await _balances_at(db, account_ids, from_date)
+    baseline_date = from_date - timedelta(days=1)
+    start_balances = await _balances_at(db, account_ids, baseline_date)
     end_balances = await _balances_at(db, account_ids, to_date)
     converter = FxConverter(
         currency_exponents=await _get_currency_exponents(
@@ -318,21 +319,20 @@ async def _query_net_worth_change(
             base_currency=base_currency,
             start_balances=start_balances,
             end_balances=end_balances,
-            from_date=from_date,
+            baseline_date=baseline_date,
             to_date=to_date,
         ),
     )
 
     net_worth_change = 0
     for account in accounts:
-        sign = 1 if account.account_kind == AccountKind.ASSET else -1
-        start_amount = start_balances.get(account.id, 0) * sign
-        end_amount = end_balances.get(account.id, 0) * sign
+        start_amount = start_balances.get(account.id, 0)
+        end_amount = end_balances.get(account.id, 0)
         converted_start = await converter.convert_minor_units(
             start_amount,
             base=account.currency,
             quote=base_currency,
-            rate_date=from_date,
+            rate_date=baseline_date,
         )
         converted_end = await converter.convert_minor_units(
             end_amount,
@@ -369,17 +369,16 @@ def _net_worth_change_rate_dates(
     base_currency: str,
     start_balances: dict[uuid.UUID, int],
     end_balances: dict[uuid.UUID, int],
-    from_date: date,
+    baseline_date: date,
     to_date: date,
 ) -> dict[str, set[date]]:
     dates_by_currency: dict[str, set[date]] = {}
     for account in accounts:
         if account.currency == base_currency:
             continue
-        sign = 1 if account.account_kind == AccountKind.ASSET else -1
-        if start_balances.get(account.id, 0) * sign != 0:
-            dates_by_currency.setdefault(account.currency, set()).add(from_date)
-        if end_balances.get(account.id, 0) * sign != 0:
+        if start_balances.get(account.id, 0) != 0:
+            dates_by_currency.setdefault(account.currency, set()).add(baseline_date)
+        if end_balances.get(account.id, 0) != 0:
             dates_by_currency.setdefault(account.currency, set()).add(to_date)
     return dates_by_currency
 

--- a/backend/tests/routes/test_insights_net_worth.py
+++ b/backend/tests/routes/test_insights_net_worth.py
@@ -4,6 +4,8 @@ from datetime import date
 from decimal import Decimal
 from uuid import UUID
 
+from sqlalchemy import update
+
 from app.models.account import AccountBalanceSnapshot
 from app.models.currency import Currency
 from tests.conftest import TestSession
@@ -78,6 +80,7 @@ async def test_net_worth_returns_compact_daily_signed_group_series(client):
         ["cash", "Cash", "asset"],
         ["revolving_debt", "Revolving Debt", "debt"],
     ]
+    assert data["baseline"] == [120_000, -50_000]
     assert data["points"] == [
         ["2026-05-01", "2026-05-01", [120_000, -50_000]],
         ["2026-05-02", "2026-05-02", [150_000, -50_000]],
@@ -125,6 +128,7 @@ async def test_net_worth_groups_tax_advantaged_assets_by_account_type(client):
             ["cash", "Cash", "asset"],
             ["investments", "Investments", "asset"],
         ],
+        "baseline": [0, 0],
         "points": [["2026-05-01", "2026-05-01", [25_000, 175_000]]],
         "fx_status": {"state": "none", "missing_pairs": []},
     }
@@ -138,10 +142,11 @@ async def test_net_worth_converts_foreign_balances_by_bucket_value_date(client, 
         assert (base, quote, start_date, end_date) == (
             "USD",
             "CAD",
-            date(2026, 5, 1),
+            date(2026, 4, 30),
             date(2026, 5, 3),
         )
         return {
+            date(2026, 4, 30): Decimal("1.5"),
             date(2026, 5, 1): Decimal("1.5"),
             date(2026, 5, 2): Decimal("2"),
             date(2026, 5, 3): Decimal("2.5"),
@@ -187,6 +192,7 @@ async def test_net_worth_converts_foreign_balances_by_bucket_value_date(client, 
             ["cash", "Cash", "asset"],
             ["revolving_debt", "Revolving Debt", "debt"],
         ],
+        "baseline": [115_000, -6_000],
         "points": [
             ["2026-05-01", "2026-05-01", [115_000, -6_000]],
             ["2026-05-02", "2026-05-02", [140_000, -8_000]],
@@ -228,12 +234,44 @@ async def test_net_worth_reports_incomplete_fx_with_missing_pairs(client, monkey
     assert resp.status_code == 200
     assert resp.json() == {
         "groups": [["cash", "Cash", "asset"]],
+        "baseline": [0],
         "points": [["2026-05-01", "2026-05-01", [100_000]]],
         "fx_status": {
             "state": "incomplete",
             "missing_pairs": [{"base": "ABC", "quote": "CAD"}],
         },
     }
+
+
+async def test_net_worth_returns_previous_day_baseline_for_first_day_activity(client):
+    """Net worth deltas can include balance movement from the first selected day."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="June Cash")).json()["id"])
+
+    async with TestSession() as session:
+        await session.execute(
+            update(AccountBalanceSnapshot)
+            .where(AccountBalanceSnapshot.account_id == account_id)
+            .values(dt=date(2026, 5, 31), balance=0),
+        )
+        session.add_all([
+            _snapshot(account_id, date(2026, 6, 1), 100_000),
+        ])
+        await session.commit()
+
+    resp = await client.get(
+        "/insights/net-worth",
+        params={"from_date": "2026-06-01", "to_date": "2026-06-30"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["groups"] == [["cash", "Cash", "asset"]]
+    assert data["baseline"] == [0]
+    assert data["points"][0] == ["2026-06-01", "2026-06-01", [100_000]]
+    assert data["points"][-1] == ["2026-06-30", "2026-06-30", [100_000]]
 
 
 async def test_net_worth_uses_weekly_buckets_for_mid_length_ranges(client):
@@ -312,7 +350,7 @@ async def test_net_worth_omits_zero_only_groups(client):
     )
 
     assert resp.status_code == 200
-    assert resp.json() == {"groups": [], "points": [], "fx_status": {"state": "none", "missing_pairs": []}}
+    assert resp.json() == {"groups": [], "baseline": [], "points": [], "fx_status": {"state": "none", "missing_pairs": []}}
 
 
 async def test_net_worth_rejects_invalid_date_range(client):

--- a/backend/tests/routes/test_insights_period_glance.py
+++ b/backend/tests/routes/test_insights_period_glance.py
@@ -4,6 +4,8 @@ from datetime import date
 from decimal import Decimal
 from uuid import UUID, uuid4
 
+from sqlalchemy import update
+
 from app.models.account import AccountBalanceSnapshot
 from app.models.base import CategoryKind
 from app.models.category import Category
@@ -43,6 +45,23 @@ async def _seed_usd_currency():
         await session.commit()
 
 
+async def _create_category_api(client, headers, **overrides):
+    payload = {"name": "Test Salary", "kind": "income", **overrides}
+    return await client.post("/categories", json=payload, headers=headers)
+
+
+async def _create_transaction_api(client, headers, account_id, category_id, **overrides):
+    payload = {
+        "account_id": account_id,
+        "category_id": category_id,
+        "dt": "2026-06-01",
+        "amount": 100_000,
+        "currency": "CAD",
+        **overrides,
+    }
+    return await client.post("/transactions", json=payload, headers=headers)
+
+
 async def test_period_glance_returns_compact_period_summary(client):
     """Period glance aggregates visible base-currency activity only."""
     signup_resp = await _create_user(client)
@@ -76,6 +95,7 @@ async def test_period_glance_returns_compact_period_summary(client):
             _transaction(user_id, visible_account_id, dining_id, date(2026, 3, 5), -100_000),
             _transaction(user_id, hidden_account_id, salary_id, date(2026, 3, 12), 700_000),
             _transaction(user_id, hidden_account_id, groceries_id, date(2026, 3, 13), -300_000),
+            _snapshot(visible_account_id, date(2026, 3, 9), 1_000_000),
             _snapshot(visible_account_id, date(2026, 3, 10), 1_000_000),
             _snapshot(visible_account_id, date(2026, 3, 16), 1_320_000),
             _snapshot(hidden_account_id, date(2026, 3, 10), 5_000_000),
@@ -113,6 +133,7 @@ async def test_period_glance_converts_foreign_income_and_expenses_and_signs_liab
 
     async def fake_get_rates(self, base, quote, start_date, end_date):
         return {
+            date(2026, 4, 30): Decimal("1.5"),
             date(2026, 5, 1): Decimal("1.5"),
             date(2026, 5, 2): Decimal("1.5"),
             date(2026, 5, 3): Decimal("1.5"),
@@ -150,10 +171,13 @@ async def test_period_glance_converts_foreign_income_and_expenses_and_signs_liab
             _transaction(user_id, cash_account_id, food_id, date(2026, 5, 3), -20_000),
             _transaction(user_id, usd_account_id, salary_id, date(2026, 5, 2), 900_000, "USD"),
             _transaction(user_id, usd_account_id, food_id, date(2026, 5, 3), -700_000, "USD"),
+            _snapshot(cash_account_id, date(2026, 4, 30), 100_000),
             _snapshot(cash_account_id, date(2026, 5, 1), 100_000),
             _snapshot(cash_account_id, date(2026, 5, 7), 200_000),
-            _snapshot(card_account_id, date(2026, 5, 1), 40_000),
-            _snapshot(card_account_id, date(2026, 5, 7), 90_000),
+            _snapshot(card_account_id, date(2026, 4, 30), -40_000),
+            _snapshot(card_account_id, date(2026, 5, 1), -40_000),
+            _snapshot(card_account_id, date(2026, 5, 7), -90_000),
+            _snapshot(usd_account_id, date(2026, 4, 30), 5_000_000),
             _snapshot(usd_account_id, date(2026, 5, 1), 5_000_000),
             _snapshot(usd_account_id, date(2026, 5, 7), 9_000_000),
         ])
@@ -319,6 +343,85 @@ async def test_period_glance_biggest_change_reports_incomplete_fx(client, monkey
     }
 
 
+async def test_period_glance_net_worth_change_includes_first_day_balance_activity(client):
+    """Selected-period balance movement starts from the day before from_date."""
+    signup_resp = await _create_user(client)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
+    transfer_id, transfer = _category(user_id, "Balance Adjustment", CategoryKind.TRANSFER)
+
+    async with TestSession() as session:
+        await session.execute(
+            update(AccountBalanceSnapshot)
+            .where(AccountBalanceSnapshot.account_id == account_id)
+            .values(dt=date(2026, 5, 31), balance=0),
+        )
+        session.add_all([
+            transfer,
+            _transaction(user_id, account_id, transfer_id, date(2026, 6, 1), 100_000),
+            _snapshot(account_id, date(2026, 6, 1), 100_000),
+        ])
+        await session.commit()
+
+    resp = await client.get(
+        "/insights/period-glance",
+        params={"from_date": "2026-06-01", "to_date": "2026-06-30"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["income"] == 0
+    assert data["expenses"] == 0
+    assert data["net_worth_change"] == 100_000
+
+
+async def test_insights_range_includes_api_created_first_day_transaction(client):
+    """A first-day API transaction is aggregated after snapshot recomputation."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    account_id = (await _create_account(client, headers, name="June Cash")).json()["id"]
+    category_id = (await _create_category_api(client, headers, name="June Salary", kind="income")).json()["id"]
+
+    create_resp = await _create_transaction_api(
+        client,
+        headers,
+        account_id,
+        category_id,
+        dt="2026-06-01",
+        amount=100_000,
+    )
+    snapshots_resp = await client.get(f"/accounts/{account_id}/snapshots", headers=headers)
+    period_glance_resp = await client.get(
+        "/insights/period-glance",
+        params={"from_date": "2026-06-01", "to_date": "2026-06-30"},
+        headers=headers,
+    )
+    net_worth_resp = await client.get(
+        "/insights/net-worth",
+        params={"from_date": "2026-06-01", "to_date": "2026-06-30"},
+        headers=headers,
+    )
+
+    assert create_resp.status_code == 201
+    assert snapshots_resp.status_code == 200
+    assert {"account_id": account_id, "dt": "2026-06-01", "balance": 100_000} in snapshots_resp.json()
+
+    assert period_glance_resp.status_code == 200
+    period_glance = period_glance_resp.json()
+    assert period_glance["income"] == 100_000
+    assert period_glance["expenses"] == 0
+    assert period_glance["net_worth_change"] == 100_000
+
+    assert net_worth_resp.status_code == 200
+    net_worth = net_worth_resp.json()
+    assert net_worth["groups"] == [["cash", "Cash", "asset"]]
+    assert net_worth["baseline"] == [0]
+    assert net_worth["points"][0] == ["2026-06-01", "2026-06-01", [100_000]]
+    assert net_worth["points"][-1] == ["2026-06-30", "2026-06-30", [100_000]]
+
+
 async def test_period_glance_net_worth_change_reports_incomplete_fx(client, monkeypatch):
     """Net-worth movement skips foreign accounts that cannot be converted."""
     from app.services.fx import FrankfurterProvider, FxRateNotFoundError
@@ -339,8 +442,10 @@ async def test_period_glance_net_worth_change_reports_incomplete_fx(client, monk
 
     async with TestSession() as session:
         session.add_all([
+            _snapshot(cad_account_id, date(2026, 4, 30), 100_000),
             _snapshot(cad_account_id, date(2026, 5, 1), 100_000),
             _snapshot(cad_account_id, date(2026, 5, 7), 150_000),
+            _snapshot(abc_account_id, date(2026, 4, 30), 500_000),
             _snapshot(abc_account_id, date(2026, 5, 1), 500_000),
             _snapshot(abc_account_id, date(2026, 5, 7), 900_000),
         ])

--- a/frontend/src/api/insights.ts
+++ b/frontend/src/api/insights.ts
@@ -59,6 +59,7 @@ export type InsightsNetWorthPoint = [string, string, number[]];
 
 export interface InsightsNetWorthResponse {
   groups: InsightsNetWorthGroup[];
+  baseline: number[];
   points: InsightsNetWorthPoint[];
   fx_status: FxStatus;
 }

--- a/frontend/src/insights/InsightsPage.tsx
+++ b/frontend/src/insights/InsightsPage.tsx
@@ -178,6 +178,7 @@ export default function InsightsPage() {
             mode={netWorthMode}
             onModeToggle={() => setNetWorthMode((mode) => (mode === 'overview' ? 'composition' : 'overview'))}
             groups={netWorthCardData.groups}
+            baseline={netWorthCardData.baseline}
             series={netWorthCardData.series}
             fxStatus={queries.netWorth.data?.fx_status}
             displayCurrency={displayCurrency}

--- a/frontend/src/insights/components/NetWorthCard.tsx
+++ b/frontend/src/insights/components/NetWorthCard.tsx
@@ -67,6 +67,7 @@ type NetWorthCardProps = {
   mode: NetWorthViewMode
   onModeToggle: () => void
   groups: NetWorthGroup[]
+  baseline: number[]
   series: NetWorthPoint[]
   fxStatus: FxStatus | undefined
   displayCurrency: string
@@ -77,6 +78,7 @@ type NetWorthCardProps = {
 type NetWorthSnapshot = {
   mode: NetWorthViewMode
   groups: NetWorthGroup[]
+  baseline: number[]
   series: NetWorthPoint[]
   fxStatus: FxStatus | undefined
   displayCurrency: string
@@ -213,6 +215,7 @@ export function NetWorthCard({
   mode,
   onModeToggle,
   groups,
+  baseline,
   series,
   fxStatus,
   displayCurrency,
@@ -224,11 +227,12 @@ export function NetWorthCard({
   const incomingSnapshot = useMemo<NetWorthSnapshot>(() => ({
     mode,
     groups,
+    baseline,
     series,
     fxStatus,
     displayCurrency,
     emptyLabel: loading ? 'Loading net worth history...' : 'No net worth history in this range.',
-  }), [displayCurrency, fxStatus, groups, loading, mode, series])
+  }), [baseline, displayCurrency, fxStatus, groups, loading, mode, series])
   const {
     displaySnapshot,
     contentConcealed,
@@ -245,8 +249,8 @@ export function NetWorthCard({
     [displaySnapshot.groups, displaySnapshot.mode],
   )
   const deltaSeries = useMemo(
-    () => getNetWorthChartData(displaySnapshot.series, chartItems, displaySnapshot.mode),
-    [chartItems, displaySnapshot.mode, displaySnapshot.series],
+    () => getNetWorthChartData(displaySnapshot.series, chartItems, displaySnapshot.mode, displaySnapshot.baseline),
+    [chartItems, displaySnapshot.baseline, displaySnapshot.mode, displaySnapshot.series],
   )
   const hasChartData = displaySnapshot.groups.length > 0 && deltaSeries.length > 0
   const dateAxisStartMs = deltaSeries[0]?.dateMs ?? 0

--- a/frontend/src/insights/utils/netWorth.ts
+++ b/frontend/src/insights/utils/netWorth.ts
@@ -17,8 +17,8 @@ export function getNetWorthCardData(
   response: InsightsNetWorthResponse | undefined,
   fromDate: string,
   toDate: string,
-): { groups: NetWorthGroup[]; series: NetWorthPoint[] } {
-  if (!response) return { groups: [], series: [] }
+): { groups: NetWorthGroup[]; baseline: number[]; series: NetWorthPoint[] } {
+  if (!response) return { groups: [], baseline: [], series: [] }
 
   const groups = response.groups ?? []
   const points = response.points ?? []
@@ -26,6 +26,7 @@ export function getNetWorthCardData(
   const granularity = getNetWorthGranularity(dayCount)
   return {
     groups: groups.map(([id, name, kind]) => ({ id, name, kind })),
+    baseline: response.baseline ?? [],
     series: points.map(([labelDate, valueDate, values]) => {
       const label = parseYmd(labelDate)
       const tooltip = parseYmd(valueDate)

--- a/frontend/src/insights/utils/netWorthChart.ts
+++ b/frontend/src/insights/utils/netWorthChart.ts
@@ -131,17 +131,24 @@ export function getNetWorthChartData(
   series: NetWorthPoint[],
   items: NetWorthChartItem[],
   mode: NetWorthViewMode,
+  baselineValues: number[] = [],
 ): NetWorthDeltaPoint[] {
   const start = series[0]
   if (!start) return []
-  const startValues = items.map((item) => item.getValue(start))
+  const effectiveBaselineValues = baselineValues.length > 0 ? baselineValues : start.values
+  const baselinePoint: NetWorthPoint = {
+    ...start,
+    total: effectiveBaselineValues.reduce((sum, value) => sum + value, 0),
+    values: effectiveBaselineValues,
+  }
+  const startValues = items.map((item) => item.getValue(baselinePoint))
 
   return series.map((point) => {
     const deltaPoint: NetWorthDeltaPoint = {
       ...point,
       dateMs: dateStringToUtcMs(point.date),
-      startTotal: start.total,
-      totalChange: point.total - start.total,
+      startTotal: baselinePoint.total,
+      totalChange: point.total - baselinePoint.total,
     }
 
     items.forEach((item, index) => {


### PR DESCRIPTION
- Measure net worth movement from the day before the selected range through the selected end date, instead of starting from the first day inside the range
- Return prior-day grouped net worth balances from the backend so the frontend can calculate chart deltas against the correct starting point
- Keep transaction-based insight totals inclusive of the selected range, so activity on the first day still appears in income, expense, category, and merchant aggregations
- Updated test cases to follow this fixed behaviour