### PR TITLE
Adjust Insights graph cadence

### DIFF
--- a/backend/app/services/insights/cash_flow.py
+++ b/backend/app/services/insights/cash_flow.py
@@ -20,13 +20,15 @@ from app.services.fx import FxConverter
 CashFlowGranularity = Literal["day", "week", "month"]
 
 _BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
+_MONTHLY_RANGE_DAY_COUNT = 31
+_HALF_YEAR_DAY_COUNT = 183
 
 
 def _get_granularity(from_date: date, to_date: date) -> CashFlowGranularity:
     day_count = (to_date - from_date).days + 1
-    if day_count <= 31:
+    if day_count <= _MONTHLY_RANGE_DAY_COUNT:
         return "day"
-    if day_count <= 90:
+    if day_count <= _HALF_YEAR_DAY_COUNT:
         return "week"
     return "month"
 

--- a/backend/app/services/insights/net_worth.py
+++ b/backend/app/services/insights/net_worth.py
@@ -19,6 +19,9 @@ from app.services.fx import FxConverter
 
 NetWorthGranularity = Literal["day", "week", "month"]
 
+_MONTHLY_RANGE_DAY_COUNT = 31
+_HALF_YEAR_DAY_COUNT = 183
+
 
 @dataclass(frozen=True)
 class NetWorthGroup:
@@ -42,11 +45,11 @@ GROUP_INDEX_BY_ID = {group.id: index for index, group in enumerate(NET_WORTH_GRO
 
 
 def _get_granularity(from_date: date, to_date: date) -> NetWorthGranularity:
-    """Match the account-detail balance chart frequency."""
+    """Return the Insights net worth chart bucket cadence."""
     day_count = (to_date - from_date).days + 1
-    if day_count <= 30:
+    if day_count <= _MONTHLY_RANGE_DAY_COUNT:
         return "day"
-    if day_count <= 90:
+    if day_count <= _HALF_YEAR_DAY_COUNT:
         return "week"
     return "month"
 

--- a/backend/tests/routes/test_insights_cash_flow.py
+++ b/backend/tests/routes/test_insights_cash_flow.py
@@ -96,6 +96,35 @@ async def test_cash_flow_returns_daily_buckets_and_excludes_non_cash_flow_rows(c
     }
 
 
+async def test_cash_flow_uses_daily_buckets_through_31_day_ranges(client):
+    """Ranges up to 31 days stay daily."""
+    signup_resp = await _create_user(client)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Daily Cash")).json()["id"])
+    salary_id, salary = _category(user_id, "Daily Salary", CategoryKind.INCOME)
+
+    async with TestSession() as session:
+        session.add_all([
+            salary,
+            _transaction(user_id, account_id, salary_id, date(2026, 6, 1), 100_000),
+            _transaction(user_id, account_id, salary_id, date(2026, 7, 1), 50_000),
+        ])
+        await session.commit()
+
+    response = await client.get(
+        "/insights/cash-flow",
+        params={"from_date": "2026-06-01", "to_date": "2026-07-01"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    points = response.json()["points"]
+    assert len(points) == 31
+    assert points[0] == ["2026-06-01", "2026-06-01", 100_000, 0]
+    assert points[-1] == ["2026-07-01", "2026-07-01", 50_000, 0]
+
+
 async def test_cash_flow_converts_foreign_entries_by_transaction_date(client, monkeypatch):
     """Foreign entries are converted daily before cash-flow buckets are built."""
     from app.services.fx import FrankfurterProvider
@@ -202,7 +231,7 @@ async def test_cash_flow_reports_incomplete_fx_with_missing_pairs(client, monkey
 
 
 async def test_cash_flow_uses_weekly_buckets_for_mid_length_ranges(client):
-    """Ranges over 31 and up to 90 days are grouped into partial weekly buckets."""
+    """Ranges over 31 days are grouped into partial weekly buckets."""
     signup_resp = await _create_user(client)
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
@@ -239,8 +268,39 @@ async def test_cash_flow_uses_weekly_buckets_for_mid_length_ranges(client):
     assert response.json()["fx_status"] == {"state": "none", "missing_pairs": []}
 
 
+async def test_cash_flow_uses_weekly_buckets_through_183_day_ranges(client):
+    """Ranges up to 183 days stay weekly."""
+    signup_resp = await _create_user(client)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Half Year Cash")).json()["id"])
+    salary_id, salary = _category(user_id, "Half Year Pay", CategoryKind.INCOME)
+    groceries_id, groceries = _category(user_id, "Half Year Groceries", CategoryKind.EXPENSE)
+
+    async with TestSession() as session:
+        session.add_all([
+            salary,
+            groceries,
+            _transaction(user_id, account_id, salary_id, date(2026, 1, 1), 100_000),
+            _transaction(user_id, account_id, groceries_id, date(2026, 7, 2), -20_000),
+        ])
+        await session.commit()
+
+    response = await client.get(
+        "/insights/cash-flow",
+        params={"from_date": "2026-01-01", "to_date": "2026-07-02"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    points = response.json()["points"]
+    assert len(points) == 27
+    assert points[0] == ["2026-01-01", "2026-01-04", 100_000, 0]
+    assert points[-1] == ["2026-06-29", "2026-07-02", 0, 20_000]
+
+
 async def test_cash_flow_uses_monthly_buckets_for_long_ranges(client):
-    """Ranges over 90 days are grouped into partial monthly buckets."""
+    """Ranges over 183 days are grouped into partial monthly buckets."""
     signup_resp = await _create_user(client)
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
@@ -260,7 +320,7 @@ async def test_cash_flow_uses_monthly_buckets_for_long_ranges(client):
 
     response = await client.get(
         "/insights/cash-flow",
-        params={"from_date": "2026-01-15", "to_date": "2026-05-20"},
+        params={"from_date": "2026-01-15", "to_date": "2026-08-01"},
         headers=headers,
     )
 
@@ -270,7 +330,10 @@ async def test_cash_flow_uses_monthly_buckets_for_long_ranges(client):
         ["2026-02-01", "2026-02-28", 0, 40_000],
         ["2026-03-01", "2026-03-31", 0, 0],
         ["2026-04-01", "2026-04-30", 0, 0],
-        ["2026-05-01", "2026-05-20", 80_000, 0],
+        ["2026-05-01", "2026-05-31", 80_000, 0],
+        ["2026-06-01", "2026-06-30", 0, 0],
+        ["2026-07-01", "2026-07-31", 0, 0],
+        ["2026-08-01", "2026-08-01", 0, 0],
     ]
     assert response.json()["fx_status"] == {"state": "none", "missing_pairs": []}
 

--- a/backend/tests/routes/test_insights_net_worth.py
+++ b/backend/tests/routes/test_insights_net_worth.py
@@ -244,7 +244,7 @@ async def test_net_worth_reports_incomplete_fx_with_missing_pairs(client, monkey
 
 
 async def test_net_worth_returns_previous_day_baseline_for_first_day_activity(client):
-    """Net worth deltas can include balance movement from the first selected day."""
+    """Monthly ranges use daily buckets and include first-day balance movement."""
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
     account_id = UUID((await _create_account(client, headers, name="June Cash")).json()["id"])
@@ -262,7 +262,7 @@ async def test_net_worth_returns_previous_day_baseline_for_first_day_activity(cl
 
     resp = await client.get(
         "/insights/net-worth",
-        params={"from_date": "2026-06-01", "to_date": "2026-06-30"},
+        params={"from_date": "2026-06-01", "to_date": "2026-07-01"},
         headers=headers,
     )
 
@@ -271,11 +271,11 @@ async def test_net_worth_returns_previous_day_baseline_for_first_day_activity(cl
     assert data["groups"] == [["cash", "Cash", "asset"]]
     assert data["baseline"] == [0]
     assert data["points"][0] == ["2026-06-01", "2026-06-01", [100_000]]
-    assert data["points"][-1] == ["2026-06-30", "2026-06-30", [100_000]]
+    assert data["points"][-1] == ["2026-07-01", "2026-07-01", [100_000]]
 
 
 async def test_net_worth_uses_weekly_buckets_for_mid_length_ranges(client):
-    """Ranges over 30 and up to 90 days use Monday-labeled weekly buckets."""
+    """Ranges over 31 days use Monday-labeled weekly buckets."""
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
     account_id = UUID((await _create_account(client, headers, name="Weekly Cash")).json()["id"])
@@ -307,15 +307,47 @@ async def test_net_worth_uses_weekly_buckets_for_mid_length_ranges(client):
     ]
 
 
+async def test_net_worth_uses_weekly_buckets_through_183_day_ranges(client):
+    """Ranges up to 183 days stay weekly."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Half Year Cash")).json()["id"])
+
+    async with TestSession() as session:
+        await session.execute(
+            update(AccountBalanceSnapshot)
+            .where(AccountBalanceSnapshot.account_id == account_id)
+            .values(dt=date(2025, 12, 31), balance=1_000),
+        )
+        session.add(_snapshot(account_id, date(2026, 7, 2), 2_000))
+        await session.commit()
+
+    resp = await client.get(
+        "/insights/net-worth",
+        params={"from_date": "2026-01-01", "to_date": "2026-07-02"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    points = resp.json()["points"]
+    assert len(points) == 27
+    assert points[0] == ["2025-12-29", "2026-01-04", [1_000]]
+    assert points[-1] == ["2026-06-29", "2026-07-02", [2_000]]
+
+
 async def test_net_worth_uses_monthly_buckets_for_long_ranges(client):
-    """Ranges over 90 days use month-start labels and month-end values."""
+    """Ranges over 183 days use month-start labels and month-end values."""
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
     account_id = UUID((await _create_account(client, headers, name="Long Cash")).json()["id"])
 
     async with TestSession() as session:
+        await session.execute(
+            update(AccountBalanceSnapshot)
+            .where(AccountBalanceSnapshot.account_id == account_id)
+            .values(dt=date(2025, 12, 31), balance=1_000),
+        )
         session.add_all([
-            _snapshot(account_id, date(2025, 12, 31), 1_000),
             _snapshot(account_id, date(2026, 2, 10), 2_000),
             _snapshot(account_id, date(2026, 5, 20), 3_000),
         ])
@@ -323,7 +355,7 @@ async def test_net_worth_uses_monthly_buckets_for_long_ranges(client):
 
     resp = await client.get(
         "/insights/net-worth",
-        params={"from_date": "2026-01-15", "to_date": "2026-05-20"},
+        params={"from_date": "2026-01-15", "to_date": "2026-08-01"},
         headers=headers,
     )
 
@@ -333,7 +365,10 @@ async def test_net_worth_uses_monthly_buckets_for_long_ranges(client):
         ["2026-02-01", "2026-02-28", [2_000]],
         ["2026-03-01", "2026-03-31", [2_000]],
         ["2026-04-01", "2026-04-30", [2_000]],
-        ["2026-05-01", "2026-05-20", [3_000]],
+        ["2026-05-01", "2026-05-31", [3_000]],
+        ["2026-06-01", "2026-06-30", [3_000]],
+        ["2026-07-01", "2026-07-31", [3_000]],
+        ["2026-08-01", "2026-08-01", [3_000]],
     ]
 
 


### PR DESCRIPTION
- Updates Insights net worth and cash flow graph bucketing
- Uses daily data through 31-day ranges
- Uses weekly data through 183-day ranges
- Uses monthly data for 184+ day ranges
- Adds boundary coverage for both graph endpoints

CU-86ba9b3wj