### PR TITLE
fix: prevent chart tooltips clipping at graph edges

### DIFF
--- a/frontend/src/components/charts/CursorTooltipPortal.tsx
+++ b/frontend/src/components/charts/CursorTooltipPortal.tsx
@@ -1,0 +1,46 @@
+import {
+  forwardRef,
+  type CSSProperties,
+  type ReactNode,
+  type TransitionEvent as ReactTransitionEvent,
+} from 'react'
+import { createPortal } from 'react-dom'
+
+type CursorTooltipPortalProps = {
+  children: ReactNode
+  className?: string
+  onTransitionEnd?: (event: ReactTransitionEvent<HTMLDivElement>) => void
+  style?: CSSProperties
+}
+
+const defaultTooltipStyle: CSSProperties = {
+  maxWidth: 'var(--app-cursor-tooltip-max-width, calc(100vw - 16px))',
+  transition: 'opacity 150ms ease-out, transform 160ms cubic-bezier(0.22, 1, 0.36, 1)',
+  willChange: 'opacity, transform',
+}
+
+const CursorTooltipPortal = forwardRef<HTMLDivElement, CursorTooltipPortalProps>(function CursorTooltipPortal({
+  children,
+  className = '',
+  onTransitionEnd,
+  style,
+}, ref) {
+  const tooltip = (
+    <div
+      ref={ref}
+      className={`app-chart-tooltip-default-content pointer-events-none fixed left-0 top-0 z-[60] ${className}`}
+      onTransitionEnd={onTransitionEnd}
+      style={{
+        ...defaultTooltipStyle,
+        ...style,
+        transition: defaultTooltipStyle.transition,
+      }}
+    >
+      {children}
+    </div>
+  )
+
+  return typeof document === 'undefined' ? tooltip : createPortal(tooltip, document.body)
+})
+
+export default CursorTooltipPortal

--- a/frontend/src/components/charts/DeferredChartTooltipOverlay.tsx
+++ b/frontend/src/components/charts/DeferredChartTooltipOverlay.tsx
@@ -13,6 +13,7 @@ import {
   type RefObject,
   type TransitionEvent as ReactTransitionEvent,
 } from 'react'
+import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import { getCursorTooltipPosition } from '@/utils/tooltipPosition'
 
 type TooltipKey = string | number
@@ -73,7 +74,7 @@ function DeferredChartTooltipOverlayInner<T>({
     const tooltip = tooltipRef.current
     if (!chart || !rect || !tooltip) return
 
-    const { x: tooltipX, y: tooltipY } = getCursorTooltipPosition({
+    const { x: tooltipX, y: tooltipY, maxWidth } = getCursorTooltipPosition({
       origin: chart,
       tooltip,
       clientX: pointer.clientX,
@@ -88,6 +89,7 @@ function DeferredChartTooltipOverlayInner<T>({
 
     tooltip.style.setProperty('--chart-tooltip-x', `${tooltipX}px`)
     tooltip.style.setProperty('--chart-tooltip-y', `${tooltipY}px`)
+    tooltip.style.setProperty('--app-cursor-tooltip-max-width', `${maxWidth}px`)
     guideRef.current?.style.setProperty('--chart-tooltip-guide-x', `${guideX}px`)
     guideRef.current?.style.setProperty('--chart-tooltip-guide-width', `${resolvedGuideWidth}px`)
     guideRef.current?.style.setProperty('--chart-tooltip-guide-offset', `${resolvedGuideWidth / -2}px`)
@@ -172,37 +174,42 @@ function DeferredChartTooltipOverlayInner<T>({
 
   useEffect(() => clearPending, [clearPending])
 
+  const tooltip = (
+    <CursorTooltipPortal
+      ref={tooltipRef}
+      className={className}
+      onTransitionEnd={handleTransitionEnd}
+      style={{
+        opacity: visible ? 1 : 0,
+        transform: 'translate3d(var(--chart-tooltip-x, 0px), var(--chart-tooltip-y, 0px), 0)',
+      }}
+    >
+      {item && renderContent(item)}
+    </CursorTooltipPortal>
+  )
+
   return (
-    <div className="pointer-events-none absolute inset-0 z-20">
-      {showGuide && (
-        <div
-          ref={guideRef}
-          className="absolute top-0 h-full"
-          style={{
-            background: guideVariant === 'bar' ? 'var(--app-border)' : 'var(--app-border-strong)',
-            borderRadius: guideVariant === 'bar' ? 4 : undefined,
-            opacity: visible && item ? (guideVariant === 'bar' ? 0.4 : 1) : 0,
-            transform: guideVariant === 'bar'
-              ? 'translate3d(calc(var(--chart-tooltip-guide-x, 0px) + var(--chart-tooltip-guide-offset, -14px)), 0, 0)'
-              : 'translate3d(var(--chart-tooltip-guide-x, 0px), 0, 0)',
-            transition: 'opacity 150ms ease-out, transform 120ms cubic-bezier(0.22, 1, 0.36, 1)',
-            width: guideVariant === 'bar' ? 'var(--chart-tooltip-guide-width, 28px)' : 1,
-          }}
-        />
-      )}
-      <div
-        ref={tooltipRef}
-        className={`app-chart-tooltip-default-content pointer-events-none absolute left-0 top-0 ${className}`}
-        onTransitionEnd={handleTransitionEnd}
-        style={{
-          opacity: visible ? 1 : 0,
-          transition: 'opacity 150ms ease-out, transform 120ms cubic-bezier(0.22, 1, 0.36, 1)',
-          transform: 'translate3d(var(--chart-tooltip-x, 0px), var(--chart-tooltip-y, 0px), 0)',
-        }}
-      >
-        {item && renderContent(item)}
+    <>
+      <div className="pointer-events-none absolute inset-0 z-20">
+        {showGuide && (
+          <div
+            ref={guideRef}
+            className="absolute top-0 h-full"
+            style={{
+              background: guideVariant === 'bar' ? 'var(--app-border)' : 'var(--app-border-strong)',
+              borderRadius: guideVariant === 'bar' ? 4 : undefined,
+              opacity: visible && item ? (guideVariant === 'bar' ? 0.4 : 1) : 0,
+              transform: guideVariant === 'bar'
+                ? 'translate3d(calc(var(--chart-tooltip-guide-x, 0px) + var(--chart-tooltip-guide-offset, -14px)), 0, 0)'
+                : 'translate3d(var(--chart-tooltip-guide-x, 0px), 0, 0)',
+              transition: 'opacity 150ms ease-out, transform 120ms cubic-bezier(0.22, 1, 0.36, 1)',
+              width: guideVariant === 'bar' ? 'var(--chart-tooltip-guide-width, 28px)' : 1,
+            }}
+          />
+        )}
       </div>
-    </div>
+      {tooltip}
+    </>
   )
 }
 

--- a/frontend/src/dashboard/widgets/RunwayWidget.tsx
+++ b/frontend/src/dashboard/widgets/RunwayWidget.tsx
@@ -9,6 +9,7 @@ import { Link } from 'react-router-dom'
 import { CircleHelp, LifeBuoy } from 'lucide-react'
 import { useAccounts } from '@/api/accounts'
 import { useRunway, useRunwayAccounts } from '@/api/user'
+import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import IconTooltip from '@/components/IconTooltip'
 import { useLoadingSnapshot } from '@/components/useLoadingSnapshot'
 import { formatCurrency } from '@/utils/formatCurrency'
@@ -231,13 +232,12 @@ export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
           </p>
         )}
       </DashboardWidgetLoadingBody>
-      <div
+      <CursorTooltipPortal
         ref={runwayTooltipRef}
-        className="app-chart-tooltip-default-content pointer-events-none absolute left-0 top-0 z-20 w-[11rem]"
+        className="w-[11rem]"
         onTransitionEnd={handleRunwayTooltipTransitionEnd}
         style={{
           opacity: runwayTooltipVisible ? 1 : 0,
-          transition: 'opacity 150ms ease-out',
           transform: 'translate3d(var(--runway-tooltip-x, 0px), var(--runway-tooltip-y, 0px), 0)',
         }}
       >
@@ -251,7 +251,7 @@ export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
             </div>
           </>
         )}
-      </div>
+      </CursorTooltipPortal>
     </div>
   )
 }

--- a/frontend/src/dashboard/widgets/SpendingBreakdownWidget.tsx
+++ b/frontend/src/dashboard/widgets/SpendingBreakdownWidget.tsx
@@ -21,6 +21,7 @@ import {
 import { AppScrambledNumber } from '@/components/AppScrambledNumber'
 import { BreakdownCrossoverBadge } from '@/components/BreakdownCrossoverBadge'
 import { AppSlotMachineText } from '@/components/AppSlotMachineText'
+import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import IconTooltip from '@/components/IconTooltip'
 import { TimeRangeSelector } from '@/components/TimeRangeSelector'
 import { useLoadingSnapshot } from '@/components/useLoadingSnapshot'
@@ -277,13 +278,12 @@ export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWi
                   </ResponsiveContainer>
                 </motion.div>
               </AnimatePresence>
-              <div
+              <CursorTooltipPortal
                 ref={breakdownTooltipRef}
-                className="app-chart-tooltip-default-content pointer-events-none absolute left-0 top-0 z-20 min-w-40"
+                className="min-w-40"
                 onTransitionEnd={handleBreakdownTooltipTransitionEnd}
                 style={{
                   opacity: breakdownTooltipVisible ? 1 : 0,
-                  transition: 'opacity 150ms ease-out, transform 120ms cubic-bezier(0.22, 1, 0.36, 1)',
                   transform: 'translate3d(var(--breakdown-tooltip-x, 0px), var(--breakdown-tooltip-y, 0px), 0)',
                 }}
               >
@@ -300,7 +300,7 @@ export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWi
                     </div>
                   </>
                 )}
-              </div>
+              </CursorTooltipPortal>
             </div>
             <div className="mt-3 flex flex-wrap justify-center gap-x-5 gap-y-2">
               {breakdownEntries.map((entry) => (

--- a/frontend/src/insights/components/FundFlowCard.tsx
+++ b/frontend/src/insights/components/FundFlowCard.tsx
@@ -16,6 +16,7 @@ import {
   type SankeyNodeProps,
 } from 'recharts'
 import type { FxStatus } from '@/api/dashboard'
+import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import IconTooltip from '@/components/IconTooltip'
 import { getFundFlowFxStatusMessage } from '@/insights/utils/fxTooltipMessages'
 import { formatCurrency } from '@/utils/formatCurrency'
@@ -544,13 +545,11 @@ export function FundFlowCard({
                 {displaySnapshot.emptyLabel}
               </div>
             )}
-            <div
+            <CursorTooltipPortal
               ref={flowTooltipRef}
-              className="app-chart-tooltip-default-content pointer-events-none absolute left-0 top-0 z-20"
               onTransitionEnd={handleFlowTooltipTransitionEnd}
               style={{
                 opacity: flowTooltipVisible ? 1 : 0,
-                transition: 'opacity 150ms ease-out, transform 120ms cubic-bezier(0.22, 1, 0.36, 1)',
                 transform: 'translate3d(var(--flow-tooltip-x, 0px), var(--flow-tooltip-y, 0px), 0)',
               }}
             >
@@ -560,7 +559,7 @@ export function FundFlowCard({
                   displayCurrency={displaySnapshot.displayCurrency}
                 />
               )}
-            </div>
+            </CursorTooltipPortal>
           </div>
         </InsightLoadingContent>
         <InsightLoadingOverlay

--- a/frontend/src/insights/components/IncomeExpenseBreakdownCard.tsx
+++ b/frontend/src/insights/components/IncomeExpenseBreakdownCard.tsx
@@ -23,6 +23,7 @@ import {
 } from './InsightLoadingTransition'
 import { AppSlotMachineText } from '@/components/AppSlotMachineText'
 import { BreakdownCrossoverBadge } from '@/components/BreakdownCrossoverBadge'
+import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import { FxStatusBadge } from './FxStatusBadge'
 import { InsightActionButton } from './InsightActionButton'
 import { SectionHeader } from './SectionHeader'
@@ -344,13 +345,12 @@ export function IncomeExpenseBreakdownCard({
                     </Pie>
                   </PieChart>
                 </ResponsiveContainer>
-                <div
+                <CursorTooltipPortal
                   ref={breakdownTooltipRef}
-                  className="app-chart-tooltip-default-content pointer-events-none absolute left-0 top-0 z-20 min-w-40"
+                  className="min-w-40"
                   onTransitionEnd={handleBreakdownTooltipTransitionEnd}
                   style={{
                     opacity: breakdownTooltipVisible ? 1 : 0,
-                    transition: 'opacity 150ms ease-out, transform 120ms cubic-bezier(0.22, 1, 0.36, 1)',
                     transform: 'translate3d(var(--breakdown-tooltip-x, 0px), var(--breakdown-tooltip-y, 0px), 0)',
                   }}
                 >
@@ -367,7 +367,7 @@ export function IncomeExpenseBreakdownCard({
                       </div>
                     </>
                   )}
-                </div>
+                </CursorTooltipPortal>
               </div>
               <div
                 className="relative mt-auto overflow-hidden"

--- a/frontend/src/insights/components/MerchantDistributionCard.tsx
+++ b/frontend/src/insights/components/MerchantDistributionCard.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react'
 import { Store } from 'lucide-react'
 import type { FxStatus } from '@/api/dashboard'
+import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import IconTooltip from '@/components/IconTooltip'
 import { getMerchantSpendingFxStatusMessage } from '@/insights/utils/fxTooltipMessages'
 import { formatCurrency } from '@/utils/formatCurrency'
@@ -318,13 +319,11 @@ function MerchantMarketMap({
           })}
         </div>
       </div>
-      <div
+      <CursorTooltipPortal
         ref={tooltipRef}
-        className="app-chart-tooltip-default-content pointer-events-none absolute left-0 top-0 z-20"
         onTransitionEnd={handleMerchantTooltipTransitionEnd}
         style={{
           opacity: tooltipVisible ? 1 : 0,
-          transition: 'opacity 150ms ease-out',
           transform: 'translate3d(var(--merchant-tooltip-x, 0px), var(--merchant-tooltip-y, 0px), 0)',
           width: tooltipWidth,
         }}
@@ -351,7 +350,7 @@ function MerchantMarketMap({
             )}
           </>
         )}
-      </div>
+      </CursorTooltipPortal>
     </div>
   )
 }

--- a/frontend/src/utils/tooltipPosition.ts
+++ b/frontend/src/utils/tooltipPosition.ts
@@ -1,3 +1,5 @@
+type CursorTooltipPositionStrategy = 'absolute' | 'fixed'
+
 type CursorTooltipPositionOptions = {
   origin: HTMLElement
   tooltip: HTMLElement
@@ -6,6 +8,7 @@ type CursorTooltipPositionOptions = {
   bounds?: HTMLElement | DOMRect
   offset?: number
   margin?: number
+  strategy?: CursorTooltipPositionStrategy
 }
 
 type ApplyCursorTooltipPositionOptions = CursorTooltipPositionOptions & {
@@ -15,6 +18,7 @@ type ApplyCursorTooltipPositionOptions = CursorTooltipPositionOptions & {
 
 const DEFAULT_CURSOR_TOOLTIP_OFFSET = 10
 const DEFAULT_CURSOR_TOOLTIP_MARGIN = 8
+const DEFAULT_CURSOR_TOOLTIP_STRATEGY: CursorTooltipPositionStrategy = 'fixed'
 
 function clamp(value: number, min: number, max: number) {
   if (max < min) return min
@@ -41,21 +45,25 @@ export function getCursorTooltipPosition({
   bounds,
   offset = DEFAULT_CURSOR_TOOLTIP_OFFSET,
   margin = DEFAULT_CURSOR_TOOLTIP_MARGIN,
+  strategy = DEFAULT_CURSOR_TOOLTIP_STRATEGY,
 }: CursorTooltipPositionOptions) {
   const originRect = origin.getBoundingClientRect()
   const boundsRect = getBoundsRect(bounds, getDefaultBoundsRect(origin))
-  const minX = boundsRect.left - originRect.left + margin
-  const minY = boundsRect.top - originRect.top + margin
-  const maxX = boundsRect.right - originRect.left - tooltip.offsetWidth - margin
-  const maxY = boundsRect.bottom - originRect.top - tooltip.offsetHeight - margin
-  const pointerX = clientX - originRect.left
-  const pointerY = clientY - originRect.top
+  const coordinateLeft = strategy === 'fixed' ? 0 : originRect.left
+  const coordinateTop = strategy === 'fixed' ? 0 : originRect.top
+  const minX = boundsRect.left - coordinateLeft + margin
+  const minY = boundsRect.top - coordinateTop + margin
+  const maxX = boundsRect.right - coordinateLeft - tooltip.offsetWidth - margin
+  const maxY = boundsRect.bottom - coordinateTop - tooltip.offsetHeight - margin
+  const pointerX = clientX - coordinateLeft
+  const pointerY = clientY - coordinateTop
   const aboveY = pointerY - tooltip.offsetHeight - offset
   const belowY = pointerY + offset
 
   return {
     x: clamp(pointerX - tooltip.offsetWidth - offset, minX, maxX),
     y: clamp(aboveY >= minY ? aboveY : belowY, minY, maxY),
+    maxWidth: Math.max(boundsRect.width - margin * 2, 1),
   }
 }
 
@@ -66,6 +74,9 @@ export function applyCursorTooltipPosition({
   ...options
 }: ApplyCursorTooltipPositionOptions) {
   const position = getCursorTooltipPosition({ tooltip, ...options })
+  tooltip.style.position = options.strategy ?? DEFAULT_CURSOR_TOOLTIP_STRATEGY
+  tooltip.style.zIndex = '60'
+  tooltip.style.setProperty('--app-cursor-tooltip-max-width', `${position.maxWidth}px`)
   tooltip.style.setProperty(xProperty, `${position.x}px`)
   tooltip.style.setProperty(yProperty, `${position.y}px`)
 }

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -707,6 +707,8 @@
     border: 1px solid var(--app-border-strong) !important;
     border-radius: 8px !important;
     box-shadow: var(--app-shadow-soft) !important;
+    max-width: var(--app-cursor-tooltip-max-width, calc(100vw - 16px)) !important;
+    overflow-wrap: anywhere !important;
     padding: 6px 10px !important;
     font-size: 13px !important;
   }


### PR DESCRIPTION
- Render chart tooltip bubbles above overflow-clipped chart containers
- Clamp tooltip positioning to the nearest chart card or tooltip bounds
- Apply consistent animated movement when tooltips flip near card edges
- Reuse the same portal behavior for custom cursor tooltips in dashboard and insights charts

CU-86ba98kw5