### PR TITLE
Fully implement account archival workflows

### DIFF
--- a/backend/alembic/versions/3f8a2f1c9d7b_rename_account_hidden_to_archived.py
+++ b/backend/alembic/versions/3f8a2f1c9d7b_rename_account_hidden_to_archived.py
@@ -1,0 +1,36 @@
+"""Rename account hidden flag to archived.
+
+Revision ID: 3f8a2f1c9d7b
+Revises: 8b7f0f3c2a91
+Create Date: 2026-06-04 00:00:00.000000
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "3f8a2f1c9d7b"
+down_revision: str | Sequence[str] | None = "8b7f0f3c2a91"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "accounts",
+        "is_hidden",
+        new_column_name="is_archived",
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "accounts",
+        "is_archived",
+        new_column_name="is_hidden",
+        existing_type=sa.Boolean(),
+        existing_nullable=False,
+    )

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -44,7 +44,7 @@ class Account(Base):
     institution: Mapped[Institution | None] = relationship(lazy="raise")
     currency: Mapped[str] = mapped_column(VARCHAR(3), ForeignKey("currencies.id"), nullable=False)
     credit_limit: Mapped[int | None] = mapped_column(BigInteger)  # Liability accounts only; null on assets and unset liabilities
-    is_hidden: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    is_archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 

--- a/backend/app/routes/account.py
+++ b/backend/app/routes/account.py
@@ -35,7 +35,7 @@ from app.services.accounts import (
     get_account_cash_flow_history,
     get_account_spending_breakdown,
 )
-from app.services.snapshots import attach_current_balances, recompute_snapshots_from
+from app.services.snapshots import attach_current_balances, get_current_balances, recompute_snapshots_from
 
 router = APIRouter(prefix="/accounts", tags=["accounts"])
 
@@ -47,6 +47,7 @@ _VALID_ACCOUNT_TYPES = {e.value for e in AccountType}
 _UPDATE_ACCOUNT_NOT_NULL_FIELDS = frozenset({"name", "is_archived"})
 _BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
 _STARTING_BALANCE_NOTE = "Starting balance"
+_ARCHIVE_BALANCE_ADJUSTMENT_NOTE = "Account archived"
 
 
 async def _attach_account_balance_fields(db: AsyncSession, accounts: list[Account], user: User) -> None:
@@ -73,6 +74,26 @@ async def _get_system_balance_adjustment_category_id(db: AsyncSession) -> uuid.U
             detail="Balance adjustment category is not configured",
         )
     return category_id
+
+
+async def _zero_account_balance_for_archive(db: AsyncSession, account: Account, user: User) -> None:
+    current_balance = (await get_current_balances(db, [account.id])).get(account.id, 0)
+    if current_balance == 0:
+        return
+
+    archive_dt = datetime.now(ZoneInfo(user.tz)).date()
+    db.add(Transaction(
+        created_by_user_id=user.id,
+        account_id=account.id,
+        dt=archive_dt,
+        category_id=await _get_system_balance_adjustment_category_id(db),
+        amount=-current_balance,
+        currency=account.currency,
+        fx_rate=None,
+        notes=_ARCHIVE_BALANCE_ADJUSTMENT_NOTE,
+    ))
+    await db.flush()
+    await recompute_snapshots_from(db, account.id, archive_dt)
 
 
 async def _validate_tax_advantaged_plan_link(
@@ -455,8 +476,13 @@ async def update_account(
             acting_user_id=user.id,
         )
 
+    should_archive = updates.get("is_archived") is True and not account.is_archived
+
     for field, value in updates.items():
         setattr(account, field, value)
+
+    if should_archive:
+        await _zero_account_balance_for_archive(db, account, user)
 
     await db.commit()
     # Re-fetch with eager loading so the institution relationship is fresh after a possible institution_id change.

--- a/backend/app/routes/account.py
+++ b/backend/app/routes/account.py
@@ -44,7 +44,7 @@ _VALID_ACCOUNT_KINDS = {e.value for e in AccountKind}
 _VALID_ACCOUNT_TYPES = {e.value for e in AccountType}
 
 # UpdateAccountRequest fields that map to NOT NULL columns — explicit null on these is rejected with 422.
-_UPDATE_ACCOUNT_NOT_NULL_FIELDS = frozenset({"name", "is_hidden"})
+_UPDATE_ACCOUNT_NOT_NULL_FIELDS = frozenset({"name", "is_archived"})
 _BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
 _STARTING_BALANCE_NOTE = "Starting balance"
 
@@ -366,7 +366,7 @@ async def create_account(
         institution_id=data.institution_id,
         currency=data.currency,
         credit_limit=data.credit_limit,
-        is_hidden=data.is_hidden,
+        is_archived=data.is_archived,
     )
     db.add(account)
     await db.flush()

--- a/backend/app/routes/transaction.py
+++ b/backend/app/routes/transaction.py
@@ -655,8 +655,14 @@ async def create_transaction(
 ):
     """Create a new transaction. Requires write access on the target account."""
     account = await check_account_access(
-        db, data.account_id, user.id, PermissionLevel.WRITE, require_open=True,
+        db,
+        data.account_id,
+        user.id,
+        PermissionLevel.WRITE,
+        require_open=True,
     )
+    if account.is_archived:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Account is archived")
 
     currency_lookup = await db.execute(select(Currency).where(Currency.id == data.currency))
     if not currency_lookup.scalar_one_or_none():
@@ -738,10 +744,16 @@ async def update_transaction(
     # Resolve the account's group_id for category/merchant validation
     account_group_id = None
     if "account_id" in changed_fields:
-        # Moving to a new account — check write access and reject closed targets
+        # Moving to a new account requires a writable target that accepts new history.
         new_account = await check_account_access(
-            db, changed_fields["account_id"], user.id, PermissionLevel.WRITE, require_open=True,
+            db,
+            changed_fields["account_id"],
+            user.id,
+            PermissionLevel.WRITE,
+            require_open=True,
         )
+        if new_account.is_archived:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Account is archived")
         account_group_id = new_account.group_id
         if txn.currency != new_account.currency and txn.fx_rate is None and "fx_rate" not in changed_fields:
             raise HTTPException(

--- a/backend/app/routes/transaction.py
+++ b/backend/app/routes/transaction.py
@@ -724,6 +724,9 @@ async def update_transaction(
 ):
     """Update a transaction. Requires write access on the target account."""
     txn = await check_transaction_access(db, transaction_id, user.id, PermissionLevel.WRITE)
+    current_account = (await db.execute(select(Account).where(Account.id == txn.account_id))).scalar_one()
+    if current_account.is_archived:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Account is archived")
 
     changed_fields = data.model_dump(exclude_unset=True)
     if not changed_fields:
@@ -761,8 +764,6 @@ async def update_transaction(
                 detail="fx_rate is required when transaction currency differs from account currency",
             )
     else:
-        # Staying on the same account — look up its group_id
-        current_account = (await db.execute(select(Account).where(Account.id == txn.account_id))).scalar_one()
         account_group_id = current_account.group_id
 
     if "category_id" in changed_fields:
@@ -815,6 +816,9 @@ async def delete_transaction(
 ):
     """Delete a transaction. Requires write access on the parent account."""
     txn = await check_transaction_access(db, transaction_id, user.id, PermissionLevel.WRITE)
+    account = (await db.execute(select(Account).where(Account.id == txn.account_id))).scalar_one()
+    if account.is_archived:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Account is archived")
 
     # Capture pre-delete values for snapshot recomputation
     account_id = txn.account_id

--- a/backend/app/routes/transaction.py
+++ b/backend/app/routes/transaction.py
@@ -101,8 +101,8 @@ def _date_sort_order(sort_order: str, tag_names):
     )
 
 
-def _accessible_account_ids(user_id: uuid.UUID, *, include_hidden: bool = False):
-    """Scalar subquery returning readable account IDs, hidden excluded by default."""
+def _accessible_account_ids(user_id: uuid.UUID, *, include_archived: bool = False):
+    """Scalar subquery returning readable account IDs, archived excluded by default."""
     query = (
         select(Account.id)
         .outerjoin(GroupMember, Account.group_id == GroupMember.group_id)
@@ -116,8 +116,8 @@ def _accessible_account_ids(user_id: uuid.UUID, *, include_hidden: bool = False)
             | (AccountPermission.user_id == user_id),
         )
     )
-    if not include_hidden:
-        query = query.where(Account.is_hidden.is_(False))
+    if not include_archived:
+        query = query.where(Account.is_archived.is_(False))
     return query.scalar_subquery()
 
 
@@ -404,7 +404,7 @@ async def get_transactions_overview(
     if from_date is not None and to_date is not None and from_date > to_date:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Start date must be before end date")
 
-    accessible = _accessible_account_ids(user.id, include_hidden=account_id is not None)
+    accessible = _accessible_account_ids(user.id, include_archived=account_id is not None)
 
     # Base filter shared by all aggregation queries
     base = select(Transaction).where(Transaction.account_id.in_(accessible))
@@ -557,7 +557,7 @@ async def list_transactions(
 
     sort_column = _SORT_FIELDS[sort_by]
 
-    accessible = _accessible_account_ids(user.id, include_hidden=account_id is not None)
+    accessible = _accessible_account_ids(user.id, include_archived=account_id is not None)
     query = select(Transaction).where(Transaction.account_id.in_(accessible))
 
     # Apply exact-match filters

--- a/backend/app/routes/transaction.py
+++ b/backend/app/routes/transaction.py
@@ -101,9 +101,9 @@ def _date_sort_order(sort_order: str, tag_names):
     )
 
 
-def _accessible_account_ids(user_id: uuid.UUID, *, include_archived: bool = False):
-    """Scalar subquery returning readable account IDs, archived excluded by default."""
-    query = (
+def _accessible_account_ids(user_id: uuid.UUID):
+    """Scalar subquery returning readable account IDs."""
+    return (
         select(Account.id)
         .outerjoin(GroupMember, Account.group_id == GroupMember.group_id)
         .outerjoin(
@@ -115,10 +115,7 @@ def _accessible_account_ids(user_id: uuid.UUID, *, include_archived: bool = Fals
             | ((GroupMember.user_id == user_id) & (GroupMember.is_admin.is_(True)))
             | (AccountPermission.user_id == user_id),
         )
-    )
-    if not include_archived:
-        query = query.where(Account.is_archived.is_(False))
-    return query.scalar_subquery()
+    ).scalar_subquery()
 
 
 async def _get_currency_exponents(db: AsyncSession, currencies: set[str]) -> dict[str, int]:
@@ -404,7 +401,7 @@ async def get_transactions_overview(
     if from_date is not None and to_date is not None and from_date > to_date:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Start date must be before end date")
 
-    accessible = _accessible_account_ids(user.id, include_archived=account_id is not None)
+    accessible = _accessible_account_ids(user.id)
 
     # Base filter shared by all aggregation queries
     base = select(Transaction).where(Transaction.account_id.in_(accessible))
@@ -557,7 +554,7 @@ async def list_transactions(
 
     sort_column = _SORT_FIELDS[sort_by]
 
-    accessible = _accessible_account_ids(user.id, include_archived=account_id is not None)
+    accessible = _accessible_account_ids(user.id)
     query = select(Transaction).where(Transaction.account_id.in_(accessible))
 
     # Apply exact-match filters

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -59,12 +59,29 @@ async def _accessible_non_archived_accounts(db: AsyncSession, user: User):
     ]
 
 
-async def _active_runway_account_ids(db: AsyncSession, user: User) -> list[uuid.UUID]:
-    accessible_ids = {a.id for a in await _accessible_non_archived_accounts(db, user)}
+async def _runway_account_ids_by_archive_state(
+    db: AsyncSession,
+    user: User,
+) -> tuple[list[uuid.UUID], list[uuid.UUID]]:
+    accessible_accounts = await get_accessible_accounts(db, user, include_archived=True)
+    active_ids = {account.id for account in accessible_accounts if not account.is_archived}
+    archived_ids = {account.id for account in accessible_accounts if account.is_archived}
     stored = await db.execute(
         select(UserRunwayAccount.account_id).where(UserRunwayAccount.user_id == user.id),
     )
-    return [aid for aid in stored.scalars().all() if aid in accessible_ids]
+    active: list[uuid.UUID] = []
+    archived: list[uuid.UUID] = []
+    for account_id in stored.scalars().all():
+        if account_id in active_ids:
+            active.append(account_id)
+        elif account_id in archived_ids:
+            archived.append(account_id)
+    return active, archived
+
+
+async def _active_runway_account_ids(db: AsyncSession, user: User) -> list[uuid.UUID]:
+    active, _archived = await _runway_account_ids_by_archive_state(db, user)
+    return active
 
 
 async def _replace_runway_account_ids(
@@ -152,7 +169,7 @@ async def list_runway_accounts(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
-    """Return the account IDs the user has picked to feed the runway calculation.
+    """Return the account IDs currently feeding the runway calculation.
 
     Filters out any stored selections the user can no longer read or has
     archived, so the response only surfaces currently active IDs.
@@ -185,8 +202,10 @@ async def get_runway_settings(
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     """Return the user's runway account selection and status thresholds."""
+    active_account_ids, archived_account_ids = await _runway_account_ids_by_archive_state(db, user)
     return RunwaySettings(
-        account_ids=await _active_runway_account_ids(db, user),
+        account_ids=active_account_ids,
+        archived_account_ids=archived_account_ids,
         thresholds=_runway_thresholds_from_user(user),
     )
 
@@ -198,13 +217,15 @@ async def replace_runway_settings(
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
     """Replace the user's runway account selection and status thresholds."""
-    selected_ids = await _replace_runway_account_ids(db, user, data.account_ids)
+    await _replace_runway_account_ids(db, user, data.account_ids)
     user.runway_risky_below_months = data.thresholds.risky_below_months
     user.runway_healthy_at_months = data.thresholds.healthy_at_months
     await db.commit()
+    active_account_ids, archived_account_ids = await _runway_account_ids_by_archive_state(db, user)
 
     return RunwaySettings(
-        account_ids=selected_ids,
+        account_ids=active_account_ids,
+        archived_account_ids=archived_account_ids,
         thresholds=_runway_thresholds_from_user(user),
     )
 

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -60,7 +60,7 @@ async def _accessible_non_archived_accounts(db: AsyncSession, user: User):
 
 
 async def _active_runway_account_ids(db: AsyncSession, user: User) -> list[uuid.UUID]:
-    accessible_ids = {a.id for a in await get_accessible_accounts(db, user)}
+    accessible_ids = {a.id for a in await _accessible_non_archived_accounts(db, user)}
     stored = await db.execute(
         select(UserRunwayAccount.account_id).where(UserRunwayAccount.user_id == user.id),
     )

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -51,6 +51,14 @@ def _runway_thresholds_from_user(user: User) -> RunwayThresholds:
     )
 
 
+async def _accessible_non_archived_accounts(db: AsyncSession, user: User):
+    return [
+        account
+        for account in await get_accessible_accounts(db, user, include_archived=True)
+        if not account.is_archived
+    ]
+
+
 async def _active_runway_account_ids(db: AsyncSession, user: User) -> list[uuid.UUID]:
     accessible_ids = {a.id for a in await get_accessible_accounts(db, user)}
     stored = await db.execute(
@@ -213,7 +221,7 @@ async def get_runway(
     Expense refunds reduce expenses, while income and transfer-category
     transactions are excluded.
     """
-    accounts = await get_accessible_accounts(db, user)
+    accounts = await _accessible_non_archived_accounts(db, user)
     account_by_id = {account.id: account for account in accounts}
     accessible_ids = set(account_by_id)
     stored = await db.execute(

--- a/backend/app/routes/user.py
+++ b/backend/app/routes/user.py
@@ -66,11 +66,11 @@ async def _replace_runway_account_ids(
 ) -> list[uuid.UUID]:
     requested_ids = set(account_ids)
 
-    all_accessible = await get_accessible_accounts(db, user, include_hidden=True)
-    visible_ids = {a.id for a in all_accessible if not a.is_hidden}
-    hidden_ids = {a.id for a in all_accessible if a.is_hidden}
+    all_accessible = await get_accessible_accounts(db, user, include_archived=True)
+    active_ids = {a.id for a in all_accessible if not a.is_archived}
+    archived_ids = {a.id for a in all_accessible if a.is_archived}
 
-    invalid = requested_ids - visible_ids
+    invalid = requested_ids - active_ids
     if invalid:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
@@ -79,10 +79,10 @@ async def _replace_runway_account_ids(
 
     # Replace the full set in a single transaction — simpler than diffing and
     # the runway selection is expected to be small (a handful of accounts).
-    # Hidden selections are left untouched so hiding an account is reversible.
+    # Archived selections are left untouched so archiving an account is reversible.
     delete_query = delete(UserRunwayAccount).where(UserRunwayAccount.user_id == user.id)
-    if hidden_ids:
-        delete_query = delete_query.where(UserRunwayAccount.account_id.not_in(hidden_ids))
+    if archived_ids:
+        delete_query = delete_query.where(UserRunwayAccount.account_id.not_in(archived_ids))
     await db.execute(delete_query)
     for account_id in requested_ids:
         db.add(UserRunwayAccount(user_id=user.id, account_id=account_id))
@@ -147,7 +147,7 @@ async def list_runway_accounts(
     """Return the account IDs the user has picked to feed the runway calculation.
 
     Filters out any stored selections the user can no longer read or has
-    hidden, so the response only surfaces currently active IDs.
+    archived, so the response only surfaces currently active IDs.
     """
     return await _active_runway_account_ids(db, user)
 
@@ -162,8 +162,8 @@ async def replace_runway_accounts(
 
     Dedupes the submitted set. Rejects the whole request with 422 if any submitted
     account isn't readable by the user (personal, household admin, or explicit
-    permission) and currently visible. Stored hidden selections are preserved
-    so they become active again if the account is unhidden.
+    permission) and currently non-archived. Stored archived selections are
+    preserved so they become active again if the account is unarchived.
     """
     selected_ids = await _replace_runway_account_ids(db, user, data.account_ids)
     await db.commit()

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -27,7 +27,7 @@ class AccountsOverview(BaseModel):
     base_currency_current_balance: int | None = None
     current_balance_fx_status: FxStatus = Field(default_factory=FxStatus)
     credit_limit: int | None
-    is_hidden: bool
+    is_archived: bool
     closed_at: datetime | None
 
     model_config = {"from_attributes": True}
@@ -49,7 +49,7 @@ class AccountResponse(BaseModel):
     base_currency_current_balance: int | None = None
     current_balance_fx_status: FxStatus = Field(default_factory=FxStatus)
     credit_limit: int | None
-    is_hidden: bool
+    is_archived: bool
     closed_at: datetime | None
     created_at: datetime
 
@@ -67,7 +67,7 @@ class CreateAccountRequest(BaseModel):
     currency: str = Field(min_length=3, max_length=3)
     credit_limit: int | None = None  # Only valid on liability accounts
     starting_balance: int | None = None  # Signed initial balance adjustment in minor units
-    is_hidden: bool = False
+    is_archived: bool = False
     group_id: uuid.UUID | None = None
 
 
@@ -78,7 +78,7 @@ class UpdateAccountRequest(BaseModel):
     name: str | None = Field(None, min_length=1, max_length=256)
     institution_id: uuid.UUID | None = None
     credit_limit: int | None = None  # Only valid on liability accounts
-    is_hidden: bool | None = None
+    is_archived: bool | None = None
     closed_at: datetime | None = None
 
 

--- a/backend/app/schemas/dashboard.py
+++ b/backend/app/schemas/dashboard.py
@@ -86,7 +86,7 @@ class MonthlyIncomeExpense(BaseModel):
 class CreditWidgetResponse(BaseModel):
     """Credit usage totals for the dashboard credit widget.
 
-    - `credit_limit_total` sums `credit_limit` across readable non-hidden
+    - `credit_limit_total` sums `credit_limit` across readable non-archived
       revolving-credit accounts converted to the user's base currency when needed.
     - `credit_used` flips negative account balances into positive usage and
       treats positive stored-credit balances as zero used.
@@ -103,7 +103,7 @@ class NetWorthWidgetResponse(BaseModel):
     """Net worth totals and trend for the dashboard net worth widget.
 
     - `current_net_worth` is the sum of latest signed balances across every readable
-      non-hidden account converted to the user's base currency when needed.
+      non-archived account converted to the user's base currency when needed.
     - `net_worth_history` is a day-by-day series of net worth over the last
       `net_worth_window_days` days (length = `net_worth_window_days`, index 0 =
       earliest day, final index = today). Forward-filled from

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -85,6 +85,7 @@ class RunwaySettings(BaseModel):
     """Persisted runway settings."""
 
     account_ids: list[uuid.UUID]
+    archived_account_ids: list[uuid.UUID] = Field(default_factory=list)
     thresholds: RunwayThresholds
 
 

--- a/backend/app/schemas/user.py
+++ b/backend/app/schemas/user.py
@@ -49,7 +49,7 @@ class UpdateProfileRequest(BaseModel):
 
 
 class RunwayAccountsRequest(BaseModel):
-    """Replacement set for visible accounts in the user's runway selection."""
+    """Replacement set for active accounts in the user's runway selection."""
 
     account_ids: list[uuid.UUID]
 
@@ -98,8 +98,8 @@ class RunwayAccountBalance(BaseModel):
 class RunwayResponse(BaseModel):
     """Runway projection in months.
 
-    How many months the user's selected visible liquid balance covers at their
-    trailing 12-month average monthly net expense across readable non-hidden accounts.
+    How many months the user's selected active liquid balance covers at their
+    trailing 12-month average monthly net expense across readable non-archived accounts.
     """
 
     months: float | None

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -6,7 +6,7 @@ a reference time ``now`` and derive any further date boundaries internally,
 so callers don't have to plumb window-start/window-end timestamps through.
 
 Scoping rules mirror the default aggregate/list endpoints:
-- accessible accounts = non-archived personal + group admin + explicit per-account permission
+- accessible accounts = readable personal + group admin + explicit per-account permission
 - accessible budgets  = same pattern against base budgets
 so the dashboard never surfaces data the user couldn't read elsewhere.
 
@@ -94,9 +94,9 @@ def _cumsum(values: list[int]) -> list[int]:
 # ---------------------------------------------------------------------------
 
 async def get_accessible_accounts(
-    db: AsyncSession, user: User, *, include_archived: bool = False,
+    db: AsyncSession, user: User, *, include_archived: bool = True,
 ) -> list[Account]:
-    """Return accounts the user can read, excluding archived accounts by default."""
+    """Return accounts the user can read, including archived accounts by default."""
     query = (
         select(Account)
         .outerjoin(GroupMember, Account.group_id == GroupMember.group_id)

--- a/backend/app/services/dashboard.py
+++ b/backend/app/services/dashboard.py
@@ -6,7 +6,7 @@ a reference time ``now`` and derive any further date boundaries internally,
 so callers don't have to plumb window-start/window-end timestamps through.
 
 Scoping rules mirror the default aggregate/list endpoints:
-- accessible accounts = non-hidden personal + group admin + explicit per-account permission
+- accessible accounts = non-archived personal + group admin + explicit per-account permission
 - accessible budgets  = same pattern against base budgets
 so the dashboard never surfaces data the user couldn't read elsewhere.
 
@@ -94,9 +94,9 @@ def _cumsum(values: list[int]) -> list[int]:
 # ---------------------------------------------------------------------------
 
 async def get_accessible_accounts(
-    db: AsyncSession, user: User, *, include_hidden: bool = False,
+    db: AsyncSession, user: User, *, include_archived: bool = False,
 ) -> list[Account]:
-    """Return accounts the user can read, excluding hidden accounts by default."""
+    """Return accounts the user can read, excluding archived accounts by default."""
     query = (
         select(Account)
         .outerjoin(GroupMember, Account.group_id == GroupMember.group_id)
@@ -110,8 +110,8 @@ async def get_accessible_accounts(
             | (AccountPermission.user_id == user.id),
         )
     )
-    if not include_hidden:
-        query = query.where(Account.is_hidden.is_(False))
+    if not include_archived:
+        query = query.where(Account.is_archived.is_(False))
 
     result = await db.execute(
         query,

--- a/backend/app/services/insights/common.py
+++ b/backend/app/services/insights/common.py
@@ -18,6 +18,6 @@ def previous_period_bounds(from_date: date, to_date: date) -> tuple[date, date]:
 
 
 async def get_base_currency_accounts(db: AsyncSession, user: User) -> list[Account]:
-    """Return readable, non-archived accounts in the user's base currency."""
+    """Return readable accounts in the user's base currency."""
     accounts = await get_accessible_accounts(db, user)
     return [account for account in accounts if account.currency == user.base_currency]

--- a/backend/app/services/insights/common.py
+++ b/backend/app/services/insights/common.py
@@ -18,6 +18,6 @@ def previous_period_bounds(from_date: date, to_date: date) -> tuple[date, date]:
 
 
 async def get_base_currency_accounts(db: AsyncSession, user: User) -> list[Account]:
-    """Return readable, non-hidden accounts in the user's base currency."""
+    """Return readable, non-archived accounts in the user's base currency."""
     accounts = await get_accessible_accounts(db, user)
     return [account for account in accounts if account.currency == user.base_currency]

--- a/backend/app/services/tax_advantaged_plans.py
+++ b/backend/app/services/tax_advantaged_plans.py
@@ -21,6 +21,9 @@ async def attach_tax_advantaged_plan_metrics(
 ) -> None:
     """Attach current-year limits and transfer tallies to plan rows.
 
+    Archived linked accounts are included because contribution and withdrawal
+    room is historical tax data, not active account availability.
+
     Args:
         db: Active database session.
         plans: Plan rows to enrich in place.
@@ -87,6 +90,7 @@ async def attach_tax_advantaged_plan_metrics(
         .join(Category, Transaction.category_id == Category.id)
         .where(
             Account.tax_advantaged_plan_id.in_(plan_ids),
+            # Archived accounts remain linked to their plan history.
             Category.kind == CategoryKind.TRANSFER,
             Category.name == _TAC_TRANSFER_CATEGORY_NAME,
         )

--- a/backend/app/services/transaction_imports.py
+++ b/backend/app/services/transaction_imports.py
@@ -135,7 +135,15 @@ async def _resolve_accounts(
             )
 
         if mapping.account_id is not None:
-            account = await check_account_access(db, mapping.account_id, user.id, PermissionLevel.WRITE, require_open=True)
+            account = await check_account_access(
+                db,
+                mapping.account_id,
+                user.id,
+                PermissionLevel.WRITE,
+                require_open=True,
+            )
+            if account.is_archived:
+                raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Account is archived")
             stats.accounts_reused += 1
         else:
             account = await _create_import_account(db, user, mapping.create)

--- a/backend/app/services/transaction_imports.py
+++ b/backend/app/services/transaction_imports.py
@@ -164,7 +164,7 @@ async def _create_import_account(db: AsyncSession, user: User, create) -> Accoun
         institution_id=create.institution_id,
         currency=currency,
         credit_limit=None,
-        is_hidden=False,
+        is_archived=False,
     )
     db.add(account)
     await db.flush()

--- a/backend/tests/models/test_account.py
+++ b/backend/tests/models/test_account.py
@@ -50,14 +50,14 @@ async def test_created_at_auto_set(db, user, currency):
     assert a.created_at is not None
 
 
-async def test_is_hidden_defaults_to_false(db, user, currency):
-    """is_hidden should default to false."""
+async def test_is_archived_defaults_to_false(db, user, currency):
+    """is_archived should default to false."""
     a = Account(owner_id=user.id, account_kind=AccountKind.ASSET, account_type=AccountType.CHECKING, name="Checking", currency="CAD")
     db.add(a)
     await db.flush()
 
     result = await db.get(Account, a.id)
-    assert result.is_hidden is False
+    assert result.is_archived is False
 
 
 async def test_nullable_fields_default_to_null(db, user, currency):

--- a/backend/tests/routes/test_account.py
+++ b/backend/tests/routes/test_account.py
@@ -83,6 +83,36 @@ def _created_at_in_tz(account_data: dict, tz: str) -> date:
     return datetime.fromisoformat(account_data["created_at"]).astimezone(ZoneInfo(tz)).date()
 
 
+def _clock_on_account_day(account_data: dict, tz: str) -> _FixedClock:
+    dt = _created_at_in_tz(account_data, tz)
+    return _FixedClock(datetime(dt.year, dt.month, dt.day, 16, 0, tzinfo=ZoneInfo(tz)))
+
+
+async def _archive_adjustment_rows(account_id: str):
+    async with TestSession() as session:
+        return (await session.execute(
+            select(Transaction, Category)
+            .join(Category, Category.id == Transaction.category_id)
+            .where(
+                Transaction.account_id == UUID(account_id),
+                Transaction.notes == "Account archived",
+            )
+            .order_by(Transaction.created_at),
+        )).all()
+
+
+async def _latest_snapshot_balance(account_id: str) -> int:
+    async with TestSession() as session:
+        balance = await session.scalar(
+            select(AccountBalanceSnapshot.balance)
+            .where(AccountBalanceSnapshot.account_id == UUID(account_id))
+            .order_by(AccountBalanceSnapshot.dt.desc())
+            .limit(1),
+        )
+        assert balance is not None
+        return balance
+
+
 # --- GET /accounts ---
 
 
@@ -882,6 +912,100 @@ async def test_patch_account_updates_is_archived(client):
 
     assert resp.status_code == 200
     assert resp.json()["is_archived"] is True
+
+
+async def test_patch_account_archiving_non_zero_balance_creates_balance_adjustment(client, monkeypatch):
+    """Archiving a non-zero account records a balance adjustment to zero it out."""
+    from app.routes import account as account_routes
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_account(client, headers, starting_balance=12_500)
+    account_data = create_resp.json()
+    account_id = account_data["id"]
+    archive_dt = _created_at_in_tz(account_data, "America/Toronto")
+    monkeypatch.setattr(account_routes, "datetime", _clock_on_account_day(account_data, "America/Toronto"))
+
+    resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["is_archived"] is True
+    assert data["current_balance"] == 0
+    assert await _latest_snapshot_balance(account_id) == 0
+
+    rows = await _archive_adjustment_rows(account_id)
+    assert len(rows) == 1
+    txn, category = rows[0]
+    assert txn.amount == -12_500
+    assert txn.currency == "CAD"
+    assert txn.dt == archive_dt
+    assert category.name == "Balance Adjustment"
+    assert category.kind == CategoryKind.TRANSFER
+
+
+async def test_patch_account_archiving_zero_balance_skips_balance_adjustment(client, monkeypatch):
+    """Archiving an already-zero account does not create a balance adjustment."""
+    from app.routes import account as account_routes
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_account(client, headers)
+    account_data = create_resp.json()
+    account_id = account_data["id"]
+    monkeypatch.setattr(account_routes, "datetime", _clock_on_account_day(account_data, "America/Toronto"))
+
+    resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["is_archived"] is True
+    assert resp.json()["current_balance"] == 0
+    assert await _archive_adjustment_rows(account_id) == []
+
+
+async def test_patch_account_archiving_is_idempotent(client, monkeypatch):
+    """Archiving an already-archived account does not create another adjustment."""
+    from app.routes import account as account_routes
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_account(client, headers, starting_balance=25_000)
+    account_data = create_resp.json()
+    account_id = account_data["id"]
+    monkeypatch.setattr(account_routes, "datetime", _clock_on_account_day(account_data, "America/Toronto"))
+
+    first = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+    second = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    assert second.json()["current_balance"] == 0
+    rows = await _archive_adjustment_rows(account_id)
+    assert len(rows) == 1
+    assert rows[0][0].amount == -25_000
+
+
+async def test_patch_account_unarchiving_keeps_zeroed_balance(client, monkeypatch):
+    """Unarchiving does not reverse the archive balance adjustment."""
+    from app.routes import account as account_routes
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_account(client, headers, starting_balance=42_000)
+    account_data = create_resp.json()
+    account_id = account_data["id"]
+    monkeypatch.setattr(account_routes, "datetime", _clock_on_account_day(account_data, "America/Toronto"))
+
+    archive_resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+    unarchive_resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": False}, headers=headers)
+
+    assert archive_resp.status_code == 200
+    assert unarchive_resp.status_code == 200
+    assert unarchive_resp.json()["is_archived"] is False
+    assert unarchive_resp.json()["current_balance"] == 0
+    rows = await _archive_adjustment_rows(account_id)
+    assert len(rows) == 1
+    assert rows[0][0].amount == -42_000
 
 
 async def test_patch_account_sets_closed_at(client):

--- a/backend/tests/routes/test_account.py
+++ b/backend/tests/routes/test_account.py
@@ -142,7 +142,7 @@ async def test_list_accounts_returns_overview_shape(client):
         "id", "owner_id", "group_id", "account_kind", "account_type", "name",
         "tax_advantaged_plan_id", "currency", "institution", "current_balance",
         "base_currency_current_balance", "current_balance_fx_status", "credit_limit",
-        "is_hidden", "closed_at",
+        "is_archived", "closed_at",
     ):
         assert field in row, f"missing overview field: {field}"
 
@@ -537,7 +537,7 @@ async def test_get_account_returns_account(client):
         "current_year_withdrawal_limit",
     ):
         assert field not in data
-    assert data["is_hidden"] is False
+    assert data["is_archived"] is False
     assert data["closed_at"] is None
     assert data["created_at"] is not None
 
@@ -599,7 +599,7 @@ async def test_create_account_returns_201(client):
     assert data["name"] == ACCOUNT_PAYLOAD["name"]
     assert data["account_type"] == ACCOUNT_PAYLOAD["account_type"]
     assert data["currency"] == ACCOUNT_PAYLOAD["currency"]
-    assert data["is_hidden"] is False
+    assert data["is_archived"] is False
     assert data["id"] is not None
     assert data["created_at"] is not None
 
@@ -820,13 +820,13 @@ async def test_create_account_with_all_optional_fields(client):
     resp = await _create_account(
         client, headers,
         institution_id=str(inst.id),
-        is_hidden=True,
+        is_archived=True,
     )
 
     assert resp.status_code == 201
     data = resp.json()
     assert data["institution"]["id"] == str(inst.id)
-    assert data["is_hidden"] is True
+    assert data["is_archived"] is True
 
 
 async def test_create_account_owner_id_cannot_be_hijacked(client):
@@ -871,17 +871,17 @@ async def test_patch_account_updates_name(client):
     assert resp.json()["name"] == "Renamed"
 
 
-async def test_patch_account_updates_is_hidden(client):
-    """PATCH toggles is_hidden."""
+async def test_patch_account_updates_is_archived(client):
+    """PATCH toggles is_archived."""
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
     create_resp = await _create_account(client, headers)
     account_id = create_resp.json()["id"]
 
-    resp = await client.patch(f"/accounts/{account_id}", json={"is_hidden": True}, headers=headers)
+    resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
 
     assert resp.status_code == 200
-    assert resp.json()["is_hidden"] is True
+    assert resp.json()["is_archived"] is True
 
 
 async def test_patch_account_sets_closed_at(client):
@@ -928,17 +928,17 @@ async def test_patch_account_explicit_null_name_returns_422(client):
     assert resp.json()["detail"] == "name cannot be null"
 
 
-async def test_patch_account_explicit_null_is_hidden_returns_422(client):
-    """Explicit null on is_hidden would violate NOT NULL — reject with 422."""
+async def test_patch_account_explicit_null_is_archived_returns_422(client):
+    """Explicit null on is_archived would violate NOT NULL — reject with 422."""
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
     create_resp = await _create_account(client, headers)
     account_id = create_resp.json()["id"]
 
-    resp = await client.patch(f"/accounts/{account_id}", json={"is_hidden": None}, headers=headers)
+    resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": None}, headers=headers)
 
     assert resp.status_code == 422
-    assert resp.json()["detail"] == "is_hidden cannot be null"
+    assert resp.json()["detail"] == "is_archived cannot be null"
 
 
 async def test_patch_account_explicit_null_closed_at_still_clears_field(client):

--- a/backend/tests/routes/test_account_tax_advantaged_plan.py
+++ b/backend/tests/routes/test_account_tax_advantaged_plan.py
@@ -102,7 +102,7 @@ async def test_list_accounts_includes_tax_advantaged_plan_id(client):
             "base_currency_current_balance": 0,
             "current_balance_fx_status": {"state": "none", "missing_pairs": []},
             "credit_limit": None,
-            "is_hidden": False,
+            "is_archived": False,
             "closed_at": None,
         },
     ]

--- a/backend/tests/routes/test_dashboard_timezone.py
+++ b/backend/tests/routes/test_dashboard_timezone.py
@@ -883,8 +883,8 @@ async def test_dashboard_spending_comparison_reports_unavailable_fx(client, monk
     }
 
 
-async def test_dashboard_excludes_hidden_accounts_from_net_worth_and_credit(client, monkeypatch):
-    """Dashboard balance aggregates use visible accounts only."""
+async def test_dashboard_excludes_archived_accounts_from_net_worth_and_credit(client, monkeypatch):
+    """Dashboard balance aggregates use non-archived accounts only."""
     from app.routes import dashboard as dashboard_routes
 
     monkeypatch.setattr(dashboard_routes, "datetime", _FixedClock(datetime(2026, 3, 20, 16, 0, tzinfo=UTC)))
@@ -892,7 +892,7 @@ async def test_dashboard_excludes_hidden_accounts_from_net_worth_and_credit(clie
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
     visible_asset = (await _create_account(client, headers, name="Visible Cash")).json()
-    hidden_asset = (await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()
+    archived_asset = (await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()
     visible_credit = (await _create_account(
         client, headers,
         account_kind="revolving",
@@ -900,27 +900,27 @@ async def test_dashboard_excludes_hidden_accounts_from_net_worth_and_credit(clie
         name="Visible Card",
         credit_limit=200_000,
     )).json()
-    hidden_credit = (await _create_account(
+    archived_credit = (await _create_account(
         client, headers,
         account_kind="revolving",
         account_type="credit_card",
-        name="Hidden Card",
+        name="Archived Card",
         credit_limit=900_000,
-        is_hidden=True,
+        is_archived=True,
     )).json()
 
     async with TestSession() as session:
         session.add_all([
             AccountBalanceSnapshot(account_id=UUID(visible_asset["id"]), dt=date(2026, 3, 20), balance=100_000),
-            AccountBalanceSnapshot(account_id=UUID(hidden_asset["id"]), dt=date(2026, 3, 20), balance=500_000),
+            AccountBalanceSnapshot(account_id=UUID(archived_asset["id"]), dt=date(2026, 3, 20), balance=500_000),
             AccountBalanceSnapshot(account_id=UUID(visible_credit["id"]), dt=date(2026, 3, 20), balance=-30_000),
-            AccountBalanceSnapshot(account_id=UUID(hidden_credit["id"]), dt=date(2026, 3, 20), balance=-70_000),
+            AccountBalanceSnapshot(account_id=UUID(archived_credit["id"]), dt=date(2026, 3, 20), balance=-70_000),
         ])
         for account, balance in [
             (visible_asset, 100_000),
-            (hidden_asset, 500_000),
+            (archived_asset, 500_000),
             (visible_credit, -30_000),
-            (hidden_credit, -70_000),
+            (archived_credit, -70_000),
         ]:
             await session.execute(
                 update(AccountBalanceSnapshot)
@@ -1310,8 +1310,8 @@ async def test_dashboard_credit_used_ignores_positive_card_balances(client, monk
     assert data["fx_status"] == {"state": "none", "missing_pairs": []}
 
 
-async def test_dashboard_spending_savings_and_activity_exclude_hidden_accounts(client, monkeypatch):
-    """Dashboard transaction aggregates and recent activity use visible accounts only."""
+async def test_dashboard_spending_savings_and_activity_exclude_archived_accounts(client, monkeypatch):
+    """Dashboard transaction aggregates and recent activity use non-archived accounts only."""
     from app.routes import dashboard as dashboard_routes
 
     monkeypatch.setattr(dashboard_routes, "datetime", _FixedClock(datetime(2026, 3, 20, 16, 0, tzinfo=UTC)))
@@ -1319,7 +1319,7 @@ async def test_dashboard_spending_savings_and_activity_exclude_hidden_accounts(c
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
     visible_account_id = (await _create_account(client, headers, name="Visible Cash")).json()["id"]
-    hidden_account_id = (await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"]
     income_id = (await _create_category(client, headers, name="Test Salary", kind="income")).json()["id"]
     expense_id = (await _create_category(client, headers, name="Test Groceries", kind="expense")).json()["id"]
     merchant_id = (await _create_merchant(client, headers, name="Visible Store")).json()["id"]
@@ -1328,8 +1328,8 @@ async def test_dashboard_spending_savings_and_activity_exclude_hidden_accounts(c
     visible_expense = await _create_transaction(
         client, headers, visible_account_id, expense_id, dt="2026-03-16", amount=-200_000, merchant_id=merchant_id,
     )
-    await _create_transaction(client, headers, hidden_account_id, income_id, dt="2026-03-17", amount=700_000)
-    await _create_transaction(client, headers, hidden_account_id, expense_id, dt="2026-03-18", amount=-300_000)
+    await _create_transaction(client, headers, archived_account_id, income_id, dt="2026-03-17", amount=700_000)
+    await _create_transaction(client, headers, archived_account_id, expense_id, dt="2026-03-18", amount=-300_000)
 
     recent_activity_resp = await client.get("/dashboard/recent-activity", headers=headers)
     savings_rate_resp = await client.get("/dashboard/savings-rate", headers=headers)

--- a/backend/tests/routes/test_dashboard_timezone.py
+++ b/backend/tests/routes/test_dashboard_timezone.py
@@ -7,6 +7,7 @@ from sqlalchemy import update
 
 from app.models.account import AccountBalanceSnapshot
 from app.models.currency import Currency
+from app.models.transaction import Transaction
 from tests.conftest import TestSession
 from tests.routes.conftest import _create_account, _create_user, _get_auth_header
 
@@ -883,8 +884,8 @@ async def test_dashboard_spending_comparison_reports_unavailable_fx(client, monk
     }
 
 
-async def test_dashboard_excludes_archived_accounts_from_net_worth_and_credit(client, monkeypatch):
-    """Dashboard balance aggregates use non-archived accounts only."""
+async def test_dashboard_includes_archived_accounts_in_net_worth_and_credit(client, monkeypatch):
+    """Dashboard balance aggregates include archived accounts."""
     from app.routes import dashboard as dashboard_routes
 
     monkeypatch.setattr(dashboard_routes, "datetime", _FixedClock(datetime(2026, 3, 20, 16, 0, tzinfo=UTC)))
@@ -936,16 +937,16 @@ async def test_dashboard_excludes_archived_accounts_from_net_worth_and_credit(cl
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["current_net_worth"] == 70_000
-    assert data["net_worth_history"][-1] == 70_000
+    assert data["current_net_worth"] == 500_000
+    assert data["net_worth_history"][-1] == 500_000
     assert data["fx_status"] == {"state": "none", "missing_pairs": []}
 
     credit_resp = await client.get("/dashboard/credit", headers=headers)
 
     assert credit_resp.status_code == 200
     credit_data = credit_resp.json()
-    assert credit_data["credit_limit_total"] == 200_000
-    assert credit_data["credit_used"] == 30_000
+    assert credit_data["credit_limit_total"] == 1_100_000
+    assert credit_data["credit_used"] == 100_000
     assert credit_data["fx_status"] == {"state": "none", "missing_pairs": []}
 
 
@@ -1310,14 +1311,15 @@ async def test_dashboard_credit_used_ignores_positive_card_balances(client, monk
     assert data["fx_status"] == {"state": "none", "missing_pairs": []}
 
 
-async def test_dashboard_spending_savings_and_activity_exclude_archived_accounts(client, monkeypatch):
-    """Dashboard transaction aggregates and recent activity use non-archived accounts only."""
+async def test_dashboard_spending_savings_and_activity_include_archived_accounts(client, monkeypatch):
+    """Dashboard transaction aggregates and recent activity include archived accounts."""
     from app.routes import dashboard as dashboard_routes
 
     monkeypatch.setattr(dashboard_routes, "datetime", _FixedClock(datetime(2026, 3, 20, 16, 0, tzinfo=UTC)))
 
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
+    user_id = UUID(signup_resp.json()["user"]["id"])
     visible_account_id = (await _create_account(client, headers, name="Visible Cash")).json()["id"]
     archived_account_id = (await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"]
     income_id = (await _create_category(client, headers, name="Test Salary", kind="income")).json()["id"]
@@ -1328,8 +1330,28 @@ async def test_dashboard_spending_savings_and_activity_exclude_archived_accounts
     visible_expense = await _create_transaction(
         client, headers, visible_account_id, expense_id, dt="2026-03-16", amount=-200_000, merchant_id=merchant_id,
     )
-    await _create_transaction(client, headers, archived_account_id, income_id, dt="2026-03-17", amount=700_000)
-    await _create_transaction(client, headers, archived_account_id, expense_id, dt="2026-03-18", amount=-300_000)
+    async with TestSession() as session:
+        archived_income = Transaction(
+            created_by_user_id=user_id,
+            account_id=UUID(archived_account_id),
+            category_id=UUID(income_id),
+            dt=date(2026, 3, 17),
+            amount=700_000,
+            currency="CAD",
+        )
+        archived_expense = Transaction(
+            created_by_user_id=user_id,
+            account_id=UUID(archived_account_id),
+            category_id=UUID(expense_id),
+            dt=date(2026, 3, 18),
+            amount=-300_000,
+            currency="CAD",
+        )
+        session.add_all([archived_income, archived_expense])
+        await session.flush()
+        archived_income_id = str(archived_income.id)
+        archived_expense_id = str(archived_expense.id)
+        await session.commit()
 
     recent_activity_resp = await client.get("/dashboard/recent-activity", headers=headers)
     savings_rate_resp = await client.get("/dashboard/savings-rate", headers=headers)
@@ -1341,19 +1363,24 @@ async def test_dashboard_spending_savings_and_activity_exclude_archived_accounts
     assert savings_rate_resp.status_code == 200
     assert savings_rate_resp.json()["savings_rate_history"][-1] == {
         "month": "2026-03-01",
-        "income": 500_000,
-        "expenses": 200_000,
+        "income": 1_200_000,
+        "expenses": 500_000,
     }
     recent_ids = {txn["id"] for txn in recent_activity["recent_transactions"]}
-    assert recent_ids == {visible_income.json()["id"], visible_expense.json()["id"]}
+    assert recent_ids == {
+        visible_income.json()["id"],
+        visible_expense.json()["id"],
+        archived_income_id,
+        archived_expense_id,
+    }
     recent_by_id = {txn["id"]: txn for txn in recent_activity["recent_transactions"]}
     assert recent_by_id[visible_expense.json()["id"]]["merchant_name"] == "Visible Store"
 
     assert breakdown_resp.status_code == 200
     breakdown_data = breakdown_resp.json()
-    assert breakdown_data["expense"][0]["amount"] == 200_000
+    assert breakdown_data["expense"][0]["amount"] == 500_000
     assert breakdown_data["fx_status"] == {"state": "none", "missing_pairs": []}
     assert comparison_resp.status_code == 200
     comparison_data = comparison_resp.json()
-    assert comparison_data["current"][-1] == 200_000
+    assert comparison_data["current"][-1] == 500_000
     assert comparison_data["fx_status"] == {"state": "none", "missing_pairs": []}

--- a/backend/tests/routes/test_insights_cash_flow.py
+++ b/backend/tests/routes/test_insights_cash_flow.py
@@ -48,13 +48,13 @@ async def _get_category_id(client, headers, name: str) -> UUID:
 
 
 async def test_cash_flow_returns_daily_buckets_and_excludes_non_cash_flow_rows(client):
-    """Daily buckets include transfers by sign and exclude hidden and adjustment rows."""
+    """Daily buckets include transfers by sign and exclude archived and adjustment rows."""
     signup_resp = await _create_user(client)
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
 
     account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
-    hidden_account_id = UUID((await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()["id"])
+    archived_account_id = UUID((await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"])
     salary_id, salary = _category(user_id, "Payroll", CategoryKind.INCOME)
     groceries_id, groceries = _category(user_id, "Groceries Test", CategoryKind.EXPENSE)
     transfer_id, transfer = _category(user_id, "Transfer Test", CategoryKind.TRANSFER)
@@ -71,7 +71,7 @@ async def test_cash_flow_returns_daily_buckets_and_excludes_non_cash_flow_rows(c
             _transaction(user_id, account_id, transfer_id, date(2026, 5, 4), -7_000),
             _transaction(user_id, account_id, balance_adjustment_id, date(2026, 5, 5), 999_999),
             _transaction(user_id, account_id, salary_id, date(2026, 4, 30), 50_000),
-            _transaction(user_id, hidden_account_id, salary_id, date(2026, 5, 1), 800_000),
+            _transaction(user_id, archived_account_id, salary_id, date(2026, 5, 1), 800_000),
         ])
         await session.commit()
 

--- a/backend/tests/routes/test_insights_cash_flow.py
+++ b/backend/tests/routes/test_insights_cash_flow.py
@@ -48,7 +48,7 @@ async def _get_category_id(client, headers, name: str) -> UUID:
 
 
 async def test_cash_flow_returns_daily_buckets_and_excludes_non_cash_flow_rows(client):
-    """Daily buckets include transfers by sign and exclude archived and adjustment rows."""
+    """Daily buckets include transfers and archived account rows, excluding adjustment rows."""
     signup_resp = await _create_user(client)
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
@@ -84,7 +84,7 @@ async def test_cash_flow_returns_daily_buckets_and_excludes_non_cash_flow_rows(c
     assert response.status_code == 200
     assert response.json() == {
         "points": [
-            ["2026-05-01", "2026-05-01", 100_000, 0],
+            ["2026-05-01", "2026-05-01", 900_000, 0],
             ["2026-05-02", "2026-05-02", 0, 25_000],
             ["2026-05-03", "2026-05-03", 10_000, 0],
             ["2026-05-04", "2026-05-04", 0, 7_000],

--- a/backend/tests/routes/test_insights_fund_flow.py
+++ b/backend/tests/routes/test_insights_fund_flow.py
@@ -44,7 +44,7 @@ async def test_fund_flow_returns_all_base_currency_entries(client):
     headers = _get_auth_header(signup_resp)
 
     visible_account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
-    hidden_account_id = UUID((await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()["id"])
+    archived_account_id = UUID((await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"])
 
     salary_id, salary = _category(user_id, "Salary", CategoryKind.INCOME)
     freelance_id, freelance = _category(user_id, "Freelance", CategoryKind.INCOME)
@@ -92,8 +92,8 @@ async def test_fund_flow_returns_all_base_currency_entries(client):
             _transaction(user_id, visible_account_id, medical_id, date(2026, 3, 16), -40_000),
             _transaction(user_id, visible_account_id, transfer_id, date(2026, 3, 15), 999_999),
             _transaction(user_id, visible_account_id, salary_id, date(2026, 2, 28), 300_000),
-            _transaction(user_id, hidden_account_id, salary_id, date(2026, 3, 11), 700_000),
-            _transaction(user_id, hidden_account_id, housing_id, date(2026, 3, 11), -700_000),
+            _transaction(user_id, archived_account_id, salary_id, date(2026, 3, 11), 700_000),
+            _transaction(user_id, archived_account_id, housing_id, date(2026, 3, 11), -700_000),
         ])
         await session.commit()
 

--- a/backend/tests/routes/test_insights_fund_flow.py
+++ b/backend/tests/routes/test_insights_fund_flow.py
@@ -38,7 +38,7 @@ async def _seed_currency(currency_id: str, name: str, symbol: str, minor_unit_ex
 
 
 async def test_fund_flow_returns_all_base_currency_entries(client):
-    """The flow endpoint returns all visible base-currency entries and counts."""
+    """The flow endpoint returns all readable base-currency entries and counts."""
     signup_resp = await _create_user(client)
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
@@ -106,7 +106,7 @@ async def test_fund_flow_returns_all_base_currency_entries(client):
     assert resp.status_code == 200
     assert resp.json() == {
         "income_sources": [
-            ["Salary", 500_000],
+            ["Salary", 1_200_000],
             ["Freelance", 100_000],
             ["Bonus", 80_000],
             ["Interest", 70_000],
@@ -114,7 +114,7 @@ async def test_fund_flow_returns_all_base_currency_entries(client):
             ["Gift", 50_000],
         ],
         "expense_categories": [
-            ["Housing", 180_000],
+            ["Housing", 880_000],
             ["Groceries", 90_000],
             ["Dining", 80_000],
             ["Shopping", 70_000],

--- a/backend/tests/routes/test_insights_income_expense_breakdown.py
+++ b/backend/tests/routes/test_insights_income_expense_breakdown.py
@@ -114,7 +114,7 @@ async def test_income_expense_breakdown_returns_limited_period_payload(client):
     assert resp.status_code == 200
     assert resp.json() == {
         "expense": [
-            [str(housing_id), "Housing", "expense", 180_000],
+            [str(housing_id), "Housing", "expense", 880_000],
             [str(groceries_id), "Groceries", "expense", 90_000],
             [str(dining_id), "Dining", "expense", 80_000],
             [str(shopping_id), "Shopping", "expense", 70_000],
@@ -125,25 +125,24 @@ async def test_income_expense_breakdown_returns_limited_period_payload(client):
             [str(pets_id), "Pets", "expense", 20_000],
         ],
         "income": [
-            [str(salary_id), "Salary", "income", 500_000],
+            [str(salary_id), "Salary", "income", 1_200_000],
             [str(freelance_id), "Freelance", "income", 100_000],
             [str(bonus_id), "Bonus", "income", 80_000],
         ],
-        "expense_total": 620_000,
-        "income_total": 680_000,
+        "expense_total": 1_320_000,
+        "income_total": 1_380_000,
         "expense_increases": [
+            [str(housing_id), "Housing", 880_000, 200_000, 340, 2],
             [str(shopping_id), "Shopping", 70_000, 0, None, 1],
             [str(groceries_id), "Groceries", 90_000, 30_000, 200, 1],
-            [str(coffee_id), "Coffee", 30_000, 0, None, 1],
         ],
         "expense_decreases": [
             [str(old_utilities_id), "Old Utilities", 0, 55_000, -100, 0],
             [str(dining_id), "Dining", 80_000, 120_000, -33, 1],
-            [str(housing_id), "Housing", 180_000, 200_000, -10, 1],
         ],
         "income_increases": [
+            [str(salary_id), "Salary", 1_200_000, 450_000, 167, 2],
             [str(bonus_id), "Bonus", 80_000, 0, None, 1],
-            [str(salary_id), "Salary", 500_000, 450_000, 11, 1],
         ],
         "income_decreases": [
             [str(freelance_id), "Freelance", 100_000, 120_000, -17, 1],

--- a/backend/tests/routes/test_insights_income_expense_breakdown.py
+++ b/backend/tests/routes/test_insights_income_expense_breakdown.py
@@ -44,7 +44,7 @@ async def test_income_expense_breakdown_returns_limited_period_payload(client):
     headers = _get_auth_header(signup_resp)
 
     account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
-    hidden_account_id = UUID((await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()["id"])
+    archived_account_id = UUID((await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"])
 
     salary_id, salary = _category(user_id, "Salary", CategoryKind.INCOME)
     freelance_id, freelance = _category(user_id, "Freelance", CategoryKind.INCOME)
@@ -100,8 +100,8 @@ async def test_income_expense_breakdown_returns_limited_period_payload(client):
             _transaction(user_id, account_id, medical_id, date(2026, 3, 9), -40_000),
             _transaction(user_id, account_id, old_utilities_id, date(2026, 3, 9), -55_000),
             _transaction(user_id, account_id, salary_id, date(2026, 2, 28), 300_000),
-            _transaction(user_id, hidden_account_id, salary_id, date(2026, 3, 11), 700_000),
-            _transaction(user_id, hidden_account_id, housing_id, date(2026, 3, 11), -700_000),
+            _transaction(user_id, archived_account_id, salary_id, date(2026, 3, 11), 700_000),
+            _transaction(user_id, archived_account_id, housing_id, date(2026, 3, 11), -700_000),
         ])
         await session.commit()
 

--- a/backend/tests/routes/test_insights_merchant_distribution.py
+++ b/backend/tests/routes/test_insights_merchant_distribution.py
@@ -51,7 +51,7 @@ async def test_merchant_distribution_returns_top_merchants_and_other_with_change
     headers = _get_auth_header(signup_resp)
 
     account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
-    hidden_account_id = UUID((await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()["id"])
+    archived_account_id = UUID((await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"])
     expense_id, expense = _category(user_id, "Shopping", CategoryKind.EXPENSE)
     income_id, income = _category(user_id, "Salary", CategoryKind.INCOME)
     transfer_id, transfer = _category(user_id, "Transfer", CategoryKind.TRANSFER)
@@ -71,7 +71,7 @@ async def test_merchant_distribution_returns_top_merchants_and_other_with_change
             "Refund Only",
             "Income Merchant",
             "Transfer Merchant",
-            "Hidden Merchant",
+            "Archived Merchant",
         ]
     ]
     merchant_ids = {merchant.name: merchant_id for merchant_id, merchant in merchant_rows}
@@ -97,7 +97,7 @@ async def test_merchant_distribution_returns_top_merchants_and_other_with_change
             _transaction(user_id, account_id, income_id, date(2026, 4, 10), -999_999, merchant_ids["Income Merchant"]),
             _transaction(user_id, account_id, transfer_id, date(2026, 4, 10), -999_999, merchant_ids["Transfer Merchant"]),
             _transaction(user_id, account_id, expense_id, date(2026, 4, 10), -999_999, None),
-            _transaction(user_id, hidden_account_id, expense_id, date(2026, 4, 10), -999_999, merchant_ids["Hidden Merchant"]),
+            _transaction(user_id, archived_account_id, expense_id, date(2026, 4, 10), -999_999, merchant_ids["Archived Merchant"]),
             _transaction(user_id, account_id, expense_id, date(2026, 3, 20), -50_000, merchant_ids["Alpha Market"]),
             _transaction(user_id, account_id, expense_id, date(2026, 3, 20), -100_000, merchant_ids["Beta Grocer"]),
             _transaction(user_id, account_id, expense_id, date(2026, 3, 20), -90_000, merchant_ids["Diner Echo"]),

--- a/backend/tests/routes/test_insights_merchant_distribution.py
+++ b/backend/tests/routes/test_insights_merchant_distribution.py
@@ -115,6 +115,7 @@ async def test_merchant_distribution_returns_top_merchants_and_other_with_change
     assert resp.status_code == 200
     assert resp.json() == {
         "merchants": [
+            [str(merchant_ids["Archived Merchant"]), "Archived Merchant", 999_999, None, 999_999],
             [str(merchant_ids["Alpha Market"]), "Alpha Market", 100_000, 100, 50_000],
             [str(merchant_ids["Beta Grocer"]), "Beta Grocer", 90_000, -10, -10_000],
             [str(merchant_ids["Cafe Delta"]), "Cafe Delta", 80_000, None, 80_000],
@@ -122,8 +123,7 @@ async def test_merchant_distribution_returns_top_merchants_and_other_with_change
             [str(merchant_ids["Fitness Foxtrot"]), "Fitness Foxtrot", 60_000, None, 60_000],
             [str(merchant_ids["Gas Gamma"]), "Gas Gamma", 50_000, None, 50_000],
             [str(merchant_ids["Hotel Indigo"]), "Hotel Indigo", 40_000, None, 40_000],
-            [str(merchant_ids["Market Juliet"]), "Market Juliet", 30_000, None, 30_000],
-            ["other-merchants", "Other", 30_000, None, None],
+            ["other-merchants", "Other", 60_000, None, None],
         ],
     }
 

--- a/backend/tests/routes/test_insights_merchant_ranking.py
+++ b/backend/tests/routes/test_insights_merchant_ranking.py
@@ -51,7 +51,7 @@ async def test_merchant_ranking_returns_ranked_rows_with_counts_and_changes(clie
     headers = _get_auth_header(signup_resp)
 
     account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
-    hidden_account_id = UUID((await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()["id"])
+    archived_account_id = UUID((await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"])
     expense_id, expense = _category(user_id, "Shopping", CategoryKind.EXPENSE)
     income_id, income = _category(user_id, "Salary", CategoryKind.INCOME)
     transfer_id, transfer = _category(user_id, "Transfer", CategoryKind.TRANSFER)
@@ -68,7 +68,7 @@ async def test_merchant_ranking_returns_ranked_rows_with_counts_and_changes(clie
             "Refund Only",
             "Income Merchant",
             "Transfer Merchant",
-            "Hidden Merchant",
+            "Archived Merchant",
         ]
     ]
     merchant_ids = {merchant.name: merchant_id for merchant_id, merchant in merchant_rows}
@@ -91,7 +91,7 @@ async def test_merchant_ranking_returns_ranked_rows_with_counts_and_changes(clie
             _transaction(user_id, account_id, income_id, date(2026, 4, 10), -999_999, merchant_ids["Income Merchant"]),
             _transaction(user_id, account_id, transfer_id, date(2026, 4, 10), -999_999, merchant_ids["Transfer Merchant"]),
             _transaction(user_id, account_id, expense_id, date(2026, 4, 10), -999_999, None),
-            _transaction(user_id, hidden_account_id, expense_id, date(2026, 4, 10), -999_999, merchant_ids["Hidden Merchant"]),
+            _transaction(user_id, archived_account_id, expense_id, date(2026, 4, 10), -999_999, merchant_ids["Archived Merchant"]),
             _transaction(user_id, account_id, expense_id, date(2026, 3, 20), -50_000, merchant_ids["Alpha Market"]),
             _transaction(user_id, account_id, expense_id, date(2026, 3, 20), -100_000, merchant_ids["Beta Grocer"]),
             _transaction(user_id, account_id, expense_id, date(2026, 3, 20), -90_000, merchant_ids["Diner Echo"]),

--- a/backend/tests/routes/test_insights_merchant_ranking.py
+++ b/backend/tests/routes/test_insights_merchant_ranking.py
@@ -108,6 +108,7 @@ async def test_merchant_ranking_returns_ranked_rows_with_counts_and_changes(clie
     assert resp.status_code == 200
     assert resp.json() == {
         "merchants": [
+            [str(merchant_ids["Archived Merchant"]), "Archived Merchant", 999_999, 1, None],
             [str(merchant_ids["Alpha Market"]), "Alpha Market", 100_000, 2, 100],
             [str(merchant_ids["Beta Grocer"]), "Beta Grocer", 90_000, 1, -10],
             [str(merchant_ids["Cafe Delta"]), "Cafe Delta", 80_000, 1, None],

--- a/backend/tests/routes/test_insights_net_worth.py
+++ b/backend/tests/routes/test_insights_net_worth.py
@@ -36,7 +36,7 @@ async def _create_plan(client, headers, **overrides):
 
 
 async def test_net_worth_returns_compact_daily_signed_group_series(client):
-    """Daily buckets group balances, preserve debt signs, and exclude archived accounts."""
+    """Daily buckets group balances, preserve debt signs, and include archived accounts."""
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
 
@@ -83,8 +83,8 @@ async def test_net_worth_returns_compact_daily_signed_group_series(client):
     assert data["baseline"] == [120_000, -50_000]
     assert data["points"] == [
         ["2026-05-01", "2026-05-01", [120_000, -50_000]],
-        ["2026-05-02", "2026-05-02", [150_000, -50_000]],
-        ["2026-05-03", "2026-05-03", [150_000, -80_000]],
+        ["2026-05-02", "2026-05-02", [9_150_000, -50_000]],
+        ["2026-05-03", "2026-05-03", [9_150_000, -80_000]],
     ]
     assert data["fx_status"] == {"state": "none", "missing_pairs": []}
 

--- a/backend/tests/routes/test_insights_net_worth.py
+++ b/backend/tests/routes/test_insights_net_worth.py
@@ -36,7 +36,7 @@ async def _create_plan(client, headers, **overrides):
 
 
 async def test_net_worth_returns_compact_daily_signed_group_series(client):
-    """Daily buckets group balances, preserve debt signs, and exclude hidden accounts."""
+    """Daily buckets group balances, preserve debt signs, and exclude archived accounts."""
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
 
@@ -50,11 +50,11 @@ async def test_net_worth_returns_compact_daily_signed_group_series(client):
         name="CAD Card",
         credit_limit=500_000,
     )).json()
-    hidden_account = (await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()
+    archived_account = (await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()
     cash_account_id = UUID(cash_account["id"])
     savings_account_id = UUID(savings_account["id"])
     card_account_id = UUID(card_account["id"])
-    hidden_account_id = UUID(hidden_account["id"])
+    archived_account_id = UUID(archived_account["id"])
 
     async with TestSession() as session:
         session.add_all([
@@ -64,7 +64,7 @@ async def test_net_worth_returns_compact_daily_signed_group_series(client):
             _snapshot(savings_account_id, date(2026, 5, 2), 30_000),
             _snapshot(card_account_id, date(2026, 4, 30), -50_000),
             _snapshot(card_account_id, date(2026, 5, 3), -80_000),
-            _snapshot(hidden_account_id, date(2026, 5, 2), 9_000_000),
+            _snapshot(archived_account_id, date(2026, 5, 2), 9_000_000),
         ])
         await session.commit()
 

--- a/backend/tests/routes/test_insights_period_glance.py
+++ b/backend/tests/routes/test_insights_period_glance.py
@@ -69,9 +69,9 @@ async def test_period_glance_returns_compact_period_summary(client):
     headers = _get_auth_header(signup_resp)
 
     visible_account = (await _create_account(client, headers, name="Visible Cash")).json()
-    hidden_account = (await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()
+    archived_account = (await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()
     visible_account_id = UUID(visible_account["id"])
-    hidden_account_id = UUID(hidden_account["id"])
+    archived_account_id = UUID(archived_account["id"])
     salary_id, salary = _category(user_id, "Salary", CategoryKind.INCOME)
     groceries_id, groceries = _category(user_id, "Groceries", CategoryKind.EXPENSE)
     dining_id, dining = _category(user_id, "Dining", CategoryKind.EXPENSE)
@@ -93,13 +93,13 @@ async def test_period_glance_returns_compact_period_summary(client):
             _transaction(user_id, visible_account_id, balance_adjustment_id, date(2026, 3, 15), 999_999),
             _transaction(user_id, visible_account_id, groceries_id, date(2026, 3, 4), -40_000),
             _transaction(user_id, visible_account_id, dining_id, date(2026, 3, 5), -100_000),
-            _transaction(user_id, hidden_account_id, salary_id, date(2026, 3, 12), 700_000),
-            _transaction(user_id, hidden_account_id, groceries_id, date(2026, 3, 13), -300_000),
+            _transaction(user_id, archived_account_id, salary_id, date(2026, 3, 12), 700_000),
+            _transaction(user_id, archived_account_id, groceries_id, date(2026, 3, 13), -300_000),
             _snapshot(visible_account_id, date(2026, 3, 9), 1_000_000),
             _snapshot(visible_account_id, date(2026, 3, 10), 1_000_000),
             _snapshot(visible_account_id, date(2026, 3, 16), 1_320_000),
-            _snapshot(hidden_account_id, date(2026, 3, 10), 5_000_000),
-            _snapshot(hidden_account_id, date(2026, 3, 16), 6_000_000),
+            _snapshot(archived_account_id, date(2026, 3, 10), 5_000_000),
+            _snapshot(archived_account_id, date(2026, 3, 16), 6_000_000),
         ])
         await session.commit()
 

--- a/backend/tests/routes/test_insights_period_glance.py
+++ b/backend/tests/routes/test_insights_period_glance.py
@@ -63,7 +63,7 @@ async def _create_transaction_api(client, headers, account_id, category_id, **ov
 
 
 async def test_period_glance_returns_compact_period_summary(client):
-    """Period glance aggregates visible base-currency activity only."""
+    """Period glance aggregates readable base-currency activity, including archived accounts."""
     signup_resp = await _create_user(client)
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
@@ -112,17 +112,17 @@ async def test_period_glance_returns_compact_period_summary(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data == {
-        "income": 500_000,
-        "expenses": 180_000,
+        "income": 1_200_000,
+        "expenses": 480_000,
         "income_expense_fx_status": {"state": "none", "missing_pairs": []},
-        "net_worth_change": 320_000,
+        "net_worth_change": 6_320_000,
         "net_worth_change_fx_status": {"state": "none", "missing_pairs": []},
         "top_category_name": "Groceries",
-        "top_category_share_pct": 67,
+        "top_category_share_pct": 88,
         "top_category_fx_status": {"state": "none", "missing_pairs": []},
         "biggest_change_name": "Groceries",
-        "biggest_change_amount": 80_000,
-        "biggest_change_pct": 200,
+        "biggest_change_amount": 380_000,
+        "biggest_change_pct": 950,
         "biggest_change_fx_status": {"state": "none", "missing_pairs": []},
     }
 

--- a/backend/tests/routes/test_insights_savings_rate_trend.py
+++ b/backend/tests/routes/test_insights_savings_rate_trend.py
@@ -57,7 +57,7 @@ async def test_savings_rate_trend_returns_latest_available_monthly_totals(client
     headers = _get_auth_header(signup_resp)
 
     account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
-    hidden_account_id = UUID((await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()["id"])
+    archived_account_id = UUID((await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"])
     salary_id, salary = _category(user_id, "Salary", CategoryKind.INCOME)
     groceries_id, groceries = _category(user_id, "Groceries", CategoryKind.EXPENSE)
     transfer_id, transfer = _category(user_id, "Transfer", CategoryKind.TRANSFER)
@@ -75,8 +75,8 @@ async def test_savings_rate_trend_returns_latest_available_monthly_totals(client
             _transaction(user_id, account_id, groceries_id, date(2026, 5, 2), -300_000),
             _transaction(user_id, account_id, salary_id, date(2026, 6, 1), 999_999),
             _transaction(user_id, account_id, groceries_id, date(2026, 6, 2), -999_999),
-            _transaction(user_id, hidden_account_id, salary_id, date(2026, 5, 1), 700_000),
-            _transaction(user_id, hidden_account_id, groceries_id, date(2026, 5, 2), -700_000),
+            _transaction(user_id, archived_account_id, salary_id, date(2026, 5, 1), 700_000),
+            _transaction(user_id, archived_account_id, groceries_id, date(2026, 5, 2), -700_000),
         ])
         await session.commit()
 
@@ -337,13 +337,13 @@ async def test_savings_rate_trend_returns_empty_payload_without_visible_accounts
     user_id = UUID(signup_resp.json()["user"]["id"])
     headers = _get_auth_header(signup_resp)
 
-    hidden_account_id = UUID((await _create_account(client, headers, name="Hidden Cash", is_hidden=True)).json()["id"])
+    archived_account_id = UUID((await _create_account(client, headers, name="Archived Cash", is_archived=True)).json()["id"])
     salary_id, salary = _category(user_id, "Salary", CategoryKind.INCOME)
 
     async with TestSession() as session:
         session.add_all([
             salary,
-            _transaction(user_id, hidden_account_id, salary_id, date(2026, 5, 1), 600_000),
+            _transaction(user_id, archived_account_id, salary_id, date(2026, 5, 1), 600_000),
         ])
         await session.commit()
 

--- a/backend/tests/routes/test_insights_savings_rate_trend.py
+++ b/backend/tests/routes/test_insights_savings_rate_trend.py
@@ -88,7 +88,7 @@ async def test_savings_rate_trend_returns_latest_available_monthly_totals(client
             ["2026-02-01", 500_000, 200_000],
             ["2026-03-01", 0, 100_000],
             ["2026-04-01", 0, 0],
-            ["2026-05-01", 600_000, 300_000],
+            ["2026-05-01", 1_300_000, 1_000_000],
         ],
         "fx_status": {"state": "none", "missing_pairs": []},
     }
@@ -328,8 +328,8 @@ async def test_savings_rate_trend_routes_flipped_categories_by_monthly_net(clien
     }
 
 
-async def test_savings_rate_trend_returns_empty_payload_without_visible_accounts(client, monkeypatch):
-    """Users without visible accounts receive an empty payload."""
+async def test_savings_rate_trend_includes_archived_only_activity(client, monkeypatch):
+    """Archived-only account activity is still included in monthly totals."""
     from app.routes import insights as insights_routes
 
     monkeypatch.setattr(insights_routes, "datetime", _FixedClock(datetime(2026, 5, 19, 16, 0, tzinfo=UTC)))
@@ -351,7 +351,7 @@ async def test_savings_rate_trend_returns_empty_payload_without_visible_accounts
 
     assert resp.status_code == 200
     assert resp.json() == {
-        "points": [],
+        "points": [["2026-05-01", 600_000, 0]],
         "fx_status": {"state": "none", "missing_pairs": []},
     }
 

--- a/backend/tests/routes/test_tax_advantaged_plan.py
+++ b/backend/tests/routes/test_tax_advantaged_plan.py
@@ -323,6 +323,30 @@ async def test_plan_detail_aggregates_transfer_activity_across_linked_accounts(c
     assert resp.json()["lifetime_withdrawals"] == 15_000
 
 
+async def test_plan_detail_includes_archived_linked_account_activity(client):
+    """Archived linked accounts still count historical transfer activity."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = signup_resp.json()["user"]["id"]
+    plan_id = (await _create_plan(client, headers)).json()["id"]
+    account_id = (await _create_account(client, headers, name="Archived TFSA", tax_advantaged_plan_id=plan_id)).json()["id"]
+    transfer_id = await _get_system_category_id("Transfer")
+    current_year = datetime.now(UTC).year
+
+    await _seed_transaction(account_id, transfer_id, user_id, 40_000, date(current_year, 2, 1))
+    await _seed_transaction(account_id, transfer_id, user_id, -5_000, date(current_year, 3, 1))
+    archive_resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
+
+    resp = await client.get(f"/tax-advantaged-plans/{plan_id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["ytd_contributions"] == 40_000
+    assert resp.json()["ytd_withdrawals"] == 5_000
+    assert resp.json()["lifetime_contributions"] == 40_000
+    assert resp.json()["lifetime_withdrawals"] == 5_000
+
+
 async def test_plan_metrics_only_count_transfer_category(client):
     """Only the seeded Transfer category counts as TAC activity."""
     signup_resp = await _create_user(client)

--- a/backend/tests/routes/test_transaction.py
+++ b/backend/tests/routes/test_transaction.py
@@ -2138,6 +2138,38 @@ async def test_move_transaction_to_archived_account_returns_422(client):
     assert resp.json()["detail"] == "Account is archived"
 
 
+async def test_patch_transaction_on_archived_account_returns_422(client):
+    """Editing existing history on an archived account is rejected."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    create_resp = await _create_transaction(client, headers, account_id, category_id, notes="before archive")
+    txn_id = create_resp.json()["id"]
+    archive_resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
+
+    resp = await client.patch(
+        f"/transactions/{txn_id}",
+        json={"notes": "after archive"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Account is archived"
+
+
+async def test_delete_transaction_on_archived_account_returns_422(client):
+    """Deleting existing history on an archived account is rejected."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    create_resp = await _create_transaction(client, headers, account_id, category_id)
+    txn_id = create_resp.json()["id"]
+    archive_resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
+
+    resp = await client.delete(f"/transactions/{txn_id}", headers=headers)
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Account is archived"
+
+
 async def test_create_transaction_on_closed_account_returns_422(client):
     """Creating a transaction on a closed account is rejected."""
     headers, account_id, category_id = await _setup_user_with_deps(client)

--- a/backend/tests/routes/test_transaction.py
+++ b/backend/tests/routes/test_transaction.py
@@ -633,31 +633,37 @@ async def test_list_transactions_returns_user_transactions(client):
     assert amounts == {-1000, -2000}
 
 
-async def test_list_transactions_excludes_archived_accounts_unscoped(client):
-    """Default transaction list excludes archived-account rows."""
+async def test_list_transactions_includes_archived_accounts_unscoped(client):
+    """Default transaction list includes archived-account history."""
     headers, account_id, category_id = await _setup_user_with_deps(client)
-    archived_account_id = (await _create_account(client, headers, name="Archived", is_archived=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived")).json()["id"]
 
     await _create_transaction(client, headers, account_id, category_id, amount=-1000)
     await _create_transaction(client, headers, archived_account_id, category_id, amount=-9000)
+    await _create_transaction(client, headers, archived_account_id, category_id, amount=9000)
+    archive_resp = await client.patch(f"/accounts/{archived_account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
 
     resp = await client.get("/transactions", headers=headers)
 
     assert resp.status_code == 200
-    assert [txn["amount"] for txn in resp.json()] == [-1000]
+    assert {txn["amount"] for txn in resp.json()} == {-1000, -9000, 9000}
 
 
 async def test_list_transactions_explicit_archived_account_is_allowed(client):
     """Directly filtering by an archived account still exposes its transactions."""
     headers, _, category_id = await _setup_user_with_deps(client)
-    archived_account_id = (await _create_account(client, headers, name="Archived", is_archived=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived")).json()["id"]
 
     await _create_transaction(client, headers, archived_account_id, category_id, amount=-9000)
+    await _create_transaction(client, headers, archived_account_id, category_id, amount=9000)
+    archive_resp = await client.patch(f"/accounts/{archived_account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
 
     resp = await client.get(f"/transactions?account_id={archived_account_id}", headers=headers)
 
     assert resp.status_code == 200
-    assert [txn["amount"] for txn in resp.json()] == [-9000]
+    assert {txn["amount"] for txn in resp.json()} == {-9000, 9000}
 
 
 async def test_list_transactions_without_auth_returns_401(client):
@@ -669,22 +675,24 @@ async def test_list_transactions_without_auth_returns_401(client):
 # --- GET /transactions/overview ---
 
 
-async def test_transactions_overview_excludes_archived_accounts_unscoped(client):
-    """Default transaction overview excludes archived-account activity."""
+async def test_transactions_overview_includes_archived_accounts_unscoped(client):
+    """Default transaction overview includes archived-account activity."""
     headers, account_id, category_id = await _setup_user_with_deps(client)
-    archived_account_id = (await _create_account(client, headers, name="Archived", is_archived=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived")).json()["id"]
 
     await _create_transaction(client, headers, account_id, category_id, amount=10_000)
     await _create_transaction(client, headers, account_id, category_id, amount=-4_000)
     await _create_transaction(client, headers, archived_account_id, category_id, amount=90_000)
     await _create_transaction(client, headers, archived_account_id, category_id, amount=-30_000)
+    archive_resp = await client.patch(f"/accounts/{archived_account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
 
     resp = await client.get("/transactions/overview", headers=headers)
 
     assert resp.status_code == 200
     data = resp.json()
-    assert data["total_inflow"] == 10_000
-    assert data["total_outflow"] == -4_000
+    assert data["total_inflow"] == 100_000
+    assert data["total_outflow"] == -34_000
     assert data["net_flow_fx_status"] == {"state": "none", "missing_pairs": []}
 
 
@@ -956,10 +964,12 @@ async def test_transactions_overview_daily_cash_flow_reports_incomplete_fx(clien
 async def test_transactions_overview_explicit_archived_account_is_allowed(client):
     """Explicit account_id keeps archived account detail inspectable."""
     headers, _, category_id = await _setup_user_with_deps(client)
-    archived_account_id = (await _create_account(client, headers, name="Archived", is_archived=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived")).json()["id"]
 
     await _create_transaction(client, headers, archived_account_id, category_id, amount=90_000)
     await _create_transaction(client, headers, archived_account_id, category_id, amount=-30_000)
+    archive_resp = await client.patch(f"/accounts/{archived_account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
 
     resp = await client.get(f"/transactions/overview?account_id={archived_account_id}", headers=headers)
 

--- a/backend/tests/routes/test_transaction.py
+++ b/backend/tests/routes/test_transaction.py
@@ -356,6 +356,27 @@ async def test_import_transactions_rejects_invalid_raw_amount(client):
     assert resp.json()["detail"] == "Invalid amount: $12.34"
 
 
+async def test_import_transactions_rejects_archived_account_mapping(client):
+    """Import cannot add new rows to an archived account."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    archive_resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
+
+    resp = await client.post("/transactions/import", json={
+        "accounts": [{"source": "Main Chequing", "account_id": account_id}],
+        "categories": [{"source": "Groceries", "category_id": category_id}],
+        "rows": [{
+            "account_source": "Main Chequing",
+            "category_source": "Groceries",
+            "dt": "2026-04-11",
+            "amount": "-10.00",
+        }],
+    }, headers=headers)
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Account is archived"
+
+
 # --- POST /transactions ---
 
 
@@ -2082,7 +2103,39 @@ async def test_delete_transaction_without_auth_returns_401(client):
     assert resp.status_code == 401
 
 
-# --- Transactions on closed accounts ---
+# --- Transactions on archived and closed accounts ---
+
+
+async def test_create_transaction_on_archived_account_returns_422(client):
+    """Creating a transaction on an archived account is rejected."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    archive_resp = await client.patch(f"/accounts/{account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
+
+    resp = await _create_transaction(client, headers, account_id, category_id)
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Account is archived"
+
+
+async def test_move_transaction_to_archived_account_returns_422(client):
+    """Moving a transaction to an archived account is rejected."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    archived_account_id = (await _create_account(client, headers, name="Archived Savings")).json()["id"]
+    archive_resp = await client.patch(f"/accounts/{archived_account_id}", json={"is_archived": True}, headers=headers)
+    assert archive_resp.status_code == 200
+
+    create_resp = await _create_transaction(client, headers, account_id, category_id)
+    txn_id = create_resp.json()["id"]
+
+    resp = await client.patch(
+        f"/transactions/{txn_id}",
+        json={"account_id": archived_account_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Account is archived"
 
 
 async def test_create_transaction_on_closed_account_returns_422(client):

--- a/backend/tests/routes/test_transaction.py
+++ b/backend/tests/routes/test_transaction.py
@@ -633,13 +633,13 @@ async def test_list_transactions_returns_user_transactions(client):
     assert amounts == {-1000, -2000}
 
 
-async def test_list_transactions_excludes_hidden_accounts_unscoped(client):
-    """Default transaction list excludes hidden-account rows."""
+async def test_list_transactions_excludes_archived_accounts_unscoped(client):
+    """Default transaction list excludes archived-account rows."""
     headers, account_id, category_id = await _setup_user_with_deps(client)
-    hidden_account_id = (await _create_account(client, headers, name="Hidden", is_hidden=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived", is_archived=True)).json()["id"]
 
     await _create_transaction(client, headers, account_id, category_id, amount=-1000)
-    await _create_transaction(client, headers, hidden_account_id, category_id, amount=-9000)
+    await _create_transaction(client, headers, archived_account_id, category_id, amount=-9000)
 
     resp = await client.get("/transactions", headers=headers)
 
@@ -647,14 +647,14 @@ async def test_list_transactions_excludes_hidden_accounts_unscoped(client):
     assert [txn["amount"] for txn in resp.json()] == [-1000]
 
 
-async def test_list_transactions_explicit_hidden_account_is_allowed(client):
-    """Directly filtering by a hidden account still exposes its transactions."""
+async def test_list_transactions_explicit_archived_account_is_allowed(client):
+    """Directly filtering by an archived account still exposes its transactions."""
     headers, _, category_id = await _setup_user_with_deps(client)
-    hidden_account_id = (await _create_account(client, headers, name="Hidden", is_hidden=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived", is_archived=True)).json()["id"]
 
-    await _create_transaction(client, headers, hidden_account_id, category_id, amount=-9000)
+    await _create_transaction(client, headers, archived_account_id, category_id, amount=-9000)
 
-    resp = await client.get(f"/transactions?account_id={hidden_account_id}", headers=headers)
+    resp = await client.get(f"/transactions?account_id={archived_account_id}", headers=headers)
 
     assert resp.status_code == 200
     assert [txn["amount"] for txn in resp.json()] == [-9000]
@@ -669,15 +669,15 @@ async def test_list_transactions_without_auth_returns_401(client):
 # --- GET /transactions/overview ---
 
 
-async def test_transactions_overview_excludes_hidden_accounts_unscoped(client):
-    """Default transaction overview excludes hidden-account activity."""
+async def test_transactions_overview_excludes_archived_accounts_unscoped(client):
+    """Default transaction overview excludes archived-account activity."""
     headers, account_id, category_id = await _setup_user_with_deps(client)
-    hidden_account_id = (await _create_account(client, headers, name="Hidden", is_hidden=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived", is_archived=True)).json()["id"]
 
     await _create_transaction(client, headers, account_id, category_id, amount=10_000)
     await _create_transaction(client, headers, account_id, category_id, amount=-4_000)
-    await _create_transaction(client, headers, hidden_account_id, category_id, amount=90_000)
-    await _create_transaction(client, headers, hidden_account_id, category_id, amount=-30_000)
+    await _create_transaction(client, headers, archived_account_id, category_id, amount=90_000)
+    await _create_transaction(client, headers, archived_account_id, category_id, amount=-30_000)
 
     resp = await client.get("/transactions/overview", headers=headers)
 
@@ -953,15 +953,15 @@ async def test_transactions_overview_daily_cash_flow_reports_incomplete_fx(clien
     }
 
 
-async def test_transactions_overview_explicit_hidden_account_is_allowed(client):
-    """Explicit account_id keeps hidden account detail inspectable."""
+async def test_transactions_overview_explicit_archived_account_is_allowed(client):
+    """Explicit account_id keeps archived account detail inspectable."""
     headers, _, category_id = await _setup_user_with_deps(client)
-    hidden_account_id = (await _create_account(client, headers, name="Hidden", is_hidden=True)).json()["id"]
+    archived_account_id = (await _create_account(client, headers, name="Archived", is_archived=True)).json()["id"]
 
-    await _create_transaction(client, headers, hidden_account_id, category_id, amount=90_000)
-    await _create_transaction(client, headers, hidden_account_id, category_id, amount=-30_000)
+    await _create_transaction(client, headers, archived_account_id, category_id, amount=90_000)
+    await _create_transaction(client, headers, archived_account_id, category_id, amount=-30_000)
 
-    resp = await client.get(f"/transactions/overview?account_id={hidden_account_id}", headers=headers)
+    resp = await client.get(f"/transactions/overview?account_id={archived_account_id}", headers=headers)
 
     assert resp.status_code == 200
     data = resp.json()

--- a/backend/tests/routes/test_user.py
+++ b/backend/tests/routes/test_user.py
@@ -505,8 +505,8 @@ async def test_get_runway_includes_threshold_settings(client):
     assert resp.json()["thresholds"] == {"risky_below_months": 2, "healthy_at_months": 8}
 
 
-async def test_hidden_runway_selection_is_inactive_but_restorable(client, monkeypatch):
-    """Hidden selected accounts are omitted from runway responses without deleting the stored pick."""
+async def test_archived_runway_selection_is_inactive_but_restorable(client, monkeypatch):
+    """Archived selected accounts are omitted from runway responses without deleting the stored pick."""
     from app.routes import user as user_routes
 
     class FixedDateTime(datetime):
@@ -521,9 +521,9 @@ async def test_hidden_runway_selection_is_inactive_but_restorable(client, monkey
     headers = _get_auth_header(signup_resp)
     user_id = signup_resp.json()["user"]["id"]
     visible_account = (await _create_account(client, headers, name="Visible Cash")).json()
-    hidden_account = (await _create_account(client, headers, name="Temporarily Hidden")).json()
+    archived_account = (await _create_account(client, headers, name="Temporarily Archived")).json()
     visible_account_id = visible_account["id"]
-    hidden_account_id = hidden_account["id"]
+    archived_account_id = archived_account["id"]
 
     async with TestSession() as session:
         category = Category(owner_id=user_id, name="Test Expense", kind=CategoryKind.EXPENSE)
@@ -540,16 +540,16 @@ async def test_hidden_runway_selection_is_inactive_but_restorable(client, monkey
             ),
             Transaction(
                 created_by_user_id=user_id,
-                account_id=UUID(hidden_account_id),
+                account_id=UUID(archived_account_id),
                 category_id=category.id,
                 dt=date(2026, 3, 2),
                 amount=-24_000,
                 currency="CAD",
             ),
             AccountBalanceSnapshot(account_id=UUID(visible_account_id), dt=date(2026, 4, 15), balance=120_000),
-            AccountBalanceSnapshot(account_id=UUID(hidden_account_id), dt=date(2026, 4, 15), balance=48_000),
+            AccountBalanceSnapshot(account_id=UUID(archived_account_id), dt=date(2026, 4, 15), balance=48_000),
         ])
-        for account, balance in [(visible_account, 120_000), (hidden_account, 48_000)]:
+        for account, balance in [(visible_account, 120_000), (archived_account, 48_000)]:
             await session.execute(
                 update(AccountBalanceSnapshot)
                 .where(
@@ -562,36 +562,36 @@ async def test_hidden_runway_selection_is_inactive_but_restorable(client, monkey
 
     await client.put(
         "/me/runway-accounts",
-        json={"account_ids": [visible_account_id, hidden_account_id]},
+        json={"account_ids": [visible_account_id, archived_account_id]},
         headers=headers,
     )
-    await client.patch(f"/accounts/{hidden_account_id}", json={"is_hidden": True}, headers=headers)
+    await client.patch(f"/accounts/{archived_account_id}", json={"is_archived": True}, headers=headers)
     await client.put("/me/runway-accounts", json={"account_ids": [visible_account_id]}, headers=headers)
 
-    hidden_list_resp = await client.get("/me/runway-accounts", headers=headers)
-    hidden_settings_resp = await client.get("/me/runway-settings", headers=headers)
-    hidden_runway_resp = await client.get("/me/runway", headers=headers)
+    archived_list_resp = await client.get("/me/runway-accounts", headers=headers)
+    archived_settings_resp = await client.get("/me/runway-settings", headers=headers)
+    archived_runway_resp = await client.get("/me/runway", headers=headers)
 
-    assert hidden_list_resp.status_code == 200
-    assert hidden_list_resp.json() == [visible_account_id]
-    assert hidden_settings_resp.status_code == 200
-    assert hidden_settings_resp.json()["account_ids"] == [visible_account_id]
-    assert hidden_runway_resp.status_code == 200
-    hidden_runway = hidden_runway_resp.json()
-    assert hidden_runway["liquid_balance"] == 120_000
-    assert hidden_runway["months_covered"] == 1
-    assert hidden_runway["avg_monthly_expense"] == 12_000
+    assert archived_list_resp.status_code == 200
+    assert archived_list_resp.json() == [visible_account_id]
+    assert archived_settings_resp.status_code == 200
+    assert archived_settings_resp.json()["account_ids"] == [visible_account_id]
+    assert archived_runway_resp.status_code == 200
+    archived_runway = archived_runway_resp.json()
+    assert archived_runway["liquid_balance"] == 120_000
+    assert archived_runway["months_covered"] == 1
+    assert archived_runway["avg_monthly_expense"] == 12_000
 
-    await client.patch(f"/accounts/{hidden_account_id}", json={"is_hidden": False}, headers=headers)
+    await client.patch(f"/accounts/{archived_account_id}", json={"is_archived": False}, headers=headers)
 
     restored_list_resp = await client.get("/me/runway-accounts", headers=headers)
     restored_settings_resp = await client.get("/me/runway-settings", headers=headers)
     restored_runway_resp = await client.get("/me/runway", headers=headers)
 
     assert restored_list_resp.status_code == 200
-    assert set(restored_list_resp.json()) == {visible_account_id, hidden_account_id}
+    assert set(restored_list_resp.json()) == {visible_account_id, archived_account_id}
     assert restored_settings_resp.status_code == 200
-    assert set(restored_settings_resp.json()["account_ids"]) == {visible_account_id, hidden_account_id}
+    assert set(restored_settings_resp.json()["account_ids"]) == {visible_account_id, archived_account_id}
     restored_runway = restored_runway_resp.json()
     assert restored_runway["liquid_balance"] == 168_000
     assert restored_runway["months_covered"] == 1

--- a/backend/tests/routes/test_user.py
+++ b/backend/tests/routes/test_user.py
@@ -363,6 +363,7 @@ async def test_get_runway_settings_returns_defaults(client):
     assert resp.status_code == 200
     assert resp.json() == {
         "account_ids": [],
+        "archived_account_ids": [],
         "thresholds": {"risky_below_months": 1, "healthy_at_months": 3},
     }
 
@@ -379,11 +380,15 @@ async def test_put_runway_settings_persists_accounts_and_thresholds(client):
     }
     put_resp = await client.put("/me/runway-settings", json=payload, headers=headers)
     get_resp = await client.get("/me/runway-settings", headers=headers)
+    expected = {
+        **payload,
+        "archived_account_ids": [],
+    }
 
     assert put_resp.status_code == 200
-    assert put_resp.json() == payload
+    assert put_resp.json() == expected
     assert get_resp.status_code == 200
-    assert get_resp.json() == payload
+    assert get_resp.json() == expected
 
 
 async def test_put_runway_settings_isolates_thresholds_across_users(client):
@@ -459,6 +464,7 @@ async def test_put_runway_settings_rejects_invalid_account_without_changing_thre
     assert get_resp.status_code == 200
     assert get_resp.json() == {
         "account_ids": [],
+        "archived_account_ids": [],
         "thresholds": {"risky_below_months": 2, "healthy_at_months": 6},
     }
 
@@ -576,6 +582,7 @@ async def test_archived_runway_selection_is_inactive_but_restorable(client, monk
     assert archived_list_resp.json() == [visible_account_id]
     assert archived_settings_resp.status_code == 200
     assert archived_settings_resp.json()["account_ids"] == [visible_account_id]
+    assert archived_settings_resp.json()["archived_account_ids"] == [archived_account_id]
     assert archived_runway_resp.status_code == 200
     archived_runway = archived_runway_resp.json()
     assert archived_runway["liquid_balance"] == 120_000
@@ -593,6 +600,7 @@ async def test_archived_runway_selection_is_inactive_but_restorable(client, monk
     assert set(restored_list_resp.json()) == {visible_account_id, archived_account_id}
     assert restored_settings_resp.status_code == 200
     assert set(restored_settings_resp.json()["account_ids"]) == {visible_account_id, archived_account_id}
+    assert restored_settings_resp.json()["archived_account_ids"] == []
     restored_runway = restored_runway_resp.json()
     assert restored_runway["liquid_balance"] == 120_000
     assert sorted(restored_runway["account_balances"], key=lambda item: item["account_id"]) == sorted([

--- a/backend/tests/routes/test_user.py
+++ b/backend/tests/routes/test_user.py
@@ -579,6 +579,7 @@ async def test_archived_runway_selection_is_inactive_but_restorable(client, monk
     assert archived_runway_resp.status_code == 200
     archived_runway = archived_runway_resp.json()
     assert archived_runway["liquid_balance"] == 120_000
+    assert archived_runway["account_balances"] == [{"account_id": visible_account_id, "balance": 120_000}]
     assert archived_runway["months_covered"] == 1
     assert archived_runway["avg_monthly_expense"] == 12_000
 
@@ -593,7 +594,11 @@ async def test_archived_runway_selection_is_inactive_but_restorable(client, monk
     assert restored_settings_resp.status_code == 200
     assert set(restored_settings_resp.json()["account_ids"]) == {visible_account_id, archived_account_id}
     restored_runway = restored_runway_resp.json()
-    assert restored_runway["liquid_balance"] == 168_000
+    assert restored_runway["liquid_balance"] == 120_000
+    assert sorted(restored_runway["account_balances"], key=lambda item: item["account_id"]) == sorted([
+        {"account_id": visible_account_id, "balance": 120_000},
+        {"account_id": archived_account_id, "balance": 0},
+    ], key=lambda item: item["account_id"])
     assert restored_runway["months_covered"] == 1
     assert restored_runway["avg_monthly_expense"] == 36_000
 

--- a/frontend/src/accounts/AccountsPage.tsx
+++ b/frontend/src/accounts/AccountsPage.tsx
@@ -9,7 +9,7 @@ import AccountFilters from '@/accounts/components/AccountFilters'
 import AccountListSection from '@/accounts/components/AccountListSection'
 import AccountSummaryStatement from '@/accounts/components/AccountSummaryStatement'
 import AccountsMetricsBand from '@/accounts/components/AccountsMetricsBand'
-import HiddenAccountsSection from '@/accounts/components/HiddenAccountsSection'
+import ArchivedAccountsSection from '@/accounts/components/ArchivedAccountsSection'
 import TaxAdvantagedLimitsSection from '@/accounts/components/TaxAdvantagedLimitsSection'
 import { useAccountFilters } from '@/accounts/hooks/useAccountFilters'
 import { useAccountSections } from '@/accounts/hooks/useAccountSections'
@@ -31,8 +31,8 @@ export default function AccountsPage() {
   ])
 
   const allRows = useMemo(() => accounts ?? [], [accounts])
-  const rows = useMemo(() => allRows.filter((account) => !account.is_hidden), [allRows])
-  const hiddenRows = useMemo(() => allRows.filter((account) => account.is_hidden), [allRows])
+  const rows = useMemo(() => allRows.filter((account) => !account.is_archived), [allRows])
+  const archivedRows = useMemo(() => allRows.filter((account) => account.is_archived), [allRows])
   const displayCurrency = user!.base_currency
 
   const {
@@ -57,7 +57,7 @@ export default function AccountsPage() {
       <header className="app-page-header">
         <h1 className="app-page-title">My Accounts</h1>
         <p className="app-page-description">
-          Review balances, account groups, contribution limits, and hidden accounts in one place.
+          Review balances, account groups, contribution limits, and archived accounts in one place.
         </p>
       </header>
 
@@ -125,8 +125,8 @@ export default function AccountsPage() {
           loading={accountsLoading}
         />
 
-        <HiddenAccountsSection
-          accounts={hiddenRows}
+        <ArchivedAccountsSection
+          accounts={archivedRows}
           taxAdvantagedPlanById={taxAdvantagedPlanById}
           displayCurrency={displayCurrency}
         />

--- a/frontend/src/accounts/components/AccountRow.tsx
+++ b/frontend/src/accounts/components/AccountRow.tsx
@@ -56,20 +56,20 @@ export default function AccountRow({
   showCreditLimit,
   taxAdvantagedPlanById,
   displayCurrency,
-  isHidden = false,
+  isArchived = false,
 }: {
   account: AccountsOverview
   accent: AccountAccent
   showCreditLimit: boolean
   taxAdvantagedPlanById: Map<string, TaxAdvantagedPlan>
   displayCurrency: string
-  isHidden?: boolean
+  isArchived?: boolean
 }) {
-  const barColor = isHidden
+  const barColor = isArchived
     ? 'var(--app-text-muted)'
     : accent === 'positive' ? 'var(--app-positive)' : 'var(--app-negative)'
   const balanceColor =
-    isHidden
+    isArchived
       ? 'var(--app-text-muted)'
       : accent === 'positive'
         ? account.current_balance > 0
@@ -94,9 +94,9 @@ export default function AccountRow({
     <Link
       to={`/accounts/${account.id}`}
       className={`flex min-w-0 items-stretch overflow-hidden rounded-xl transition-colors duration-150 hover:bg-[var(--app-accent-soft)] ${
-        isHidden ? 'my-1 border border-dashed opacity-75 hover:opacity-100' : ''
+        isArchived ? 'my-1 border border-dashed opacity-75 hover:opacity-100' : ''
       }`}
-      style={isHidden ? { borderColor: 'var(--app-border)' } : undefined}
+      style={isArchived ? { borderColor: 'var(--app-border)' } : undefined}
     >
       <div
         className="my-3 w-0.5 rounded-full"
@@ -121,7 +121,7 @@ export default function AccountRow({
             )}
           </div>
           <div className="mt-0.5 flex min-w-0 items-center gap-2">
-            {isHidden && (
+            {isArchived && (
               <EyeOff
                 size={13}
                 className="shrink-0"

--- a/frontend/src/accounts/components/ArchivedAccountsSection.tsx
+++ b/frontend/src/accounts/components/ArchivedAccountsSection.tsx
@@ -4,7 +4,7 @@ import type { AccountsOverview } from '@/api/accounts'
 import type { TaxAdvantagedPlan } from '@/api/taxAdvantagedPlans'
 import AccountRow from '@/accounts/components/AccountRow'
 
-export default function HiddenAccountsSection({
+export default function ArchivedAccountsSection({
   accounts,
   taxAdvantagedPlanById,
   displayCurrency,
@@ -30,7 +30,7 @@ export default function HiddenAccountsSection({
         onClick={() => setExpanded((value) => !value)}
       >
         <EyeOff size={16} aria-hidden />
-        <span className="font-medium">Hidden accounts</span>
+        <span className="font-medium">Archived accounts</span>
         <span
           className="rounded-full px-2 py-0.5 text-xs font-semibold"
           style={{ background: 'var(--app-accent-soft)' }}
@@ -54,7 +54,7 @@ export default function HiddenAccountsSection({
               showCreditLimit={account.account_kind === 'revolving'}
               taxAdvantagedPlanById={taxAdvantagedPlanById}
               displayCurrency={displayCurrency}
-              isHidden
+              isArchived
             />
           ))}
         </div>

--- a/frontend/src/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/accounts/detail/AccountDetailPage.tsx
@@ -36,12 +36,16 @@ export default function AccountDetailPage() {
   } = useTaxAdvantagedPlan(linkedTaxAdvantagedPlanId)
 
   const openCreateTransaction = () => {
+    if (visibleAccount?.is_archived) return
+
     setEditingTransaction(null)
     setTxnModalKey((key) => key + 1)
     setShowTxnModal(true)
   }
 
   const openEditTransaction = (transaction: Transaction) => {
+    if (visibleAccount?.is_archived) return
+
     setEditingTransaction(transaction)
     setTxnModalKey((key) => key + 1)
     setShowTxnModal(true)
@@ -134,6 +138,7 @@ export default function AccountDetailPage() {
                 name: visibleAccount.name,
                 currency: visibleAccount.currency,
                 institution: visibleAccount.institution,
+                is_archived: visibleAccount.is_archived,
               }}
               currency={visibleAccount.currency}
               onCreateTransaction={openCreateTransaction}

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -86,25 +86,25 @@ function ArchiveBalanceWarning({
 
   return (
     <div
-      className="rounded-xl p-4"
+      className="rounded-lg px-3 py-2.5"
       style={{
         background: 'var(--app-warning-soft)',
-        border: '1px solid var(--app-warning)',
+        border: '1px solid var(--app-border)',
       }}
     >
-      <div className="flex gap-3">
+      <div className="flex gap-2.5">
         <div
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+          className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
           style={{ background: 'var(--app-bg)', color: 'var(--app-warning)' }}
         >
-          <AlertTriangle size={16} aria-hidden />
+          <AlertTriangle size={13} aria-hidden />
         </div>
         <div className="min-w-0">
-          <p className="app-label font-semibold">Archiving will affect this account balance</p>
-          <p className="mt-1 text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
+          <p className="text-sm font-semibold leading-5">Balance will be set to zero</p>
+          <p className="mt-0.5 text-sm leading-5" style={{ color: 'var(--app-text-muted)' }}>
             {hasBalance
-              ? `A Balance Adjustment of ${formatCurrency(adjustmentAmount, currency)} will be recorded with note "Account archived" so this account balance becomes ${formatCurrency(0, currency)}. Unarchiving will not restore the previous balance.`
-              : `This account already has a zero balance, so archiving will not create a balance adjustment.`}
+              ? `${formatCurrency(adjustmentAmount, currency)} will be recorded as a Balance Adjustment with note "Account archived". Unarchiving will not restore the previous balance.`
+              : 'This account already has a zero balance, so no balance adjustment will be recorded.'}
           </p>
         </div>
       </div>
@@ -527,10 +527,11 @@ export default function EditAccountIdentityModal({
                           <AnimatePresence initial={false}>
                             {isArchiving && (
                               <motion.div
-                                initial={{ opacity: 0, y: -4 }}
-                                animate={{ opacity: 1, y: 0 }}
-                                exit={{ opacity: 0, y: -4 }}
-                                transition={{ duration: 0.15 }}
+                                className="overflow-hidden"
+                                initial={{ height: 0, opacity: 0 }}
+                                animate={{ height: 'auto', opacity: 1 }}
+                                exit={{ height: 0, opacity: 0 }}
+                                transition={{ duration: 0.18, ease: EASE }}
                               >
                                 <ArchiveBalanceWarning balance={account.current_balance} currency={account.currency} />
                               </motion.div>
@@ -592,10 +593,11 @@ export default function EditAccountIdentityModal({
                                     <AnimatePresence initial={false}>
                                       {confirmingArchiveInstead && (
                                         <motion.div
-                                          initial={{ opacity: 0, y: -4 }}
-                                          animate={{ opacity: 1, y: 0 }}
-                                          exit={{ opacity: 0, y: -4 }}
-                                          transition={{ duration: 0.15 }}
+                                          className="overflow-hidden"
+                                          initial={{ height: 0, opacity: 0 }}
+                                          animate={{ height: 'auto', opacity: 1 }}
+                                          exit={{ height: 0, opacity: 0 }}
+                                          transition={{ duration: 0.18, ease: EASE }}
                                         >
                                           <ArchiveBalanceWarning balance={account.current_balance} currency={account.currency} />
                                         </motion.div>

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -21,6 +21,7 @@ import {
   sanitizeMoneyInput,
   toMinorUnits,
 } from '@/accounts/detail/utils/moneyInput'
+import { formatCurrency } from '@/utils/formatCurrency'
 
 function FieldLabelRow({
   label,
@@ -73,6 +74,44 @@ function wait(ms: number): Promise<void> {
   })
 }
 
+function ArchiveBalanceWarning({
+  balance,
+  currency,
+}: {
+  balance: number
+  currency: string
+}) {
+  const adjustmentAmount = -balance
+  const hasBalance = balance !== 0
+
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{
+        background: 'var(--app-warning-soft)',
+        border: '1px solid var(--app-warning)',
+      }}
+    >
+      <div className="flex gap-3">
+        <div
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+          style={{ background: 'var(--app-bg)', color: 'var(--app-warning)' }}
+        >
+          <AlertTriangle size={16} aria-hidden />
+        </div>
+        <div className="min-w-0">
+          <p className="app-label font-semibold">Archiving will affect this account balance</p>
+          <p className="mt-1 text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
+            {hasBalance
+              ? `A Balance Adjustment of ${formatCurrency(adjustmentAmount, currency)} will be recorded with note "Account archived" so this account balance becomes ${formatCurrency(0, currency)}. Unarchiving will not restore the previous balance.`
+              : `This account already has a zero balance, so archiving will not create a balance adjustment.`}
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function EditAccountIdentityModal({
   account,
   onClose,
@@ -107,6 +146,7 @@ export default function EditAccountIdentityModal({
   const [institutionModalName, setInstitutionModalName] = useState('')
   const [showInstitutionModal, setShowInstitutionModal] = useState(false)
   const [institutionModalKey, setInstitutionModalKey] = useState(0)
+  const [confirmingArchiveInstead, setConfirmingArchiveInstead] = useState(false)
 
   const isRevolving = account.account_kind === 'revolving'
   const canLinkTaxAdvantagedCategory = account.account_kind === 'asset' && account.group_id === null
@@ -223,11 +263,13 @@ export default function EditAccountIdentityModal({
   }
 
   const deleteLoading = deleteAccount.isPending
+  const archiveInsteadLoading = updateAccount.isPending && deleteStage !== 'idle'
   const saveLoading = (updateAccount.isPending && deleteStage === 'idle') || saveDelayPending
   const isBusy = updateAccount.isPending || saveDelayPending || deleteLoading
   const canDelete = deleteNameInput === account.name
   const hasEditableAccountContext = canLinkTaxAdvantagedCategory || isRevolving
   const visibilitySectionNumber = hasEditableAccountContext ? '03' : '02'
+  const isArchiving = !account.is_archived && form.is_archived
 
   const requestClose = () => {
     if (isBusy) return
@@ -463,7 +505,10 @@ export default function EditAccountIdentityModal({
                                 type="checkbox"
                                 role="switch"
                                 checked={form.is_archived}
-                                onChange={(event) => setField('is_archived', event.target.checked)}
+                                onChange={(event) => {
+                                  setField('is_archived', event.target.checked)
+                                  setConfirmingArchiveInstead(false)
+                                }}
                                 className="peer sr-only"
                               />
                               <span
@@ -478,6 +523,19 @@ export default function EditAccountIdentityModal({
                               />
                             </span>
                           </label>
+
+                          <AnimatePresence initial={false}>
+                            {isArchiving && (
+                              <motion.div
+                                initial={{ opacity: 0, y: -4 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                exit={{ opacity: 0, y: -4 }}
+                                transition={{ duration: 0.15 }}
+                              >
+                                <ArchiveBalanceWarning balance={account.current_balance} currency={account.currency} />
+                              </motion.div>
+                            )}
+                          </AnimatePresence>
                         </div>
                       </section>
 
@@ -530,13 +588,20 @@ export default function EditAccountIdentityModal({
                                     if you only want it out of view.
                                   </p>
 
-                                  <div
-                                    className="mt-4 overflow-hidden"
-                                    style={{
-                                      maxHeight: deleteStage === 'type-name' ? '18rem' : '7rem',
-                                      transition: 'max-height 320ms cubic-bezier(0.25, 0.1, 0.25, 1)',
-                                    }}
-                                  >
+                                  <div className="mt-4 space-y-4 overflow-hidden">
+                                    <AnimatePresence initial={false}>
+                                      {confirmingArchiveInstead && (
+                                        <motion.div
+                                          initial={{ opacity: 0, y: -4 }}
+                                          animate={{ opacity: 1, y: 0 }}
+                                          exit={{ opacity: 0, y: -4 }}
+                                          transition={{ duration: 0.15 }}
+                                        >
+                                          <ArchiveBalanceWarning balance={account.current_balance} currency={account.currency} />
+                                        </motion.div>
+                                      )}
+                                    </AnimatePresence>
+
                                     {deleteStage === 'confirm' ? (
                                       <motion.div
                                         key="confirm"
@@ -550,15 +615,21 @@ export default function EditAccountIdentityModal({
                                             type="button"
                                             className="inline-flex items-center gap-2 text-sm font-medium"
                                             style={{ color: 'var(--app-text-muted)' }}
-                                            onClick={handleArchiveAccount}
+                                            onClick={() => {
+                                              if (!confirmingArchiveInstead) {
+                                                setConfirmingArchiveInstead(true)
+                                                return
+                                              }
+                                              handleArchiveAccount()
+                                            }}
                                             disabled={isBusy}
                                           >
-                                            {updateAccount.isPending ? (
+                                            {archiveInsteadLoading ? (
                                               <span className="app-spinner" />
                                             ) : (
                                               <>
                                                 <EyeOff size={15} aria-hidden />
-                                                Archive instead
+                                                {confirmingArchiveInstead ? 'Confirm archive' : 'Archive instead'}
                                               </>
                                             )}
                                           </button>
@@ -568,7 +639,10 @@ export default function EditAccountIdentityModal({
                                         <button
                                           type="button"
                                           className="app-danger-button justify-center sm:ml-auto"
-                                          onClick={() => setDeleteStage('type-name')}
+                                          onClick={() => {
+                                            setConfirmingArchiveInstead(false)
+                                            setDeleteStage('type-name')
+                                          }}
                                           disabled={isBusy}
                                         >
                                           Continue

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -642,7 +642,7 @@ export default function EditAccountIdentityModal({
                                           <div>
                                             <label
                                               htmlFor="delete-account-name"
-                                              className="mb-1.5 block break-words text-[0.9375rem]"
+                                              className="mb-1.5 block break-words text-sm leading-5"
                                               style={{ color: 'var(--app-text-muted)' }}
                                             >
                                               Type <strong className="font-semibold">"{account.name}"</strong> to delete.

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -569,30 +569,30 @@ export default function EditAccountIdentityModal({
                           >
                             <motion.div
                               layout
-                              className="rounded-xl p-4"
+                              className="rounded-lg px-3 py-2.5"
                               style={{
                                 background: 'var(--app-negative-soft)',
-                                border: '1px solid var(--app-negative-border)',
+                                border: '1px solid var(--app-border)',
                               }}
                               transition={{ duration: 0.22, ease: EASE }}
                             >
-                              <div className="flex gap-3">
+                              <div className="flex gap-2.5">
                                 <div
-                                  className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg"
+                                  className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
                                   style={{ background: 'var(--app-bg)', color: 'var(--app-negative)' }}
                                 >
-                                  <AlertTriangle size={16} aria-hidden />
+                                  <AlertTriangle size={13} aria-hidden />
                                 </div>
                                 <div className="min-w-0 flex-1">
-                                  <p className="app-label break-words font-semibold">
+                                  <p className="break-words text-sm font-semibold leading-5">
                                     Delete {account.name}?
                                   </p>
-                                  <p className="mt-1 text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
+                                  <p className="mt-0.5 text-sm leading-5" style={{ color: 'var(--app-text-muted)' }}>
                                     Permanent deletion removes its transactions, budgets, and balance history. Archive it instead
                                     if you only want it out of view.
                                   </p>
 
-                                  <div className="mt-4 overflow-hidden">
+                                  <div className="mt-3 overflow-hidden">
                                     {deleteStage === 'confirm' ? (
                                       <motion.div
                                         key="confirm"

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -146,7 +146,6 @@ export default function EditAccountIdentityModal({
   const [institutionModalName, setInstitutionModalName] = useState('')
   const [showInstitutionModal, setShowInstitutionModal] = useState(false)
   const [institutionModalKey, setInstitutionModalKey] = useState(0)
-  const [confirmingArchiveInstead, setConfirmingArchiveInstead] = useState(false)
 
   const isRevolving = account.account_kind === 'revolving'
   const canLinkTaxAdvantagedCategory = account.account_kind === 'asset' && account.group_id === null && !account.is_archived
@@ -232,27 +231,26 @@ export default function EditAccountIdentityModal({
     }
   }
 
-  const handleArchiveAccount = () => {
-    setDeleteError(null)
-    updateAccount.mutate(
-      {
-        accountId: account.id,
-        payload: { is_archived: true },
-      },
-      {
-        onSuccess: onClose,
-        onError: (error) => {
-          setDeleteError(error instanceof Error ? error.message : 'Failed to archive account.')
-        },
-      },
-    )
-  }
-
   const handleStartDeleteAccount = () => {
     setField('is_archived', account.is_archived)
-    setConfirmingArchiveInstead(false)
     setDeleteError(null)
     setDeleteStage('confirm')
+  }
+
+  const handleArchiveInstead = () => {
+    setDeleteError(null)
+    setDeleteNameInput('')
+    setDeleteStage('idle')
+    setField('is_archived', true)
+  }
+
+  const handleArchiveToggle = (checked: boolean) => {
+    if (deleteStage !== 'idle') {
+      setDeleteError(null)
+      setDeleteNameInput('')
+      setDeleteStage('idle')
+    }
+    setField('is_archived', checked)
   }
 
   const handleDeleteAccount = async () => {
@@ -270,7 +268,6 @@ export default function EditAccountIdentityModal({
   }
 
   const deleteLoading = deleteAccount.isPending
-  const archiveInsteadLoading = updateAccount.isPending && deleteStage !== 'idle'
   const saveLoading = (updateAccount.isPending && deleteStage === 'idle') || saveDelayPending
   const isBusy = updateAccount.isPending || saveDelayPending || deleteLoading
   const canDelete = deleteNameInput === account.name
@@ -513,8 +510,7 @@ export default function EditAccountIdentityModal({
                                 role="switch"
                                 checked={form.is_archived}
                                 onChange={(event) => {
-                                  setField('is_archived', event.target.checked)
-                                  setConfirmingArchiveInstead(false)
+                                  handleArchiveToggle(event.target.checked)
                                 }}
                                 className="peer sr-only"
                               />
@@ -596,21 +592,7 @@ export default function EditAccountIdentityModal({
                                     if you only want it out of view.
                                   </p>
 
-                                  <div className="mt-4 space-y-4 overflow-hidden">
-                                    <AnimatePresence initial={false}>
-                                      {confirmingArchiveInstead && (
-                                        <motion.div
-                                          className="overflow-hidden"
-                                          initial={{ height: 0, opacity: 0 }}
-                                          animate={{ height: 'auto', opacity: 1 }}
-                                          exit={{ height: 0, opacity: 0 }}
-                                          transition={{ duration: 0.18, ease: EASE }}
-                                        >
-                                          <ArchiveBalanceWarning balance={account.current_balance} currency={account.currency} />
-                                        </motion.div>
-                                      )}
-                                    </AnimatePresence>
-
+                                  <div className="mt-4 overflow-hidden">
                                     {deleteStage === 'confirm' ? (
                                       <motion.div
                                         key="confirm"
@@ -624,23 +606,11 @@ export default function EditAccountIdentityModal({
                                             type="button"
                                             className="inline-flex items-center gap-2 text-sm font-medium"
                                             style={{ color: 'var(--app-text-muted)' }}
-                                            onClick={() => {
-                                              if (!confirmingArchiveInstead) {
-                                                setConfirmingArchiveInstead(true)
-                                                return
-                                              }
-                                              handleArchiveAccount()
-                                            }}
+                                            onClick={handleArchiveInstead}
                                             disabled={isBusy}
                                           >
-                                            {archiveInsteadLoading ? (
-                                              <span className="app-spinner" />
-                                            ) : (
-                                              <>
-                                                <EyeOff size={15} aria-hidden />
-                                                {confirmingArchiveInstead ? 'Confirm archive' : 'Archive instead'}
-                                              </>
-                                            )}
+                                            <EyeOff size={15} aria-hidden />
+                                            Archive instead
                                           </button>
                                         ) : (
                                           <span aria-hidden />
@@ -649,7 +619,6 @@ export default function EditAccountIdentityModal({
                                           type="button"
                                           className="app-danger-button justify-center sm:ml-auto"
                                           onClick={() => {
-                                            setConfirmingArchiveInstead(false)
                                             setDeleteStage('type-name')
                                           }}
                                           disabled={isBusy}

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -593,88 +593,97 @@ export default function EditAccountIdentityModal({
                                   </p>
 
                                   <div className="mt-3 overflow-hidden">
-                                    {deleteStage === 'confirm' ? (
-                                      <motion.div
-                                        key="confirm"
-                                        className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between"
-                                        initial={false}
-                                        animate={{ opacity: 1, y: 0 }}
-                                        transition={{ duration: 0.16, ease: EASE }}
-                                      >
-                                        {!account.is_archived ? (
-                                          <button
-                                            type="button"
-                                            className="inline-flex items-center gap-2 text-sm font-medium"
-                                            style={{ color: 'var(--app-text-muted)' }}
-                                            onClick={handleArchiveInstead}
-                                            disabled={isBusy}
-                                          >
-                                            <EyeOff size={15} aria-hidden />
-                                            Archive instead
-                                          </button>
-                                        ) : (
-                                          <span aria-hidden />
-                                        )}
-                                        <button
-                                          type="button"
-                                          className="app-danger-button justify-center sm:ml-auto"
-                                          onClick={() => {
-                                            setDeleteStage('type-name')
-                                          }}
-                                          disabled={isBusy}
+                                    <AnimatePresence initial={false} mode="wait">
+                                      {deleteStage === 'confirm' ? (
+                                        <motion.div
+                                          key="confirm"
+                                          className="overflow-hidden"
+                                          initial={{ height: 0, opacity: 0 }}
+                                          animate={{ height: 'auto', opacity: 1 }}
+                                          exit={{ height: 0, opacity: 0 }}
+                                          transition={{ duration: 0.18, ease: EASE }}
                                         >
-                                          Continue
-                                        </button>
-                                      </motion.div>
-                                    ) : (
-                                      <motion.div
-                                        key="type-name"
-                                        initial={{ opacity: 0, y: 6 }}
-                                        animate={{ opacity: 1, y: 0 }}
-                                        transition={{ duration: 0.18, ease: EASE }}
-                                      >
-                                        <label
-                                          htmlFor="delete-account-name"
-                                          className="mb-1.5 block break-words text-[0.9375rem]"
-                                          style={{ color: 'var(--app-text-muted)' }}
+                                          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                                            {!account.is_archived ? (
+                                              <button
+                                                type="button"
+                                                className="inline-flex items-center gap-2 text-sm font-medium"
+                                                style={{ color: 'var(--app-text-muted)' }}
+                                                onClick={handleArchiveInstead}
+                                                disabled={isBusy}
+                                              >
+                                                <EyeOff size={15} aria-hidden />
+                                                Archive instead
+                                              </button>
+                                            ) : (
+                                              <span aria-hidden />
+                                            )}
+                                            <button
+                                              type="button"
+                                              className="app-danger-button justify-center sm:ml-auto"
+                                              onClick={() => {
+                                                setDeleteStage('type-name')
+                                              }}
+                                              disabled={isBusy}
+                                            >
+                                              Continue
+                                            </button>
+                                          </div>
+                                        </motion.div>
+                                      ) : (
+                                        <motion.div
+                                          key="type-name"
+                                          className="overflow-hidden"
+                                          initial={{ height: 0, opacity: 0 }}
+                                          animate={{ height: 'auto', opacity: 1 }}
+                                          exit={{ height: 0, opacity: 0 }}
+                                          transition={{ duration: 0.18, ease: EASE }}
                                         >
-                                          Type <strong className="font-semibold">"{account.name}"</strong> to delete.
-                                        </label>
-                                        <input
-                                          id="delete-account-name"
-                                          className="app-input"
-                                          value={deleteNameInput}
-                                          onChange={(event) => {
-                                            setDeleteNameInput(event.target.value)
-                                            setDeleteError(null)
-                                          }}
-                                          onKeyDown={(event) => {
-                                            if (event.key !== 'Enter') return
-                                            event.preventDefault()
-                                            handleDeleteAccount()
-                                          }}
-                                          disabled={isBusy}
-                                          autoComplete="off"
-                                        />
+                                          <div>
+                                            <label
+                                              htmlFor="delete-account-name"
+                                              className="mb-1.5 block break-words text-[0.9375rem]"
+                                              style={{ color: 'var(--app-text-muted)' }}
+                                            >
+                                              Type <strong className="font-semibold">"{account.name}"</strong> to delete.
+                                            </label>
+                                            <input
+                                              id="delete-account-name"
+                                              className="app-input"
+                                              value={deleteNameInput}
+                                              onChange={(event) => {
+                                                setDeleteNameInput(event.target.value)
+                                                setDeleteError(null)
+                                              }}
+                                              onKeyDown={(event) => {
+                                                if (event.key !== 'Enter') return
+                                                event.preventDefault()
+                                                handleDeleteAccount()
+                                              }}
+                                              disabled={isBusy}
+                                              autoComplete="off"
+                                            />
 
-                                        {deleteError && (
-                                          <p className="mt-3 text-[0.9375rem] font-medium" style={{ color: 'var(--app-negative)' }}>
-                                            {deleteError}
-                                          </p>
-                                        )}
+                                            {deleteError && (
+                                              <p className="mt-3 text-[0.9375rem] font-medium" style={{ color: 'var(--app-negative)' }}>
+                                                {deleteError}
+                                              </p>
+                                            )}
 
-                                        <div className="mt-4 flex justify-end">
-                                          <button
-                                            type="button"
-                                            className={`app-danger-button ${deleteLoading ? 'app-primary-button-loading' : ''}`}
-                                            onClick={handleDeleteAccount}
-                                            disabled={!canDelete || isBusy}
-                                          >
-                                            {deleteLoading ? <span className="app-spinner" /> : 'Delete account'}
-                                          </button>
-                                        </div>
-                                      </motion.div>
-                                    )}
+                                            <div className="mt-4 flex justify-end">
+                                              <button
+                                                type="button"
+                                                className={`app-danger-button ${deleteLoading ? 'app-primary-button-loading' : ''}`}
+                                                onClick={handleDeleteAccount}
+                                                disabled={!canDelete || isBusy}
+                                              >
+                                                {deleteLoading ? <span className="app-spinner" /> : 'Delete account'}
+                                              </button>
+                                            </div>
+                                          </div>
+                                        </motion.div>
+                                      )}
+                                    </AnimatePresence>
                                   </div>
                                 </div>
                               </div>

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -60,7 +60,7 @@ interface AccountIdentityForm {
   institution_id: string
   tax_advantaged_plan_id: string
   credit_limit: string
-  is_hidden: boolean
+  is_archived: boolean
 }
 
 type DeleteAccountStage = 'idle' | 'confirm' | 'type-name'
@@ -96,7 +96,7 @@ export default function EditAccountIdentityModal({
     institution_id: account.institution?.id ?? '',
     tax_advantaged_plan_id: account.tax_advantaged_plan_id ?? '',
     credit_limit: fromMinorUnits(account.credit_limit, currencies, account.currency),
-    is_hidden: account.is_hidden,
+    is_archived: account.is_archived,
   })
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [deleteError, setDeleteError] = useState<string | null>(null)
@@ -174,7 +174,7 @@ export default function EditAccountIdentityModal({
         payload: {
           name: form.name.trim(),
           institution_id: form.institution_id || null,
-          is_hidden: form.is_hidden,
+          is_archived: form.is_archived,
           ...(isRevolving
             ? { credit_limit: toMinorUnits(form.credit_limit, currencies, account.currency) }
             : {}),
@@ -192,17 +192,17 @@ export default function EditAccountIdentityModal({
     }
   }
 
-  const handleHideAccount = () => {
+  const handleArchiveAccount = () => {
     setDeleteError(null)
     updateAccount.mutate(
       {
         accountId: account.id,
-        payload: { is_hidden: true },
+        payload: { is_archived: true },
       },
       {
         onSuccess: onClose,
         onError: (error) => {
-          setDeleteError(error instanceof Error ? error.message : 'Failed to hide account.')
+          setDeleteError(error instanceof Error ? error.message : 'Failed to archive account.')
         },
       },
     )
@@ -437,11 +437,11 @@ export default function EditAccountIdentityModal({
 
                         <div className="min-w-0 space-y-3">
                           <p className="flex h-4 items-center text-base font-bold leading-none" style={{ color: 'var(--app-accent)' }}>
-                            Visibility
+                            Archive
                           </p>
 
                           <label
-                            htmlFor="edit-account-hidden"
+                            htmlFor="edit-account-archived"
                             className="flex cursor-pointer items-center justify-between gap-4 rounded-xl p-4"
                             style={{
                               background: 'var(--app-input-bg)',
@@ -451,29 +451,29 @@ export default function EditAccountIdentityModal({
                             <span className="min-w-0">
                               <span className="flex items-center gap-2 font-medium">
                                 <EyeOff size={16} style={{ color: 'var(--app-text-muted)' }} aria-hidden />
-                                Hide account
+                                Archive account
                               </span>
                               <span className="mt-0.5 block text-sm" style={{ color: 'var(--app-text-muted)' }}>
-                                Exclude this account from overview totals and primary lists.
+                                Move this account out of active lists while keeping its history.
                               </span>
                             </span>
                             <span className="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors">
                               <input
-                                id="edit-account-hidden"
+                                id="edit-account-archived"
                                 type="checkbox"
                                 role="switch"
-                                checked={form.is_hidden}
-                                onChange={(event) => setField('is_hidden', event.target.checked)}
+                                checked={form.is_archived}
+                                onChange={(event) => setField('is_archived', event.target.checked)}
                                 className="peer sr-only"
                               />
                               <span
                                 className="absolute inset-0 rounded-full transition-colors peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2"
-                                style={{ background: form.is_hidden ? 'var(--app-accent)' : 'var(--app-border-strong)' }}
+                                style={{ background: form.is_archived ? 'var(--app-accent)' : 'var(--app-border-strong)' }}
                                 aria-hidden
                               />
                               <span
                                 className="relative h-5 w-5 rounded-full bg-white shadow-sm transition-transform"
-                                style={{ transform: form.is_hidden ? 'translateX(1.25rem)' : 'translateX(0)' }}
+                                style={{ transform: form.is_archived ? 'translateX(1.25rem)' : 'translateX(0)' }}
                                 aria-hidden
                               />
                             </span>
@@ -526,7 +526,7 @@ export default function EditAccountIdentityModal({
                                     Delete {account.name}?
                                   </p>
                                   <p className="mt-1 text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
-                                    Permanent deletion removes its transactions, budgets, and balance history. Hide it instead
+                                    Permanent deletion removes its transactions, budgets, and balance history. Archive it instead
                                     if you only want it out of view.
                                   </p>
 
@@ -545,12 +545,12 @@ export default function EditAccountIdentityModal({
                                         animate={{ opacity: 1, y: 0 }}
                                         transition={{ duration: 0.16, ease: EASE }}
                                       >
-                                        {!account.is_hidden ? (
+                                        {!account.is_archived ? (
                                           <button
                                             type="button"
                                             className="inline-flex items-center gap-2 text-sm font-medium"
                                             style={{ color: 'var(--app-text-muted)' }}
-                                            onClick={handleHideAccount}
+                                            onClick={handleArchiveAccount}
                                             disabled={isBusy}
                                           >
                                             {updateAccount.isPending ? (
@@ -558,7 +558,7 @@ export default function EditAccountIdentityModal({
                                             ) : (
                                               <>
                                                 <EyeOff size={15} aria-hidden />
-                                                Hide instead
+                                                Archive instead
                                               </>
                                             )}
                                           </button>

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -531,9 +531,9 @@ export default function EditAccountIdentityModal({
                             {isArchiving && (
                               <motion.div
                                 className="overflow-hidden"
-                                initial={{ height: 0, opacity: 0 }}
-                                animate={{ height: 'auto', opacity: 1 }}
-                                exit={{ height: 0, opacity: 0 }}
+                                initial={{ height: 0, marginTop: 0, opacity: 0 }}
+                                animate={{ height: 'auto', marginTop: 12, opacity: 1 }}
+                                exit={{ height: 0, marginTop: 0, opacity: 0 }}
                                 transition={{ duration: 0.18, ease: EASE }}
                               >
                                 <ArchiveBalanceWarning balance={account.current_balance} currency={account.currency} />
@@ -562,9 +562,9 @@ export default function EditAccountIdentityModal({
                         {deleteStage !== 'idle' && (
                           <motion.div
                             className="overflow-hidden"
-                            initial={{ height: 0, opacity: 0 }}
-                            animate={{ height: 'auto', opacity: 1 }}
-                            exit={{ height: 0, opacity: 0 }}
+                            initial={{ height: 0, marginTop: 0, opacity: 0 }}
+                            animate={{ height: 'auto', marginTop: 20, opacity: 1 }}
+                            exit={{ height: 0, marginTop: 0, opacity: 0 }}
                             transition={{ duration: 0.2, ease: EASE }}
                           >
                             <motion.div

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -149,7 +149,7 @@ export default function EditAccountIdentityModal({
   const [confirmingArchiveInstead, setConfirmingArchiveInstead] = useState(false)
 
   const isRevolving = account.account_kind === 'revolving'
-  const canLinkTaxAdvantagedCategory = account.account_kind === 'asset' && account.group_id === null
+  const canLinkTaxAdvantagedCategory = account.account_kind === 'asset' && account.group_id === null && !account.is_archived
   const selectedCurrencySymbol = currencies.find((currency) => currency.id === account.currency)?.symbol ?? ''
 
   const institutionOptions = useMemo(

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -673,7 +673,7 @@ export default function EditAccountIdentityModal({
                                             <div className="mt-4 flex justify-end">
                                               <button
                                                 type="button"
-                                                className={`app-danger-button ${deleteLoading ? 'app-primary-button-loading' : ''}`}
+                                                className={`app-danger-button w-full justify-center min-[1050px]:w-auto ${deleteLoading ? 'app-primary-button-loading' : ''}`}
                                                 onClick={handleDeleteAccount}
                                                 disabled={!canDelete || isBusy}
                                               >

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -248,6 +248,13 @@ export default function EditAccountIdentityModal({
     )
   }
 
+  const handleStartDeleteAccount = () => {
+    setField('is_archived', account.is_archived)
+    setConfirmingArchiveInstead(false)
+    setDeleteError(null)
+    setDeleteStage('confirm')
+  }
+
   const handleDeleteAccount = async () => {
     if (deleteNameInput !== account.name || isBusy) return
     setDeleteError(null)
@@ -716,7 +723,7 @@ export default function EditAccountIdentityModal({
                     <button
                       type="button"
                       className="app-danger-button h-10 w-10 shrink-0 px-0"
-                      onClick={() => setDeleteStage('confirm')}
+                      onClick={handleStartDeleteAccount}
                       disabled={isBusy || deleteStage !== 'idle'}
                       aria-label="Delete account"
                       title="Delete account"

--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -4,7 +4,9 @@ import { authenticatedFetch } from '@/api/client';
 import type { FxStatus } from '@/api/dashboard';
 import {
   accountKeys,
+  budgetKeys,
   dashboardKeys,
+  insightsKeys,
   taxAdvantagedPlanKeys,
   transactionKeys,
   transactionOverviewKeys,
@@ -206,17 +208,27 @@ export function useUpdateAccount() {
 
       if ('is_archived' in variables.payload && previousIsArchived !== account.is_archived) {
         queryClient.invalidateQueries({ queryKey: accountKeys.list(), exact: true });
+        queryClient.invalidateQueries({ queryKey: accountKeys.accountScope(account.id), exact: false });
         queryClient.invalidateQueries({ queryKey: transactionKeys.all, exact: false });
         queryClient.invalidateQueries({ queryKey: transactionOverviewKeys.all, exact: false });
+        queryClient.invalidateQueries({ queryKey: budgetKeys.all, exact: false });
         queryClient.invalidateQueries({ queryKey: dashboardKeys.credit(), exact: true });
         queryClient.invalidateQueries({ queryKey: dashboardKeys.netWorthAll, exact: false });
         queryClient.invalidateQueries({ queryKey: dashboardKeys.savingsRateAll, exact: false });
         queryClient.invalidateQueries({ queryKey: dashboardKeys.recentActivityAll, exact: false });
         queryClient.invalidateQueries({ queryKey: dashboardKeys.spendingComparisonAll, exact: false });
         queryClient.invalidateQueries({ queryKey: dashboardKeys.spendingBreakdownAll, exact: false });
+        queryClient.invalidateQueries({ queryKey: insightsKeys.periodGlanceAll, exact: false });
+        queryClient.invalidateQueries({ queryKey: insightsKeys.fundFlowAll, exact: false });
+        queryClient.invalidateQueries({ queryKey: insightsKeys.incomeExpenseBreakdownAll, exact: false });
+        queryClient.invalidateQueries({ queryKey: insightsKeys.cashFlowAll, exact: false });
+        queryClient.invalidateQueries({ queryKey: insightsKeys.netWorthAll, exact: false });
+        queryClient.invalidateQueries({ queryKey: insightsKeys.savingsRateTrendAll, exact: false });
+        queryClient.invalidateQueries({ queryKey: insightsKeys.merchantsAll, exact: false });
         queryClient.invalidateQueries({ queryKey: userKeys.runwayAccounts(), exact: true });
         queryClient.invalidateQueries({ queryKey: userKeys.runwaySettings(), exact: true });
         queryClient.invalidateQueries({ queryKey: userKeys.runway(), exact: true });
+        invalidateTaxAdvantagedPlanCaches(queryClient, [account.tax_advantaged_plan_id]);
       }
 
       if (

--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -54,7 +54,7 @@ export interface AccountsOverview {
   base_currency_current_balance: number | null;
   current_balance_fx_status: FxStatus;
   credit_limit: number | null;
-  is_hidden: boolean;
+  is_archived: boolean;
   closed_at: string | null;
 }
 
@@ -97,7 +97,7 @@ export interface CreateAccountPayload {
   currency: string;
   credit_limit: number | null;
   starting_balance: number | null;
-  is_hidden: boolean;
+  is_archived: boolean;
 }
 
 export interface UpdateAccountPayload {
@@ -105,7 +105,7 @@ export interface UpdateAccountPayload {
   name?: string;
   institution_id?: string | null;
   credit_limit?: number | null;
-  is_hidden?: boolean;
+  is_archived?: boolean;
   closed_at?: string | null;
 }
 
@@ -155,12 +155,12 @@ function getCachedTaxAdvantagedPlanId(
   return accounts?.find((account) => account.id === accountId)?.tax_advantaged_plan_id;
 }
 
-function getCachedIsHidden(queryClient: QueryClient, accountId: string): boolean | undefined {
+function getCachedIsArchived(queryClient: QueryClient, accountId: string): boolean | undefined {
   const detail = queryClient.getQueryData<Account>(accountKeys.detail(accountId));
-  if (detail) return detail.is_hidden;
+  if (detail) return detail.is_archived;
 
   const accounts = queryClient.getQueryData<AccountsOverview[]>(accountKeys.list());
-  return accounts?.find((account) => account.id === accountId)?.is_hidden;
+  return accounts?.find((account) => account.id === accountId)?.is_archived;
 }
 
 function getCachedCreditLimit(queryClient: QueryClient, accountId: string): number | null | undefined {
@@ -198,13 +198,13 @@ export function useUpdateAccount() {
     mutationFn: updateAccount,
     onSuccess: (account, variables) => {
       const previousPlanId = getCachedTaxAdvantagedPlanId(queryClient, account.id);
-      const previousIsHidden = getCachedIsHidden(queryClient, account.id);
+      const previousIsArchived = getCachedIsArchived(queryClient, account.id);
       const previousCreditLimit = getCachedCreditLimit(queryClient, account.id);
 
       queryClient.setQueryData(accountKeys.detail(account.id), account);
       updateCachedAccountList(queryClient, account);
 
-      if ('is_hidden' in variables.payload && previousIsHidden !== account.is_hidden) {
+      if ('is_archived' in variables.payload && previousIsArchived !== account.is_archived) {
         queryClient.invalidateQueries({ queryKey: accountKeys.list(), exact: true });
         queryClient.invalidateQueries({ queryKey: transactionKeys.all, exact: false });
         queryClient.invalidateQueries({ queryKey: transactionOverviewKeys.all, exact: false });

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -74,12 +74,19 @@ export const dashboardKeys = {
 };
 
 export const insightsKeys = {
+  periodGlanceAll: ['insights-period-glance'] as const,
   periodGlance: (fromDate: string, toDate: string) => ['insights-period-glance', fromDate, toDate] as const,
+  fundFlowAll: ['insights-fund-flow'] as const,
   fundFlow: (fromDate: string, toDate: string) => ['insights-fund-flow', fromDate, toDate] as const,
+  incomeExpenseBreakdownAll: ['insights-income-expense-breakdown'] as const,
   incomeExpenseBreakdown: (fromDate: string, toDate: string) => ['insights-income-expense-breakdown', fromDate, toDate] as const,
+  cashFlowAll: ['insights-cash-flow'] as const,
   cashFlow: (fromDate: string, toDate: string) => ['insights-cash-flow', fromDate, toDate] as const,
+  netWorthAll: ['insights-net-worth'] as const,
   netWorth: (fromDate: string, toDate: string) => ['insights-net-worth', fromDate, toDate] as const,
+  savingsRateTrendAll: ['insights-savings-rate-trend'] as const,
   savingsRateTrend: () => ['insights-savings-rate-trend'] as const,
+  merchantsAll: ['insights-merchants'] as const,
   merchants: (fromDate: string, toDate: string) => ['insights-merchants', fromDate, toDate] as const,
 };
 

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -69,11 +69,18 @@ interface RunwayThresholdsResponse {
 
 interface RunwaySettingsResponse {
   account_ids: string[];
+  archived_account_ids: string[];
+  thresholds: RunwayThresholdsResponse;
+}
+
+interface RunwaySettingsPayload {
+  account_ids: string[];
   thresholds: RunwayThresholdsResponse;
 }
 
 export interface RunwaySettings {
   accountIds: string[];
+  archivedAccountIds: string[];
   thresholds: RunwayThresholds;
 }
 
@@ -95,11 +102,12 @@ function toRunwayThresholdsPayload(thresholds: RunwayThresholds): RunwayThreshol
 function fromRunwaySettingsResponse(settings: RunwaySettingsResponse): RunwaySettings {
   return {
     accountIds: settings.account_ids,
+    archivedAccountIds: settings.archived_account_ids,
     thresholds: fromRunwayThresholdsResponse(settings.thresholds),
   };
 }
 
-function toRunwaySettingsPayload(settings: RunwaySettings): RunwaySettingsResponse {
+function toRunwaySettingsPayload(settings: RunwaySettings): RunwaySettingsPayload {
   return {
     account_ids: settings.accountIds,
     thresholds: toRunwayThresholdsPayload(settings.thresholds),

--- a/frontend/src/api/user.ts
+++ b/frontend/src/api/user.ts
@@ -84,6 +84,11 @@ export interface RunwaySettings {
   thresholds: RunwayThresholds;
 }
 
+export interface RunwaySettingsUpdate {
+  accountIds: string[];
+  thresholds: RunwayThresholds;
+}
+
 function fromRunwayThresholdsResponse(thresholds: RunwayThresholdsResponse): RunwayThresholds {
   return normalizeRunwayThresholds({
     riskyBelowMonths: thresholds.risky_below_months,
@@ -107,7 +112,7 @@ function fromRunwaySettingsResponse(settings: RunwaySettingsResponse): RunwaySet
   };
 }
 
-function toRunwaySettingsPayload(settings: RunwaySettings): RunwaySettingsPayload {
+function toRunwaySettingsPayload(settings: RunwaySettingsUpdate): RunwaySettingsPayload {
   return {
     account_ids: settings.accountIds,
     thresholds: toRunwayThresholdsPayload(settings.thresholds),
@@ -129,7 +134,7 @@ export function useRunwaySettings() {
 export function useUpdateRunwaySettings() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async (settings: RunwaySettings) => fromRunwaySettingsResponse(
+    mutationFn: async (settings: RunwaySettingsUpdate) => fromRunwaySettingsResponse(
       await authenticatedFetch<RunwaySettingsResponse>('/me/runway-settings', {
         method: 'PUT',
         body: JSON.stringify(toRunwaySettingsPayload(settings)),

--- a/frontend/src/components/CreateAccountModal.tsx
+++ b/frontend/src/components/CreateAccountModal.tsx
@@ -279,7 +279,7 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
         if (amount === null) return null;
         return isLiability ? -amount : amount;
       })(),
-      is_hidden: false,
+      is_archived: false,
     };
 
     mutation.mutate(payload, {

--- a/frontend/src/components/CreateTransactionModal.tsx
+++ b/frontend/src/components/CreateTransactionModal.tsx
@@ -314,14 +314,21 @@ export default function CreateTransactionModal({
   const { data: accounts = [] } = useAccounts()
   const { data: categories = [] } = useCategories()
   const { data: currencies = [] } = useCurrencies()
+  const selectableAccounts = useMemo(
+    () => accounts.filter((account) => !account.is_archived),
+    [accounts],
+  )
 
   // Build the initial form from the existing transaction (edit) or sensible defaults (create).
   const initialForm = useMemo<TransactionForm>(() => {
     if (!transaction) {
+      const defaultAccount = defaultAccountId
+        ? selectableAccounts.find((account) => account.id === defaultAccountId)
+        : undefined
       return {
         ...INITIAL_FORM,
-        account_id: defaultAccountId ?? INITIAL_FORM.account_id,
-        currency: defaultCurrency ?? INITIAL_FORM.currency,
+        account_id: defaultAccount?.id ?? INITIAL_FORM.account_id,
+        currency: defaultAccount?.currency ?? defaultCurrency ?? INITIAL_FORM.currency,
         date: todayLocalString(),
       }
     }
@@ -340,7 +347,7 @@ export default function CreateTransactionModal({
       date: transaction.dt,
       tag_ids: transaction.tags?.map((tag) => tag.id) ?? transaction.tag_ids,
     }
-  }, [transaction, categories, currencies, defaultAccountId, defaultCurrency])
+  }, [transaction, categories, currencies, defaultAccountId, defaultCurrency, selectableAccounts])
 
   const [form, setForm] = useState(initialForm)
   const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
@@ -677,9 +684,12 @@ export default function CreateTransactionModal({
   }, [categories])
 
   const accountOptions = useMemo(
-    () => accounts.map((a) => ({ value: a.id, label: a.name })),
-    [accounts],
+    () => selectableAccounts.map((account) => ({ value: account.id, label: account.name })),
+    [selectableAccounts],
   )
+  const selectedArchivedAccountOption = editing && selectedAccount?.is_archived
+    ? { value: selectedAccount.id, label: selectedAccount.name }
+    : undefined
   const categoryOptions = useMemo(
     () => buildCategoryOptions(categories, form.kind),
     [categories, form.kind],
@@ -1222,6 +1232,7 @@ export default function CreateTransactionModal({
                           <FieldLabelRow label="Account" error={showError('account_id')} />
                           <Dropdown
                             options={accountOptions}
+                            selectedOption={selectedArchivedAccountOption}
                             value={form.account_id}
                             onChange={handleAccountChange}
                             className={`app-input ${showError('account_id') ? 'app-input-error' : ''}`}

--- a/frontend/src/components/TransactionRow.tsx
+++ b/frontend/src/components/TransactionRow.tsx
@@ -66,6 +66,17 @@ function AccountLogo({
   )
 }
 
+function ReadOnlyReasonPill({ reason }: { reason: string }) {
+  return (
+    <span
+      className="inline-flex w-fit max-w-full rounded-full border px-1.5 py-0.5 text-[0.6875rem] leading-none"
+      style={{ borderColor: 'var(--app-border)', color: 'var(--app-text-subtle)' }}
+    >
+      <span className="min-w-0 truncate">{reason}</span>
+    </span>
+  )
+}
+
 function TagTooltip({ tags }: { tags: Transaction['tags'] }) {
   return (
     <span className="pointer-events-none absolute bottom-full left-1/2 z-20 mb-2 flex w-52 -translate-x-1/2 flex-col items-start gap-1 opacity-0 transition-opacity duration-150 group-hover:opacity-100">
@@ -153,16 +164,14 @@ export default function TransactionRow({
         <span className="flex min-w-0 items-center self-stretch">
           {hasAccountMeta ? (
             <span
-              className="inline-flex max-w-full items-center gap-2 text-sm font-medium leading-none"
+              className="flex min-w-0 max-w-full flex-col gap-1 text-sm font-medium leading-none"
               style={{ color: 'var(--app-text-muted)' }}
             >
-              <AccountLogo accountName={accountName} institution={accountInstitution} />
-              {accountName && <span className="min-w-0 truncate">{accountName}</span>}
-              {readOnlyReason && (
-                <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[0.6875rem] leading-none" style={{ borderColor: 'var(--app-border)', color: 'var(--app-text-subtle)' }}>
-                  {readOnlyReason}
-                </span>
-              )}
+              <span className="inline-flex min-w-0 max-w-full items-center gap-2">
+                <AccountLogo accountName={accountName} institution={accountInstitution} />
+                {accountName && <span className="min-w-0 truncate">{accountName}</span>}
+              </span>
+              {readOnlyReason && <ReadOnlyReasonPill reason={readOnlyReason} />}
             </span>
           ) : (
             <span aria-hidden>&nbsp;</span>
@@ -252,25 +261,23 @@ export default function TransactionRow({
 
         {(hasAccountMeta || hasSupplementalMeta) && (
           <span
-            className="col-start-2 col-span-2 row-start-3 flex min-w-0 items-center gap-2 text-sm leading-5"
+            className="col-start-2 col-span-2 row-start-3 flex min-w-0 items-start gap-2 text-sm leading-5"
             style={{ color: 'var(--app-text-muted)' }}
           >
             {hasAccountMeta ? (
-              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                <AccountLogo accountName={accountName} institution={accountInstitution} />
-                {accountName && <span className="min-w-0 truncate">{accountName}</span>}
-                {readOnlyReason && (
-                  <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[0.6875rem] leading-none" style={{ borderColor: 'var(--app-border)', color: 'var(--app-text-subtle)' }}>
-                    {readOnlyReason}
-                  </span>
-                )}
+              <span className="flex min-w-0 flex-1 flex-col gap-1">
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <AccountLogo accountName={accountName} institution={accountInstitution} />
+                  {accountName && <span className="min-w-0 truncate">{accountName}</span>}
+                </span>
+                {readOnlyReason && <ReadOnlyReasonPill reason={readOnlyReason} />}
               </span>
             ) : (
               <span className="min-w-0 flex-1" aria-hidden />
             )}
 
             {hasSupplementalMeta && (
-              <span className="inline-flex shrink-0 items-center gap-2">
+              <span className="inline-flex shrink-0 items-center gap-2 pt-0.5">
                 {hasNotes && (
                   <span className="inline-flex" aria-label="Has note">
                     <StickyNote size={14} strokeWidth={2} aria-hidden />
@@ -317,14 +324,12 @@ export default function TransactionRow({
           {hasAccountMeta && (
             <>
               <span aria-hidden>·</span>
-              <span className="inline-flex min-w-0 items-center gap-1.5">
-                <AccountLogo accountName={accountName} institution={accountInstitution} />
-                {accountName && <span className="min-w-0 truncate">{accountName}</span>}
-                {readOnlyReason && (
-                  <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[0.6875rem] leading-none" style={{ borderColor: 'var(--app-border)', color: 'var(--app-text-subtle)' }}>
-                    {readOnlyReason}
-                  </span>
-                )}
+              <span className="flex min-w-0 flex-col gap-1">
+                <span className="inline-flex min-w-0 items-center gap-1.5">
+                  <AccountLogo accountName={accountName} institution={accountInstitution} />
+                  {accountName && <span className="min-w-0 truncate">{accountName}</span>}
+                </span>
+                {readOnlyReason && <ReadOnlyReasonPill reason={readOnlyReason} />}
               </span>
             </>
           )}

--- a/frontend/src/components/TransactionRow.tsx
+++ b/frontend/src/components/TransactionRow.tsx
@@ -12,6 +12,7 @@ interface TransactionRowProps {
   accountInstitution?: Institution | null
   category: Category | undefined
   currency: string
+  readOnlyReason?: string
   transaction: Transaction
   onOpen: (transaction: Transaction) => void
 }
@@ -102,6 +103,7 @@ export default function TransactionRow({
   accountInstitution,
   category,
   currency,
+  readOnlyReason,
   transaction,
   onOpen,
 }: TransactionRowProps) {
@@ -116,15 +118,22 @@ export default function TransactionRow({
   const hasVisibleTags = visibleTags.length > 0
   const hasSupplementalMeta = hasNotes || hasVisibleTags
   const hasAccountMeta = !!accountName || !!accountInstitution
+  const readOnly = Boolean(readOnlyReason)
   const formattedAmount = `${transaction.amount >= 0 ? '+' : '-'}${formatCurrency(Math.abs(transaction.amount), currency)}`
   const transactionAmountColor = amountColor(category, transaction.amount)
 
   return (
     <button
       type="button"
-      onClick={() => onOpen(transaction)}
-      className="block w-full cursor-pointer px-3 py-2.5 text-left transition-colors duration-100 hover:bg-[var(--app-surface-soft)] focus-visible:bg-[var(--app-surface-soft)] focus-visible:outline-none"
-      style={{ borderBottom: '1px solid var(--app-border)' }}
+      onClick={() => {
+        if (!readOnly) onOpen(transaction)
+      }}
+      disabled={readOnly}
+      className={`block w-full px-3 py-2.5 text-left transition-colors duration-100 focus-visible:bg-[var(--app-surface-soft)] focus-visible:outline-none ${readOnly ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--app-surface-soft)]'}`}
+      style={{
+        borderBottom: '1px solid var(--app-border)',
+        opacity: readOnly ? 0.68 : 1,
+      }}
     >
       <span className="hidden min-[1300px]:grid min-[1300px]:grid-cols-[2.5rem_14rem_13rem_minmax(2.75rem,1fr)_max-content_minmax(8rem,1fr)] min-[1300px]:items-center min-[1300px]:gap-3">
         <span className="text-2xl leading-none" aria-hidden>
@@ -148,7 +157,12 @@ export default function TransactionRow({
               style={{ color: 'var(--app-text-muted)' }}
             >
               <AccountLogo accountName={accountName} institution={accountInstitution} />
-              {accountName && <span className="truncate">{accountName}</span>}
+              {accountName && <span className="min-w-0 truncate">{accountName}</span>}
+              {readOnlyReason && (
+                <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[0.6875rem] leading-none" style={{ borderColor: 'var(--app-border)', color: 'var(--app-text-subtle)' }}>
+                  {readOnlyReason}
+                </span>
+              )}
             </span>
           ) : (
             <span aria-hidden>&nbsp;</span>
@@ -244,7 +258,12 @@ export default function TransactionRow({
             {hasAccountMeta ? (
               <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
                 <AccountLogo accountName={accountName} institution={accountInstitution} />
-                {accountName && <span className="truncate">{accountName}</span>}
+                {accountName && <span className="min-w-0 truncate">{accountName}</span>}
+                {readOnlyReason && (
+                  <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[0.6875rem] leading-none" style={{ borderColor: 'var(--app-border)', color: 'var(--app-text-subtle)' }}>
+                    {readOnlyReason}
+                  </span>
+                )}
               </span>
             ) : (
               <span className="min-w-0 flex-1" aria-hidden />
@@ -300,7 +319,12 @@ export default function TransactionRow({
               <span aria-hidden>·</span>
               <span className="inline-flex min-w-0 items-center gap-1.5">
                 <AccountLogo accountName={accountName} institution={accountInstitution} />
-                {accountName && <span className="truncate">{accountName}</span>}
+                {accountName && <span className="min-w-0 truncate">{accountName}</span>}
+                {readOnlyReason && (
+                  <span className="shrink-0 rounded-full border px-1.5 py-0.5 text-[0.6875rem] leading-none" style={{ borderColor: 'var(--app-border)', color: 'var(--app-text-subtle)' }}>
+                    {readOnlyReason}
+                  </span>
+                )}
               </span>
             </>
           )}

--- a/frontend/src/dashboard/utils/getRunwaySegments.ts
+++ b/frontend/src/dashboard/utils/getRunwaySegments.ts
@@ -9,7 +9,7 @@ function getRunwayAccountColorSeed(accountName: string) {
 
 /**
  * Converts selected positive-balance runway accounts into proportional bar segments.
- * Hidden accounts and unavailable runway states produce no segments.
+ * Archived accounts and unavailable runway states produce no segments.
  */
 export function getRunwaySegments(
   accounts: AccountsOverview[] | undefined,
@@ -25,14 +25,14 @@ export function getRunwaySegments(
       accountBalance.balance,
     ]),
   )
-  // Only selected visible accounts with positive balances contribute to the
-  // bar; hidden accounts and liabilities are excluded before this helper.
+  // Only selected active accounts with positive balances contribute to the
+  // bar; archived accounts and liabilities are excluded before this helper.
   const rows = (accounts ?? [])
     .map((account) => ({
       account,
       balance: balanceByAccountId.get(account.id) ?? 0,
     }))
-    .filter(({ account, balance }) => ids.has(account.id) && !account.is_hidden && balance > 0)
+    .filter(({ account, balance }) => ids.has(account.id) && !account.is_archived && balance > 0)
     .sort((a, b) => b.balance - a.balance)
   const total = rows.reduce((sum, row) => sum + row.balance, 0)
   if (total === 0) return []

--- a/frontend/src/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/imports/hooks/useTransactionImportWorkflow.ts
@@ -77,17 +77,21 @@ export function useTransactionImportWorkflow() {
   const { data: institutions = [], isLoading: institutionsLoading } = useInstitutions()
   const { data: categories, isLoading: categoriesLoading } = useCategories()
   const importTransactions = useImportTransactions()
+  const selectableAccounts = useMemo(
+    () => accounts.filter((account) => !account.is_archived),
+    [accounts],
+  )
 
   const accountOptions = useMemo<DropdownOption[]>(
     () => [
       { value: CREATE_ACCOUNT_VALUE, label: 'Create New Account', group: 'Import Action' },
-      ...accounts.map((account) => ({
+      ...selectableAccounts.map((account) => ({
         value: account.id,
         label: account.name,
         group: ACCOUNT_KIND_LABELS[account.account_kind],
       })),
     ],
-    [accounts],
+    [selectableAccounts],
   )
 
   const currencyOptions = useMemo<DropdownOption[]>(
@@ -131,8 +135,8 @@ export function useTransactionImportWorkflow() {
   )
 
   const accountById = useMemo(
-    () => new Map(accounts.map((account) => [account.id, account])),
-    [accounts],
+    () => new Map(selectableAccounts.map((account) => [account.id, account])),
+    [selectableAccounts],
   )
 
   const categoryById = useMemo(
@@ -204,10 +208,10 @@ export function useTransactionImportWorkflow() {
   const resolvedAccountMappings = useMemo(
     () => (
       canInferAccountMappings
-        ? inferAccountMappings(accountMappingSources, accountMappings, accounts)
+        ? inferAccountMappings(accountMappingSources, accountMappings, selectableAccounts)
         : accountMappings
     ),
-    [accountMappingSources, accountMappings, accounts, canInferAccountMappings],
+    [accountMappingSources, accountMappings, canInferAccountMappings, selectableAccounts],
   )
 
   const autoFilledAccountSources = useMemo(

--- a/frontend/src/settings/SettingsPage.tsx
+++ b/frontend/src/settings/SettingsPage.tsx
@@ -76,7 +76,7 @@ export default function SettingsPage() {
   const selectableAccounts = useMemo(
     () =>
       (accounts ?? []).filter(
-        (a) => a.closed_at === null && !a.is_hidden && a.account_kind === 'asset',
+        (a) => a.closed_at === null && !a.is_archived && a.account_kind === 'asset',
       ),
     [accounts],
   )

--- a/frontend/src/settings/SettingsPage.tsx
+++ b/frontend/src/settings/SettingsPage.tsx
@@ -68,6 +68,10 @@ export default function SettingsPage() {
   // tile, keep a local override until Save or Discard resolves it.
   const [runwayDraft, setRunwayDraft] = useState<Set<string> | null>(null)
   const runwayServerSet = useMemo(() => new Set(runwaySettings?.accountIds ?? []), [runwaySettings?.accountIds])
+  const archivedRunwayServerSet = useMemo(
+    () => new Set(runwaySettings?.archivedAccountIds ?? []),
+    [runwaySettings?.archivedAccountIds],
+  )
   const runwaySelection = runwayDraft ?? runwayServerSet
   // Only open asset accounts are eligible. Credit products (credit cards,
   // lines of credit, HELOCs) are borrowed headroom — treating them as runway
@@ -79,6 +83,10 @@ export default function SettingsPage() {
         (a) => a.closed_at === null && !a.is_archived && a.account_kind === 'asset',
       ),
     [accounts],
+  )
+  const archivedRunwayAccounts = useMemo(
+    () => (accounts ?? []).filter((account) => archivedRunwayServerSet.has(account.id)),
+    [accounts, archivedRunwayServerSet],
   )
   const toggleRunwayAccount = (id: string) => {
     setRunwayDraft((prev) => {
@@ -516,6 +524,7 @@ export default function SettingsPage() {
           <RunwaySection
             loading={accountsLoading || runwaySettingsLoading}
             accounts={selectableAccounts}
+            archivedAccounts={archivedRunwayAccounts}
             selection={runwaySelection}
             onToggle={toggleRunwayAccount}
             thresholds={runwayThresholdValues}

--- a/frontend/src/settings/components/RunwaySection.tsx
+++ b/frontend/src/settings/components/RunwaySection.tsx
@@ -112,31 +112,23 @@ export default function RunwaySection({
               </div>
             )}
 
-            {!loading && archivedAccounts.length > 0 && (
-              <div
-                className="space-y-3 rounded-xl border px-3 py-3"
-                style={{
-                  background: 'var(--app-surface)',
-                  borderColor: 'var(--app-border)',
-                }}
-              >
-                <div className="flex items-start gap-2">
-                  <Archive size={16} className="mt-0.5 shrink-0" aria-hidden style={{ color: 'var(--app-text-muted)' }} />
-                  <div className="min-w-0 space-y-1">
-                    <h4 className="text-sm font-semibold">Archived selections</h4>
-                    <p className="text-xs leading-5" style={{ color: 'var(--app-text-muted)' }}>
-                      These accounts were selected before being archived. Archived accounts do not count toward runway and cannot be changed here. Unarchive an account to make it eligible again.
-                    </p>
-                  </div>
-                </div>
-                <div className="grid gap-2 min-[1500px]:grid-cols-2">
-                  {archivedAccounts.map((account) => (
-                    <ArchivedRunwayAccountTile key={account.id} account={account} />
-                  ))}
-                </div>
-              </div>
-            )}
           </div>
+
+          {!loading && archivedAccounts.length > 0 && (
+            <div className="space-y-4 border-t pt-6" style={{ borderColor: 'var(--app-border)' }}>
+              <div className="space-y-1">
+                <h3 className="text-base font-semibold">Archived selections</h3>
+                <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                  These accounts were selected before being archived. Archived accounts do not count toward runway and cannot be changed here. Unarchive an account to make it eligible again.
+                </p>
+              </div>
+              <div className="grid gap-2 min-[1500px]:grid-cols-2">
+                {archivedAccounts.map((account) => (
+                  <ArchivedRunwayAccountTile key={account.id} account={account} />
+                ))}
+              </div>
+            </div>
+          )}
 
           {actions}
         </div>

--- a/frontend/src/settings/components/RunwaySection.tsx
+++ b/frontend/src/settings/components/RunwaySection.tsx
@@ -1,4 +1,4 @@
-import { Check } from 'lucide-react'
+import { Archive, Check } from 'lucide-react'
 import {
   useRef,
   useState,
@@ -32,6 +32,7 @@ const RUNWAY_TRACK_LABEL_MIN_PCT = 12
 interface RunwaySectionProps {
   loading: boolean
   accounts: AccountsOverview[]
+  archivedAccounts: AccountsOverview[]
   selection: Set<string>
   onToggle: (id: string) => void
   thresholds: RunwayThresholds
@@ -42,6 +43,7 @@ interface RunwaySectionProps {
 export default function RunwaySection({
   loading,
   accounts,
+  archivedAccounts,
   selection,
   onToggle,
   thresholds,
@@ -109,12 +111,73 @@ export default function RunwaySection({
                 </p>
               </div>
             )}
+
+            {!loading && archivedAccounts.length > 0 && (
+              <div
+                className="space-y-3 rounded-xl border px-3 py-3"
+                style={{
+                  background: 'var(--app-surface)',
+                  borderColor: 'var(--app-border)',
+                }}
+              >
+                <div className="flex items-start gap-2">
+                  <Archive size={16} className="mt-0.5 shrink-0" aria-hidden style={{ color: 'var(--app-text-muted)' }} />
+                  <div className="min-w-0 space-y-1">
+                    <h4 className="text-sm font-semibold">Archived selections</h4>
+                    <p className="text-xs leading-5" style={{ color: 'var(--app-text-muted)' }}>
+                      These accounts were selected before being archived. Archived accounts do not count toward runway and cannot be changed here. Unarchive an account to make it eligible again.
+                    </p>
+                  </div>
+                </div>
+                <div className="grid gap-2 min-[1500px]:grid-cols-2">
+                  {archivedAccounts.map((account) => (
+                    <ArchivedRunwayAccountTile key={account.id} account={account} />
+                  ))}
+                </div>
+              </div>
+            )}
           </div>
 
           {actions}
         </div>
       </SettingsCard>
     </section>
+  )
+}
+
+function ArchivedRunwayAccountTile({ account }: { account: AccountsOverview }) {
+  const institutionName = account.institution?.name ?? 'Cash'
+  return (
+    <div
+      className="app-marquee-trigger flex w-full min-w-0 items-center gap-3 overflow-hidden rounded-xl px-3 py-2.5 text-left"
+      style={{
+        background: 'var(--app-input-bg)',
+        border: '1px solid var(--app-input-border)',
+        opacity: 0.6,
+      }}
+    >
+      <span
+        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-md"
+        style={{
+          background: 'transparent',
+          border: '1px solid var(--app-border-strong)',
+          color: 'var(--app-text-muted)',
+        }}
+      >
+        <Archive size={12} aria-hidden />
+      </span>
+      <span className="min-w-0 flex-1 overflow-hidden">
+        <MarqueeText active className="font-medium">{account.name}</MarqueeText>
+        <span className="block text-xs truncate" style={{ color: 'var(--app-text-muted)' }}>
+          {institutionName} · Archived
+        </span>
+      </span>
+      <span className="shrink-0 text-right tabular-nums">
+        <span className="block font-financial text-sm font-medium" style={{ color: 'var(--app-text-muted)' }}>
+          {formatCurrency(account.current_balance, account.currency)}
+        </span>
+      </span>
+    </div>
   )
 }
 

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -374,6 +374,7 @@ export default function TaxAdvantagedCategoryModal({
   const bindableAccounts = accounts.filter(
     (account) =>
       account.closed_at === null
+      && !account.is_archived
       && account.account_kind === 'asset'
       && account.currency === plan.currency,
   )

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -374,7 +374,6 @@ export default function TaxAdvantagedCategoryModal({
   const bindableAccounts = accounts.filter(
     (account) =>
       account.closed_at === null
-      && !account.is_archived
       && account.account_kind === 'asset'
       && account.currency === plan.currency,
   )
@@ -552,6 +551,8 @@ export default function TaxAdvantagedCategoryModal({
   }
 
   const handleToggleAccount = (account: AccountsOverview) => {
+    if (account.is_archived) return
+
     const isLinked = account.tax_advantaged_plan_id === plan.id
     showAutosaveNotice({ status: 'saving', message: 'Saving account link...' })
     updateAccount.mutate(
@@ -1222,7 +1223,7 @@ export default function TaxAdvantagedCategoryModal({
                   <div className="space-y-4">
                     <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
                       <p className="text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
-                        Choose eligible {plan.currency} accounts for this category.
+                        Choose eligible {plan.currency} accounts for this category. Archived accounts stay visible for history but cannot be linked or unlinked until unarchived.
                       </p>
                       <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
                         {bindableAccounts.filter((account) => account.tax_advantaged_plan_id === plan.id).length} of {bindableAccounts.length} linked
@@ -1248,20 +1249,26 @@ export default function TaxAdvantagedCategoryModal({
                           const linked = account.tax_advantaged_plan_id === plan.id
                           const linkedElsewhere = account.tax_advantaged_plan_id !== null && !linked
                           const pending = updateAccount.isPending && updateAccount.variables?.accountId === account.id
+                          const disabled = account.is_archived || linkedElsewhere || pending
+                          const statusParts = [
+                            account.institution?.name ?? 'Cash',
+                            account.is_archived ? 'Archived' : null,
+                            linkedElsewhere ? 'Linked elsewhere' : null,
+                          ].filter((part): part is string => part !== null)
                           return (
                             <label
                               key={account.id}
-                              className="grid cursor-pointer grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-sm transition-colors duration-150 hover:bg-[var(--app-accent-soft)]"
+                              className={`grid grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 px-4 py-3 text-sm transition-colors duration-150 ${disabled ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--app-accent-soft)]'}`}
                               style={{
                                 borderTop: index === 0 ? 'none' : '1px solid var(--app-border)',
-                                opacity: linkedElsewhere ? 0.55 : 1,
+                                opacity: account.is_archived || linkedElsewhere ? 0.55 : 1,
                               }}
                             >
                               <input
                                 type="checkbox"
                                 checked={linked}
                                 onChange={() => handleToggleAccount(account)}
-                                disabled={linkedElsewhere || pending}
+                                disabled={disabled}
                                 aria-label={`${linked ? 'Unlink' : 'Link'} ${account.name}`}
                                 className="h-4 w-4 cursor-pointer disabled:cursor-not-allowed"
                                 style={{ accentColor: 'var(--app-accent)' }}
@@ -1269,8 +1276,7 @@ export default function TaxAdvantagedCategoryModal({
                               <span className="min-w-0">
                                 <span className="block truncate font-medium">{account.name}</span>
                                 <span className="block truncate text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                                  {account.institution?.name ?? 'Cash'}
-                                  {linkedElsewhere ? ' · Linked elsewhere' : ''}
+                                  {statusParts.join(' · ')}
                                 </span>
                               </span>
                               <span className="font-financial text-sm">

--- a/frontend/src/transactions/TransactionsPage.tsx
+++ b/frontend/src/transactions/TransactionsPage.tsx
@@ -54,20 +54,28 @@ export default function TransactionsPage() {
   }
 
   const openEditModal = (transaction: Transaction) => {
+    const account = accounts?.find((item) => item.id === transaction.account_id)
+    if (account?.is_archived) return
+
     setEditingTransaction(transaction)
     setCreateModalKey((key) => key + 1)
     setShowCreateModal(true)
   }
 
   const openOutlierTransaction = async (transactionId: string) => {
+    setOutlierOpenError(null)
     // Outliers may not be in the currently loaded list page, so fall back to a detail fetch.
     const loadedTransaction = latestTransactionsRef.current.find((transaction) => transaction.id === transactionId)
     if (loadedTransaction) {
+      const account = accounts?.find((item) => item.id === loadedTransaction.account_id)
+      if (account?.is_archived) {
+        setOutlierOpenError('Archived account transactions are read-only')
+        return
+      }
       openEditModal(loadedTransaction)
       return
     }
 
-    setOutlierOpenError(null)
     setOpeningOutlierId(transactionId)
     try {
       const transaction = await queryClient.fetchQuery({
@@ -75,6 +83,11 @@ export default function TransactionsPage() {
         queryFn: () => fetchTransaction(transactionId),
         staleTime: 10 * 60 * 1000,
       })
+      const account = accounts?.find((item) => item.id === transaction.account_id)
+      if (account?.is_archived) {
+        setOutlierOpenError('Archived account transactions are read-only')
+        return
+      }
       openEditModal(transaction)
     } catch {
       setOutlierOpenError('Unable to open transaction')
@@ -121,6 +134,7 @@ export default function TransactionsPage() {
       name: account.name,
       currency: account.currency,
       institution: account.institution,
+      is_archived: account.is_archived,
     })),
     [accounts],
   )

--- a/frontend/src/transactions/components/TransactionDateGroupList.tsx
+++ b/frontend/src/transactions/components/TransactionDateGroupList.tsx
@@ -73,6 +73,7 @@ export default function TransactionDateGroupList({
               {transactions.map((transaction) => {
                 const category = categoryMap.get(transaction.category_id)
                 const rowAccount = fixedAccount ?? accountMap.get(transaction.account_id)
+                const readOnlyReason = rowAccount?.is_archived ? 'Archived · Read-only' : undefined
                 return (
                   <TransactionRow
                     key={transaction.id}
@@ -80,6 +81,7 @@ export default function TransactionDateGroupList({
                     accountName={rowAccount?.name}
                     category={category}
                     currency={fixedAccount?.currency ?? currency}
+                    readOnlyReason={readOnlyReason}
                     transaction={transaction}
                     onOpen={onEditTransaction}
                   />

--- a/frontend/src/transactions/components/TransactionListSection.tsx
+++ b/frontend/src/transactions/components/TransactionListSection.tsx
@@ -148,6 +148,8 @@ export default function TransactionListSection({
     () => groupTransactionsByDate(displayedTransactions),
     [displayedTransactions],
   )
+  const createDisabled = Boolean(fixedAccount?.is_archived)
+  const createDisabledReason = createDisabled ? 'Archived accounts are read-only' : undefined
 
   // Filter changes can schedule delayed loading cleanup; clear that timer if
   // the list unmounts mid-transition.
@@ -236,6 +238,8 @@ export default function TransactionListSection({
         }}
         onDateRangeClose={commitDateRange}
         onCreateTransaction={onCreateTransaction}
+        createDisabled={createDisabled}
+        createDisabledReason={createDisabledReason}
         onStickyOffsetChange={setDateHeaderStickyTop}
       />
 

--- a/frontend/src/transactions/components/TransactionListToolbar.tsx
+++ b/frontend/src/transactions/components/TransactionListToolbar.tsx
@@ -36,6 +36,8 @@ export default function TransactionListToolbar({
   onDateRangeReset,
   onDateRangeClose,
   onCreateTransaction,
+  createDisabled = false,
+  createDisabledReason,
   onStickyOffsetChange,
 }: {
   search: string
@@ -55,6 +57,8 @@ export default function TransactionListToolbar({
   onDateRangeReset: () => void
   onDateRangeClose: () => void
   onCreateTransaction: () => void
+  createDisabled?: boolean
+  createDisabledReason?: string
   onStickyOffsetChange?: (offset: number) => void
 }) {
   const [isMobileSheetOpen, setIsMobileSheetOpen] = useState(false)
@@ -368,7 +372,9 @@ export default function TransactionListToolbar({
             type="button"
             className="app-primary-button h-11 w-11 shrink-0 px-0"
             onClick={onCreateTransaction}
-            aria-label="Add transaction"
+            disabled={createDisabled}
+            title={createDisabledReason}
+            aria-label={createDisabledReason ?? 'Add transaction'}
           >
             <Plus size={18} aria-hidden />
           </button>
@@ -443,6 +449,8 @@ export default function TransactionListToolbar({
             type="button"
             className={`app-primary-button h-10 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
             onClick={onCreateTransaction}
+            disabled={createDisabled}
+            title={createDisabledReason}
           >
             <Plus size={18} aria-hidden />
             <span>Add Transaction</span>

--- a/frontend/src/transactions/types/transactionList.ts
+++ b/frontend/src/transactions/types/transactionList.ts
@@ -13,6 +13,7 @@ export interface TransactionListAccount {
   name?: string
   currency?: string
   institution?: AccountsOverview['institution']
+  is_archived?: boolean
 }
 
 export interface TransactionDateGroup {


### PR DESCRIPTION
- Rename hidden accounts to archived accounts across backend, frontend, and tests
- Zero account balances on archive with an `Account archived` balance adjustment transaction
- Keep archived account history visible and included in financial aggregates, insights, transaction browsing, and tax category metrics
- Block new or modified transactions against archived accounts
- Exclude archived accounts from active selectors, runway calculation balances, runway settings edits, and tax category linking
- Add archive warnings, read-only transaction states, archived runway visibility, and archived TAC account states
- Refresh dependent dashboard, insight, transaction, and runway caches after archiving

CU-86ba83tq0