### PR TITLE
fix: correct and clarify transaction cash flow graph and stats

### DIFF
--- a/backend/app/routes/transaction.py
+++ b/backend/app/routes/transaction.py
@@ -46,6 +46,8 @@ from app.services.transaction_responses import (
 
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
+_BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
+
 # Sortable fields mapped to their SQLAlchemy column objects
 _SORT_FIELDS: dict[str, MappedColumn] = {
     "dt": Transaction.dt,
@@ -431,7 +433,17 @@ async def get_transactions_overview(
             sa.func.coalesce(sa.func.sum(sa.case((Transaction.amount > 0, Transaction.amount))), 0).label("inflow"),
             sa.func.coalesce(sa.func.sum(sa.case((Transaction.amount < 0, Transaction.amount))), 0).label("outflow"),
         )
+        .join(Category, Transaction.category_id == Category.id)
         .where(base_where)
+        .where(
+            sa.or_(
+                Category.kind.in_([CategoryKind.EXPENSE, CategoryKind.INCOME]),
+                (
+                    (Category.kind == CategoryKind.TRANSFER)
+                    & (Category.name != _BALANCE_ADJUSTMENT_CATEGORY_NAME)
+                ),
+            ),
+        )
         .group_by(Transaction.dt, Transaction.account_id)
     )
     flow_rows = (await db.execute(flow_query)).all()

--- a/backend/tests/routes/test_transaction.py
+++ b/backend/tests/routes/test_transaction.py
@@ -688,6 +688,30 @@ async def test_transactions_overview_excludes_hidden_accounts_unscoped(client):
     assert data["net_flow_fx_status"] == {"state": "none", "missing_pairs": []}
 
 
+async def test_transactions_overview_net_flow_excludes_balance_adjustments(client):
+    """Balance Adjustment is a reconciliation row, not net cash flow."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    balance_adjustment_id = await _get_system_category_id(client, headers, "Balance Adjustment")
+    transfer_id = (await _create_category(client, headers, name="Account Move", kind="transfer")).json()["id"]
+
+    await _create_transaction(client, headers, account_id, category_id, amount=10_000)
+    await _create_transaction(client, headers, account_id, category_id, amount=-4_000)
+    await _create_transaction(client, headers, account_id, transfer_id, amount=2_500)
+    await _create_transaction(client, headers, account_id, transfer_id, amount=-1_500)
+    await _create_transaction(client, headers, account_id, balance_adjustment_id, amount=99_999)
+    await _create_transaction(client, headers, account_id, balance_adjustment_id, amount=-88_888)
+
+    resp = await client.get("/transactions/overview", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["total_inflow"] == 12_500
+    assert data["total_outflow"] == -5_500
+    assert data["daily_cash_flow"] == [
+        {"date": "2026-03-15", "inflow": 12_500, "outflow": -5_500},
+    ]
+
+
 async def test_transactions_overview_net_flow_converts_foreign_accounts(client, monkeypatch):
     """Net flow totals are converted by transaction date into the user's base currency."""
     from app.services.fx import FrankfurterProvider

--- a/frontend/src/transactions/TransactionsPage.tsx
+++ b/frontend/src/transactions/TransactionsPage.tsx
@@ -142,6 +142,8 @@ export default function TransactionsPage() {
             displayCurrency={displayCurrency}
             loading={filterListLoading || isOverviewFetching}
             rangeLabel={rangeLabel}
+            fromDate={overviewFromDate}
+            toDate={overviewToDate}
             chartAnimationKey={chartAnimationKey}
             prefersReducedMotion={prefersReducedMotion}
             openingOutlierId={openingOutlierId}

--- a/frontend/src/transactions/components/TransactionsTopBand.tsx
+++ b/frontend/src/transactions/components/TransactionsTopBand.tsx
@@ -29,6 +29,8 @@ export default function TransactionsTopBand({
   displayCurrency,
   loading,
   rangeLabel,
+  fromDate,
+  toDate,
   chartAnimationKey,
   prefersReducedMotion,
   openingOutlierId,
@@ -39,6 +41,8 @@ export default function TransactionsTopBand({
   displayCurrency: string
   loading: boolean
   rangeLabel: string
+  fromDate: string
+  toDate: string
   chartAnimationKey: string
   prefersReducedMotion: boolean | null
   openingOutlierId: string | null
@@ -168,6 +172,8 @@ export default function TransactionsTopBand({
 
       <DailyCashFlowChart
         rawDailyFlow={overviewDailyCashFlow}
+        fromDate={fromDate}
+        toDate={toDate}
         fxStatus={overview?.daily_cash_flow_fx_status}
         showPlaceholderData={!hasOverviewData}
         displayCurrency={displayCurrency}

--- a/frontend/src/transactions/components/TransactionsTopBand.tsx
+++ b/frontend/src/transactions/components/TransactionsTopBand.tsx
@@ -45,19 +45,35 @@ export default function TransactionsTopBand({
   outlierOpenError: string | null
   onOpenOutlierTransaction: (transactionId: string) => void
 }) {
-  // Null overview totals mean "no data"; placeholders preserve chart geometry under the empty overlay.
-  const hasOverviewData = overview?.total_inflow !== null && overview?.total_inflow !== undefined
-  const inflow = hasOverviewData ? overview!.total_inflow! : PLACEHOLDER_FLOW.total_inflow
-  const outflow = hasOverviewData ? overview!.total_outflow! : PLACEHOLDER_FLOW.total_outflow
-  const outliers = hasOverviewData
-    ? (overview!.outliers ?? [])
-    : PLACEHOLDER_OUTLIERS.map((outlier) => ({ ...outlier, currency: displayCurrency }))
-  const categorySpend = hasOverviewData
-    ? (overview!.top_categories ?? []).map((category) => ({
+  const overviewOutliers = overview?.outliers ?? []
+  const overviewCategories = overview?.top_categories ?? []
+  const overviewDailyCashFlow = overview?.daily_cash_flow ?? []
+  const hasTransactions = overview?.total_inflow !== null && overview?.total_inflow !== undefined
+  const hasNetFlowData =
+    (overview?.total_inflow ?? 0) !== 0 || (overview?.total_outflow ?? 0) !== 0
+  const hasOutlierData = overviewOutliers.length > 0
+  const hasCategoryData = overviewCategories.length > 0
+  const hasDailyCashFlowData = overviewDailyCashFlow.some((day) => day.inflow !== 0 || day.outflow !== 0)
+  const hasOverviewData = hasNetFlowData || hasOutlierData || hasCategoryData || hasDailyCashFlowData
+  const emptyOverlayMessage = hasTransactions
+    ? `No qualifying transactions for ${rangeLabel}`
+    : `No transaction data for ${rangeLabel}.`
+  // Placeholders preserve chart geometry only when the whole top band is under the empty overlay.
+  const inflow = hasNetFlowData ? overview!.total_inflow! : PLACEHOLDER_FLOW.total_inflow
+  const outflow = hasNetFlowData ? overview!.total_outflow! : PLACEHOLDER_FLOW.total_outflow
+  const outliers = hasOutlierData
+    ? overviewOutliers
+    : hasOverviewData
+      ? []
+      : PLACEHOLDER_OUTLIERS.map((outlier) => ({ ...outlier, currency: displayCurrency }))
+  const categorySpend = hasCategoryData
+    ? overviewCategories.map((category) => ({
         name: category.category_name,
         amount: Math.abs(category.total),
       }))
-    : PLACEHOLDER_CATEGORIES
+    : hasOverviewData
+      ? []
+      : PLACEHOLDER_CATEGORIES
   const metricsLayoutTransition = {
     duration: prefersReducedMotion ? 0 : 0.28,
     ease: [0.25, 0.1, 0.25, 1],
@@ -99,7 +115,7 @@ export default function TransactionsTopBand({
           }}
         >
           <p className="text-lg font-medium" style={{ color: 'var(--app-text-muted)' }}>
-            No transaction data for {rangeLabel}.
+            {emptyOverlayMessage}
           </p>
         </div>
       )}
@@ -151,9 +167,9 @@ export default function TransactionsTopBand({
       </div>
 
       <DailyCashFlowChart
-        rawDailyFlow={overview?.daily_cash_flow ?? []}
+        rawDailyFlow={overviewDailyCashFlow}
         fxStatus={overview?.daily_cash_flow_fx_status}
-        hasOverviewData={hasOverviewData}
+        showPlaceholderData={!hasOverviewData}
         displayCurrency={displayCurrency}
         chartAnimationKey={chartAnimationKey}
         prefersReducedMotion={prefersReducedMotion}

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -60,6 +60,10 @@ const titleCharVariants = {
   enter: { y: 0, opacity: 1, filter: 'blur(0px)' },
   exit: { y: '-0.7em', opacity: 0, filter: 'blur(2px)' },
 } as const
+const dailyNetCashFlowCalculation =
+  'Each day\'s money in minus money out. Transfers count except Balance Adjustment.'
+const dailyCashFlowCalculation =
+  'Each day\'s money in and money out. Transfers count except Balance Adjustment.'
 // Recharts runtime accepts cubic-bezier strings, but Area's public type only lists preset names.
 const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-out'
 
@@ -239,6 +243,12 @@ export default function DailyCashFlowChart({
   )
   const chartAnimationDuration = prefersReducedMotion ? 0 : 1000
   const toggleLabel = mode === 'net' ? 'Show inflow and outflow' : 'Show net cash flow'
+  const calculationTooltipLabel = mode === 'net'
+    ? 'How daily net cash flow is calculated'
+    : 'How daily cash flow is calculated'
+  const calculationTooltipMessage = mode === 'net'
+    ? dailyNetCashFlowCalculation
+    : dailyCashFlowCalculation
   const showDailyCashFlowTooltip = (
     state: DailyCashFlowTooltipState,
     event: ReactMouseEvent<SVGGraphicsElement>,
@@ -264,6 +274,14 @@ export default function DailyCashFlowChart({
             <DailyCashFlowTitleWord visible={mode === 'net'} />
             <span className="ml-[0.25em]">Cash Flow</span>
           </span>
+          <IconTooltip
+            label={calculationTooltipLabel}
+            level="info"
+            placement="top"
+            widthClassName="w-72"
+          >
+            {calculationTooltipMessage}
+          </IconTooltip>
           {fxStatus && (
             <IconTooltip
               label="Daily cash flow FX status"

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -211,7 +211,7 @@ function DailyCashFlowTitleWord({ visible }: { visible: boolean }) {
 export default function DailyCashFlowChart({
   rawDailyFlow,
   fxStatus,
-  hasOverviewData,
+  showPlaceholderData,
   displayCurrency,
   chartAnimationKey,
   prefersReducedMotion,
@@ -220,7 +220,7 @@ export default function DailyCashFlowChart({
 }: {
   rawDailyFlow: DailyCashFlow[]
   fxStatus: FxStatus | undefined
-  hasOverviewData: boolean
+  showPlaceholderData: boolean
   displayCurrency: string
   chartAnimationKey: string
   prefersReducedMotion: boolean | null
@@ -230,8 +230,8 @@ export default function DailyCashFlowChart({
   const dailyFlowChartRef = useRef<HTMLDivElement>(null)
   const dailyFlowTooltipRef = useRef<DeferredChartTooltipOverlayHandle<DailyCashFlowPoint>>(null)
   const dailyFlow = useMemo(
-    () => (hasOverviewData ? getDailyCashFlowSeries(rawDailyFlow) : PLACEHOLDER_DAILY_FLOW),
-    [hasOverviewData, rawDailyFlow],
+    () => (showPlaceholderData ? PLACEHOLDER_DAILY_FLOW : getDailyCashFlowSeries(rawDailyFlow)),
+    [showPlaceholderData, rawDailyFlow],
   )
   const dailyFlowPointsByDate = useMemo(
     () => new Map(dailyFlow.map((point) => [point.date, point])),

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -69,14 +69,15 @@ const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-o
 
 function getDailyCashFlowSeries(
   raw: DailyCashFlow[],
+  fromDate: string,
+  toDate: string,
 ): DailyCashFlowPoint[] {
-  if (raw.length === 0) return []
+  if (fromDate > toDate) return []
 
   // The API only returns days with activity; pad missing days so the line chart has a continuous axis.
   const byDate = new Map(raw.map((day) => [day.date, day]))
-  const first = parseYmdLocal(raw[0].date)
-  const last = parseYmdLocal(raw[raw.length - 1].date)
-  const cursor = new Date(first.getFullYear(), first.getMonth(), 1)
+  const cursor = parseYmdLocal(fromDate)
+  const last = parseYmdLocal(toDate)
   const result: DailyCashFlowPoint[] = []
 
   while (cursor <= last) {
@@ -214,6 +215,8 @@ function DailyCashFlowTitleWord({ visible }: { visible: boolean }) {
 
 export default function DailyCashFlowChart({
   rawDailyFlow,
+  fromDate,
+  toDate,
   fxStatus,
   showPlaceholderData,
   displayCurrency,
@@ -223,6 +226,8 @@ export default function DailyCashFlowChart({
   onModeToggle,
 }: {
   rawDailyFlow: DailyCashFlow[]
+  fromDate: string
+  toDate: string
   fxStatus: FxStatus | undefined
   showPlaceholderData: boolean
   displayCurrency: string
@@ -234,8 +239,12 @@ export default function DailyCashFlowChart({
   const dailyFlowChartRef = useRef<HTMLDivElement>(null)
   const dailyFlowTooltipRef = useRef<DeferredChartTooltipOverlayHandle<DailyCashFlowPoint>>(null)
   const dailyFlow = useMemo(
-    () => (showPlaceholderData ? PLACEHOLDER_DAILY_FLOW : getDailyCashFlowSeries(rawDailyFlow)),
-    [showPlaceholderData, rawDailyFlow],
+    () => (
+      showPlaceholderData
+        ? PLACEHOLDER_DAILY_FLOW
+        : getDailyCashFlowSeries(rawDailyFlow, fromDate, toDate)
+    ),
+    [fromDate, rawDailyFlow, showPlaceholderData, toDate],
   )
   const dailyFlowPointsByDate = useMemo(
     () => new Map(dailyFlow.map((point) => [point.date, point])),

--- a/frontend/src/transactions/components/topBand/NetFlowSummary.tsx
+++ b/frontend/src/transactions/components/topBand/NetFlowSummary.tsx
@@ -7,6 +7,8 @@ import { getCashFlowFxStatusMessage } from '@/transactions/utils/fxTooltipMessag
 import { formatCurrency } from '@/utils/formatCurrency'
 
 const MAX_NET_FLOW_FONT_SIZE = 60
+const netFlowCalculation =
+  'Money in minus money out for this period. Transfers count except Balance Adjustment.'
 
 export default function NetFlowSummary({
   inflow,
@@ -56,7 +58,17 @@ export default function NetFlowSummary({
   return (
     <div ref={containerRef} className={`relative min-w-0 ${className}`}>
       <div className="mb-1.5 flex items-center gap-2">
-        <p className="app-label">Net Flow</p>
+        <p className="app-label inline-flex items-center gap-2">
+          Net Flow
+          <IconTooltip
+            label="How net flow is calculated"
+            level="info"
+            placement="bottom"
+            widthClassName="w-72"
+          >
+            {netFlowCalculation}
+          </IconTooltip>
+        </p>
         {fxStatus && (
           <IconTooltip
             label="Net flow FX status"


### PR DESCRIPTION
- Exclude Balance Adjustment transactions from transaction cash flow calculations
- Show the top-band empty overlay only when all summary areas have no data
- Distinguish no transactions from no qualifying transactions in "no data" texts
- Add concise info tooltips for net flow and daily cash flow calculations
- Keep days with no (qualifying) transactions visible in the daily cash flow chart with zero values

CU-86ba9h21d