### PR TITLE
Improve transactions cash flow chart and empty states

### DIFF
--- a/frontend/src/transactions/components/TransactionsTopBand.tsx
+++ b/frontend/src/transactions/components/TransactionsTopBand.tsx
@@ -2,7 +2,9 @@ import { useLayoutEffect, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import type { TransactionsOverview } from '@/api/transactions'
 import TransactionFilterLoadingOverlay from '@/transactions/components/TransactionFilterLoadingOverlay'
-import DailyCashFlowChart from '@/transactions/components/topBand/DailyCashFlowChart'
+import DailyCashFlowChart, {
+  type DailyCashFlowChartMode,
+} from '@/transactions/components/topBand/DailyCashFlowChart'
 import MostExpensiveTransactionsPanel from '@/transactions/components/topBand/MostExpensiveTransactionsPanel'
 import NetFlowSummary from '@/transactions/components/topBand/NetFlowSummary'
 import TopCategoriesChart from '@/transactions/components/topBand/TopCategoriesChart'
@@ -62,6 +64,7 @@ export default function TransactionsTopBand({
   } as const
   const metricsBandContentRef = useRef<HTMLDivElement>(null)
   const [metricsBandHeight, setMetricsBandHeight] = useState<number | null>(null)
+  const [dailyCashFlowMode, setDailyCashFlowMode] = useState<DailyCashFlowChartMode>('net')
 
   // Keep the animated metrics band height in sync with responsive content.
   useLayoutEffect(() => {
@@ -154,6 +157,8 @@ export default function TransactionsTopBand({
         displayCurrency={displayCurrency}
         chartAnimationKey={chartAnimationKey}
         prefersReducedMotion={prefersReducedMotion}
+        mode={dailyCashFlowMode}
+        onModeToggle={() => setDailyCashFlowMode((mode) => (mode === 'net' ? 'gross' : 'net'))}
       />
     </section>
   )

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -4,6 +4,7 @@ import {
   type MouseEvent as ReactMouseEvent,
 } from 'react'
 import { Repeat } from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import {
   Area,
   AreaChart,
@@ -45,6 +46,20 @@ type DailyCashFlowTooltipState = {
     payload?: DailyCashFlowPoint
   }>
 }
+
+const titleWordTransition = { duration: 0.34, ease: [0.16, 1, 0.3, 1] } as const
+const titleWidthTransition = { duration: 0.3, ease: [0.16, 1, 0.3, 1] } as const
+const titleExitWidthTransition = { delay: 0.34, duration: 0.22, ease: [0.16, 1, 0.3, 1] } as const
+const titleWordVariants = {
+  initial: { transition: { staggerChildren: 0.018 } },
+  enter: { transition: { staggerChildren: 0.018 } },
+  exit: { transition: { staggerChildren: 0.014, staggerDirection: -1 } },
+} as const
+const titleCharVariants = {
+  initial: { y: '0.7em', opacity: 0, filter: 'blur(2px)' },
+  enter: { y: 0, opacity: 1, filter: 'blur(0px)' },
+  exit: { y: '-0.7em', opacity: 0, filter: 'blur(2px)' },
+} as const
 
 function getDailyCashFlowSeries(
   raw: DailyCashFlow[],
@@ -144,6 +159,53 @@ function DailyCashFlowTooltipContent({
   )
 }
 
+function DailyCashFlowTitleWord({ visible }: { visible: boolean }) {
+  const shouldReduceMotion = useReducedMotion()
+
+  return (
+    <AnimatePresence initial={false}>
+      {visible && (
+        <motion.span
+          key="net-title-word"
+          className="inline-block overflow-hidden align-bottom"
+          initial={shouldReduceMotion ? false : { width: 0 }}
+          animate={{
+            width: 'auto',
+            transition: shouldReduceMotion ? { duration: 0 } : titleWidthTransition,
+          }}
+          exit={{
+            width: 0,
+            transition: shouldReduceMotion ? { duration: 0 } : titleExitWidthTransition,
+          }}
+          style={{ whiteSpace: 'nowrap' }}
+        >
+          <motion.span
+            className="flex pl-[0.25em]"
+            aria-hidden
+            initial={shouldReduceMotion ? false : 'initial'}
+            animate="enter"
+            exit={shouldReduceMotion ? undefined : 'exit'}
+            variants={titleWordVariants}
+            transition={shouldReduceMotion ? { duration: 0 } : titleWordTransition}
+          >
+            {'Net'.split('').map((char, index) => (
+              <motion.span
+                key={`${char}-${index}`}
+                className="inline-block"
+                variants={titleCharVariants}
+                transition={shouldReduceMotion ? { duration: 0 } : titleWordTransition}
+              >
+                {char}
+              </motion.span>
+            ))}
+          </motion.span>
+          <span className="sr-only">Net</span>
+        </motion.span>
+      )}
+    </AnimatePresence>
+  )
+}
+
 export default function DailyCashFlowChart({
   rawDailyFlow,
   fxStatus,
@@ -174,7 +236,6 @@ export default function DailyCashFlowChart({
     [dailyFlow],
   )
   const chartAnimationDuration = prefersReducedMotion ? 0 : 550
-  const title = mode === 'net' ? 'Daily Net Cash Flow' : 'Daily Cash Flow'
   const toggleLabel = mode === 'net' ? 'Show inflow and outflow' : 'Show net cash flow'
   const showDailyCashFlowTooltip = (
     state: DailyCashFlowTooltipState,
@@ -196,7 +257,11 @@ export default function DailyCashFlowChart({
     <>
       <div className="mb-3 flex items-center justify-between gap-3">
         <p className="app-label inline-flex items-center gap-2">
-          {title}
+          <span className="inline-flex items-baseline whitespace-nowrap">
+            <span>Daily</span>
+            <DailyCashFlowTitleWord visible={mode === 'net'} />
+            <span className="ml-[0.25em]">Cash Flow</span>
+          </span>
           {fxStatus && (
             <IconTooltip
               label="Daily cash flow FX status"

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -60,6 +60,8 @@ const titleCharVariants = {
   enter: { y: 0, opacity: 1, filter: 'blur(0px)' },
   exit: { y: '-0.7em', opacity: 0, filter: 'blur(2px)' },
 } as const
+// Recharts runtime accepts cubic-bezier strings, but Area's public type only lists preset names.
+const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-out'
 
 function getDailyCashFlowSeries(
   raw: DailyCashFlow[],
@@ -235,7 +237,7 @@ export default function DailyCashFlowChart({
     () => new Map(dailyFlow.map((point) => [point.date, point])),
     [dailyFlow],
   )
-  const chartAnimationDuration = prefersReducedMotion ? 0 : 550
+  const chartAnimationDuration = prefersReducedMotion ? 0 : 1000
   const toggleLabel = mode === 'net' ? 'Show inflow and outflow' : 'Show net cash flow'
   const showDailyCashFlowTooltip = (
     state: DailyCashFlowTooltipState,
@@ -333,6 +335,7 @@ export default function DailyCashFlowChart({
                 strokeWidth={1.5}
                 isAnimationActive={!prefersReducedMotion}
                 animationDuration={chartAnimationDuration}
+                animationEasing={chartAnimationEasing}
               />
             ) : (
               <>
@@ -344,6 +347,7 @@ export default function DailyCashFlowChart({
                   strokeWidth={1.5}
                   isAnimationActive={!prefersReducedMotion}
                   animationDuration={chartAnimationDuration}
+                  animationEasing={chartAnimationEasing}
                 />
                 <Area
                   type="monotone"
@@ -353,6 +357,7 @@ export default function DailyCashFlowChart({
                   strokeWidth={1.5}
                   isAnimationActive={!prefersReducedMotion}
                   animationDuration={chartAnimationDuration}
+                  animationEasing={chartAnimationEasing}
                 />
               </>
             )}

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -3,6 +3,7 @@ import {
   useRef,
   type MouseEvent as ReactMouseEvent,
 } from 'react'
+import { Repeat } from 'lucide-react'
 import {
   Area,
   AreaChart,
@@ -29,7 +30,10 @@ type DailyCashFlowPoint = {
   date: string
   inflow: number
   outflow: number
+  net: number
 }
+
+export type DailyCashFlowChartMode = 'net' | 'gross'
 
 type DailyCashFlowTooltipState = {
   activeLabel?: string | number
@@ -52,7 +56,7 @@ function getDailyCashFlowSeries(
   const first = parseYmdLocal(raw[0].date)
   const last = parseYmdLocal(raw[raw.length - 1].date)
   const cursor = new Date(first.getFullYear(), first.getMonth(), 1)
-  const result: { date: string; inflow: number; outflow: number }[] = []
+  const result: DailyCashFlowPoint[] = []
 
   while (cursor <= last) {
     const iso = [
@@ -65,6 +69,7 @@ function getDailyCashFlowSeries(
       date: cursor.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
       inflow: entry?.inflow ?? 0,
       outflow: entry?.outflow ?? 0,
+      net: (entry?.inflow ?? 0) + (entry?.outflow ?? 0),
     })
     cursor.setDate(cursor.getDate() + 1)
   }
@@ -106,13 +111,23 @@ function getDailyCashFlowTooltipPoint(
 function DailyCashFlowTooltipContent({
   point,
   displayCurrency,
+  mode,
 }: {
   point: DailyCashFlowPoint
   displayCurrency: string
+  mode: DailyCashFlowChartMode
 }) {
   return (
     <>
       <p className="app-chart-tooltip-default-title">{point.date}</p>
+      {mode === 'net' && (
+        <div className="mt-1 flex justify-between gap-4">
+          <span className="app-chart-tooltip-default-value">Net</span>
+          <span className="app-chart-tooltip-default-value font-financial">
+            {formatCurrency(point.net, displayCurrency)}
+          </span>
+        </div>
+      )}
       <div className="mt-1 flex justify-between gap-4">
         <span className="app-chart-tooltip-default-value">Inflow</span>
         <span className="app-chart-tooltip-default-value font-financial">
@@ -136,6 +151,8 @@ export default function DailyCashFlowChart({
   displayCurrency,
   chartAnimationKey,
   prefersReducedMotion,
+  mode,
+  onModeToggle,
 }: {
   rawDailyFlow: DailyCashFlow[]
   fxStatus: FxStatus | undefined
@@ -143,6 +160,8 @@ export default function DailyCashFlowChart({
   displayCurrency: string
   chartAnimationKey: string
   prefersReducedMotion: boolean | null
+  mode: DailyCashFlowChartMode
+  onModeToggle: () => void
 }) {
   const dailyFlowChartRef = useRef<HTMLDivElement>(null)
   const dailyFlowTooltipRef = useRef<DeferredChartTooltipOverlayHandle<DailyCashFlowPoint>>(null)
@@ -155,6 +174,8 @@ export default function DailyCashFlowChart({
     [dailyFlow],
   )
   const chartAnimationDuration = prefersReducedMotion ? 0 : 550
+  const title = mode === 'net' ? 'Daily Net Cash Flow' : 'Daily Cash Flow'
+  const toggleLabel = mode === 'net' ? 'Show inflow and outflow' : 'Show net cash flow'
   const showDailyCashFlowTooltip = (
     state: DailyCashFlowTooltipState,
     event: ReactMouseEvent<SVGGraphicsElement>,
@@ -173,24 +194,35 @@ export default function DailyCashFlowChart({
 
   return (
     <>
-      <p className="app-label mb-3 inline-flex items-center gap-2">
-        Daily Cash Flow
-        {fxStatus && (
-          <IconTooltip
-            label="Daily cash flow FX status"
-            icon="fx"
-            fxTone={getFxStatusTone(fxStatus)}
-            placement="top"
-          >
-            <span className="block">{getCashFlowFxStatusMessage(fxStatus)}</span>
-            {fxStatus.missing_pairs.length > 0 && (
-              <span className="mt-2 block text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                Missing: {formatMissingFxPairs(fxStatus.missing_pairs)}
-              </span>
-            )}
-          </IconTooltip>
-        )}
-      </p>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <p className="app-label inline-flex items-center gap-2">
+          {title}
+          {fxStatus && (
+            <IconTooltip
+              label="Daily cash flow FX status"
+              icon="fx"
+              fxTone={getFxStatusTone(fxStatus)}
+              placement="top"
+            >
+              <span className="block">{getCashFlowFxStatusMessage(fxStatus)}</span>
+              {fxStatus.missing_pairs.length > 0 && (
+                <span className="mt-2 block text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                  Missing: {formatMissingFxPairs(fxStatus.missing_pairs)}
+                </span>
+              )}
+            </IconTooltip>
+          )}
+        </p>
+        <button
+          type="button"
+          title={toggleLabel}
+          aria-label={toggleLabel}
+          onClick={onModeToggle}
+          className="app-icon-button h-8 w-8 shrink-0"
+        >
+          <Repeat size={12} />
+        </button>
+      </div>
       <div
         ref={dailyFlowChartRef}
         className="relative h-[11.75rem]"
@@ -198,13 +230,17 @@ export default function DailyCashFlowChart({
       >
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart
-            key={`daily-flow-${chartAnimationKey}`}
+            key={`daily-flow-${mode}-${chartAnimationKey}`}
             data={dailyFlow}
             margin={{ top: 4, right: 12, bottom: 0, left: 12 }}
             onMouseMove={(state, event) => showDailyCashFlowTooltip(state, event)}
             onMouseLeave={hideDailyCashFlowTooltip}
           >
             <defs>
+              <linearGradient id="netFlowGrad" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor="var(--app-text-muted)" stopOpacity={0.25} />
+                <stop offset="100%" stopColor="var(--app-text-muted)" stopOpacity={0.02} />
+              </linearGradient>
               <linearGradient id="inflowGrad" x1="0" y1="0" x2="0" y2="1">
                 <stop offset="0%" stopColor="var(--app-positive)" stopOpacity={0.25} />
                 <stop offset="100%" stopColor="var(--app-positive)" stopOpacity={0.02} />
@@ -223,24 +259,38 @@ export default function DailyCashFlowChart({
             />
             <YAxis hide />
             <ReferenceLine y={0} stroke="var(--app-border-strong)" strokeWidth={1} />
-            <Area
-              type="monotone"
-              dataKey="inflow"
-              stroke="var(--app-positive)"
-              fill="url(#inflowGrad)"
-              strokeWidth={1.5}
-              isAnimationActive={!prefersReducedMotion}
-              animationDuration={chartAnimationDuration}
-            />
-            <Area
-              type="monotone"
-              dataKey="outflow"
-              stroke="var(--app-negative)"
-              fill="url(#outflowGrad)"
-              strokeWidth={1.5}
-              isAnimationActive={!prefersReducedMotion}
-              animationDuration={chartAnimationDuration}
-            />
+            {mode === 'net' ? (
+              <Area
+                type="monotone"
+                dataKey="net"
+                stroke="var(--app-text-muted)"
+                fill="url(#netFlowGrad)"
+                strokeWidth={1.5}
+                isAnimationActive={!prefersReducedMotion}
+                animationDuration={chartAnimationDuration}
+              />
+            ) : (
+              <>
+                <Area
+                  type="monotone"
+                  dataKey="inflow"
+                  stroke="var(--app-positive)"
+                  fill="url(#inflowGrad)"
+                  strokeWidth={1.5}
+                  isAnimationActive={!prefersReducedMotion}
+                  animationDuration={chartAnimationDuration}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="outflow"
+                  stroke="var(--app-negative)"
+                  fill="url(#outflowGrad)"
+                  strokeWidth={1.5}
+                  isAnimationActive={!prefersReducedMotion}
+                  animationDuration={chartAnimationDuration}
+                />
+              </>
+            )}
           </AreaChart>
         </ResponsiveContainer>
         <DeferredChartTooltipOverlay
@@ -252,6 +302,7 @@ export default function DailyCashFlowChart({
             <DailyCashFlowTooltipContent
               point={point}
               displayCurrency={displayCurrency}
+              mode={mode}
             />
           )}
         />

--- a/frontend/src/transactions/components/topBand/MostExpensiveTransactionsPanel.tsx
+++ b/frontend/src/transactions/components/topBand/MostExpensiveTransactionsPanel.tsx
@@ -65,14 +65,12 @@ export default function MostExpensiveTransactionsPanel({
       <div className="mt-2 flex flex-col gap-2.5">
         <AnimatePresence initial={false} mode="popLayout">
           {outliers.length === 0 ? (
-            <motion.div
+            <motion.p
               key="empty-outliers"
               layout
-              className="flex items-center justify-center rounded-md border px-2.5 py-2 text-sm italic"
+              className="flex items-center justify-center text-center text-sm italic"
               style={{
                 minHeight: emptyOutliersHeight,
-                background: 'var(--app-surface-soft)',
-                borderColor: 'var(--app-border)',
                 color: 'var(--app-text-subtle)',
               }}
               initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 4 }}
@@ -80,8 +78,8 @@ export default function MostExpensiveTransactionsPanel({
               exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
               transition={contentTransition}
             >
-              No expensive transactions
-            </motion.div>
+              No qualifying transactions found
+            </motion.p>
           ) : outliers.map((transaction) => {
               const loading = openingOutlierId === transaction.id
               const label = transaction.merchant_name ?? transaction.notes ?? 'Unknown'

--- a/frontend/src/transactions/components/topBand/TopCategoriesChart.tsx
+++ b/frontend/src/transactions/components/topBand/TopCategoriesChart.tsx
@@ -214,7 +214,7 @@ export default function TopCategoriesChart({
               exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
               transition={contentTransition}
             >
-              No qualifying categories found
+              No qualifying transactions found
             </motion.p>
           ) : (
             <motion.div

--- a/frontend/src/transactions/components/topBand/TopCategoriesChart.tsx
+++ b/frontend/src/transactions/components/topBand/TopCategoriesChart.tsx
@@ -201,14 +201,12 @@ export default function TopCategoriesChart({
       <div className="mt-2">
         <AnimatePresence initial={false} mode="popLayout">
           {categorySpend.length === 0 ? (
-            <motion.div
+            <motion.p
               key="empty-categories"
               layout
-              className="flex items-center justify-center rounded-md border px-2.5 py-2 text-sm italic"
+              className="flex items-center justify-center text-center text-sm italic"
               style={{
                 height: emptyTopCategoryHeight,
-                background: 'var(--app-surface-soft)',
-                borderColor: 'var(--app-border)',
                 color: 'var(--app-text-subtle)',
               }}
               initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 4 }}
@@ -216,8 +214,8 @@ export default function TopCategoriesChart({
               exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
               transition={contentTransition}
             >
-              No category spend
-            </motion.div>
+              No qualifying categories found
+            </motion.p>
           ) : (
             <motion.div
               ref={topCategoryChartRef}

--- a/frontend/src/transactions/components/topBand/constants.ts
+++ b/frontend/src/transactions/components/topBand/constants.ts
@@ -13,18 +13,18 @@ export const PLACEHOLDER_CATEGORIES = [
 ]
 
 export const PLACEHOLDER_DAILY_FLOW = [
-  { date: 'Day 1', inflow: 320, outflow: -185 },
-  { date: 'Day 2', inflow: 0, outflow: -42 },
-  { date: 'Day 3', inflow: 0, outflow: -2450 },
-  { date: 'Day 4', inflow: 150, outflow: -67 },
-  { date: 'Day 5', inflow: 0, outflow: -23 },
-  { date: 'Day 6', inflow: 0, outflow: -95 },
-  { date: 'Day 7', inflow: 0, outflow: -875 },
-  { date: 'Day 8', inflow: 4200, outflow: -310 },
-  { date: 'Day 9', inflow: 0, outflow: -56 },
-  { date: 'Day 10', inflow: 0, outflow: -128 },
-  { date: 'Day 11', inflow: 0, outflow: -44 },
-  { date: 'Day 12', inflow: 3780, outflow: -159 },
+  { date: 'Day 1', inflow: 320, outflow: -185, net: 135 },
+  { date: 'Day 2', inflow: 0, outflow: -42, net: -42 },
+  { date: 'Day 3', inflow: 0, outflow: -2450, net: -2450 },
+  { date: 'Day 4', inflow: 150, outflow: -67, net: 83 },
+  { date: 'Day 5', inflow: 0, outflow: -23, net: -23 },
+  { date: 'Day 6', inflow: 0, outflow: -95, net: -95 },
+  { date: 'Day 7', inflow: 0, outflow: -875, net: -875 },
+  { date: 'Day 8', inflow: 4200, outflow: -310, net: 3890 },
+  { date: 'Day 9', inflow: 0, outflow: -56, net: -56 },
+  { date: 'Day 10', inflow: 0, outflow: -128, net: -128 },
+  { date: 'Day 11', inflow: 0, outflow: -44, net: -44 },
+  { date: 'Day 12', inflow: 3780, outflow: -159, net: 3621 },
 ]
 
 export const TOP_CATEGORY_AXIS_MIN_WIDTH = 110


### PR DESCRIPTION
- Add a default daily net cash flow chart to the transactions summary
- Add a toggle between net cash flow and inflow/outflow views
- Animate the `Net` title word in and out with the same roulette motion as the expense/income title
- Tune the daily cash-flow chart draw animation
- Simplify no-data states for Most Expensive Transactions and Top Categories to plain muted text
- Update empty-state copy to "No qualifying transactions found"

CU-86ba82zqr