### PR TITLE
Fix foreign-currency transaction list amounts

### DIFF
--- a/backend/app/routes/transaction.py
+++ b/backend/app/routes/transaction.py
@@ -175,6 +175,59 @@ async def _prefetch_overview_rates(
             )
 
 
+async def _get_accounts_by_id(db: AsyncSession, account_ids: set[uuid.UUID]) -> dict[uuid.UUID, Account]:
+    accounts = (
+        (await db.execute(select(Account).where(Account.id.in_(account_ids)))).scalars().all()
+        if account_ids
+        else []
+    )
+    return {account.id: account for account in accounts}
+
+
+async def _get_transaction_response_context(
+    db: AsyncSession,
+    transactions: list[Transaction],
+    *,
+    extra_currencies: set[str] | None = None,
+) -> tuple[dict[uuid.UUID, Account], dict[str, int]]:
+    account_by_id = await _get_accounts_by_id(db, {txn.account_id for txn in transactions})
+    currencies = {
+        txn.currency
+        for txn in transactions
+    } | {
+        account.currency
+        for account in account_by_id.values()
+    } | (extra_currencies or set())
+    return account_by_id, await _get_currency_exponents(db, currencies)
+
+
+async def _prefetch_transaction_response_rates(
+    converter: FxConverter,
+    *,
+    transactions: list[Transaction],
+    account_by_id: dict[uuid.UUID, Account],
+    base_currency: str,
+) -> None:
+    if not transactions:
+        return
+
+    start = min(txn.dt for txn in transactions)
+    end = max(txn.dt for txn in transactions)
+    pairs = {
+        (txn.currency, quote)
+        for txn in transactions
+        for quote in (account_by_id[txn.account_id].currency, base_currency)
+        if txn.currency != quote
+    }
+    for base, quote in sorted(pairs):
+        await converter.prefetch_rates(
+            base=base,
+            quote=quote,
+            start_date=start,
+            end_date=end,
+        )
+
+
 def _fork_overview_converter(converter: FxConverter) -> FxConverter:
     fork = FxConverter(
         provider=converter.provider,
@@ -685,12 +738,45 @@ async def list_transactions(
     tag_map = await get_tag_ids_batch(db, [txn.id for txn in transactions])
     tag_summary_map = await get_tags_batch(db, [txn.id for txn in transactions])
     merchant_names = await get_merchant_names_batch(db, [txn.merchant_id for txn in transactions])
+    account_by_id, currency_exponents = await _get_transaction_response_context(
+        db,
+        transactions,
+        extra_currencies={user.base_currency},
+    )
+    base_converter = FxConverter(currency_exponents=currency_exponents)
+    await _prefetch_transaction_response_rates(
+        base_converter,
+        transactions=transactions,
+        account_by_id=account_by_id,
+        base_currency=user.base_currency,
+    )
+
+    account_amounts = {
+        txn.id: await base_converter.convert_minor_units(
+            txn.amount,
+            base=txn.currency,
+            quote=account_by_id[txn.account_id].currency,
+            rate_date=txn.dt,
+        )
+        for txn in transactions
+    }
+    base_currency_amounts = {
+        txn.id: await base_converter.convert_minor_units(
+            txn.amount,
+            base=txn.currency,
+            quote=user.base_currency,
+            rate_date=txn.dt,
+        )
+        for txn in transactions
+    }
     return [
         build_transaction_response(
             txn,
             tag_map[txn.id],
             merchant_names.get(txn.merchant_id) if txn.merchant_id else None,
             tag_summary_map[txn.id],
+            account_amount=account_amounts[txn.id],
+            base_currency_amount=base_currency_amounts[txn.id],
         )
         for txn in transactions
     ]

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -71,6 +71,8 @@ class TransactionResponse(BaseModel):
     merchant_name: str | None = None
     category_id: uuid.UUID
     amount: int
+    account_amount: int | None = None
+    base_currency_amount: int | None = None
     currency: str
     fx_rate: float | None
     notes: str | None

--- a/backend/app/services/transaction_responses.py
+++ b/backend/app/services/transaction_responses.py
@@ -86,9 +86,13 @@ def build_transaction_response(
     tag_ids: list[uuid.UUID],
     merchant_name: str | None = None,
     tags: list[TransactionTagSummary] | None = None,
+    account_amount: int | None = None,
+    base_currency_amount: int | None = None,
 ) -> TransactionResponse:
     """Build a TransactionResponse from a Transaction model and its tag IDs."""
     data = TransactionResponse.model_validate(txn)
+    data.account_amount = account_amount
+    data.base_currency_amount = base_currency_amount
     data.tag_ids = tag_ids
     data.merchant_name = merchant_name
     data.tags = tags or []

--- a/backend/tests/routes/test_transaction.py
+++ b/backend/tests/routes/test_transaction.py
@@ -536,6 +536,84 @@ async def test_create_transaction_fx_rate_accepted_for_different_currency(client
     assert resp.json()["fx_rate"] == 1.35
 
 
+async def test_list_transactions_returns_account_amount_for_foreign_currency(client, monkeypatch):
+    """Transaction responses include the amount converted into the account currency."""
+    from app.models.account import Account
+    from app.services.fx import FrankfurterProvider
+
+    async def fake_get_rates(self, base, quote, start_date, end_date):
+        return {date(2026, 3, 15): Decimal("1.35")}
+
+    monkeypatch.setattr(FrankfurterProvider, "get_rates", fake_get_rates)
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    await _seed_usd_currency()
+
+    async with TestSession() as session:
+        account = await session.get(Account, uuid.UUID(account_id))
+        session.add(Transaction(
+            created_by_user_id=account.owner_id,
+            account_id=uuid.UUID(account_id),
+            category_id=uuid.UUID(category_id),
+            dt=date(2026, 3, 15),
+            amount=-10_00,
+            currency="USD",
+            fx_rate=None,
+        ))
+        await session.commit()
+
+    list_resp = await client.get("/transactions", headers=headers)
+
+    assert list_resp.status_code == 200
+    transaction = list_resp.json()[0]
+    assert transaction["amount"] == -10_00
+    assert transaction["currency"] == "USD"
+    assert transaction["account_amount"] == -13_50
+    assert transaction["base_currency_amount"] == -13_50
+
+
+async def test_list_transactions_returns_per_day_base_currency_amount_for_foreign_account(client, monkeypatch):
+    """Transaction list responses convert account amounts into user base currency by transaction date."""
+    from app.services.fx import FrankfurterProvider
+
+    calls = []
+
+    async def fake_get_rates(self, base, quote, start_date, end_date):
+        calls.append((base, quote, start_date, end_date))
+        return {
+            date(2026, 3, 14): Decimal("1.4"),
+            date(2026, 3, 15): Decimal("1.5"),
+        }
+
+    monkeypatch.setattr(FrankfurterProvider, "get_rates", fake_get_rates)
+    headers, _, category_id = await _setup_user_with_deps(client)
+    await _seed_usd_currency()
+    usd_account_id = (await _create_account(
+        client,
+        headers,
+        name="USD Chequing",
+        currency="USD",
+    )).json()["id"]
+
+    await _create_transaction(
+        client,
+        headers,
+        usd_account_id,
+        category_id,
+        amount=-10_00,
+        currency="USD",
+        dt="2026-03-15",
+    )
+
+    list_resp = await client.get("/transactions", headers=headers)
+
+    assert list_resp.status_code == 200
+    transaction = list_resp.json()[0]
+    assert transaction["amount"] == -10_00
+    assert transaction["account_amount"] == -10_00
+    assert transaction["base_currency_amount"] == -15_00
+    assert calls == [("USD", "CAD", date(2026, 3, 15), date(2026, 3, 15))]
+
+
 async def test_create_transaction_duplicate_tags_deduplicated(client):
     """Duplicate tag IDs are deduplicated — no integrity error."""
     headers, account_id, category_id = await _setup_user_with_deps(client)

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -35,6 +35,8 @@ export interface Transaction {
   merchant_name: string | null;
   category_id: string;
   amount: number;
+  account_amount: number | null;
+  base_currency_amount: number | null;
   currency: string;
   fx_rate: number | null;
   notes: string | null;

--- a/frontend/src/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/imports/hooks/useTransactionImportWorkflow.ts
@@ -334,6 +334,8 @@ export function useTransactionImportWorkflow() {
             merchant_name: merchant || null,
             category_id: category?.id ?? '',
             amount,
+            account_amount: amount,
+            base_currency_amount: amount,
             currency,
             fx_rate: null,
             notes: notes || null,

--- a/frontend/src/transactions/components/TransactionDateGroupList.tsx
+++ b/frontend/src/transactions/components/TransactionDateGroupList.tsx
@@ -30,7 +30,10 @@ export default function TransactionDateGroupList({
   return (
     <>
       {dateGroups.map(({ dateLabel, transactions }, groupIndex) => {
-        const dailyTotal = transactions.reduce((sum, transaction) => sum + transaction.amount, 0)
+        const dailyTotal = transactions.reduce((sum, transaction) => {
+          const displayAmount = fixedAccount ? transaction.account_amount : transaction.base_currency_amount
+          return sum + (displayAmount ?? 0)
+        }, 0)
         const dailyColor = dailyTotal >= 0 ? 'var(--app-positive)' : 'var(--app-negative)'
         return (
           <motion.div
@@ -80,7 +83,7 @@ export default function TransactionDateGroupList({
                     accountInstitution={rowAccount?.institution}
                     accountName={rowAccount?.name}
                     category={category}
-                    currency={fixedAccount?.currency ?? currency}
+                    currency={transaction.currency}
                     readOnlyReason={readOnlyReason}
                     transaction={transaction}
                     onOpen={onEditTransaction}


### PR DESCRIPTION
- Add converted transaction amounts to list responses for account-currency and base-currency views
- Calculate list totals with the exchange rate for each transaction date
- Keep transaction rows displayed in their original transaction currency
- Use converted amounts for date-header sums on the transactions page and account detail page
- Add backend coverage for converted list totals

CU-86baaj04b