### PR TITLE
fix: handle no-income savings rate trend values

### DIFF
--- a/frontend/src/insights/components/SavingsRateTrendCard.tsx
+++ b/frontend/src/insights/components/SavingsRateTrendCard.tsx
@@ -82,7 +82,7 @@ type SavingsRateTooltipState = {
 
 const savingsRateChartMargin = { top: 8, right: 8, bottom: 0, left: 4 } as const
 const savingsRateCalculation = 'Monthly savings rate is income minus expenses, divided by income. Income and expense categories are netted first. Transfers are excluded'
-const latestSavingsRateCalculation = 'Savings rate for the latest available month. The current month may be partial'
+const latestSavingsRateCalculation = 'Savings rate for the latest available month. The current month may be partial. Shows −∞% when expenses exist without income because the calculation divides by zero'
 const averageSavingsRateCalculation = 'Average savings rate across completed months only. The current month is excluded'
 const bestSavingsRateCalculation = 'Highest savings rate across completed months. The current month is excluded'
 const worstSavingsRateCalculation = 'Lowest savings rate across completed months. The current month is excluded'
@@ -118,12 +118,20 @@ function getSavingsTierColor(tier: ReturnType<typeof getSavingsTier>) {
 }
 
 function formatSavingsRateValue(rate: number | null) {
-  return rate === null ? 'N/A' : `${rate}%`
+  if (rate === null) return 'N/A'
+  if (!Number.isFinite(rate)) return rate < 0 ? '−∞%' : '∞%'
+  return `${rate}%`
 }
 
 function clampSavingsRate(rate: number | null) {
   if (rate === null) return null
   return Math.max(-100, Math.min(100, rate))
+}
+
+function getSavingsRateChartRate(rate: number | null, capRates: boolean) {
+  if (rate === null) return null
+  if (!Number.isFinite(rate)) return rate < 0 ? -100 : 100
+  return capRates ? clampSavingsRate(rate) : rate
 }
 
 function SavingsRateHistoryTooltipContent({
@@ -229,12 +237,12 @@ export function SavingsRateTrendCard({
   )
   const chartSeries = displaySnapshot.series.map((point) => ({
     ...point,
-    chartRate: displaySnapshot.capRates ? clampSavingsRate(point.rate) : point.rate,
+    chartRate: getSavingsRateChartRate(point.rate, displaySnapshot.capRates),
   }))
   const chartRates = chartSeries
     .map((point) => point.chartRate)
     .filter((rate): rate is number => rate !== null)
-  const averageChartRate = displaySnapshot.capRates ? clampSavingsRate(averageRate) : averageRate
+  const averageChartRate = getSavingsRateChartRate(averageRate, displaySnapshot.capRates)
   const highestRate = chartRates.length > 0 ? Math.max(...chartRates) : 100
   const lowestRate = chartRates.length > 0 ? Math.min(...chartRates) : -100
   const hasPositiveRate = chartRates.some((rate) => rate > 0)

--- a/frontend/src/insights/components/SavingsRateTrendCard.tsx
+++ b/frontend/src/insights/components/SavingsRateTrendCard.tsx
@@ -83,7 +83,7 @@ type SavingsRateTooltipState = {
 const savingsRateChartMargin = { top: 8, right: 8, bottom: 0, left: 4 } as const
 const savingsRateCalculation = 'Monthly savings rate is income minus expenses, divided by income. Income and expense categories are netted first. Transfers are excluded'
 const latestSavingsRateCalculation = 'Savings rate for the latest available month. The current month may be partial. Shows −∞% when expenses exist without income because the calculation divides by zero'
-const averageSavingsRateCalculation = 'Average savings rate across completed months only. The current month is excluded'
+const averageSavingsRateCalculation = 'Average savings rate across completed months with income. The current month and no-income months are excluded'
 const bestSavingsRateCalculation = 'Highest savings rate across completed months. The current month is excluded'
 const worstSavingsRateCalculation = 'Lowest savings rate across completed months. The current month is excluded'
 const savingsRateStatLabelClass = 'app-label inline-flex items-center gap-2 text-sm leading-5'
@@ -132,6 +132,10 @@ function getSavingsRateChartRate(rate: number | null, capRates: boolean) {
   if (rate === null) return null
   if (!Number.isFinite(rate)) return rate < 0 ? -100 : 100
   return capRates ? clampSavingsRate(rate) : rate
+}
+
+function hasFiniteSavingsRate(point: SavingsRateHistoryPoint): point is SavingsRateHistoryPoint & { rate: number } {
+  return point.rate !== null && Number.isFinite(point.rate)
 }
 
 function SavingsRateHistoryTooltipContent({
@@ -223,8 +227,9 @@ export function SavingsRateTrendCard({
   const tickLabels = new Map(displaySnapshot.series.map((point) => [point.monthKey, point.tickLabel]))
   const ratedPoints = displaySnapshot.series.filter((point) => point.rate !== null)
   const completedRatedPoints = ratedPoints.filter((point) => !point.isCurrent)
-  const averageRate = completedRatedPoints.length > 0
-    ? Math.round(completedRatedPoints.reduce((sum, point) => sum + (point.rate ?? 0), 0) / completedRatedPoints.length)
+  const completedAveragePoints = completedRatedPoints.filter(hasFiniteSavingsRate)
+  const averageRate = completedAveragePoints.length > 0
+    ? Math.round(completedAveragePoints.reduce((sum, point) => sum + point.rate, 0) / completedAveragePoints.length)
     : null
   const latestPoint = displaySnapshot.series.at(-1)
   const bestPoint = completedRatedPoints.reduce<SavingsRateHistoryPoint | null>(
@@ -365,7 +370,7 @@ export function SavingsRateTrendCard({
                       {formatSavingsRateValue(averageRate)}
                     </p>
                     <p className={savingsRateStatCaptionClass} style={{ color: 'var(--app-text-muted)' }}>
-                      Across completed months
+                      Completed months with income
                     </p>
                   </div>
                 </div>

--- a/frontend/src/insights/utils/savingsRateTrend.ts
+++ b/frontend/src/insights/utils/savingsRateTrend.ts
@@ -13,7 +13,7 @@ export function getSavingsRateHistory(
     const rate = income > 0
       ? getSavingsRate(income, expenses)
       : expenses > 0
-        ? -100
+        ? Number.NEGATIVE_INFINITY
         : null
     const monthLabel = getMonthLabel(month)
 


### PR DESCRIPTION
- Show `−∞%` for Insights savings-rate months with expenses and no income
- Plot no-income savings-rate bars at `-100%` so the trend remains visible
- Exclude no-income months from the Average stat while keeping them eligible for Worst
- Update Latest and Average tooltip explanation text to explain no-income handling

CU-86ba9bftm