### PR TITLE
fix: improve transaction cash flow graph and data cadence

### DIFF
--- a/backend/app/routes/transaction.py
+++ b/backend/app/routes/transaction.py
@@ -1,6 +1,6 @@
 import uuid
-from datetime import date
-from typing import Annotated
+from datetime import date, timedelta
+from typing import Annotated, Literal
 
 import sqlalchemy as sa
 from fastapi import APIRouter, Depends, HTTPException, Query, status
@@ -47,6 +47,9 @@ from app.services.transaction_responses import (
 router = APIRouter(prefix="/transactions", tags=["transactions"])
 
 _BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
+OverviewCashFlowGranularity = Literal["day", "week", "month"]
+_MONTHLY_RANGE_DAY_COUNT = 31
+_HALF_YEAR_DAY_COUNT = 183
 
 # Sortable fields mapped to their SQLAlchemy column objects
 _SORT_FIELDS: dict[str, MappedColumn] = {
@@ -182,12 +185,79 @@ def _fork_overview_converter(converter: FxConverter) -> FxConverter:
     return fork
 
 
+def _get_overview_cash_flow_granularity(from_date: date, to_date: date) -> OverviewCashFlowGranularity:
+    day_count = (to_date - from_date).days + 1
+    if day_count <= _MONTHLY_RANGE_DAY_COUNT:
+        return "day"
+    if day_count <= _HALF_YEAR_DAY_COUNT:
+        return "week"
+    return "month"
+
+
+def _overview_cash_flow_bucket_key(
+    target: date,
+    granularity: OverviewCashFlowGranularity,
+) -> tuple[int, ...]:
+    if granularity == "day":
+        return (target.year, target.month, target.day)
+    if granularity == "week":
+        iso_year, iso_week, _weekday = target.isocalendar()
+        return (iso_year, iso_week)
+    return (target.year, target.month)
+
+
+def _build_overview_cash_flow_buckets(from_date: date, to_date: date) -> list[tuple[date, date]]:
+    granularity = _get_overview_cash_flow_granularity(from_date, to_date)
+    buckets: list[tuple[date, date]] = []
+    bucket_start = from_date
+    current_key = _overview_cash_flow_bucket_key(from_date, granularity)
+    cursor = from_date
+
+    while cursor <= to_date:
+        key = _overview_cash_flow_bucket_key(cursor, granularity)
+        if key != current_key:
+            buckets.append((bucket_start, cursor - timedelta(days=1)))
+            bucket_start = cursor
+            current_key = key
+        cursor += timedelta(days=1)
+
+    buckets.append((bucket_start, to_date))
+    return buckets
+
+
+def _bucket_overview_daily_cash_flow(
+    daily_totals: dict[date, tuple[int, int]],
+    *,
+    from_date: date,
+    to_date: date,
+) -> list[DailyCashFlow]:
+    daily_cash_flow: list[DailyCashFlow] = []
+    for bucket_start, bucket_end in _build_overview_cash_flow_buckets(from_date, to_date):
+        inflow = 0
+        outflow = 0
+        cursor = bucket_start
+        while cursor <= bucket_end:
+            day_inflow, day_outflow = daily_totals.get(cursor, (0, 0))
+            inflow += day_inflow
+            outflow += day_outflow
+            cursor += timedelta(days=1)
+        daily_cash_flow.append(DailyCashFlow(
+            date=bucket_start,
+            end_date=bucket_end,
+            inflow=inflow,
+            outflow=outflow,
+        ))
+    return daily_cash_flow
+
+
 async def _convert_overview_daily_cash_flow(
     *,
     flow_rows,
     account_by_id: dict[uuid.UUID, Account],
     converter: FxConverter,
     base_currency: str,
+    from_date: date | None,
+    to_date: date | None,
 ) -> tuple[list[DailyCashFlow], FxStatus]:
     daily_totals: dict[date, tuple[int, int]] = {}
     for row in flow_rows:
@@ -218,10 +288,16 @@ async def _convert_overview_daily_cash_flow(
             outflow + (converted_outflow or 0),
         )
 
-    daily_cash_flow = [
-        DailyCashFlow(date=flow_date, inflow=inflow, outflow=outflow)
-        for flow_date, (inflow, outflow) in sorted(daily_totals.items())
-    ]
+    if not daily_totals:
+        return [], converter.get_status()
+
+    period_start = from_date or min(daily_totals)
+    period_end = to_date or max(daily_totals)
+    daily_cash_flow = _bucket_overview_daily_cash_flow(
+        daily_totals,
+        from_date=period_start,
+        to_date=period_end,
+    )
     return daily_cash_flow, converter.get_status()
 
 
@@ -505,6 +581,8 @@ async def get_transactions_overview(
         account_by_id=account_by_id,
         converter=_fork_overview_converter(overview_converter),
         base_currency=user.base_currency,
+        from_date=from_date,
+        to_date=to_date,
     )
     total_inflow, total_outflow = _sum_overview_net_flow(daily_cash_flow)
     outliers, outliers_fx_status = await _convert_overview_outliers(

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -15,9 +15,10 @@ class TopCategorySpend(BaseModel):
 
 
 class DailyCashFlow(BaseModel):
-    """Inflow and outflow totals for a single day."""
+    """Inflow and outflow totals for one cash-flow chart period."""
 
     date: date
+    end_date: date
     inflow: int
     outflow: int
 

--- a/backend/tests/routes/test_transaction.py
+++ b/backend/tests/routes/test_transaction.py
@@ -737,7 +737,7 @@ async def test_transactions_overview_net_flow_excludes_balance_adjustments(clien
     assert data["total_inflow"] == 12_500
     assert data["total_outflow"] == -5_500
     assert data["daily_cash_flow"] == [
-        {"date": "2026-03-15", "inflow": 12_500, "outflow": -5_500},
+        {"date": "2026-03-15", "end_date": "2026-03-15", "inflow": 12_500, "outflow": -5_500},
     ]
 
 
@@ -912,8 +912,8 @@ async def test_transactions_overview_daily_cash_flow_converts_foreign_accounts(c
     assert resp.status_code == 200
     data = resp.json()
     assert data["daily_cash_flow"] == [
-        {"date": "2026-03-14", "inflow": 16_000, "outflow": -1_000},
-        {"date": "2026-03-15", "inflow": 0, "outflow": -7_500},
+        {"date": "2026-03-14", "end_date": "2026-03-14", "inflow": 16_000, "outflow": -1_000},
+        {"date": "2026-03-15", "end_date": "2026-03-15", "inflow": 0, "outflow": -7_500},
     ]
     assert data["daily_cash_flow_fx_status"] == {"state": "complete", "missing_pairs": []}
 
@@ -974,12 +974,79 @@ async def test_transactions_overview_daily_cash_flow_reports_incomplete_fx(clien
     assert resp.status_code == 200
     data = resp.json()
     assert data["daily_cash_flow"] == [
-        {"date": "2026-03-14", "inflow": 15_000, "outflow": 0},
+        {"date": "2026-03-14", "end_date": "2026-03-14", "inflow": 15_000, "outflow": 0},
     ]
     assert data["daily_cash_flow_fx_status"] == {
         "state": "incomplete",
         "missing_pairs": [{"base": "ABC", "quote": "CAD"}],
     }
+
+
+async def test_transactions_overview_cash_flow_uses_daily_buckets_through_31_day_ranges(client):
+    """Overview cash flow ranges up to 31 days stay daily."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+
+    await _create_transaction(client, headers, account_id, category_id, amount=100_000, dt="2026-06-01")
+    await _create_transaction(client, headers, account_id, category_id, amount=50_000, dt="2026-07-01")
+
+    resp = await client.get(
+        "/transactions/overview",
+        params={"from_date": "2026-06-01", "to_date": "2026-07-01"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    points = resp.json()["daily_cash_flow"]
+    assert len(points) == 31
+    assert points[0] == {"date": "2026-06-01", "end_date": "2026-06-01", "inflow": 100_000, "outflow": 0}
+    assert points[-1] == {"date": "2026-07-01", "end_date": "2026-07-01", "inflow": 50_000, "outflow": 0}
+
+
+async def test_transactions_overview_cash_flow_uses_weekly_buckets_through_183_day_ranges(client):
+    """Overview cash flow ranges up to 183 days stay weekly."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+
+    await _create_transaction(client, headers, account_id, category_id, amount=100_000, dt="2026-01-01")
+    await _create_transaction(client, headers, account_id, category_id, amount=-20_000, dt="2026-07-02")
+
+    resp = await client.get(
+        "/transactions/overview",
+        params={"from_date": "2026-01-01", "to_date": "2026-07-02"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    points = resp.json()["daily_cash_flow"]
+    assert len(points) == 27
+    assert points[0] == {"date": "2026-01-01", "end_date": "2026-01-04", "inflow": 100_000, "outflow": 0}
+    assert points[-1] == {"date": "2026-06-29", "end_date": "2026-07-02", "inflow": 0, "outflow": -20_000}
+
+
+async def test_transactions_overview_cash_flow_uses_monthly_buckets_for_long_ranges(client):
+    """Overview cash flow ranges over 183 days are grouped monthly."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+
+    await _create_transaction(client, headers, account_id, category_id, amount=100_000, dt="2026-01-15")
+    await _create_transaction(client, headers, account_id, category_id, amount=-40_000, dt="2026-02-01")
+    await _create_transaction(client, headers, account_id, category_id, amount=80_000, dt="2026-05-20")
+
+    resp = await client.get(
+        "/transactions/overview",
+        params={"from_date": "2026-01-15", "to_date": "2026-08-01"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["daily_cash_flow"] == [
+        {"date": "2026-01-15", "end_date": "2026-01-31", "inflow": 100_000, "outflow": 0},
+        {"date": "2026-02-01", "end_date": "2026-02-28", "inflow": 0, "outflow": -40_000},
+        {"date": "2026-03-01", "end_date": "2026-03-31", "inflow": 0, "outflow": 0},
+        {"date": "2026-04-01", "end_date": "2026-04-30", "inflow": 0, "outflow": 0},
+        {"date": "2026-05-01", "end_date": "2026-05-31", "inflow": 80_000, "outflow": 0},
+        {"date": "2026-06-01", "end_date": "2026-06-30", "inflow": 0, "outflow": 0},
+        {"date": "2026-07-01", "end_date": "2026-07-31", "inflow": 0, "outflow": 0},
+        {"date": "2026-08-01", "end_date": "2026-08-01", "inflow": 0, "outflow": 0},
+    ]
 
 
 async def test_transactions_overview_explicit_archived_account_is_allowed(client):

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -58,6 +58,7 @@ export interface TopCategorySpend {
 
 export interface DailyCashFlow {
   date: string;
+  end_date: string;
   inflow: number;
   outflow: number;
 }

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -1,6 +1,8 @@
 import {
+  useLayoutEffect,
   useMemo,
   useRef,
+  useState,
   type MouseEvent as ReactMouseEvent,
 } from 'react'
 import { Repeat } from 'lucide-react'
@@ -64,9 +66,11 @@ const dailyNetCashFlowCalculation =
   'Each day\'s money in minus money out. Transfers count except Balance Adjustment.'
 const dailyCashFlowCalculation =
   'Each day\'s money in and money out. Transfers count except Balance Adjustment.'
-const dailyCashFlowXAxisTickCount = 10
+const dailyCashFlowMaxXAxisTickCount = 10
+const dailyCashFlowXAxisTickSpacing = 64
 const dailyCashFlowChartMargin = { top: 4, right: 12, bottom: 0, left: 12 } as const
 const dailyCashFlowXAxisPadding = { left: 20, right: 20 } as const
+const dailyCashFlowXAxisCandidateSteps = [1, 2, 3, 4, 5, 7, 10, 14, 15, 21, 30] as const
 // Recharts runtime accepts cubic-bezier strings, but Area's public type only lists preset names.
 const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-out'
 
@@ -102,13 +106,83 @@ function getDailyCashFlowSeries(
   return result
 }
 
-function getDailyCashFlowXAxisTicks(data: DailyCashFlowPoint[]) {
-  const tickCount = Math.min(dailyCashFlowXAxisTickCount, data.length)
-  if (tickCount <= 1) return data.map((point) => point.date)
+function getDailyCashFlowXAxisTickCount(chartWidth: number | undefined) {
+  if (chartWidth === undefined) return dailyCashFlowMaxXAxisTickCount
 
-  const lastIndex = data.length - 1
-  return Array.from({ length: tickCount }, (_, index) => (
-    data[Math.round((lastIndex * index) / (tickCount - 1))].date
+  const usableWidth = Math.max(
+    chartWidth
+      - dailyCashFlowChartMargin.left
+      - dailyCashFlowChartMargin.right
+      - dailyCashFlowXAxisPadding.left
+      - dailyCashFlowXAxisPadding.right,
+    0,
+  )
+
+  return Math.max(
+    2,
+    Math.min(
+      dailyCashFlowMaxXAxisTickCount,
+      Math.floor(usableWidth / dailyCashFlowXAxisTickSpacing) + 1,
+    ),
+  )
+}
+
+function getDailyCashFlowXAxisTickIndexesForStep(dataLength: number, step: number) {
+  const lastIndex = dataLength - 1
+  const indexes: number[] = []
+
+  for (let index = 0; index < lastIndex; index += step) {
+    indexes.push(index)
+  }
+
+  const finalGap = lastIndex - indexes[indexes.length - 1]
+  if (finalGap === 0) return indexes
+
+  if (indexes.length > 1 && finalGap < step / 2) {
+    indexes[indexes.length - 1] = lastIndex
+    return indexes
+  }
+
+  return [...indexes, lastIndex]
+}
+
+function getDailyCashFlowXAxisTickIndexes(dataLength: number, maxTickCount: number) {
+  const cappedTickCount = Math.min(maxTickCount, dataLength)
+  if (cappedTickCount === 0) return []
+  if (cappedTickCount === 1) return [0]
+
+  const lastIndex = dataLength - 1
+  const minimumStep = Math.max(1, Math.ceil(lastIndex / (cappedTickCount - 1)))
+  const candidateSteps = dailyCashFlowXAxisCandidateSteps.some((step) => step === minimumStep)
+    ? dailyCashFlowXAxisCandidateSteps
+    : [...dailyCashFlowXAxisCandidateSteps, minimumStep].sort((a, b) => a - b)
+
+  let bestIndexes = [0, lastIndex]
+  let bestScore = Number.POSITIVE_INFINITY
+
+  for (const step of candidateSteps) {
+    if (step < minimumStep) continue
+
+    const indexes = getDailyCashFlowXAxisTickIndexesForStep(dataLength, step)
+    if (indexes.length > cappedTickCount) continue
+
+    const gaps = indexes.slice(1).map((index, gapIndex) => index - indexes[gapIndex])
+    const gapSpread = Math.max(...gaps) - Math.min(...gaps)
+    const unusedTickPenalty = (cappedTickCount - indexes.length) * 0.2
+    const score = gapSpread / step + unusedTickPenalty
+
+    if (score < bestScore) {
+      bestIndexes = indexes
+      bestScore = score
+    }
+  }
+
+  return bestIndexes
+}
+
+function getDailyCashFlowXAxisTicks(data: DailyCashFlowPoint[], maxTickCount: number) {
+  return getDailyCashFlowXAxisTickIndexes(data.length, maxTickCount).map((index) => (
+    data[index].date
   ))
 }
 
@@ -251,6 +325,7 @@ export default function DailyCashFlowChart({
 }) {
   const dailyFlowChartRef = useRef<HTMLDivElement>(null)
   const dailyFlowTooltipRef = useRef<DeferredChartTooltipOverlayHandle<DailyCashFlowPoint>>(null)
+  const [dailyFlowChartWidth, setDailyFlowChartWidth] = useState<number>()
   const dailyFlow = useMemo(
     () => (
       showPlaceholderData
@@ -263,9 +338,10 @@ export default function DailyCashFlowChart({
     () => new Map(dailyFlow.map((point) => [point.date, point])),
     [dailyFlow],
   )
+  const dailyFlowXAxisTickCount = getDailyCashFlowXAxisTickCount(dailyFlowChartWidth)
   const dailyFlowXAxisTicks = useMemo(
-    () => getDailyCashFlowXAxisTicks(dailyFlow),
-    [dailyFlow],
+    () => getDailyCashFlowXAxisTicks(dailyFlow, dailyFlowXAxisTickCount),
+    [dailyFlow, dailyFlowXAxisTickCount],
   )
   const dailyFlowBaselineSegment = useMemo(() => {
     if (dailyFlow.length === 0) return undefined
@@ -283,6 +359,29 @@ export default function DailyCashFlowChart({
   const calculationTooltipMessage = mode === 'net'
     ? dailyNetCashFlowCalculation
     : dailyCashFlowCalculation
+
+  useLayoutEffect(() => {
+    const element = dailyFlowChartRef.current
+    if (!element) return undefined
+
+    const updateChartWidth = (width: number) => {
+      const nextWidth = Math.max(Math.round(width), 0)
+      setDailyFlowChartWidth((currentWidth) => (
+        currentWidth === nextWidth ? currentWidth : nextWidth
+      ))
+    }
+
+    updateChartWidth(element.getBoundingClientRect().width)
+
+    if (typeof ResizeObserver === 'undefined') return undefined
+
+    const resizeObserver = new ResizeObserver(([entry]) => {
+      updateChartWidth(entry.contentRect.width)
+    })
+    resizeObserver.observe(element)
+    return () => resizeObserver.disconnect()
+  }, [])
+
   const showDailyCashFlowTooltip = (
     state: DailyCashFlowTooltipState,
     event: ReactMouseEvent<SVGGraphicsElement>,

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -30,13 +30,16 @@ import { parseYmdLocal } from '@/transactions/utils/date'
 import { getCashFlowFxStatusMessage } from '@/transactions/utils/fxTooltipMessages'
 
 type DailyCashFlowPoint = {
+  key: string
   date: string
+  rangeLabel: string
   inflow: number
   outflow: number
   net: number
 }
 
 export type DailyCashFlowChartMode = 'net' | 'gross'
+type DailyCashFlowGranularity = 'day' | 'week' | 'month'
 
 type DailyCashFlowTooltipState = {
   activeLabel?: string | number
@@ -62,10 +65,8 @@ const titleCharVariants = {
   enter: { y: 0, opacity: 1, filter: 'blur(0px)' },
   exit: { y: '-0.7em', opacity: 0, filter: 'blur(2px)' },
 } as const
-const dailyNetCashFlowCalculation =
-  'Each day\'s money in minus money out. Transfers count except Balance Adjustment.'
-const dailyCashFlowCalculation =
-  'Each day\'s money in and money out. Transfers count except Balance Adjustment.'
+const dailyCashFlowRangeDayCount = 31
+const weeklyCashFlowRangeDayCount = 183
 const dailyCashFlowMaxXAxisTickCount = 10
 const dailyCashFlowXAxisTickSpacing = 64
 const dailyCashFlowChartMargin = { top: 4, right: 12, bottom: 0, left: 12 } as const
@@ -74,36 +75,91 @@ const dailyCashFlowXAxisCandidateSteps = [1, 2, 3, 4, 5, 7, 10, 14, 15, 21, 30] 
 // Recharts runtime accepts cubic-bezier strings, but Area's public type only lists preset names.
 const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-out'
 
-function getDailyCashFlowSeries(
-  raw: DailyCashFlow[],
-  fromDate: string,
-  toDate: string,
-): DailyCashFlowPoint[] {
-  if (fromDate > toDate) return []
+function formatYmdLocal(date: Date) {
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-')
+}
 
-  // The API only returns days with activity; pad missing days so the line chart has a continuous axis.
-  const byDate = new Map(raw.map((day) => [day.date, day]))
-  const cursor = parseYmdLocal(fromDate)
-  const last = parseYmdLocal(toDate)
-  const result: DailyCashFlowPoint[] = []
+function getDailyCashFlowGranularity(fromDate: string, toDate: string): DailyCashFlowGranularity {
+  if (fromDate > toDate) return 'day'
 
-  while (cursor <= last) {
-    const iso = [
-      cursor.getFullYear(),
-      String(cursor.getMonth() + 1).padStart(2, '0'),
-      String(cursor.getDate()).padStart(2, '0'),
-    ].join('-')
-    const entry = byDate.get(iso)
-    result.push({
-      date: cursor.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-      inflow: entry?.inflow ?? 0,
-      outflow: entry?.outflow ?? 0,
-      net: (entry?.inflow ?? 0) + (entry?.outflow ?? 0),
-    })
-    cursor.setDate(cursor.getDate() + 1)
+  const from = parseYmdLocal(fromDate)
+  const to = parseYmdLocal(toDate)
+  const dayCount = Math.max(
+    1,
+    Math.round((to.getTime() - from.getTime()) / 86400000) + 1,
+  )
+
+  if (dayCount <= dailyCashFlowRangeDayCount) return 'day'
+  if (dayCount <= weeklyCashFlowRangeDayCount) return 'week'
+  return 'month'
+}
+
+function getDailyCashFlowCadenceTitle(granularity: DailyCashFlowGranularity) {
+  if (granularity === 'week') return 'Weekly'
+  if (granularity === 'month') return 'Monthly'
+  return 'Daily'
+}
+
+function getDailyCashFlowPeriodName(granularity: DailyCashFlowGranularity) {
+  if (granularity === 'week') return 'week'
+  if (granularity === 'month') return 'month'
+  return 'day'
+}
+
+function getDailyCashFlowCalculation(
+  granularity: DailyCashFlowGranularity,
+  mode: DailyCashFlowChartMode,
+) {
+  const period = getDailyCashFlowPeriodName(granularity)
+  return mode === 'net'
+    ? `Each ${period}'s money in minus money out. Transfers count except Balance Adjustment.`
+    : `Each ${period}'s money in and money out. Transfers count except Balance Adjustment.`
+}
+
+function formatCashFlowPointLabel(date: Date, granularity: DailyCashFlowGranularity) {
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: granularity === 'month' ? undefined : 'numeric',
+  })
+}
+
+function formatCashFlowTooltipDate(date: Date) {
+  return date.toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function formatCashFlowRangeLabel(start: Date, end: Date, granularity: DailyCashFlowGranularity) {
+  if (granularity === 'day' || formatYmdLocal(start) === formatYmdLocal(end)) {
+    return formatCashFlowTooltipDate(start)
   }
 
-  return result
+  return `${formatCashFlowTooltipDate(start)} - ${formatCashFlowTooltipDate(end)}`
+}
+
+function getDailyCashFlowSeries(
+  raw: DailyCashFlow[],
+  granularity: DailyCashFlowGranularity,
+): DailyCashFlowPoint[] {
+  return raw.map((entry) => {
+    const bucketStart = parseYmdLocal(entry.date)
+    const bucketEnd = parseYmdLocal(entry.end_date)
+
+    return {
+      key: entry.date,
+      date: formatCashFlowPointLabel(bucketStart, granularity),
+      rangeLabel: formatCashFlowRangeLabel(bucketStart, bucketEnd, granularity),
+      inflow: entry.inflow,
+      outflow: entry.outflow,
+      net: entry.inflow + entry.outflow,
+    }
+  })
 }
 
 function getDailyCashFlowXAxisTickCount(chartWidth: number | undefined) {
@@ -182,12 +238,12 @@ function getDailyCashFlowXAxisTickIndexes(dataLength: number, maxTickCount: numb
 
 function getDailyCashFlowXAxisTicks(data: DailyCashFlowPoint[], maxTickCount: number) {
   return getDailyCashFlowXAxisTickIndexes(data.length, maxTickCount).map((index) => (
-    data[index].date
+    data[index].key
   ))
 }
 
 function getDailyCashFlowTooltipKey(point: DailyCashFlowPoint) {
-  return point.date
+  return point.key
 }
 
 function getDailyCashFlowTooltipPointer(
@@ -204,7 +260,7 @@ function getDailyCashFlowTooltipPointer(
 function getDailyCashFlowTooltipPoint(
   state: DailyCashFlowTooltipState,
   data: DailyCashFlowPoint[],
-  pointsByDate: Map<string, DailyCashFlowPoint>,
+  pointsByKey: Map<string, DailyCashFlowPoint>,
 ) {
   const payloadPoint = state.activePayload?.[0]?.payload
   if (payloadPoint) return payloadPoint
@@ -214,7 +270,7 @@ function getDailyCashFlowTooltipPoint(
 
   return state.activeLabel === undefined
     ? undefined
-    : pointsByDate.get(String(state.activeLabel))
+    : pointsByKey.get(String(state.activeLabel))
 }
 
 function DailyCashFlowTooltipContent({
@@ -228,7 +284,7 @@ function DailyCashFlowTooltipContent({
 }) {
   return (
     <>
-      <p className="app-chart-tooltip-default-title">{point.date}</p>
+      <p className="app-chart-tooltip-default-title">{point.rangeLabel}</p>
       {mode === 'net' && (
         <div className="mt-1 flex justify-between gap-4">
           <span className="app-chart-tooltip-default-value">Net</span>
@@ -326,16 +382,24 @@ export default function DailyCashFlowChart({
   const dailyFlowChartRef = useRef<HTMLDivElement>(null)
   const dailyFlowTooltipRef = useRef<DeferredChartTooltipOverlayHandle<DailyCashFlowPoint>>(null)
   const [dailyFlowChartWidth, setDailyFlowChartWidth] = useState<number>()
+  const dailyFlowGranularity = useMemo(
+    () => getDailyCashFlowGranularity(fromDate, toDate),
+    [fromDate, toDate],
+  )
   const dailyFlow = useMemo(
     () => (
       showPlaceholderData
-        ? PLACEHOLDER_DAILY_FLOW
-        : getDailyCashFlowSeries(rawDailyFlow, fromDate, toDate)
+        ? PLACEHOLDER_DAILY_FLOW.map((point) => ({ ...point, key: point.date, rangeLabel: point.date }))
+        : getDailyCashFlowSeries(rawDailyFlow, dailyFlowGranularity)
     ),
-    [fromDate, rawDailyFlow, showPlaceholderData, toDate],
+    [dailyFlowGranularity, rawDailyFlow, showPlaceholderData],
   )
-  const dailyFlowPointsByDate = useMemo(
-    () => new Map(dailyFlow.map((point) => [point.date, point])),
+  const dailyFlowPointsByKey = useMemo(
+    () => new Map(dailyFlow.map((point) => [point.key, point])),
+    [dailyFlow],
+  )
+  const dailyFlowLabelsByKey = useMemo(
+    () => new Map(dailyFlow.map((point) => [point.key, point.date])),
     [dailyFlow],
   )
   const dailyFlowXAxisTickCount = getDailyCashFlowXAxisTickCount(dailyFlowChartWidth)
@@ -347,18 +411,17 @@ export default function DailyCashFlowChart({
     if (dailyFlow.length === 0) return undefined
 
     return [
-      { x: dailyFlow[0].date, y: 0 },
-      { x: dailyFlow[dailyFlow.length - 1].date, y: 0 },
+      { x: dailyFlow[0].key, y: 0 },
+      { x: dailyFlow[dailyFlow.length - 1].key, y: 0 },
     ] as const
   }, [dailyFlow])
   const chartAnimationDuration = prefersReducedMotion ? 0 : 1000
   const toggleLabel = mode === 'net' ? 'Show inflow and outflow' : 'Show net cash flow'
+  const cashFlowCadenceTitle = getDailyCashFlowCadenceTitle(dailyFlowGranularity)
   const calculationTooltipLabel = mode === 'net'
-    ? 'How daily net cash flow is calculated'
-    : 'How daily cash flow is calculated'
-  const calculationTooltipMessage = mode === 'net'
-    ? dailyNetCashFlowCalculation
-    : dailyCashFlowCalculation
+    ? `How ${cashFlowCadenceTitle.toLowerCase()} net cash flow is calculated`
+    : `How ${cashFlowCadenceTitle.toLowerCase()} cash flow is calculated`
+  const calculationTooltipMessage = getDailyCashFlowCalculation(dailyFlowGranularity, mode)
 
   useLayoutEffect(() => {
     const element = dailyFlowChartRef.current
@@ -386,7 +449,7 @@ export default function DailyCashFlowChart({
     state: DailyCashFlowTooltipState,
     event: ReactMouseEvent<SVGGraphicsElement>,
   ) => {
-    const point = getDailyCashFlowTooltipPoint(state, dailyFlow, dailyFlowPointsByDate)
+    const point = getDailyCashFlowTooltipPoint(state, dailyFlow, dailyFlowPointsByKey)
     const pointer = getDailyCashFlowTooltipPointer(state, event)
 
     if (!point) {
@@ -403,7 +466,7 @@ export default function DailyCashFlowChart({
       <div className="mb-3 flex items-center justify-between gap-3">
         <p className="app-label inline-flex items-center gap-2">
           <span className="inline-flex items-baseline whitespace-nowrap">
-            <span>Daily</span>
+            <span>{cashFlowCadenceTitle}</span>
             <DailyCashFlowTitleWord visible={mode === 'net'} />
             <span className="ml-[0.25em]">Cash Flow</span>
           </span>
@@ -469,8 +532,9 @@ export default function DailyCashFlowChart({
               </linearGradient>
             </defs>
             <XAxis
-              dataKey="date"
+              dataKey="key"
               tick={{ fontSize: 11, fill: 'var(--app-text-subtle)' }}
+              tickFormatter={(value) => dailyFlowLabelsByKey.get(String(value)) ?? String(value)}
               axisLine={false}
               tickLine={false}
               padding={dailyCashFlowXAxisPadding}

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -47,16 +47,6 @@ type DailyCashFlowTooltipState = {
   }>
 }
 
-type DailyCashFlowXAxisTickProps = {
-  x?: string | number
-  y?: string | number
-  payload?: {
-    value?: string | number
-  }
-  firstLabel?: string
-  lastLabel?: string
-}
-
 const titleWordTransition = { duration: 0.34, ease: [0.16, 1, 0.3, 1] } as const
 const titleWidthTransition = { duration: 0.3, ease: [0.16, 1, 0.3, 1] } as const
 const titleExitWidthTransition = { delay: 0.34, duration: 0.22, ease: [0.16, 1, 0.3, 1] } as const
@@ -75,6 +65,7 @@ const dailyNetCashFlowCalculation =
 const dailyCashFlowCalculation =
   'Each day\'s money in and money out. Transfers count except Balance Adjustment.'
 const dailyCashFlowXAxisTickCount = 10
+const dailyCashFlowChartMargin = { top: 4, right: 12, bottom: 0, left: 12 } as const
 const dailyCashFlowXAxisPadding = { left: 20, right: 20 } as const
 // Recharts runtime accepts cubic-bezier strings, but Area's public type only lists preset names.
 const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-out'
@@ -188,30 +179,6 @@ function DailyCashFlowTooltipContent({
   )
 }
 
-function DailyCashFlowXAxisTick({
-  x = 0,
-  y = 0,
-  payload,
-  firstLabel,
-  lastLabel,
-}: DailyCashFlowXAxisTickProps) {
-  const value = String(payload?.value ?? '')
-  const textAnchor = value === firstLabel ? 'start' : value === lastLabel ? 'end' : 'middle'
-
-  return (
-    <text
-      x={Number(x)}
-      y={Number(y)}
-      dy={12}
-      textAnchor={textAnchor}
-      fill="var(--app-text-subtle)"
-      fontSize={11}
-    >
-      {value}
-    </text>
-  )
-}
-
 function DailyCashFlowTitleWord({ visible }: { visible: boolean }) {
   const shouldReduceMotion = useReducedMotion()
 
@@ -300,8 +267,14 @@ export default function DailyCashFlowChart({
     () => getDailyCashFlowXAxisTicks(dailyFlow),
     [dailyFlow],
   )
-  const firstDailyFlowXAxisTick = dailyFlowXAxisTicks[0]
-  const lastDailyFlowXAxisTick = dailyFlowXAxisTicks[dailyFlowXAxisTicks.length - 1]
+  const dailyFlowBaselineSegment = useMemo(() => {
+    if (dailyFlow.length === 0) return undefined
+
+    return [
+      { x: dailyFlow[0].date, y: 0 },
+      { x: dailyFlow[dailyFlow.length - 1].date, y: 0 },
+    ] as const
+  }, [dailyFlow])
   const chartAnimationDuration = prefersReducedMotion ? 0 : 1000
   const toggleLabel = mode === 'net' ? 'Show inflow and outflow' : 'Show net cash flow'
   const calculationTooltipLabel = mode === 'net'
@@ -378,7 +351,7 @@ export default function DailyCashFlowChart({
           <AreaChart
             key={`daily-flow-${mode}-${chartAnimationKey}`}
             data={dailyFlow}
-            margin={{ top: 4, right: 12, bottom: 0, left: 12 }}
+            margin={dailyCashFlowChartMargin}
             onMouseMove={(state, event) => showDailyCashFlowTooltip(state, event)}
             onMouseLeave={hideDailyCashFlowTooltip}
           >
@@ -398,21 +371,21 @@ export default function DailyCashFlowChart({
             </defs>
             <XAxis
               dataKey="date"
+              tick={{ fontSize: 11, fill: 'var(--app-text-subtle)' }}
               axisLine={false}
               tickLine={false}
               padding={dailyCashFlowXAxisPadding}
               interval={0}
               ticks={dailyFlowXAxisTicks}
-              tick={(props) => (
-                <DailyCashFlowXAxisTick
-                  {...props}
-                  firstLabel={firstDailyFlowXAxisTick}
-                  lastLabel={lastDailyFlowXAxisTick}
-                />
-              )}
             />
             <YAxis hide />
-            <ReferenceLine y={0} stroke="var(--app-border-strong)" strokeWidth={1} />
+            {dailyFlowBaselineSegment && (
+              <ReferenceLine
+                segment={dailyFlowBaselineSegment}
+                stroke="var(--app-border-strong)"
+                strokeWidth={1}
+              />
+            )}
             {mode === 'net' ? (
               <Area
                 type="monotone"

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -64,6 +64,7 @@ const dailyNetCashFlowCalculation =
   'Each day\'s money in minus money out. Transfers count except Balance Adjustment.'
 const dailyCashFlowCalculation =
   'Each day\'s money in and money out. Transfers count except Balance Adjustment.'
+const dailyCashFlowXAxisPadding = { left: 20, right: 20 } as const
 // Recharts runtime accepts cubic-bezier strings, but Area's public type only lists preset names.
 const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-out'
 
@@ -349,6 +350,7 @@ export default function DailyCashFlowChart({
               tick={{ fontSize: 11, fill: 'var(--app-text-subtle)' }}
               axisLine={false}
               tickLine={false}
+              padding={dailyCashFlowXAxisPadding}
               interval={Math.max(0, Math.ceil(dailyFlow.length / 10) - 1)}
             />
             <YAxis hide />

--- a/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
+++ b/frontend/src/transactions/components/topBand/DailyCashFlowChart.tsx
@@ -47,6 +47,16 @@ type DailyCashFlowTooltipState = {
   }>
 }
 
+type DailyCashFlowXAxisTickProps = {
+  x?: string | number
+  y?: string | number
+  payload?: {
+    value?: string | number
+  }
+  firstLabel?: string
+  lastLabel?: string
+}
+
 const titleWordTransition = { duration: 0.34, ease: [0.16, 1, 0.3, 1] } as const
 const titleWidthTransition = { duration: 0.3, ease: [0.16, 1, 0.3, 1] } as const
 const titleExitWidthTransition = { delay: 0.34, duration: 0.22, ease: [0.16, 1, 0.3, 1] } as const
@@ -64,6 +74,7 @@ const dailyNetCashFlowCalculation =
   'Each day\'s money in minus money out. Transfers count except Balance Adjustment.'
 const dailyCashFlowCalculation =
   'Each day\'s money in and money out. Transfers count except Balance Adjustment.'
+const dailyCashFlowXAxisTickCount = 10
 const dailyCashFlowXAxisPadding = { left: 20, right: 20 } as const
 // Recharts runtime accepts cubic-bezier strings, but Area's public type only lists preset names.
 const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-out'
@@ -98,6 +109,16 @@ function getDailyCashFlowSeries(
   }
 
   return result
+}
+
+function getDailyCashFlowXAxisTicks(data: DailyCashFlowPoint[]) {
+  const tickCount = Math.min(dailyCashFlowXAxisTickCount, data.length)
+  if (tickCount <= 1) return data.map((point) => point.date)
+
+  const lastIndex = data.length - 1
+  return Array.from({ length: tickCount }, (_, index) => (
+    data[Math.round((lastIndex * index) / (tickCount - 1))].date
+  ))
 }
 
 function getDailyCashFlowTooltipKey(point: DailyCashFlowPoint) {
@@ -164,6 +185,30 @@ function DailyCashFlowTooltipContent({
         </span>
       </div>
     </>
+  )
+}
+
+function DailyCashFlowXAxisTick({
+  x = 0,
+  y = 0,
+  payload,
+  firstLabel,
+  lastLabel,
+}: DailyCashFlowXAxisTickProps) {
+  const value = String(payload?.value ?? '')
+  const textAnchor = value === firstLabel ? 'start' : value === lastLabel ? 'end' : 'middle'
+
+  return (
+    <text
+      x={Number(x)}
+      y={Number(y)}
+      dy={12}
+      textAnchor={textAnchor}
+      fill="var(--app-text-subtle)"
+      fontSize={11}
+    >
+      {value}
+    </text>
   )
 }
 
@@ -251,6 +296,12 @@ export default function DailyCashFlowChart({
     () => new Map(dailyFlow.map((point) => [point.date, point])),
     [dailyFlow],
   )
+  const dailyFlowXAxisTicks = useMemo(
+    () => getDailyCashFlowXAxisTicks(dailyFlow),
+    [dailyFlow],
+  )
+  const firstDailyFlowXAxisTick = dailyFlowXAxisTicks[0]
+  const lastDailyFlowXAxisTick = dailyFlowXAxisTicks[dailyFlowXAxisTicks.length - 1]
   const chartAnimationDuration = prefersReducedMotion ? 0 : 1000
   const toggleLabel = mode === 'net' ? 'Show inflow and outflow' : 'Show net cash flow'
   const calculationTooltipLabel = mode === 'net'
@@ -347,11 +398,18 @@ export default function DailyCashFlowChart({
             </defs>
             <XAxis
               dataKey="date"
-              tick={{ fontSize: 11, fill: 'var(--app-text-subtle)' }}
               axisLine={false}
               tickLine={false}
               padding={dailyCashFlowXAxisPadding}
-              interval={Math.max(0, Math.ceil(dailyFlow.length / 10) - 1)}
+              interval={0}
+              ticks={dailyFlowXAxisTicks}
+              tick={(props) => (
+                <DailyCashFlowXAxisTick
+                  {...props}
+                  firstLabel={firstDailyFlowXAxisTick}
+                  lastLabel={lastDailyFlowXAxisTick}
+                />
+              )}
             />
             <YAxis hide />
             <ReferenceLine y={0} stroke="var(--app-border-strong)" strokeWidth={1} />


### PR DESCRIPTION
- Prevent the transaction cash flow x-axis endpoint labels from being clipped
- Align the zero baseline with the first and last plotted data points
- Make x-axis tick density responsive and more evenly spaced across screen widths
- Move cash-flow cadence bucketing into the transaction overview API
- Match Insights cadence: daily through 31 days, weekly through 183 days, monthly after

CU-86ba9hw7y