### PR TITLE
feat: visualize TAC limits with opening usage tracking

### DIFF
--- a/backend/alembic/versions/59b2a047c3ad_add_tax_advantaged_plan_accruals.py
+++ b/backend/alembic/versions/59b2a047c3ad_add_tax_advantaged_plan_accruals.py
@@ -1,0 +1,44 @@
+"""Add tax-advantaged plan accrual baselines.
+
+Revision ID: 59b2a047c3ad
+Revises: 3f8a2f1c9d7b
+Create Date: 2026-06-05 00:00:00.000000
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "59b2a047c3ad"
+down_revision: str | Sequence[str] | None = "3f8a2f1c9d7b"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "tax_advantaged_plans",
+        sa.Column(
+            "accrued_contributions",
+            sa.BigInteger(),
+            server_default="0",
+            nullable=False,
+        ),
+    )
+    op.add_column(
+        "tax_advantaged_plan_limits",
+        sa.Column("accrued_contributions", sa.BigInteger(), server_default="0", nullable=False),
+    )
+    op.add_column(
+        "tax_advantaged_plan_limits",
+        sa.Column("accrued_withdrawals", sa.BigInteger(), server_default="0", nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("tax_advantaged_plan_limits", "accrued_withdrawals")
+    op.drop_column("tax_advantaged_plan_limits", "accrued_contributions")
+    op.drop_column("tax_advantaged_plans", "accrued_contributions")

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -97,6 +97,12 @@ class TaxAdvantagedPlan(Base):
     tax_treatment: Mapped[TaxTreatment] = mapped_column(nullable=False)
     currency: Mapped[str] = mapped_column(VARCHAR(3), ForeignKey("currencies.id"), nullable=False)
     lifetime_contribution_limit: Mapped[int | None] = mapped_column(BigInteger)
+    accrued_contributions: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        default=0,
+        server_default="0",
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
 
@@ -111,3 +117,15 @@ class TaxAdvantagedPlanLimit(Base):
     year: Mapped[int] = mapped_column(SmallInteger, primary_key=True, nullable=False)
     contribution_limit: Mapped[int] = mapped_column(BigInteger, nullable=False)  # Annual limit in currency base units
     withdrawal_limit: Mapped[int | None] = mapped_column(BigInteger)  # Null = no limit
+    accrued_contributions: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        default=0,
+        server_default="0",
+    )
+    accrued_withdrawals: Mapped[int] = mapped_column(
+        BigInteger,
+        nullable=False,
+        default=0,
+        server_default="0",
+    )

--- a/backend/app/routes/tax_advantaged_plan.py
+++ b/backend/app/routes/tax_advantaged_plan.py
@@ -150,6 +150,7 @@ async def create_tax_advantaged_plan(
         tax_treatment=TaxTreatment(data.tax_treatment),
         currency=data.currency,
         lifetime_contribution_limit=data.lifetime_contribution_limit,
+        accrued_contributions=data.accrued_contributions,
     )
     db.add(plan)
     await db.commit()
@@ -311,6 +312,8 @@ async def create_tax_advantaged_plan_limit(
         year=data.year,
         contribution_limit=data.contribution_limit,
         withdrawal_limit=data.withdrawal_limit,
+        accrued_contributions=data.accrued_contributions,
+        accrued_withdrawals=data.accrued_withdrawals,
     )
     db.add(row)
     await db.commit()

--- a/backend/app/schemas/tax_advantaged_plan.py
+++ b/backend/app/schemas/tax_advantaged_plan.py
@@ -11,6 +11,8 @@ class TaxAdvantagedPlanLimitResponse(BaseModel):
     year: int
     contribution_limit: int
     withdrawal_limit: int | None
+    accrued_contributions: int
+    accrued_withdrawals: int
 
     model_config = {"from_attributes": True}
 
@@ -21,6 +23,8 @@ class CreateTaxAdvantagedPlanLimitRequest(BaseModel):
     year: int = Field(ge=1900, le=2100)
     contribution_limit: int = Field(ge=0)
     withdrawal_limit: int | None = Field(default=None, ge=0)
+    accrued_contributions: int = Field(default=0, ge=0)
+    accrued_withdrawals: int = Field(default=0, ge=0)
 
 
 class UpdateTaxAdvantagedPlanLimitRequest(BaseModel):
@@ -28,6 +32,8 @@ class UpdateTaxAdvantagedPlanLimitRequest(BaseModel):
 
     contribution_limit: int | None = Field(default=None, ge=0)
     withdrawal_limit: int | None = Field(default=None, ge=0)
+    accrued_contributions: int = Field(default=0, ge=0)
+    accrued_withdrawals: int = Field(default=0, ge=0)
 
 
 class TaxAdvantagedPlanResponse(BaseModel):
@@ -40,6 +46,7 @@ class TaxAdvantagedPlanResponse(BaseModel):
     tax_treatment: str
     currency: str
     lifetime_contribution_limit: int | None
+    accrued_contributions: int
     accrued_lifetime_contribution_limit: int | None
     current_year_contribution_limit: int | None
     current_year_withdrawal_limit: int | None
@@ -59,6 +66,7 @@ class CreateTaxAdvantagedPlanRequest(BaseModel):
     tax_treatment: str
     currency: str = Field(min_length=3, max_length=3)
     lifetime_contribution_limit: int | None = Field(default=None, ge=0)
+    accrued_contributions: int = Field(default=0, ge=0)
     group_id: uuid.UUID | None = None
 
 
@@ -68,4 +76,5 @@ class UpdateTaxAdvantagedPlanRequest(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=256)
     tax_treatment: str | None = None
     lifetime_contribution_limit: int | None = Field(default=None, ge=0)
+    accrued_contributions: int = Field(default=0, ge=0)
     group_id: uuid.UUID | None = None

--- a/backend/app/schemas/tax_advantaged_plan.py
+++ b/backend/app/schemas/tax_advantaged_plan.py
@@ -31,7 +31,7 @@ class UpdateTaxAdvantagedPlanLimitRequest(BaseModel):
 
 
 class TaxAdvantagedPlanResponse(BaseModel):
-    """Tax-advantaged plan plus current-year limit fields."""
+    """Tax-advantaged plan plus derived limit fields."""
 
     id: uuid.UUID
     plan_owner_user_id: uuid.UUID
@@ -40,6 +40,7 @@ class TaxAdvantagedPlanResponse(BaseModel):
     tax_treatment: str
     currency: str
     lifetime_contribution_limit: int | None
+    accrued_lifetime_contribution_limit: int | None
     current_year_contribution_limit: int | None
     current_year_withdrawal_limit: int | None
     ytd_contributions: int

--- a/backend/app/services/tax_advantaged_plans.py
+++ b/backend/app/services/tax_advantaged_plans.py
@@ -40,7 +40,7 @@ async def attach_tax_advantaged_plan_metrics(
         for plan in plans
     }
 
-    limits: dict[tuple[uuid.UUID, int], tuple[int, int | None]] = {}
+    limits: dict[tuple[uuid.UUID, int], tuple[int, int | None, int, int]] = {}
     accrued_lifetime_limits: dict[uuid.UUID, int] = {plan.id: 0 for plan in plans}
     has_accrued_limit_rows: set[uuid.UUID] = set()
 
@@ -50,10 +50,17 @@ async def attach_tax_advantaged_plan_metrics(
             TaxAdvantagedPlanLimit.year,
             TaxAdvantagedPlanLimit.contribution_limit,
             TaxAdvantagedPlanLimit.withdrawal_limit,
+            TaxAdvantagedPlanLimit.accrued_contributions,
+            TaxAdvantagedPlanLimit.accrued_withdrawals,
         ).where(TaxAdvantagedPlanLimit.plan_id.in_(plan_ids)),
     )
     for row in result:
-        limits[(row.plan_id, row.year)] = (row.contribution_limit, row.withdrawal_limit)
+        limits[(row.plan_id, row.year)] = (
+            row.contribution_limit,
+            row.withdrawal_limit,
+            row.accrued_contributions,
+            row.accrued_withdrawals,
+        )
         if row.year <= plan_years[row.plan_id]:
             accrued_lifetime_limits[row.plan_id] += row.contribution_limit
             has_accrued_limit_rows.add(row.plan_id)
@@ -75,9 +82,9 @@ async def attach_tax_advantaged_plan_metrics(
 
     tallies: dict[uuid.UUID, dict[str, int]] = {
         plan.id: {
-            "ytd_contributions": 0,
-            "ytd_withdrawals": 0,
-            "lifetime_contributions": 0,
+            "ytd_contributions": limits.get((plan.id, plan_years[plan.id]), (0, None, 0, 0))[2],
+            "ytd_withdrawals": limits.get((plan.id, plan_years[plan.id]), (0, None, 0, 0))[3],
+            "lifetime_contributions": plan.accrued_contributions,
             "lifetime_withdrawals": 0,
         }
         for plan in plans

--- a/backend/app/services/tax_advantaged_plans.py
+++ b/backend/app/services/tax_advantaged_plans.py
@@ -41,6 +41,8 @@ async def attach_tax_advantaged_plan_metrics(
     }
 
     limits: dict[tuple[uuid.UUID, int], tuple[int, int | None]] = {}
+    accrued_lifetime_limits: dict[uuid.UUID, int] = {plan.id: 0 for plan in plans}
+    has_accrued_limit_rows: set[uuid.UUID] = set()
 
     result = await db.execute(
         select(
@@ -48,18 +50,25 @@ async def attach_tax_advantaged_plan_metrics(
             TaxAdvantagedPlanLimit.year,
             TaxAdvantagedPlanLimit.contribution_limit,
             TaxAdvantagedPlanLimit.withdrawal_limit,
-        ).where(
-            TaxAdvantagedPlanLimit.plan_id.in_(plan_ids),
-            TaxAdvantagedPlanLimit.year.in_(set(plan_years.values())),
-        ),
+        ).where(TaxAdvantagedPlanLimit.plan_id.in_(plan_ids)),
     )
     for row in result:
         limits[(row.plan_id, row.year)] = (row.contribution_limit, row.withdrawal_limit)
+        if row.year <= plan_years[row.plan_id]:
+            accrued_lifetime_limits[row.plan_id] += row.contribution_limit
+            has_accrued_limit_rows.add(row.plan_id)
 
     for plan in plans:
         row = limits.get((plan.id, plan_years[plan.id]))
         plan.current_year_contribution_limit = row[0] if row else None
         plan.current_year_withdrawal_limit = row[1] if row else None
+        if plan.lifetime_contribution_limit is not None and plan.id in has_accrued_limit_rows:
+            plan.accrued_lifetime_contribution_limit = min(
+                accrued_lifetime_limits[plan.id],
+                plan.lifetime_contribution_limit,
+            )
+        else:
+            plan.accrued_lifetime_contribution_limit = None
 
     positive = Transaction.amount > 0
     negative = Transaction.amount < 0

--- a/backend/tests/routes/test_account.py
+++ b/backend/tests/routes/test_account.py
@@ -159,6 +159,7 @@ async def test_list_accounts_returns_overview_shape(client):
     for field in (
         "tax_treatment",
         "lifetime_contribution_limit",
+        "accrued_contributions",
         "accrued_lifetime_contribution_limit",
         "ytd_contributions",
         "ytd_withdrawals",
@@ -560,6 +561,7 @@ async def test_get_account_returns_account(client):
     for field in (
         "tax_treatment",
         "lifetime_contribution_limit",
+        "accrued_contributions",
         "accrued_lifetime_contribution_limit",
         "ytd_contributions",
         "ytd_withdrawals",

--- a/backend/tests/routes/test_account.py
+++ b/backend/tests/routes/test_account.py
@@ -159,6 +159,7 @@ async def test_list_accounts_returns_overview_shape(client):
     for field in (
         "tax_treatment",
         "lifetime_contribution_limit",
+        "accrued_lifetime_contribution_limit",
         "ytd_contributions",
         "ytd_withdrawals",
         "lifetime_contributions",
@@ -559,6 +560,7 @@ async def test_get_account_returns_account(client):
     for field in (
         "tax_treatment",
         "lifetime_contribution_limit",
+        "accrued_lifetime_contribution_limit",
         "ytd_contributions",
         "ytd_withdrawals",
         "lifetime_contributions",

--- a/backend/tests/routes/test_tax_advantaged_plan.py
+++ b/backend/tests/routes/test_tax_advantaged_plan.py
@@ -106,6 +106,7 @@ async def test_create_plan_returns_201_with_shape(client):
     assert data["tax_treatment"] == "tax_free"
     assert data["currency"] == "CAD"
     assert data["lifetime_contribution_limit"] == 9_500_000
+    assert data["accrued_contributions"] == 0
     assert data["accrued_lifetime_contribution_limit"] is None
     assert data["current_year_contribution_limit"] is None
     assert data["current_year_withdrawal_limit"] is None
@@ -177,7 +178,12 @@ async def test_owner_can_update_and_delete_plan(client):
 
     patch = await client.patch(
         f"/tax-advantaged-plans/{plan_id}",
-        json={"name": "RRSP", "tax_treatment": "tax_deferred", "lifetime_contribution_limit": 1_000_000},
+        json={
+            "name": "RRSP",
+            "tax_treatment": "tax_deferred",
+            "lifetime_contribution_limit": 1_000_000,
+            "accrued_contributions": 500_000,
+        },
         headers=headers,
     )
     delete = await client.delete(f"/tax-advantaged-plans/{plan_id}", headers=headers)
@@ -187,6 +193,7 @@ async def test_owner_can_update_and_delete_plan(client):
     assert patch.json()["name"] == "RRSP"
     assert patch.json()["tax_treatment"] == "tax_deferred"
     assert patch.json()["lifetime_contribution_limit"] == 1_000_000
+    assert patch.json()["accrued_contributions"] == 500_000
     assert delete.status_code == 204
     assert get_after_delete.status_code == 404
 
@@ -199,7 +206,13 @@ async def test_plan_limits_crud(client):
 
     create = await client.post(
         f"/tax-advantaged-plans/{plan_id}/limits",
-        json={"year": 2026, "contribution_limit": 700_000, "withdrawal_limit": 200_000},
+        json={
+            "year": 2026,
+            "contribution_limit": 700_000,
+            "withdrawal_limit": 200_000,
+            "accrued_contributions": 100_000,
+            "accrued_withdrawals": 25_000,
+        },
         headers=headers,
     )
     duplicate = await client.post(
@@ -209,7 +222,7 @@ async def test_plan_limits_crud(client):
     )
     patch = await client.patch(
         f"/tax-advantaged-plans/{plan_id}/limits/2026",
-        json={"withdrawal_limit": None},
+        json={"withdrawal_limit": None, "accrued_contributions": 120_000, "accrued_withdrawals": 30_000},
         headers=headers,
     )
     listed = await client.get(f"/tax-advantaged-plans/{plan_id}/limits", headers=headers)
@@ -218,9 +231,13 @@ async def test_plan_limits_crud(client):
 
     assert create.status_code == 201
     assert create.json()["contribution_limit"] == 700_000
+    assert create.json()["accrued_contributions"] == 100_000
+    assert create.json()["accrued_withdrawals"] == 25_000
     assert duplicate.status_code == 409
     assert patch.status_code == 200
     assert patch.json()["withdrawal_limit"] is None
+    assert patch.json()["accrued_contributions"] == 120_000
+    assert patch.json()["accrued_withdrawals"] == 30_000
     assert listed.status_code == 200
     assert [row["year"] for row in listed.json()] == [2026]
     assert delete.status_code == 204
@@ -352,6 +369,38 @@ async def test_plan_detail_aggregates_transfer_activity_across_linked_accounts(c
     assert resp.json()["ytd_withdrawals"] == 10_000
     assert resp.json()["lifetime_contributions"] == 100_000
     assert resp.json()["lifetime_withdrawals"] == 15_000
+
+
+async def test_plan_metrics_include_accrued_activity(client):
+    """Plan metrics include user-entered activity from before Lumina tracking."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = signup_resp.json()["user"]["id"]
+    plan_id = (await _create_plan(client, headers, accrued_contributions=90_000)).json()["id"]
+    account_id = (await _create_account(client, headers, tax_advantaged_plan_id=plan_id)).json()["id"]
+    transfer_id = await _get_system_category_id("Transfer")
+    current_year = datetime.now(UTC).year
+    await client.post(
+        f"/tax-advantaged-plans/{plan_id}/limits",
+        json={
+            "year": current_year,
+            "contribution_limit": 700_000,
+            "accrued_contributions": 10_000,
+            "accrued_withdrawals": 3_000,
+        },
+        headers=headers,
+    )
+
+    await _seed_transaction(account_id, transfer_id, user_id, 20_000, date(current_year, 2, 1))
+    await _seed_transaction(account_id, transfer_id, user_id, -4_000, date(current_year, 3, 1))
+    await _seed_transaction(account_id, transfer_id, user_id, 30_000, date(current_year - 1, 4, 1))
+
+    resp = await client.get(f"/tax-advantaged-plans/{plan_id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["ytd_contributions"] == 30_000
+    assert resp.json()["ytd_withdrawals"] == 7_000
+    assert resp.json()["lifetime_contributions"] == 140_000
 
 
 async def test_plan_detail_includes_archived_linked_account_activity(client):

--- a/backend/tests/routes/test_tax_advantaged_plan.py
+++ b/backend/tests/routes/test_tax_advantaged_plan.py
@@ -106,6 +106,7 @@ async def test_create_plan_returns_201_with_shape(client):
     assert data["tax_treatment"] == "tax_free"
     assert data["currency"] == "CAD"
     assert data["lifetime_contribution_limit"] == 9_500_000
+    assert data["accrued_lifetime_contribution_limit"] is None
     assert data["current_year_contribution_limit"] is None
     assert data["current_year_withdrawal_limit"] is None
     assert data["ytd_contributions"] == 0
@@ -243,6 +244,36 @@ async def test_plan_detail_surfaces_current_year_limits(client):
     assert resp.status_code == 200
     assert resp.json()["current_year_contribution_limit"] == 700_000
     assert resp.json()["current_year_withdrawal_limit"] is None
+
+
+async def test_plan_detail_surfaces_accrued_lifetime_limit(client):
+    """Accrued lifetime contribution room is summed through the owner's current year."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    plan_id = (await _create_plan(client, headers, lifetime_contribution_limit=1_200_000)).json()["id"]
+    current_year = datetime.now(UTC).year
+
+    await client.post(
+        f"/tax-advantaged-plans/{plan_id}/limits",
+        json={"year": current_year - 1, "contribution_limit": 700_000},
+        headers=headers,
+    )
+    await client.post(
+        f"/tax-advantaged-plans/{plan_id}/limits",
+        json={"year": current_year, "contribution_limit": 800_000},
+        headers=headers,
+    )
+    await client.post(
+        f"/tax-advantaged-plans/{plan_id}/limits",
+        json={"year": current_year + 1, "contribution_limit": 900_000},
+        headers=headers,
+    )
+
+    resp = await client.get(f"/tax-advantaged-plans/{plan_id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["current_year_contribution_limit"] == 800_000
+    assert resp.json()["accrued_lifetime_contribution_limit"] == 1_200_000
 
 
 async def test_plan_metrics_use_plan_owner_timezone_for_current_year(client, monkeypatch):

--- a/frontend/src/accounts/components/TaxAdvantagedLimitsSection.tsx
+++ b/frontend/src/accounts/components/TaxAdvantagedLimitsSection.tsx
@@ -1,13 +1,13 @@
-import { formatCompactMoney, type CompactMoneyRule } from '@/utils/formatCompactMoney'
+import {
+  useRef,
+  type MouseEvent as ReactMouseEvent,
+} from 'react'
+import {
+  DeferredChartTooltipOverlay,
+  type DeferredChartTooltipOverlayHandle,
+} from '@/components/charts/DeferredChartTooltipOverlay'
+import type { TaxAdvantagedPlan } from '@/api/taxAdvantagedPlans'
 import type { TaxAdvantagedLimitSummary } from '@/accounts/types/accounts'
-
-const TAX_LIMIT_MONEY_RULES: CompactMoneyRule[] = [
-  { threshold: 100_000_000, divisor: 1_000_000, suffix: 'M', fractionDigits: 0 },
-  { threshold: 10_000_000, divisor: 1_000_000, suffix: 'M', fractionDigits: 1 },
-  { threshold: 1_000_000, divisor: 1_000_000, suffix: 'M', fractionDigits: 2 },
-  { threshold: 100_000, divisor: 1_000, suffix: 'K', fractionDigits: 0 },
-  { threshold: 10_000, divisor: 1_000, suffix: 'K', fractionDigits: 1 },
-]
 
 function limitUsageColor(used: number, limit: number): string {
   if (limit <= 0) return used > 0 ? 'var(--app-negative)' : 'var(--app-text-muted)'
@@ -22,32 +22,159 @@ function limitUsagePercent(used: number, limit: number): number {
   return Math.min(Math.max((used / limit) * 100, 0), 100)
 }
 
+function clampPercent(value: number): number {
+  return Math.min(Math.max(value, 0), 100)
+}
+
 function limitRemainingColor(remaining: number): string {
   if (remaining < 0) return 'var(--app-negative)'
   if (remaining === 0) return 'var(--app-text-muted)'
   return 'var(--app-accent)'
 }
 
-function TaxLimitLedgerRow({
+function getMajorCurrencyAmount(minorUnits: number, currency: string): number {
+  const formatter = new Intl.NumberFormat(undefined, { style: 'currency', currency })
+  const exponent = formatter.resolvedOptions().maximumFractionDigits ?? 2
+  return minorUnits / Math.pow(10, exponent) || 0
+}
+
+function formatNoDecimalCurrency(value: number, currency: string): string {
+  return new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    currencySign: 'accounting',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value)
+}
+
+function formatNoDecimalCurrencyWithSuffix(
+  value: number,
+  currency: string,
+  suffix: 'K' | 'M',
+): string {
+  const formatter = new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency,
+    currencySign: 'accounting',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  })
+  const parts = formatter.formatToParts(value)
+  const numberPartTypes = new Set(['integer', 'group'])
+  const suffixIndex = parts.findLastIndex((part) => numberPartTypes.has(part.type))
+
+  return parts
+    .map((part, index) => `${part.value}${index === suffixIndex ? suffix : ''}`)
+    .join('')
+}
+
+function formatMeterLimitMoney(amount: number, currency: string): string {
+  const majorUnits = getMajorCurrencyAmount(amount, currency)
+  const absoluteMajorUnits = Math.abs(majorUnits)
+  if (absoluteMajorUnits >= 1_000_000) {
+    return formatNoDecimalCurrencyWithSuffix(majorUnits / 1_000_000, currency, 'M')
+  }
+  if (absoluteMajorUnits >= 1_000) {
+    return formatNoDecimalCurrencyWithSuffix(majorUnits / 1_000, currency, 'K')
+  }
+  return formatNoDecimalCurrency(majorUnits, currency)
+}
+
+function formatRawLimitMoney(amount: number, currency: string): string {
+  return formatNoDecimalCurrency(getMajorCurrencyAmount(amount, currency), currency)
+}
+
+function getLifetimeAvailableBoundary(plan: TaxAdvantagedPlan): number | null {
+  if (
+    plan.lifetime_contribution_limit === null ||
+    plan.accrued_lifetime_contribution_limit === null
+  ) {
+    return null
+  }
+
+  const boundary = Math.min(
+    plan.accrued_lifetime_contribution_limit,
+    plan.lifetime_contribution_limit,
+  )
+  if (
+    boundary <= plan.lifetime_contributions ||
+    boundary >= plan.lifetime_contribution_limit
+  ) {
+    return null
+  }
+
+  return Math.max(boundary, 0)
+}
+
+type LimitMeterTooltipData = {
+  key: string
+  label: string
+  used: number
+  remaining: number
+  currency: string
+}
+
+function LimitMeterTooltipContent({
+  label,
+  used,
+  remaining,
+  currency,
+}: {
+  label: string
+  used: number
+  remaining: number
+  currency: string
+}) {
+  return (
+    <>
+      <p className="app-chart-tooltip-default-title font-medium">{label}</p>
+      <div className="mt-1 grid grid-cols-[auto_auto] gap-x-4 gap-y-1">
+        <span className="app-chart-tooltip-default-value">Used</span>
+        <span className="app-chart-tooltip-default-value text-right font-financial">
+          {formatRawLimitMoney(used, currency)}
+        </span>
+        <span className="app-chart-tooltip-default-value">Remaining</span>
+        <span
+          className="app-chart-tooltip-default-value text-right font-financial"
+          style={remaining < 0 ? { color: 'var(--app-negative)' } : undefined}
+        >
+          {formatRawLimitMoney(remaining, currency)}
+        </span>
+      </div>
+    </>
+  )
+}
+
+function CompactLimitMeter({
   label,
   used,
   limit,
   currency,
+  emptyLabel = 'Not set',
+  availableBoundary = null,
+  valueMode = 'usage',
 }: {
   label: string
   used: number
   limit: number | null
   currency: string
+  emptyLabel?: string
+  availableBoundary?: number | null
+  valueMode?: 'usage' | 'remaining'
 }) {
+  const meterRef = useRef<HTMLDivElement | null>(null)
+  const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<LimitMeterTooltipData>>(null)
+
   if (limit === null) {
     return (
-      <div>
+      <div className="min-w-0">
         <div className="flex items-baseline justify-between gap-2">
-          <p className="text-xs font-medium uppercase" style={{ color: 'var(--app-text-subtle)' }}>
+          <p className="truncate text-xs font-medium uppercase" style={{ color: 'var(--app-text-subtle)' }}>
             {label}
           </p>
-          <p className="font-financial text-sm font-medium tabular-nums" style={{ color: 'var(--app-text-muted)' }}>
-            Not set
+          <p className="font-financial truncate text-xs font-medium tabular-nums" style={{ color: 'var(--app-text-muted)' }}>
+            {emptyLabel}
           </p>
         </div>
         <div className="mt-1 h-1 rounded-full" style={{ background: 'var(--app-border)' }} />
@@ -56,44 +183,160 @@ function TaxLimitLedgerRow({
   }
 
   const color = limitUsageColor(used, limit)
-  const remaining = limit - used
-  const overLimit = remaining < 0
   const barWidth = limitUsagePercent(used, limit)
-  const amountColor = limitRemainingColor(remaining)
-  const remainingLabel = formatCompactMoney(Math.abs(remaining), currency, TAX_LIMIT_MONEY_RULES, {
-    prefix: '',
-  })
+  const usageLabel = `${formatMeterLimitMoney(used, currency)} / ${formatMeterLimitMoney(limit, currency)}`
+  const remaining = limit - used
+  const remainingLabel =
+    remaining < 0
+      ? `${formatMeterLimitMoney(Math.abs(remaining), currency)} over`
+      : formatMeterLimitMoney(remaining, currency)
+  const valueLabel = valueMode === 'remaining' ? remainingLabel : usageLabel
+  const availablePercent =
+    availableBoundary === null ? 0 : limitUsagePercent(availableBoundary, limit)
+  const availableWidth = Math.max(availablePercent - Math.min(barWidth, 100), 0)
+  const tooltipData: LimitMeterTooltipData = {
+    key: `${label}-${used}-${limit}-${currency}`,
+    label,
+    used,
+    remaining,
+    currency,
+  }
 
   return (
-    <div>
-      <div className="flex items-baseline justify-between gap-2">
-        <p className="text-xs font-medium uppercase" style={{ color: 'var(--app-text-subtle)' }}>
+    <div
+      ref={meterRef}
+      className="relative min-w-0"
+      onMouseLeave={() => tooltipRef.current?.hide()}
+      onMouseMove={(event: ReactMouseEvent<HTMLDivElement>) => {
+        tooltipRef.current?.show(tooltipData, {
+          clientX: event.clientX,
+          clientY: event.clientY,
+        })
+      }}
+    >
+      <div className="flex min-w-0 items-baseline justify-between gap-2">
+        <p className="truncate text-xs font-medium uppercase" style={{ color: 'var(--app-text-subtle)' }}>
           {label}
         </p>
-        <p className="font-financial truncate text-sm font-semibold tabular-nums" style={{ color: amountColor }}>
-          {overLimit ? `${remainingLabel} over` : `${remainingLabel} left`}
+        <p className="font-financial truncate text-xs font-medium tabular-nums" style={{ color: valueMode === 'remaining' ? limitRemainingColor(remaining) : 'var(--app-text-muted)' }}>
+          {valueLabel}
         </p>
       </div>
       <div className="mt-1">
         <div
-          className="h-1 overflow-hidden rounded-full"
+          className="relative h-1 overflow-hidden rounded-full"
           style={{ background: 'var(--app-border)' }}
           role="progressbar"
           aria-label={`${label} usage`}
           aria-valuemin={0}
           aria-valuemax={Math.max(limit, 0)}
           aria-valuenow={Math.min(Math.max(used, 0), Math.max(limit, 0))}
+          aria-valuetext={usageLabel}
         >
+          {availableBoundary !== null && (
+            <div
+              className="absolute inset-y-0 rounded-full"
+              style={{
+                left: `${clampPercent(barWidth)}%`,
+                width: `${clampPercent(availableWidth)}%`,
+                background: 'color-mix(in srgb, var(--app-accent) 26%, var(--app-border))',
+              }}
+            />
+          )}
           <div
-            className="h-full rounded-full"
+            className="absolute inset-y-0 left-0 rounded-full"
             style={{
               background: color,
-              width: `${barWidth}%`,
+              width: `${clampPercent(barWidth)}%`,
             }}
           />
         </div>
       </div>
+      <DeferredChartTooltipOverlay
+        ref={tooltipRef}
+        chartRef={meterRef}
+        className="min-w-44"
+        showGuide={false}
+        tooltipTransition="opacity 150ms ease-out"
+        getKey={(item) => item.key}
+        renderContent={(item) => (
+          <LimitMeterTooltipContent
+            label={item.label}
+            used={item.used}
+            remaining={item.remaining}
+            currency={item.currency}
+          />
+        )}
+      />
     </div>
+  )
+}
+
+function ContributionMeterStack({
+  plan,
+}: {
+  plan: TaxAdvantagedPlan
+}) {
+  const showLifetimeMeter = plan.lifetime_contribution_limit !== null
+  const annualMeter = (
+    <CompactLimitMeter
+      label="Annual"
+      used={plan.ytd_contributions}
+      limit={plan.current_year_contribution_limit}
+      currency={plan.currency}
+      valueMode="remaining"
+    />
+  )
+  const lifetimeMeter = showLifetimeMeter ? (
+    <CompactLimitMeter
+      label="Lifetime"
+      used={plan.lifetime_contributions}
+      limit={plan.lifetime_contribution_limit}
+      currency={plan.currency}
+      availableBoundary={getLifetimeAvailableBoundary(plan)}
+    />
+  ) : null
+  const withdrawalMeter = (
+    <CompactLimitMeter
+      label="Withdrawals"
+      used={plan.ytd_withdrawals}
+      limit={plan.current_year_withdrawal_limit}
+      currency={plan.currency}
+      emptyLabel="No limit"
+      valueMode="remaining"
+    />
+  )
+
+  if (!lifetimeMeter) {
+    return (
+      <div className="grid min-h-11 min-w-0 content-center gap-1.5">
+        {annualMeter}
+        {withdrawalMeter}
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid min-h-11 min-w-0 content-center gap-1.5">
+      {lifetimeMeter}
+      <div className="grid min-w-0 gap-3 min-[620px]:grid-cols-2">
+        {annualMeter}
+        {withdrawalMeter}
+      </div>
+    </div>
+  )
+}
+
+function hasLimitTracking(plan: TaxAdvantagedPlan): boolean {
+  return (
+    plan.current_year_contribution_limit !== null ||
+    plan.current_year_withdrawal_limit !== null ||
+    plan.lifetime_contribution_limit !== null ||
+    plan.accrued_lifetime_contribution_limit !== null ||
+    plan.ytd_contributions !== 0 ||
+    plan.ytd_withdrawals !== 0 ||
+    plan.lifetime_contributions !== 0 ||
+    plan.lifetime_withdrawals !== 0
   )
 }
 
@@ -112,6 +355,7 @@ export default function TaxAdvantagedLimitsSection({
             <div
               key={plan.id}
               className="min-w-0 py-3"
+              data-tooltip-bounds
             >
               <div className="mb-2 flex min-w-0 items-baseline justify-between gap-3">
                 <div className="flex min-w-0 items-baseline gap-2">
@@ -122,19 +366,8 @@ export default function TaxAdvantagedLimitsSection({
                 </div>
               </div>
 
-              <div className="grid min-w-0 gap-3 sm:grid-cols-2">
-                <TaxLimitLedgerRow
-                  label="Contributions"
-                  used={plan.ytd_contributions}
-                  limit={plan.current_year_contribution_limit}
-                  currency={plan.currency}
-                />
-                <TaxLimitLedgerRow
-                  label="Withdrawals"
-                  used={plan.ytd_withdrawals}
-                  limit={plan.current_year_withdrawal_limit}
-                  currency={plan.currency}
-                />
+              <div className="space-y-3">
+                {hasLimitTracking(plan) && <ContributionMeterStack plan={plan} />}
               </div>
             </div>
           )

--- a/frontend/src/accounts/hooks/useTaxAdvantagedLimitSummaries.ts
+++ b/frontend/src/accounts/hooks/useTaxAdvantagedLimitSummaries.ts
@@ -41,7 +41,9 @@ export function useTaxAdvantagedLimitSummaries({
       .filter((plan) => visiblePlanIds.has(plan.id))
       .filter((plan) =>
         plan.current_year_contribution_limit !== null ||
-        plan.current_year_withdrawal_limit !== null)
+        plan.current_year_withdrawal_limit !== null ||
+        plan.lifetime_contribution_limit !== null ||
+        plan.accrued_lifetime_contribution_limit !== null)
       .map((plan) => ({
         plan,
         linkedAccountCount: linkedAccountCountByPlanId.get(plan.id) ?? 0,

--- a/frontend/src/api/taxAdvantagedPlans.ts
+++ b/frontend/src/api/taxAdvantagedPlans.ts
@@ -14,6 +14,7 @@ export interface TaxAdvantagedPlan {
   tax_treatment: TaxTreatment;
   currency: string;
   lifetime_contribution_limit: number | null;
+  accrued_contributions: number;
   accrued_lifetime_contribution_limit: number | null;
   current_year_contribution_limit: number | null;
   current_year_withdrawal_limit: number | null;
@@ -29,6 +30,8 @@ export interface TaxAdvantagedPlanLimit {
   year: number;
   contribution_limit: number;
   withdrawal_limit: number | null;
+  accrued_contributions: number;
+  accrued_withdrawals: number;
 }
 
 export interface CreateTaxAdvantagedPlanPayload {
@@ -36,6 +39,7 @@ export interface CreateTaxAdvantagedPlanPayload {
   tax_treatment: TaxTreatment;
   currency: string;
   lifetime_contribution_limit: number | null;
+  accrued_contributions?: number;
   group_id?: string | null;
 }
 
@@ -43,6 +47,7 @@ export interface UpdateTaxAdvantagedPlanPayload {
   name?: string;
   tax_treatment?: TaxTreatment;
   lifetime_contribution_limit?: number | null;
+  accrued_contributions?: number;
   group_id?: string | null;
 }
 
@@ -51,6 +56,8 @@ export interface CreateTaxAdvantagedPlanLimitPayload {
   year: number;
   contribution_limit: number;
   withdrawal_limit: number | null;
+  accrued_contributions?: number;
+  accrued_withdrawals?: number;
 }
 
 export interface UpdateTaxAdvantagedPlanLimitPayload {
@@ -58,6 +65,8 @@ export interface UpdateTaxAdvantagedPlanLimitPayload {
   year: number;
   contribution_limit?: number;
   withdrawal_limit?: number | null;
+  accrued_contributions?: number;
+  accrued_withdrawals?: number;
 }
 
 function delay(ms: number) {

--- a/frontend/src/api/taxAdvantagedPlans.ts
+++ b/frontend/src/api/taxAdvantagedPlans.ts
@@ -14,6 +14,7 @@ export interface TaxAdvantagedPlan {
   tax_treatment: TaxTreatment;
   currency: string;
   lifetime_contribution_limit: number | null;
+  accrued_lifetime_contribution_limit: number | null;
   current_year_contribution_limit: number | null;
   current_year_withdrawal_limit: number | null;
   ytd_contributions: number;

--- a/frontend/src/components/charts/CursorTooltipPortal.tsx
+++ b/frontend/src/components/charts/CursorTooltipPortal.tsx
@@ -33,7 +33,6 @@ const CursorTooltipPortal = forwardRef<HTMLDivElement, CursorTooltipPortalProps>
       style={{
         ...defaultTooltipStyle,
         ...style,
-        transition: defaultTooltipStyle.transition,
       }}
     >
       {children}

--- a/frontend/src/components/charts/DeferredChartTooltipOverlay.tsx
+++ b/frontend/src/components/charts/DeferredChartTooltipOverlay.tsx
@@ -11,6 +11,7 @@ import {
   type ReactNode,
   type Ref,
   type RefObject,
+  type CSSProperties,
   type TransitionEvent as ReactTransitionEvent,
 } from 'react'
 import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
@@ -41,6 +42,7 @@ type DeferredChartTooltipOverlayProps<T> = {
   guideVariant?: GuideVariant
   guideWidth?: number
   guideMaxWidth?: number | ((chartWidth: number) => number)
+  tooltipTransition?: CSSProperties['transition']
 }
 
 const DEFAULT_DEFERRED_TOOLTIP_DELAY_MS = 45
@@ -56,6 +58,7 @@ function DeferredChartTooltipOverlayInner<T>({
   guideVariant = 'line',
   guideWidth = 28,
   guideMaxWidth,
+  tooltipTransition,
 }: DeferredChartTooltipOverlayProps<T>, ref: ForwardedRef<DeferredChartTooltipOverlayHandle<T>>) {
   const tooltipRef = useRef<HTMLDivElement>(null)
   const guideRef = useRef<HTMLDivElement>(null)
@@ -182,6 +185,7 @@ function DeferredChartTooltipOverlayInner<T>({
       style={{
         opacity: visible ? 1 : 0,
         transform: 'translate3d(var(--chart-tooltip-x, 0px), var(--chart-tooltip-y, 0px), 0)',
+        transition: tooltipTransition,
       }}
     >
       {item && renderContent(item)}

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/CreateTaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/CreateTaxAdvantagedCategoryModal.tsx
@@ -37,6 +37,7 @@ export default function CreateTaxAdvantagedCategoryModal({
     tax_treatment: 'tax_free',
     currency: userBaseCurrency ?? '',
     lifetime_contribution_limit: '',
+    accrued_contributions: '',
   })
   const [createError, setCreateError] = useState<string | null>(null)
   const [createInProgress, setCreateInProgress] = useState(false)
@@ -77,6 +78,10 @@ export default function CreateTaxAdvantagedCategoryModal({
       setCreateError('Lifetime contribution limit must be zero or higher.')
       return
     }
+    if (!isValidMoneyInput(form.accrued_contributions)) {
+      setCreateError('Accrued contributions must be zero or higher.')
+      return
+    }
 
     setCreateInProgress(true)
     const minimumLoading = new Promise((resolve) => window.setTimeout(resolve, CREATE_TAX_CATEGORY_MIN_LOADING_MS))
@@ -87,6 +92,7 @@ export default function CreateTaxAdvantagedCategoryModal({
         tax_treatment: form.tax_treatment,
         currency: selectedCurrency,
         lifetime_contribution_limit: toMinorUnits(form.lifetime_contribution_limit, currencies, selectedCurrency),
+        accrued_contributions: toMinorUnits(form.accrued_contributions, currencies, selectedCurrency) ?? 0,
         group_id: null,
       },
     ).then(async () => {
@@ -248,6 +254,16 @@ export default function CreateTaxAdvantagedCategoryModal({
                           value={form.lifetime_contribution_limit}
                           onChange={(value) => setField('lifetime_contribution_limit', value)}
                           placeholder="Optional"
+                        />
+                      </div>
+                      <div>
+                        <span className="app-label mb-1.5 block text-[0.9375rem] leading-5">Accrued Contributions</span>
+                        <CurrencyInput
+                          currencies={currencies}
+                          currency={selectedCurrency}
+                          value={form.accrued_contributions}
+                          onChange={(value) => setField('accrued_contributions', value)}
+                          placeholder="0"
                         />
                       </div>
                     </div>

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
-import type React from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { Check, LoaderCircle, Pencil, Plus, Trash2, X } from 'lucide-react'
 import { useUpdateAccount, type AccountsOverview } from '@/api/accounts'
@@ -50,11 +49,6 @@ import {
   TaxAdvantagedCurrencyWarning,
 } from '@/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedFormControls'
 
-const LIMIT_FIELD_ACTION_TRANSITION = {
-  duration: 0.18,
-  ease: [0.25, 0.1, 0.25, 1] as const,
-}
-
 type LimitDraftField = keyof Pick<
   TaxPlanLimitFormState,
   'contribution_limit' | 'withdrawal_limit' | 'accrued_contributions' | 'accrued_withdrawals'
@@ -64,71 +58,6 @@ function delay(ms: number) {
   return new Promise<void>((resolve) => {
     window.setTimeout(resolve, ms)
   })
-}
-
-function LimitInputShell({
-  children,
-  dirty,
-  discardLabel,
-  disabled,
-  onDiscard,
-  onSave,
-  saveLabel,
-  saving,
-}: {
-  children: React.ReactNode
-  dirty: boolean
-  discardLabel: string
-  disabled: boolean
-  onDiscard: () => void
-  onSave: () => void
-  saveLabel: string
-  saving: boolean
-}) {
-  return (
-    <div className="flex min-w-0 items-center gap-1.5">
-      <div className="min-w-0 flex-1">
-        {children}
-      </div>
-      <AnimatePresence initial={false}>
-        {dirty && (
-          <motion.div
-            className="flex shrink-0 items-center gap-1 overflow-hidden"
-            initial={{ opacity: 0, width: 0, x: -4, filter: 'blur(3px)' }}
-            animate={{ opacity: 1, width: 68, x: 0, filter: 'blur(0px)' }}
-            exit={{ opacity: 0, width: 0, x: -4, filter: 'blur(3px)' }}
-            transition={LIMIT_FIELD_ACTION_TRANSITION}
-          >
-            <button
-              type="button"
-              className="app-icon-button h-8 w-8 shrink-0 disabled:cursor-wait disabled:opacity-60"
-              onClick={onSave}
-              disabled={disabled}
-              aria-label={saveLabel}
-              title="Save"
-              style={{ color: 'var(--app-accent)' }}
-            >
-              {saving ? (
-                <LoaderCircle size={14} className="animate-spin motion-reduce:animate-none" aria-hidden />
-              ) : (
-                <Check size={14} aria-hidden />
-              )}
-            </button>
-            <button
-              type="button"
-              className="app-icon-button h-8 w-8 shrink-0 disabled:cursor-wait disabled:opacity-60"
-              onClick={onDiscard}
-              disabled={disabled}
-              aria-label={discardLabel}
-              title="Discard"
-            >
-              <X size={14} aria-hidden />
-            </button>
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
-  )
 }
 
 export default function TaxAdvantagedCategoryModal({
@@ -323,6 +252,14 @@ export default function TaxAdvantagedCategoryModal({
 
   const closeLimitDetailsModal = () => {
     if (creatingLimit || updateLimit.isPending) return
+    if (selectedLimitYear !== null) {
+      setLimitDrafts((current) => {
+        if (!(selectedLimitYear in current)) return current
+        const next = { ...current }
+        delete next[selectedLimitYear]
+        return next
+      })
+    }
     setShowAddTaxYear(false)
     setSelectedLimitYear(null)
     setLimitError(null)
@@ -455,39 +392,6 @@ export default function TaxAdvantagedCategoryModal({
       || (toMinorUnits(draft.accrued_withdrawals, currencies, plan.currency) ?? 0) !== limit.accrued_withdrawals
   }
 
-  const limitFieldDirty = (year: number, key: LimitDraftField) => {
-    const limit = limits.find((row) => row.year === year)
-    if (!limit) return false
-    const draft = limitDraft(year)
-    const baseline = {
-      contribution_limit: limit.contribution_limit,
-      withdrawal_limit: limit.withdrawal_limit,
-      accrued_contributions: limit.accrued_contributions,
-      accrued_withdrawals: limit.accrued_withdrawals,
-    }[key]
-    const value = key === 'accrued_contributions' || key === 'accrued_withdrawals'
-      ? toMinorUnits(draft[key], currencies, plan.currency) ?? 0
-      : toMinorUnits(draft[key], currencies, plan.currency)
-    return value !== baseline
-  }
-
-  const discardLimitField = (year: number, key: LimitDraftField) => {
-    setLimitDrafts((current) => {
-      const draft = current[year]
-      if (!draft || !(key in draft)) return current
-
-      const nextDraft = { ...draft }
-      delete nextDraft[key]
-
-      const next = { ...current }
-      if (Object.keys(nextDraft).length === 0) delete next[year]
-      else next[year] = nextDraft
-      return next
-    })
-    setLimitError(null)
-    setDeleteConfirmYear(null)
-  }
-
   const handleSaveLimit = (year: number) => {
     if (!limitDirty(year) || updateLimit.isPending) return
     const draft = limitDraft(year)
@@ -530,6 +434,7 @@ export default function TaxAdvantagedCategoryModal({
             return next
           })
           setLimitError(null)
+          setSelectedLimitYear(null)
           showAutosaveNotice({ status: 'saved', message: 'Limits saved.' })
         },
         onError: (error) => {
@@ -677,30 +582,18 @@ export default function TaxAdvantagedCategoryModal({
     label: string,
     ariaLabel: string,
     value: string,
-    dirty: boolean,
-    saving: boolean,
     placeholder?: string,
   ) => (
     <div className="min-w-0">
       <span className="app-label mb-1 block text-xs">{label}</span>
-      <LimitInputShell
-        dirty={dirty}
-        disabled={updateLimit.isPending}
-        saving={saving}
-        onSave={() => handleSaveLimit(year)}
-        onDiscard={() => discardLimitField(year, key)}
-        saveLabel={`Save ${year} ${ariaLabel.toLowerCase()}`}
-        discardLabel={`Discard ${year} ${ariaLabel.toLowerCase()} changes`}
-      >
-        <CompactCurrencyInput
-          ariaLabel={`${year} ${ariaLabel.toLowerCase()}`}
-          currencies={currencies}
-          currency={plan.currency}
-          value={value}
-          onChange={(nextValue) => setLimitField(year, key, nextValue)}
-          placeholder={placeholder}
-        />
-      </LimitInputShell>
+      <CompactCurrencyInput
+        ariaLabel={`${year} ${ariaLabel.toLowerCase()}`}
+        currencies={currencies}
+        currency={plan.currency}
+        value={value}
+        onChange={(nextValue) => setLimitField(year, key, nextValue)}
+        placeholder={placeholder}
+      />
     </div>
   )
 
@@ -732,10 +625,7 @@ export default function TaxAdvantagedCategoryModal({
   const selectedSavingLimit = selectedLimit !== null
     && updateLimit.isPending
     && updateLimit.variables?.year === selectedLimit.year
-  const selectedContributionDirty = selectedLimit ? limitFieldDirty(selectedLimit.year, 'contribution_limit') : false
-  const selectedWithdrawalDirty = selectedLimit ? limitFieldDirty(selectedLimit.year, 'withdrawal_limit') : false
-  const selectedPriorContributionDirty = selectedLimit ? limitFieldDirty(selectedLimit.year, 'accrued_contributions') : false
-  const selectedPriorWithdrawalDirty = selectedLimit ? limitFieldDirty(selectedLimit.year, 'accrued_withdrawals') : false
+  const selectedLimitDirty = selectedLimit ? limitDirty(selectedLimit.year) : false
 
   return (
     <>
@@ -1515,15 +1405,15 @@ export default function TaxAdvantagedCategoryModal({
                     <div className="space-y-2">
                       <p className="text-sm font-medium">Contribution</p>
                       <div className="grid grid-cols-2 gap-3">
-                        {renderLimitEditorField(selectedLimit.year, 'contribution_limit', 'Limit', 'Contribution limit', selectedDraft.contribution_limit, selectedContributionDirty, selectedSavingLimit)}
-                        {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Prior', 'Prior contributions', selectedDraft.accrued_contributions, selectedPriorContributionDirty, selectedSavingLimit, '0')}
+                        {renderLimitEditorField(selectedLimit.year, 'contribution_limit', 'Limit', 'Contribution limit', selectedDraft.contribution_limit)}
+                        {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Prior', 'Prior contributions', selectedDraft.accrued_contributions, '0')}
                       </div>
                     </div>
                     <div className="space-y-2">
                       <p className="text-sm font-medium">Withdrawal</p>
                       <div className="grid grid-cols-2 gap-3">
-                        {renderLimitEditorField(selectedLimit.year, 'withdrawal_limit', 'Limit', 'Withdrawal limit', selectedDraft.withdrawal_limit, selectedWithdrawalDirty, selectedSavingLimit, 'Optional')}
-                        {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Prior', 'Prior withdrawals', selectedDraft.accrued_withdrawals, selectedPriorWithdrawalDirty, selectedSavingLimit, '0')}
+                        {renderLimitEditorField(selectedLimit.year, 'withdrawal_limit', 'Limit', 'Withdrawal limit', selectedDraft.withdrawal_limit, 'Optional')}
+                        {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Prior', 'Prior withdrawals', selectedDraft.accrued_withdrawals, '0')}
                       </div>
                     </div>
                     {limitError && (
@@ -1531,6 +1421,24 @@ export default function TaxAdvantagedCategoryModal({
                         {limitError}
                       </p>
                     )}
+                    <div className="grid grid-cols-2 gap-2 pt-1">
+                      <button
+                        type="button"
+                        className="app-secondary-button justify-center"
+                        onClick={closeLimitDetailsModal}
+                        disabled={selectedSavingLimit}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        className="app-primary-button justify-center"
+                        onClick={() => handleSaveLimit(selectedLimit.year)}
+                        disabled={selectedSavingLimit || !selectedLimitDirty}
+                      >
+                        {selectedSavingLimit ? <div className="app-spinner" aria-label="Saving" /> : 'Save'}
+                      </button>
+                    </div>
                   </div>
                 ) : null}
               </div>

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -407,13 +407,13 @@ export default function TaxAdvantagedCategoryModal({
       return
     }
     if (!isValidMoneyInput(draft.accrued_contributions)) {
-      setLimitError(`${year} prior contributions must be zero or higher.`)
-      showAutosaveNotice({ status: 'error', message: `${year} prior contributions must be zero or higher.` })
+      setLimitError(`${year} opening contributions must be zero or higher.`)
+      showAutosaveNotice({ status: 'error', message: `${year} opening contributions must be zero or higher.` })
       return
     }
     if (!isValidMoneyInput(draft.accrued_withdrawals)) {
-      setLimitError(`${year} prior withdrawals must be zero or higher.`)
-      showAutosaveNotice({ status: 'error', message: `${year} prior withdrawals must be zero or higher.` })
+      setLimitError(`${year} opening withdrawals must be zero or higher.`)
+      showAutosaveNotice({ status: 'error', message: `${year} opening withdrawals must be zero or higher.` })
       return
     }
 
@@ -472,13 +472,13 @@ export default function TaxAdvantagedCategoryModal({
       return
     }
     if (!isValidMoneyInput(newLimitForm.accrued_contributions)) {
-      setLimitError('Prior contributions must be zero or higher.')
-      showAutosaveNotice({ status: 'error', message: 'Prior contributions must be zero or higher.' })
+      setLimitError('Opening contributions must be zero or higher.')
+      showAutosaveNotice({ status: 'error', message: 'Opening contributions must be zero or higher.' })
       return
     }
     if (!isValidMoneyInput(newLimitForm.accrued_withdrawals)) {
-      setLimitError('Prior withdrawals must be zero or higher.')
-      showAutosaveNotice({ status: 'error', message: 'Prior withdrawals must be zero or higher.' })
+      setLimitError('Opening withdrawals must be zero or higher.')
+      showAutosaveNotice({ status: 'error', message: 'Opening withdrawals must be zero or higher.' })
       return
     }
 
@@ -870,7 +870,7 @@ export default function TaxAdvantagedCategoryModal({
                           </span>
                         </div>
                         <div className="grid min-w-0 gap-1 min-[750px]:grid-cols-[auto_minmax(0,1fr)] min-[750px]:items-baseline min-[750px]:gap-4">
-                          <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>Prior activity</span>
+                          <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>Opening usage</span>
                           <span className="min-w-0 truncate text-sm font-medium">
                             {hasLifetimePriorActivity ? 'Noted' : 'None'}
                           </span>
@@ -909,7 +909,7 @@ export default function TaxAdvantagedCategoryModal({
                               <th className="sticky top-0 z-10 py-2 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Year</th>
                               <th className="sticky top-0 z-10 py-2 pl-0 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Contribution limit</th>
                               <th className="sticky top-0 z-10 py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Withdrawal limit</th>
-                              <th className="sticky top-0 z-10 py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Prior activity</th>
+                              <th className="sticky top-0 z-10 py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Opening usage</th>
                               <th className="sticky top-0 z-10 py-2 pl-2 font-medium" style={{ background: 'var(--app-bg)' }} aria-label="Actions" />
                             </tr>
                           </thead>
@@ -970,10 +970,10 @@ export default function TaxAdvantagedCategoryModal({
                                     <td className="col-span-2 row-start-4 min-w-0 pt-2 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
                                       {hasPriorActivity ? (
                                         <span className="block truncate text-sm font-medium">
-                                          Prior activity noted
+                                          Opening usage noted
                                         </span>
                                       ) : (
-                                        <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>No prior activity</span>
+                                        <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>No opening usage</span>
                                       )}
                                     </td>
                                     <td
@@ -1336,7 +1336,7 @@ export default function TaxAdvantagedCategoryModal({
                       {showAddTaxYear ? 'New Year' : selectedLimit?.year}
                     </h4>
                     <p className="mt-1 text-sm" style={{ color: 'var(--app-text-muted)' }}>
-                      {showAddTaxYear ? 'Configure annual limits and prior activity.' : 'Edit annual limits and prior activity.'}
+                      {showAddTaxYear ? 'Configure annual limits and opening usage.' : 'Edit annual limits and opening usage.'}
                     </p>
                   </div>
                   <button
@@ -1381,14 +1381,14 @@ export default function TaxAdvantagedCategoryModal({
                         <p className="text-sm font-medium">Contribution</p>
                         <div className="grid grid-cols-2 gap-3">
                           {renderNewLimitEditorField('contribution_limit', 'Limit', 'New tax-year contribution limit', 'Required')}
-                          {renderNewLimitEditorField('accrued_contributions', 'Prior', 'New tax-year prior contributions', '0')}
+                          {renderNewLimitEditorField('accrued_contributions', 'Opening', 'New tax-year opening contributions', '0')}
                         </div>
                       </div>
                       <div className="space-y-2">
                         <p className="text-sm font-medium">Withdrawal</p>
                         <div className="grid grid-cols-2 gap-3">
                           {renderNewLimitEditorField('withdrawal_limit', 'Limit', 'New tax-year withdrawal limit', 'Optional')}
-                          {renderNewLimitEditorField('accrued_withdrawals', 'Prior', 'New tax-year prior withdrawals', '0')}
+                          {renderNewLimitEditorField('accrued_withdrawals', 'Opening', 'New tax-year opening withdrawals', '0')}
                         </div>
                       </div>
                       {limitError && (
@@ -1403,14 +1403,14 @@ export default function TaxAdvantagedCategoryModal({
                         <p className="text-sm font-medium">Contribution</p>
                         <div className="grid grid-cols-2 gap-3">
                           {renderLimitEditorField(selectedLimit.year, 'contribution_limit', 'Limit', 'Contribution limit', selectedDraft.contribution_limit)}
-                          {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Prior', 'Prior contributions', selectedDraft.accrued_contributions, '0')}
+                          {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Opening', 'Opening contributions', selectedDraft.accrued_contributions, '0')}
                         </div>
                       </div>
                       <div className="space-y-2">
                         <p className="text-sm font-medium">Withdrawal</p>
                         <div className="grid grid-cols-2 gap-3">
                           {renderLimitEditorField(selectedLimit.year, 'withdrawal_limit', 'Limit', 'Withdrawal limit', selectedDraft.withdrawal_limit, 'Optional')}
-                          {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Prior', 'Prior withdrawals', selectedDraft.accrued_withdrawals, '0')}
+                          {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Opening', 'Opening withdrawals', selectedDraft.accrued_withdrawals, '0')}
                         </div>
                       </div>
                       {limitError && (

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -707,7 +707,7 @@ export default function TaxAdvantagedCategoryModal({
           }}
           onClick={(event) => event.stopPropagation()}
         >
-          <div className="flex h-full min-h-0 w-full flex-col min-[1050px]:grid min-[1050px]:max-h-[86vh] min-[1050px]:min-h-[580px] min-[1050px]:grid-cols-[280px_minmax(0,1fr)]">
+          <div className="flex h-full min-h-0 w-full flex-col min-[1050px]:grid min-[1050px]:h-[580px] min-[1050px]:max-h-[86vh] min-[1050px]:grid-cols-[280px_minmax(0,1fr)]">
             <aside
               className="flex shrink-0 min-w-0 flex-col gap-3 border-b p-4 min-[750px]:gap-6 min-[750px]:p-7 min-[1050px]:min-h-0 min-[1050px]:shrink min-[1050px]:border-b-0 min-[1050px]:border-r"
               style={{ background: 'var(--app-surface-soft)', borderColor: 'var(--app-border)' }}
@@ -879,7 +879,7 @@ export default function TaxAdvantagedCategoryModal({
                 </button>
               </div>
 
-              <div className="min-h-0 flex-1 overflow-y-auto p-5 min-[750px]:p-6">
+              <div className={`min-h-0 flex-1 p-5 min-[750px]:p-6 ${activeTab === 'accounts' ? 'overflow-hidden' : 'overflow-y-auto'}`}>
                 {activeTab === 'limits' ? (
                   <div className="space-y-5">
                     <div className="space-y-2 border-b pb-4" style={{ borderColor: 'var(--app-border)' }}>
@@ -1141,29 +1141,26 @@ export default function TaxAdvantagedCategoryModal({
                     )}
                   </div>
                 ) : (
-                  <div className="flex min-h-0 flex-col gap-4">
-                    <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+                  <div className="flex h-full min-h-0 flex-col gap-4">
+                    <div className="shrink-0">
                       <p className="text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
                         Choose eligible {plan.currency} accounts for this category. Archived accounts stay visible for history but cannot be linked or unlinked until unarchived.
-                      </p>
-                      <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
-                        {linkedAccountsCount} of {bindableAccounts.length} linked
                       </p>
                     </div>
 
                     {accountError && (
-                      <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
+                      <p className="shrink-0 text-sm" style={{ color: 'var(--app-negative)' }}>
                         {accountError}
                       </p>
                     )}
 
                     {bindableAccounts.length === 0 ? (
-                      <p className="py-3 text-sm italic" style={{ color: 'var(--app-text-subtle)' }}>
+                      <p className="min-h-0 flex-1 py-3 text-sm italic" style={{ color: 'var(--app-text-subtle)' }}>
                         No eligible {plan.currency} asset accounts.
                       </p>
                     ) : (
                       <div
-                        className="max-h-[22rem] overflow-y-auto overflow-x-hidden rounded-xl border"
+                        className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden rounded-xl border"
                         style={{ borderColor: 'var(--app-border)' }}
                       >
                         {bindableAccounts.map((account, index) => {
@@ -1208,6 +1205,10 @@ export default function TaxAdvantagedCategoryModal({
                         })}
                       </div>
                     )}
+
+                    <p className="shrink-0 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                      {linkedAccountsCount} of {bindableAccounts.length} linked
+                    </p>
                   </div>
                 )}
               </div>

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -27,8 +27,6 @@ import { autosaveNoticeColor } from '@/settings/components/tax-advantaged/TaxAdv
 import {
   ACCOUNT_LINK_SAVE_MIN_LOADING_MS,
   ACCOUNT_LINK_SAVE_NOTICE_DELAY_MS,
-  CATEGORY_SUMMARY_LABEL_CLASS,
-  CATEGORY_SUMMARY_VALUE_CLASS,
   DEFAULT_NEW_LIMIT_YEAR,
   DELETE_TAX_CATEGORY_MIN_LOADING_MS,
   LIMIT_DELETE_BUTTON_TRANSITION,
@@ -360,12 +358,15 @@ export default function TaxAdvantagedCategoryModal({
   }, [limits, pendingCreateLimitYear, pendingDeletedLimit])
   const hasScrollableLimitRows = sortedLimits.length > MAX_VISIBLE_LIMIT_ROWS
   const creatingLimit = pendingCreateLimitYear !== null || createLimit.isPending
+  const hasLifetimePriorActivity = plan.accrued_contributions > 0
   const bindableAccounts = accounts.filter(
     (account) =>
       account.closed_at === null
       && account.account_kind === 'asset'
       && account.currency === plan.currency,
   )
+  const linkedAccountsCount = bindableAccounts.filter((account) => account.tax_advantaged_plan_id === plan.id).length
+  const linkedAccountsSummary = `${linkedAccountsCount} linked`
 
   const limitDraft = (year: number) => {
     const limit = limits.find((row) => row.year === year)
@@ -686,12 +687,12 @@ export default function TaxAdvantagedCategoryModal({
         >
           <div className="flex h-full min-h-0 w-full flex-col min-[1050px]:grid min-[1050px]:max-h-[86vh] min-[1050px]:min-h-[580px] min-[1050px]:grid-cols-[280px_minmax(0,1fr)]">
             <aside
-              className="flex shrink-0 min-w-0 flex-col gap-5 border-b p-5 min-[750px]:gap-6 min-[750px]:p-7 min-[1050px]:min-h-0 min-[1050px]:shrink min-[1050px]:border-b-0 min-[1050px]:border-r"
+              className="flex shrink-0 min-w-0 flex-col gap-3 border-b p-4 min-[750px]:gap-6 min-[750px]:p-7 min-[1050px]:min-h-0 min-[1050px]:shrink min-[1050px]:border-b-0 min-[1050px]:border-r"
               style={{ background: 'var(--app-surface-soft)', borderColor: 'var(--app-border)' }}
             >
               <div className="flex min-w-0 items-start justify-between gap-4">
-                <div className="h-10 min-w-0 flex-1 overflow-hidden">
-                  <h3 id="tax-advantaged-category-title" className="h-10 truncate font-serif text-3xl font-medium leading-10 tracking-tight">
+                <div className="min-w-0 flex-1 overflow-hidden">
+                  <h3 id="tax-advantaged-category-title" className="truncate font-serif text-2xl font-medium leading-8 tracking-tight min-[750px]:text-3xl min-[750px]:leading-10">
                     {plan.name}
                   </h3>
                 </div>
@@ -705,8 +706,8 @@ export default function TaxAdvantagedCategoryModal({
                 </button>
               </div>
 
-              <div className="space-y-3 min-[750px]:hidden">
-                <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[0.9375rem] font-medium">
+              <div className="space-y-2.5 min-[750px]:hidden">
+                <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-sm font-medium" style={{ color: 'var(--app-text-muted)' }}>
                   <span className="truncate">
                     {formatTaxTreatment(plan.tax_treatment)}
                   </span>
@@ -721,16 +722,10 @@ export default function TaxAdvantagedCategoryModal({
                   </span>
                 </div>
 
-                <div className="flex min-w-0 items-center justify-between gap-4 border-t pt-3" style={{ borderColor: 'var(--app-border)' }}>
-                  <span className="app-label min-w-0">Lifetime Contribution Limit</span>
-                  <span className="font-financial text-[0.9375rem] font-medium">
-                    {plan.lifetime_contribution_limit === null ? 'Not set' : formatCurrency(plan.lifetime_contribution_limit, plan.currency)}
-                  </span>
-                </div>
-                <div className="flex min-w-0 items-center justify-between gap-4">
-                  <span className="app-label min-w-0">Accrued Contributions</span>
-                  <span className="font-financial text-[0.9375rem] font-medium">
-                    {formatCurrency(plan.accrued_contributions, plan.currency)}
+                <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-t pt-2.5" style={{ borderColor: 'var(--app-border)' }}>
+                  <span className="app-label min-w-0">Linked Accounts</span>
+                  <span className="text-sm font-medium">
+                    {linkedAccountsSummary}
                   </span>
                 </div>
               </div>
@@ -743,20 +738,7 @@ export default function TaxAdvantagedCategoryModal({
                   value={plan.currency}
                 />
                 <InfoItem label="Scope" value={plan.group_id ? 'Group' : 'Personal'} />
-
-                <div className="relative h-14 min-w-0 overflow-hidden">
-                  <p className={CATEGORY_SUMMARY_LABEL_CLASS}>Lifetime Contribution Limit</p>
-                  <p className={`font-financial ${CATEGORY_SUMMARY_VALUE_CLASS}`}>
-                    {plan.lifetime_contribution_limit === null ? 'Not set' : formatCurrency(plan.lifetime_contribution_limit, plan.currency)}
-                  </p>
-                </div>
-
-                <div className="relative h-14 min-w-0 overflow-hidden">
-                  <p className={CATEGORY_SUMMARY_LABEL_CLASS}>Accrued Contributions</p>
-                  <p className={`font-financial ${CATEGORY_SUMMARY_VALUE_CLASS}`}>
-                    {formatCurrency(plan.accrued_contributions, plan.currency)}
-                  </p>
-                </div>
+                <InfoItem label="Linked Accounts" value={linkedAccountsSummary} />
               </div>
 
               {planError && (
@@ -765,10 +747,10 @@ export default function TaxAdvantagedCategoryModal({
                 </p>
               )}
 
-              <div className="flex items-center justify-between border-t pt-4 min-[1050px]:mt-auto" style={{ borderColor: 'var(--app-border)' }}>
+              <div className="grid grid-cols-2 gap-2 border-t pt-3 min-[750px]:flex min-[750px]:items-center min-[750px]:justify-between min-[750px]:pt-4 min-[1050px]:mt-auto" style={{ borderColor: 'var(--app-border)' }}>
                 <button
                   type="button"
-                  className="app-secondary-button w-[72px]"
+                  className="app-secondary-button w-full justify-center min-[750px]:w-[72px]"
                   disabled={planSaveStatus !== 'idle'}
                   onClick={openCategoryDetailsModal}
                 >
@@ -777,7 +759,7 @@ export default function TaxAdvantagedCategoryModal({
                 <button
                   ref={planDeleteButtonRef}
                   type="button"
-                  className={`app-danger-button ${deletePlan.isPending && confirmingPlanDelete ? 'app-primary-button-loading' : ''}`}
+                  className={`app-danger-button w-full justify-center min-[750px]:w-auto ${deletePlan.isPending && confirmingPlanDelete ? 'app-primary-button-loading' : ''}`}
                   onClick={() => {
                     if (deletePlan.isPending) return
                     if (confirmingPlanDelete) handleDeletePlan()
@@ -877,11 +859,31 @@ export default function TaxAdvantagedCategoryModal({
 
               <div className="min-h-0 flex-1 overflow-y-auto p-5 min-[750px]:p-6">
                 {activeTab === 'limits' ? (
-                  <div className="space-y-4">
+                  <div className="space-y-5">
+                    <div className="space-y-2 border-b pb-4" style={{ borderColor: 'var(--app-border)' }}>
+                      <p className="text-sm font-medium">Lifetime Contribution Room</p>
+                      <div className="grid grid-cols-2 gap-3 min-[750px]:gap-x-8">
+                        <div className="grid min-w-0 gap-1 min-[750px]:grid-cols-[auto_minmax(0,1fr)] min-[750px]:items-baseline min-[750px]:gap-4">
+                          <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>Limit</span>
+                          <span className="min-w-0 truncate font-financial text-sm font-medium">
+                            {plan.lifetime_contribution_limit === null ? 'Not set' : formatCurrency(plan.lifetime_contribution_limit, plan.currency)}
+                          </span>
+                        </div>
+                        <div className="grid min-w-0 gap-1 min-[750px]:grid-cols-[auto_minmax(0,1fr)] min-[750px]:items-baseline min-[750px]:gap-4">
+                          <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>Prior activity</span>
+                          <span className="min-w-0 truncate text-sm font-medium">
+                            {hasLifetimePriorActivity ? 'Noted' : 'None'}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
                     <div className="flex flex-col gap-3 min-[750px]:flex-row min-[750px]:items-center min-[750px]:justify-between">
-                      <p className="text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
-                        Configure annual contribution and withdrawal limits.
-                      </p>
+                      <div className="space-y-1">
+                        <p className="text-sm font-medium">Annual Limits</p>
+                        <p className="text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
+                          Configure annual contribution and withdrawal limits.
+                        </p>
+                      </div>
                       <button
                         type="button"
                         className="app-secondary-button w-full shrink-0 justify-center min-[750px]:w-auto"
@@ -1042,7 +1044,7 @@ export default function TaxAdvantagedCategoryModal({
                         Choose eligible {plan.currency} accounts for this category. Archived accounts stay visible for history but cannot be linked or unlinked until unarchived.
                       </p>
                       <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
-                        {bindableAccounts.filter((account) => account.tax_advantaged_plan_id === plan.id).length} of {bindableAccounts.length} linked
+                        {linkedAccountsCount} of {bindableAccounts.length} linked
                       </p>
                     </div>
 

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
-import { Check, LoaderCircle, Pencil, Plus, Trash2, X } from 'lucide-react'
+import { Check, ChevronRight, LoaderCircle, Pencil, Plus, Trash2, X } from 'lucide-react'
 import { useUpdateAccount, type AccountsOverview } from '@/api/accounts'
 import type { Currency } from '@/api/currency'
 import {
@@ -434,6 +434,7 @@ export default function TaxAdvantagedCategoryModal({
             return next
           })
           setLimitError(null)
+          setDeleteConfirmYear(null)
           setSelectedLimitYear(null)
           showAutosaveNotice({ status: 'saved', message: 'Limits saved.' })
         },
@@ -626,6 +627,8 @@ export default function TaxAdvantagedCategoryModal({
     && updateLimit.isPending
     && updateLimit.variables?.year === selectedLimit.year
   const selectedLimitDirty = selectedLimit ? limitDirty(selectedLimit.year) : false
+  const selectedLimitDeleteConfirming = selectedLimit !== null && deleteConfirmYear === selectedLimit.year
+  const selectedLimitDeleting = selectedLimit !== null && pendingDeleteLimitYear === selectedLimit.year
 
   return (
     <>
@@ -924,7 +927,7 @@ export default function TaxAdvantagedCategoryModal({
                                 return (
                                   <tr
                                     key={limit.year}
-                                    className={`grid cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-3 rounded-xl border p-3 transition-colors duration-150 hover:bg-[var(--app-accent-soft)] min-[750px]:table-row min-[750px]:rounded-none min-[750px]:border-x-0 min-[750px]:border-t-0 min-[750px]:p-0 ${index === sortedLimits.length - 1 ? 'min-[750px]:border-b-0' : 'min-[750px]:border-b'}`}
+                                    className={`grid cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-3 rounded-xl border px-3.5 py-3 transition-colors duration-150 hover:bg-[var(--app-accent-soft)] min-[750px]:table-row min-[750px]:rounded-none min-[750px]:border-x-0 min-[750px]:border-t-0 min-[750px]:p-0 ${index === sortedLimits.length - 1 ? 'min-[750px]:border-b-0' : 'min-[750px]:border-b'}`}
                                     style={{
                                       borderColor: isSelected ? 'var(--app-accent-border)' : 'var(--app-border)',
                                       background: isSelected ? 'var(--app-accent-soft)' : undefined,
@@ -939,24 +942,30 @@ export default function TaxAdvantagedCategoryModal({
                                       }
                                     }}
                                   >
-                                    <td className="col-start-1 row-start-1 py-0 pr-0 font-medium min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pr-4">
-                                      <span className="app-label mb-1 block min-[750px]:hidden">Year</span>
+                                    <td className="col-start-1 row-start-1 min-w-0 py-0 pr-0 text-base font-medium min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pr-4 min-[750px]:text-[0.9375rem]">
                                       {limit.year}
                                     </td>
-                                    <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 font-financial min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-0 min-[750px]:pr-4">
-                                      <span className="app-label mb-1 block min-[750px]:hidden">Contribution limit</span>
-                                      {formatCurrency(limit.contribution_limit, plan.currency)}
+                                    <td className="col-span-2 row-start-2 mt-3 grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-t pt-3 text-sm min-[750px]:table-cell min-[750px]:mt-0 min-[750px]:border-t-0 min-[750px]:py-3 min-[750px]:pl-0 min-[750px]:pr-4">
+                                      <span className="font-medium min-[750px]:hidden" style={{ color: 'var(--app-text-muted)' }}>
+                                        Contribution
+                                      </span>
+                                      <span className="min-w-0 truncate font-financial font-medium min-[750px]:font-normal">
+                                        {formatCurrency(limit.contribution_limit, plan.currency)}
+                                      </span>
                                     </td>
-                                    <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 font-financial min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
-                                      <span className="app-label mb-1 block min-[750px]:hidden">Withdrawal limit</span>
-                                      {limit.withdrawal_limit === null ? (
-                                        <span className="font-sans text-sm" style={{ color: 'var(--app-text-muted)' }}>No limit</span>
-                                      ) : (
-                                        formatCurrency(limit.withdrawal_limit, plan.currency)
-                                      )}
+                                    <td className="col-span-2 row-start-3 grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 pt-2 text-sm min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
+                                      <span className="font-medium min-[750px]:hidden" style={{ color: 'var(--app-text-muted)' }}>
+                                        Withdrawal
+                                      </span>
+                                      <span className="min-w-0 truncate font-financial font-medium min-[750px]:font-normal">
+                                        {limit.withdrawal_limit === null ? (
+                                          <span className="font-sans text-sm font-normal" style={{ color: 'var(--app-text-muted)' }}>No limit</span>
+                                        ) : (
+                                          formatCurrency(limit.withdrawal_limit, plan.currency)
+                                        )}
+                                      </span>
                                     </td>
-                                    <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
-                                      <span className="app-label mb-1 block min-[750px]:hidden">Prior activity</span>
+                                    <td className="col-span-2 row-start-4 min-w-0 pt-2 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
                                       {hasPriorActivity ? (
                                         <span className="block truncate text-sm font-medium">
                                           Prior activity noted
@@ -966,11 +975,14 @@ export default function TaxAdvantagedCategoryModal({
                                       )}
                                     </td>
                                     <td
-                                      className="col-start-2 row-start-1 py-0 pl-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-2"
-                                      onClick={(event) => event.stopPropagation()}
-                                      onKeyDown={(event) => event.stopPropagation()}
+                                      className="col-start-2 row-start-1 flex items-center justify-end py-0 pl-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-2"
                                     >
-                                      <div className="flex items-center justify-center">
+                                      <ChevronRight size={16} className="min-[750px]:hidden" style={{ color: 'var(--app-text-subtle)' }} aria-hidden />
+                                      <div
+                                        className="hidden items-center justify-center min-[750px]:flex"
+                                        onClick={(event) => event.stopPropagation()}
+                                        onKeyDown={(event) => event.stopPropagation()}
+                                      >
                                         <button
                                           ref={confirmingDelete ? limitDeleteButtonRef : undefined}
                                           type="button"
@@ -1297,7 +1309,7 @@ export default function TaxAdvantagedCategoryModal({
               aria-hidden
             />
             <motion.div
-              className="fixed inset-0 z-[61] flex items-center justify-center p-4"
+              className="fixed inset-0 z-[61] flex items-stretch justify-center p-0 min-[620px]:items-center min-[620px]:p-4"
               initial={{ opacity: 0, scale: 0.97, y: 8 }}
               animate={{ opacity: 1, scale: 1, y: 0 }}
               exit={{ opacity: 0, scale: 0.97, y: 8 }}
@@ -1308,7 +1320,7 @@ export default function TaxAdvantagedCategoryModal({
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="tax-year-limit-title"
-                className="app-modal-panel w-full max-w-[38rem] rounded-2xl p-5"
+                className="app-modal-panel flex max-h-[100dvh] min-h-[100dvh] w-full flex-col overflow-hidden rounded-none min-[620px]:min-h-0 min-[620px]:max-h-[calc(100dvh-2rem)] min-[620px]:max-w-[38rem] min-[620px]:rounded-2xl"
                 style={{
                   background: 'var(--app-bg)',
                   border: '1px solid var(--app-border-strong)',
@@ -1316,7 +1328,7 @@ export default function TaxAdvantagedCategoryModal({
                 }}
                 onClick={(event) => event.stopPropagation()}
               >
-                <div className="mb-5 flex items-start justify-between gap-4">
+                <div className="flex shrink-0 items-start justify-between gap-4 border-b p-5" style={{ borderColor: 'var(--app-border)' }}>
                   <div className="min-w-0">
                     <h4 id="tax-year-limit-title" className="font-serif text-2xl font-medium tracking-tight">
                       {showAddTaxYear ? 'New Year' : selectedLimit?.year}
@@ -1336,52 +1348,80 @@ export default function TaxAdvantagedCategoryModal({
                   </button>
                 </div>
 
-                {showAddTaxYear ? (
-                  <div className="space-y-4">
-                    <div>
-                      <span className="app-label mb-1 block text-xs">Year</span>
-                      <div
-                        className="group flex h-9 w-full items-center gap-1.5 rounded-md border border-transparent px-2 transition-colors duration-150 hover:border-[var(--app-border)] focus-within:border-[var(--app-accent-border)]"
-                        style={{ background: 'color-mix(in srgb, var(--app-input-bg) 55%, var(--app-bg))' }}
-                      >
-                        <input
-                          aria-label="New tax year"
-                          className="block h-8 min-w-0 flex-1 bg-transparent text-[0.9375rem] font-medium leading-8 outline-none"
-                          inputMode="numeric"
-                          pattern="[0-9]*"
-                          type="text"
-                          value={newLimitForm.year}
-                          onChange={(event) => setNewLimitField('year', event.target.value.replace(/\D/g, '').slice(0, 4))}
-                          style={{ color: 'var(--app-text)' }}
-                        />
-                        <Pencil
-                          size={13}
-                          className="shrink-0 opacity-45 transition-opacity duration-150 group-hover:opacity-70 group-focus-within:opacity-80"
-                          style={{ color: 'var(--app-text-subtle)' }}
-                          aria-hidden
-                        />
+                <div className="min-h-0 flex-1 overflow-y-auto p-5">
+                  {showAddTaxYear ? (
+                    <div className="space-y-4">
+                      <div>
+                        <span className="app-label mb-1 block text-xs">Year</span>
+                        <div
+                          className="group flex h-9 w-full items-center gap-1.5 rounded-md border border-transparent px-2 transition-colors duration-150 hover:border-[var(--app-border)] focus-within:border-[var(--app-accent-border)]"
+                          style={{ background: 'color-mix(in srgb, var(--app-input-bg) 55%, var(--app-bg))' }}
+                        >
+                          <input
+                            aria-label="New tax year"
+                            className="block h-8 min-w-0 flex-1 bg-transparent text-[0.9375rem] font-medium leading-8 outline-none"
+                            inputMode="numeric"
+                            pattern="[0-9]*"
+                            type="text"
+                            value={newLimitForm.year}
+                            onChange={(event) => setNewLimitField('year', event.target.value.replace(/\D/g, '').slice(0, 4))}
+                            style={{ color: 'var(--app-text)' }}
+                          />
+                          <Pencil
+                            size={13}
+                            className="shrink-0 opacity-45 transition-opacity duration-150 group-hover:opacity-70 group-focus-within:opacity-80"
+                            style={{ color: 'var(--app-text-subtle)' }}
+                            aria-hidden
+                          />
+                        </div>
                       </div>
-                    </div>
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">Contribution</p>
-                      <div className="grid grid-cols-2 gap-3">
-                        {renderNewLimitEditorField('contribution_limit', 'Limit', 'New tax-year contribution limit', 'Required')}
-                        {renderNewLimitEditorField('accrued_contributions', 'Prior', 'New tax-year prior contributions', '0')}
+                      <div className="space-y-2">
+                        <p className="text-sm font-medium">Contribution</p>
+                        <div className="grid grid-cols-2 gap-3">
+                          {renderNewLimitEditorField('contribution_limit', 'Limit', 'New tax-year contribution limit', 'Required')}
+                          {renderNewLimitEditorField('accrued_contributions', 'Prior', 'New tax-year prior contributions', '0')}
+                        </div>
                       </div>
-                    </div>
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">Withdrawal</p>
-                      <div className="grid grid-cols-2 gap-3">
-                        {renderNewLimitEditorField('withdrawal_limit', 'Limit', 'New tax-year withdrawal limit', 'Optional')}
-                        {renderNewLimitEditorField('accrued_withdrawals', 'Prior', 'New tax-year prior withdrawals', '0')}
+                      <div className="space-y-2">
+                        <p className="text-sm font-medium">Withdrawal</p>
+                        <div className="grid grid-cols-2 gap-3">
+                          {renderNewLimitEditorField('withdrawal_limit', 'Limit', 'New tax-year withdrawal limit', 'Optional')}
+                          {renderNewLimitEditorField('accrued_withdrawals', 'Prior', 'New tax-year prior withdrawals', '0')}
+                        </div>
                       </div>
+                      {limitError && (
+                        <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
+                          {limitError}
+                        </p>
+                      )}
                     </div>
-                    {limitError && (
-                      <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
-                        {limitError}
-                      </p>
-                    )}
-                    <div className="grid grid-cols-2 gap-2 pt-1">
+                  ) : selectedLimit && selectedDraft ? (
+                    <div className="space-y-4">
+                      <div className="space-y-2">
+                        <p className="text-sm font-medium">Contribution</p>
+                        <div className="grid grid-cols-2 gap-3">
+                          {renderLimitEditorField(selectedLimit.year, 'contribution_limit', 'Limit', 'Contribution limit', selectedDraft.contribution_limit)}
+                          {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Prior', 'Prior contributions', selectedDraft.accrued_contributions, '0')}
+                        </div>
+                      </div>
+                      <div className="space-y-2">
+                        <p className="text-sm font-medium">Withdrawal</p>
+                        <div className="grid grid-cols-2 gap-3">
+                          {renderLimitEditorField(selectedLimit.year, 'withdrawal_limit', 'Limit', 'Withdrawal limit', selectedDraft.withdrawal_limit, 'Optional')}
+                          {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Prior', 'Prior withdrawals', selectedDraft.accrued_withdrawals, '0')}
+                        </div>
+                      </div>
+                      {limitError && (
+                        <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
+                          {limitError}
+                        </p>
+                      )}
+                    </div>
+                  ) : null}
+                </div>
+                <div className="shrink-0 border-t px-5 py-4" style={{ borderColor: 'var(--app-border)' }}>
+                  {showAddTaxYear ? (
+                    <div className="grid grid-cols-2 gap-2">
                       <button
                         type="button"
                         className="app-secondary-button justify-center"
@@ -1399,48 +1439,46 @@ export default function TaxAdvantagedCategoryModal({
                         {creatingLimit ? <div className="app-spinner" aria-label="Saving" /> : 'Save'}
                       </button>
                     </div>
-                  </div>
-                ) : selectedLimit && selectedDraft ? (
-                  <div className="space-y-4">
+                  ) : selectedLimit ? (
                     <div className="space-y-2">
-                      <p className="text-sm font-medium">Contribution</p>
-                      <div className="grid grid-cols-2 gap-3">
-                        {renderLimitEditorField(selectedLimit.year, 'contribution_limit', 'Limit', 'Contribution limit', selectedDraft.contribution_limit)}
-                        {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Prior', 'Prior contributions', selectedDraft.accrued_contributions, '0')}
-                      </div>
-                    </div>
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">Withdrawal</p>
-                      <div className="grid grid-cols-2 gap-3">
-                        {renderLimitEditorField(selectedLimit.year, 'withdrawal_limit', 'Limit', 'Withdrawal limit', selectedDraft.withdrawal_limit, 'Optional')}
-                        {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Prior', 'Prior withdrawals', selectedDraft.accrued_withdrawals, '0')}
-                      </div>
-                    </div>
-                    {limitError && (
-                      <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
-                        {limitError}
-                      </p>
-                    )}
-                    <div className="grid grid-cols-2 gap-2 pt-1">
                       <button
                         type="button"
-                        className="app-secondary-button justify-center"
-                        onClick={closeLimitDetailsModal}
-                        disabled={selectedSavingLimit}
+                        className={`app-danger-button w-full justify-center min-[750px]:hidden ${selectedLimitDeleting ? 'app-primary-button-loading' : ''}`}
+                        onClick={() => { void handleDeleteLimit(selectedLimit) }}
+                        disabled={selectedSavingLimit || pendingDeleteLimitYear !== null}
                       >
-                        Cancel
+                        {selectedLimitDeleting ? (
+                          <div className="app-spinner" aria-label="Deleting" />
+                        ) : selectedLimitDeleteConfirming ? (
+                          'Confirm delete'
+                        ) : (
+                          <>
+                            <Trash2 size={16} aria-hidden />
+                            Delete year
+                          </>
+                        )}
                       </button>
-                      <button
-                        type="button"
-                        className="app-primary-button justify-center"
-                        onClick={() => handleSaveLimit(selectedLimit.year)}
-                        disabled={selectedSavingLimit || !selectedLimitDirty}
-                      >
-                        {selectedSavingLimit ? <div className="app-spinner" aria-label="Saving" /> : 'Save'}
-                      </button>
+                      <div className="grid grid-cols-2 gap-2">
+                        <button
+                          type="button"
+                          className="app-secondary-button justify-center"
+                          onClick={closeLimitDetailsModal}
+                          disabled={selectedSavingLimit}
+                        >
+                          Cancel
+                        </button>
+                        <button
+                          type="button"
+                          className="app-primary-button justify-center"
+                          onClick={() => handleSaveLimit(selectedLimit.year)}
+                          disabled={selectedSavingLimit || !selectedLimitDirty}
+                        >
+                          {selectedSavingLimit ? <div className="app-spinner" aria-label="Saving" /> : 'Save'}
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                ) : null}
+                  ) : null}
+                </div>
               </div>
             </motion.div>
           </>

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -858,7 +858,7 @@ export default function TaxAdvantagedCategoryModal({
                       type="button"
                       role="tab"
                       aria-selected={activeTab === tab}
-                      className="border-b-2 px-0 py-4 text-sm font-medium transition-colors duration-150"
+                      className="border-b-2 px-0 pb-2 pt-4 text-sm font-medium transition-colors duration-150"
                       onClick={() => setActiveTab(tab)}
                       style={{
                         color: activeTab === tab ? 'var(--app-text)' : 'var(--app-text-muted)',

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -918,30 +918,31 @@ export default function TaxAdvantagedCategoryModal({
                       </button>
                     </div>
 
-                    <div className="hidden min-[750px]:block">
-                      <table className="w-full table-fixed text-left text-[0.9375rem]">
-                        <colgroup>
-                          <col style={{ width: '5rem' }} />
-                          <col style={{ width: '25%' }} />
-                          <col style={{ width: '25%' }} />
-                          <col style={{ width: 'auto' }} />
-                          <col style={{ width: '3.5rem' }} />
-                        </colgroup>
-                        <thead>
-                          <tr style={{ color: 'var(--app-text-muted)', borderBottom: '1px solid var(--app-border)' }}>
-                            <th className="py-2 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Year</th>
-                            <th className="py-2 pl-0 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Contribution limit</th>
-                            <th className="py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Withdrawal limit</th>
-                            <th className="py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>
-                              <OpeningUsageLabel />
-                            </th>
-                            <th className="py-2 pl-2 font-medium" style={{ background: 'var(--app-bg)' }} aria-label="Actions" />
-                          </tr>
-                        </thead>
-                      </table>
-                    </div>
+                    <div>
+                      <div className="hidden min-[750px]:block">
+                        <table className="w-full table-fixed text-left text-[0.9375rem]">
+                          <colgroup>
+                            <col style={{ width: '5rem' }} />
+                            <col style={{ width: '25%' }} />
+                            <col style={{ width: '25%' }} />
+                            <col style={{ width: 'auto' }} />
+                            <col style={{ width: '3.5rem' }} />
+                          </colgroup>
+                          <thead>
+                            <tr style={{ color: 'var(--app-text-muted)', borderBottom: '1px solid var(--app-border)' }}>
+                              <th className="py-2 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Year</th>
+                              <th className="py-2 pl-0 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Contribution limit</th>
+                              <th className="py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Withdrawal limit</th>
+                              <th className="py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>
+                                <OpeningUsageLabel />
+                              </th>
+                              <th className="py-2 pl-2 font-medium" style={{ background: 'var(--app-bg)' }} aria-label="Actions" />
+                            </tr>
+                          </thead>
+                        </table>
+                      </div>
 
-                    <div className={hasScrollableLimitRows ? 'max-h-[22rem] overflow-y-auto overflow-x-hidden pr-1' : 'overflow-hidden'}>
+                      <div className={hasScrollableLimitRows ? 'max-h-[22rem] overflow-y-auto overflow-x-hidden pr-1' : 'overflow-hidden'}>
                         <table className="block w-full text-left text-[0.9375rem] min-[750px]:table min-[750px]:table-fixed">
                           <colgroup className="hidden min-[750px]:table-column-group">
                             <col style={{ width: '5rem' }} />
@@ -1067,6 +1068,7 @@ export default function TaxAdvantagedCategoryModal({
                           </tbody>
                         </table>
                       </div>
+                    </div>
 
                     {limitError && (
                       <p className="text-sm" style={{ color: 'var(--app-negative)' }}>

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -1036,7 +1036,7 @@ export default function TaxAdvantagedCategoryModal({
                     )}
                   </div>
                 ) : (
-                  <div className="space-y-4">
+                  <div className="flex min-h-0 flex-col gap-4">
                     <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
                       <p className="text-[0.9375rem]" style={{ color: 'var(--app-text-muted)' }}>
                         Choose eligible {plan.currency} accounts for this category. Archived accounts stay visible for history but cannot be linked or unlinked until unarchived.
@@ -1058,7 +1058,7 @@ export default function TaxAdvantagedCategoryModal({
                       </p>
                     ) : (
                       <div
-                        className="overflow-hidden rounded-xl border"
+                        className="max-h-[22rem] overflow-y-auto overflow-x-hidden rounded-xl border"
                         style={{ borderColor: 'var(--app-border)' }}
                       >
                         {bindableAccounts.map((account, index) => {

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -14,6 +14,7 @@ import {
   type TaxAdvantagedPlanLimit,
 } from '@/api/taxAdvantagedPlans'
 import ActionFeedbackButton from '@/components/ActionFeedbackButton'
+import IconTooltip from '@/components/IconTooltip'
 import { formatCurrency } from '@/utils/formatCurrency'
 import type {
   AutosaveNotice,
@@ -51,6 +52,25 @@ type LimitDraftField = keyof Pick<
   TaxPlanLimitFormState,
   'contribution_limit' | 'withdrawal_limit' | 'accrued_contributions' | 'accrued_withdrawals'
 >
+
+const OPENING_USAGE_TOOLTIP = 'Opening usage is the amount already contributed or withdrawn before Lumina started tracking this TAC. Add it when setting up an existing limit so remaining room starts from the correct baseline.'
+
+function OpeningUsageLabel({ label = 'Opening usage' }: { label?: string }) {
+  return (
+    <span className="inline-flex min-w-0 items-center gap-1.5">
+      <span className="min-w-0 truncate">{label}</span>
+      <IconTooltip
+        label="Opening usage info"
+        placement="bottom"
+        widthClassName="w-72"
+        size={13}
+        strokeWidth={2.25}
+      >
+        {OPENING_USAGE_TOOLTIP}
+      </IconTooltip>
+    </span>
+  )
+}
 
 function delay(ms: number) {
   return new Promise<void>((resolve) => {
@@ -677,6 +697,7 @@ export default function TaxAdvantagedCategoryModal({
           role="dialog"
           aria-modal="true"
           aria-labelledby="tax-advantaged-category-title"
+          data-tooltip-bounds
           className="app-modal-panel flex max-h-[86vh] w-full max-w-[64rem] overflow-hidden rounded-2xl"
           style={{
             background: 'var(--app-bg)',
@@ -870,7 +891,9 @@ export default function TaxAdvantagedCategoryModal({
                           </span>
                         </div>
                         <div className="grid min-w-0 gap-1 min-[750px]:grid-cols-[auto_minmax(0,1fr)] min-[750px]:items-baseline min-[750px]:gap-4">
-                          <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>Opening usage</span>
+                          <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                            <OpeningUsageLabel />
+                          </span>
                           <span className="min-w-0 truncate text-sm font-medium">
                             {hasLifetimePriorActivity ? 'Noted' : 'None'}
                           </span>
@@ -895,6 +918,29 @@ export default function TaxAdvantagedCategoryModal({
                       </button>
                     </div>
 
+                    <div className="hidden min-[750px]:block">
+                      <table className="w-full table-fixed text-left text-[0.9375rem]">
+                        <colgroup>
+                          <col style={{ width: '5rem' }} />
+                          <col style={{ width: '25%' }} />
+                          <col style={{ width: '25%' }} />
+                          <col style={{ width: 'auto' }} />
+                          <col style={{ width: '3.5rem' }} />
+                        </colgroup>
+                        <thead>
+                          <tr style={{ color: 'var(--app-text-muted)', borderBottom: '1px solid var(--app-border)' }}>
+                            <th className="py-2 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Year</th>
+                            <th className="py-2 pl-0 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Contribution limit</th>
+                            <th className="py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Withdrawal limit</th>
+                            <th className="py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>
+                              <OpeningUsageLabel />
+                            </th>
+                            <th className="py-2 pl-2 font-medium" style={{ background: 'var(--app-bg)' }} aria-label="Actions" />
+                          </tr>
+                        </thead>
+                      </table>
+                    </div>
+
                     <div className={hasScrollableLimitRows ? 'max-h-[22rem] overflow-y-auto overflow-x-hidden pr-1' : 'overflow-hidden'}>
                         <table className="block w-full text-left text-[0.9375rem] min-[750px]:table min-[750px]:table-fixed">
                           <colgroup className="hidden min-[750px]:table-column-group">
@@ -904,15 +950,6 @@ export default function TaxAdvantagedCategoryModal({
                             <col style={{ width: 'auto' }} />
                             <col style={{ width: '3.5rem' }} />
                           </colgroup>
-                          <thead className="hidden min-[750px]:table-header-group">
-                            <tr style={{ color: 'var(--app-text-muted)', borderBottom: '1px solid var(--app-border)' }}>
-                              <th className="sticky top-0 z-10 py-2 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Year</th>
-                              <th className="sticky top-0 z-10 py-2 pl-0 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Contribution limit</th>
-                              <th className="sticky top-0 z-10 py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Withdrawal limit</th>
-                              <th className="sticky top-0 z-10 py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Opening usage</th>
-                              <th className="sticky top-0 z-10 py-2 pl-2 font-medium" style={{ background: 'var(--app-bg)' }} aria-label="Actions" />
-                            </tr>
-                          </thead>
                           <tbody className="block space-y-3 min-[750px]:table-row-group min-[750px]:space-y-0">
                             {limitsLoading ? null : sortedLimits.length === 0 ? (
                               <tr className="block min-[750px]:table-row">

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -16,7 +16,12 @@ import {
 } from '@/api/taxAdvantagedPlans'
 import ActionFeedbackButton from '@/components/ActionFeedbackButton'
 import { formatCurrency } from '@/utils/formatCurrency'
-import type { AutosaveNotice, CategoryModalTab, TaxPlanFormState, TaxPlanLimitFormState } from '@/settings/components/tax-advantaged/taxAdvantagedTypes'
+import type {
+  AutosaveNotice,
+  CategoryModalTab,
+  TaxPlanFormState,
+  TaxPlanLimitFormState,
+} from '@/settings/components/tax-advantaged/taxAdvantagedTypes'
 import AutosaveStatusIcon from '@/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/AutosaveStatusIcon'
 import InfoItem from '@/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/InfoItem'
 import { autosaveNoticeColor } from '@/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/taxAdvantagedAutosave'
@@ -52,7 +57,10 @@ const LIMIT_FIELD_ACTION_TRANSITION = {
   ease: [0.25, 0.1, 0.25, 1] as const,
 }
 
-type LimitDraftField = keyof Pick<TaxPlanLimitFormState, 'contribution_limit' | 'withdrawal_limit'>
+type LimitDraftField = keyof Pick<
+  TaxPlanLimitFormState,
+  'contribution_limit' | 'withdrawal_limit' | 'accrued_contributions' | 'accrued_withdrawals'
+>
 
 function delay(ms: number) {
   return new Promise<void>((resolve) => {
@@ -146,6 +154,7 @@ export default function TaxAdvantagedCategoryModal({
   const [activeTab, setActiveTab] = useState<CategoryModalTab>('limits')
   const [categoryEditOpen, setCategoryEditOpen] = useState(false)
   const [showAddTaxYear, setShowAddTaxYear] = useState(false)
+  const [selectedLimitYear, setSelectedLimitYear] = useState<number | null>(null)
   const [accountError, setAccountError] = useState<string | null>(null)
   const [confirmingPlanDelete, setConfirmingPlanDelete] = useState(false)
   const planDeleteButtonRef = useRef<HTMLButtonElement>(null)
@@ -161,14 +170,17 @@ export default function TaxAdvantagedCategoryModal({
     tax_treatment: plan.tax_treatment,
     currency: plan.currency,
     lifetime_contribution_limit: fromMinorUnits(plan.lifetime_contribution_limit, currencies, plan.currency),
+    accrued_contributions: fromMinorUnits(plan.accrued_contributions, currencies, plan.currency),
   }
   const [planOverrides, setPlanOverrides] = useState<Partial<TaxPlanFormState>>({})
   const planForm: TaxPlanFormState = { ...planBase, ...planOverrides }
-  const [limitDrafts, setLimitDrafts] = useState<Record<number, Partial<Pick<TaxPlanLimitFormState, 'contribution_limit' | 'withdrawal_limit'>>>>({})
+  const [limitDrafts, setLimitDrafts] = useState<Record<number, Partial<Pick<TaxPlanLimitFormState, LimitDraftField>>>>({})
   const [newLimitForm, setNewLimitForm] = useState<TaxPlanLimitFormState>({
     year: String(DEFAULT_NEW_LIMIT_YEAR),
     contribution_limit: '',
     withdrawal_limit: '',
+    accrued_contributions: '',
+    accrued_withdrawals: '',
   })
   const [pendingCreateLimitYear, setPendingCreateLimitYear] = useState<number | null>(null)
   const [deleteConfirmYear, setDeleteConfirmYear] = useState<number | null>(null)
@@ -269,6 +281,8 @@ export default function TaxAdvantagedCategoryModal({
       year: String(nextAvailableLimitYear(limits)),
       contribution_limit: '',
       withdrawal_limit: '',
+      accrued_contributions: '',
+      accrued_withdrawals: '',
     })
     setShowAddTaxYear(false)
     setLimitError(null)
@@ -279,14 +293,17 @@ export default function TaxAdvantagedCategoryModal({
       year: String(nextAvailableLimitYear(limits)),
       contribution_limit: '',
       withdrawal_limit: '',
+      accrued_contributions: '',
+      accrued_withdrawals: '',
     })
     setShowAddTaxYear(true)
+    setSelectedLimitYear(null)
     setLimitError(null)
   }
 
   const setLimitField = (
     year: number,
-    key: keyof Pick<TaxPlanLimitFormState, 'contribution_limit' | 'withdrawal_limit'>,
+    key: LimitDraftField,
     value: string,
   ) => {
     setLimitDrafts((current) => ({
@@ -300,12 +317,28 @@ export default function TaxAdvantagedCategoryModal({
     setDeleteConfirmYear(null)
   }
 
+  const selectLimitYear = (year: number) => {
+    setSelectedLimitYear(year)
+    setShowAddTaxYear(false)
+    setDeleteConfirmYear(null)
+  }
+
+  const closeLimitDetailsModal = () => {
+    if (creatingLimit || updateLimit.isPending) return
+    setShowAddTaxYear(false)
+    setSelectedLimitYear(null)
+    setLimitError(null)
+    setDeleteConfirmYear(null)
+  }
+
   const getPlanUpdateState = (form: TaxPlanFormState) => {
     const nextLifetimeLimit = toMinorUnits(form.lifetime_contribution_limit, currencies, plan.currency)
+    const nextAccruedContributions = toMinorUnits(form.accrued_contributions, currencies, plan.currency) ?? 0
     const dirty = form.name.trim() !== plan.name
       || form.tax_treatment !== plan.tax_treatment
       || nextLifetimeLimit !== plan.lifetime_contribution_limit
-    return { dirty, nextLifetimeLimit }
+      || nextAccruedContributions !== plan.accrued_contributions
+    return { dirty, nextAccruedContributions, nextLifetimeLimit }
   }
 
   const validatePlanForm = (form: TaxPlanFormState) => {
@@ -314,6 +347,9 @@ export default function TaxAdvantagedCategoryModal({
     }
     if (!isValidMoneyInput(form.lifetime_contribution_limit)) {
       return 'Lifetime contribution limit must be zero or higher.'
+    }
+    if (!isValidMoneyInput(form.accrued_contributions)) {
+      return 'Accrued contributions must be zero or higher.'
     }
     return null
   }
@@ -331,7 +367,7 @@ export default function TaxAdvantagedCategoryModal({
       return
     }
 
-    const { dirty, nextLifetimeLimit } = getPlanUpdateState(planForm)
+    const { dirty, nextAccruedContributions, nextLifetimeLimit } = getPlanUpdateState(planForm)
     setPlanSaveStatus('loading')
     const minimumLoading = new Promise((resolve) => window.setTimeout(resolve, 1000))
     try {
@@ -340,6 +376,7 @@ export default function TaxAdvantagedCategoryModal({
           name: planForm.name.trim(),
           tax_treatment: planForm.tax_treatment,
           lifetime_contribution_limit: nextLifetimeLimit,
+          accrued_contributions: nextAccruedContributions,
         })
         setPlanOverrides({})
         setPlanError(null)
@@ -394,6 +431,10 @@ export default function TaxAdvantagedCategoryModal({
         ?? fromMinorUnits(limit?.contribution_limit ?? null, currencies, plan.currency),
       withdrawal_limit: limitDrafts[year]?.withdrawal_limit
         ?? fromMinorUnits(limit?.withdrawal_limit ?? null, currencies, plan.currency),
+      accrued_contributions: limitDrafts[year]?.accrued_contributions
+        ?? fromMinorUnits(limit?.accrued_contributions ?? null, currencies, plan.currency),
+      accrued_withdrawals: limitDrafts[year]?.accrued_withdrawals
+        ?? fromMinorUnits(limit?.accrued_withdrawals ?? null, currencies, plan.currency),
     }
   }
 
@@ -403,14 +444,24 @@ export default function TaxAdvantagedCategoryModal({
     const draft = limitDraft(year)
     return toMinorUnits(draft.contribution_limit, currencies, plan.currency) !== limit.contribution_limit
       || toMinorUnits(draft.withdrawal_limit, currencies, plan.currency) !== limit.withdrawal_limit
+      || (toMinorUnits(draft.accrued_contributions, currencies, plan.currency) ?? 0) !== limit.accrued_contributions
+      || (toMinorUnits(draft.accrued_withdrawals, currencies, plan.currency) ?? 0) !== limit.accrued_withdrawals
   }
 
   const limitFieldDirty = (year: number, key: LimitDraftField) => {
     const limit = limits.find((row) => row.year === year)
     if (!limit) return false
     const draft = limitDraft(year)
-    const baseline = key === 'contribution_limit' ? limit.contribution_limit : limit.withdrawal_limit
-    return toMinorUnits(draft[key], currencies, plan.currency) !== baseline
+    const baseline = {
+      contribution_limit: limit.contribution_limit,
+      withdrawal_limit: limit.withdrawal_limit,
+      accrued_contributions: limit.accrued_contributions,
+      accrued_withdrawals: limit.accrued_withdrawals,
+    }[key]
+    const value = key === 'accrued_contributions' || key === 'accrued_withdrawals'
+      ? toMinorUnits(draft[key], currencies, plan.currency) ?? 0
+      : toMinorUnits(draft[key], currencies, plan.currency)
+    return value !== baseline
   }
 
   const discardLimitField = (year: number, key: LimitDraftField) => {
@@ -443,6 +494,16 @@ export default function TaxAdvantagedCategoryModal({
       showAutosaveNotice({ status: 'error', message: `${year} withdrawal limit must be zero or higher.` })
       return
     }
+    if (!isValidMoneyInput(draft.accrued_contributions)) {
+      setLimitError(`${year} prior contributions must be zero or higher.`)
+      showAutosaveNotice({ status: 'error', message: `${year} prior contributions must be zero or higher.` })
+      return
+    }
+    if (!isValidMoneyInput(draft.accrued_withdrawals)) {
+      setLimitError(`${year} prior withdrawals must be zero or higher.`)
+      showAutosaveNotice({ status: 'error', message: `${year} prior withdrawals must be zero or higher.` })
+      return
+    }
 
     showAutosaveNotice({ status: 'saving', message: 'Saving limits...' })
     updateLimit.mutate(
@@ -451,6 +512,8 @@ export default function TaxAdvantagedCategoryModal({
         year,
         contribution_limit: toMinorUnits(draft.contribution_limit, currencies, plan.currency) ?? 0,
         withdrawal_limit: toMinorUnits(draft.withdrawal_limit, currencies, plan.currency),
+        accrued_contributions: toMinorUnits(draft.accrued_contributions, currencies, plan.currency) ?? 0,
+        accrued_withdrawals: toMinorUnits(draft.accrued_withdrawals, currencies, plan.currency) ?? 0,
       },
       {
         onSuccess: () => {
@@ -494,6 +557,16 @@ export default function TaxAdvantagedCategoryModal({
       showAutosaveNotice({ status: 'error', message: 'Withdrawal limit must be zero or higher.' })
       return
     }
+    if (!isValidMoneyInput(newLimitForm.accrued_contributions)) {
+      setLimitError('Prior contributions must be zero or higher.')
+      showAutosaveNotice({ status: 'error', message: 'Prior contributions must be zero or higher.' })
+      return
+    }
+    if (!isValidMoneyInput(newLimitForm.accrued_withdrawals)) {
+      setLimitError('Prior withdrawals must be zero or higher.')
+      showAutosaveNotice({ status: 'error', message: 'Prior withdrawals must be zero or higher.' })
+      return
+    }
 
     setPendingCreateLimitYear(year)
     showAutosaveNotice({ status: 'saving', message: 'Saving limits...' })
@@ -501,12 +574,15 @@ export default function TaxAdvantagedCategoryModal({
 
     let createError: unknown = null
     try {
-      await createLimit.mutateAsync({
+      const createdLimit = await createLimit.mutateAsync({
         planId: plan.id,
         year,
         contribution_limit: toMinorUnits(newLimitForm.contribution_limit, currencies, plan.currency) ?? 0,
         withdrawal_limit: toMinorUnits(newLimitForm.withdrawal_limit, currencies, plan.currency),
+        accrued_contributions: toMinorUnits(newLimitForm.accrued_contributions, currencies, plan.currency) ?? 0,
+        accrued_withdrawals: toMinorUnits(newLimitForm.accrued_withdrawals, currencies, plan.currency) ?? 0,
       })
+      setSelectedLimitYear(createdLimit.year)
     } catch (error) {
       createError = error
     }
@@ -535,6 +611,7 @@ export default function TaxAdvantagedCategoryModal({
 
     setPendingDeleteLimitYear(limit.year)
     setPendingDeletedLimit(limit)
+    setSelectedLimitYear((current) => (current === limit.year ? null : current))
     const minimumFeedback = new Promise((resolve) => window.setTimeout(resolve, LIMIT_DELETE_FEEDBACK_MS))
 
     let deleteError: unknown = null
@@ -586,6 +663,72 @@ export default function TaxAdvantagedCategoryModal({
       showAutosaveNotice({ status: 'error', message })
     }
   }
+
+  const renderLimitEditorField = (
+    year: number,
+    key: LimitDraftField,
+    label: string,
+    ariaLabel: string,
+    value: string,
+    dirty: boolean,
+    saving: boolean,
+    placeholder?: string,
+  ) => (
+    <div className="min-w-0">
+      <span className="app-label mb-1 block text-xs">{label}</span>
+      <LimitInputShell
+        dirty={dirty}
+        disabled={updateLimit.isPending}
+        saving={saving}
+        onSave={() => handleSaveLimit(year)}
+        onDiscard={() => discardLimitField(year, key)}
+        saveLabel={`Save ${year} ${ariaLabel.toLowerCase()}`}
+        discardLabel={`Discard ${year} ${ariaLabel.toLowerCase()} changes`}
+      >
+        <CompactCurrencyInput
+          ariaLabel={`${year} ${ariaLabel.toLowerCase()}`}
+          currencies={currencies}
+          currency={plan.currency}
+          value={value}
+          onChange={(nextValue) => setLimitField(year, key, nextValue)}
+          placeholder={placeholder}
+        />
+      </LimitInputShell>
+    </div>
+  )
+
+  const renderNewLimitEditorField = (
+    key: keyof Pick<TaxPlanLimitFormState, 'contribution_limit' | 'withdrawal_limit' | 'accrued_contributions' | 'accrued_withdrawals'>,
+    label: string,
+    ariaLabel: string,
+    placeholder?: string,
+  ) => (
+    <div className="min-w-0">
+      <span className="app-label mb-1 block text-xs">{label}</span>
+      <CompactCurrencyInput
+        ariaLabel={ariaLabel}
+        currencies={currencies}
+        currency={plan.currency}
+        value={newLimitForm[key]}
+        onChange={(value) => setNewLimitField(key, value)}
+        placeholder={placeholder}
+      />
+    </div>
+  )
+
+  const selectedLimit = showAddTaxYear
+    ? null
+    : selectedLimitYear === null
+      ? null
+      : sortedLimits.find((limit) => limit.year === selectedLimitYear) ?? null
+  const selectedDraft = selectedLimit ? limitDraft(selectedLimit.year) : null
+  const selectedSavingLimit = selectedLimit !== null
+    && updateLimit.isPending
+    && updateLimit.variables?.year === selectedLimit.year
+  const selectedContributionDirty = selectedLimit ? limitFieldDirty(selectedLimit.year, 'contribution_limit') : false
+  const selectedWithdrawalDirty = selectedLimit ? limitFieldDirty(selectedLimit.year, 'withdrawal_limit') : false
+  const selectedPriorContributionDirty = selectedLimit ? limitFieldDirty(selectedLimit.year, 'accrued_contributions') : false
+  const selectedPriorWithdrawalDirty = selectedLimit ? limitFieldDirty(selectedLimit.year, 'accrued_withdrawals') : false
 
   return (
     <>
@@ -767,6 +910,36 @@ export default function TaxAdvantagedCategoryModal({
                     </motion.span>
                   </span>
                 </div>
+                <div className="flex min-w-0 items-center justify-between gap-4">
+                  <span className="app-label min-w-0">Accrued Contributions</span>
+                  <span className="relative block h-6 min-w-[7rem] flex-1">
+                    <motion.span
+                      className={`absolute inset-y-0 right-0 w-full max-w-[10rem] ${categoryEditOpen ? '' : 'pointer-events-none'}`}
+                      animate={{ opacity: categoryEditOpen ? 1 : 0 }}
+                      initial={false}
+                      transition={CATEGORY_FIELD_TRANSITION}
+                      aria-hidden={!categoryEditOpen}
+                    >
+                      <InlineCurrencyInput
+                        ariaLabel="Accrued contributions"
+                        currencies={currencies}
+                        currency={plan.currency}
+                        value={planForm.accrued_contributions}
+                        onChange={(value) => setPlanField('accrued_contributions', value)}
+                        placeholder="0"
+                      />
+                    </motion.span>
+                    <motion.span
+                      className={`flex h-6 items-center justify-end truncate text-right text-[0.9375rem] font-medium leading-6 ${categoryEditOpen ? 'pointer-events-none' : ''}`}
+                      animate={{ opacity: categoryEditOpen ? 0 : 1 }}
+                      initial={false}
+                      transition={CATEGORY_FIELD_TRANSITION}
+                      aria-hidden={categoryEditOpen}
+                    >
+                      {formatCurrency(plan.accrued_contributions, plan.currency)}
+                    </motion.span>
+                  </span>
+                </div>
               </div>
 
               <div className="hidden min-[750px]:grid min-[750px]:grid-cols-4 min-[750px]:gap-x-4 min-[750px]:gap-y-3 min-[1050px]:block min-[1050px]:space-y-4">
@@ -831,6 +1004,37 @@ export default function TaxAdvantagedCategoryModal({
                       aria-hidden={categoryEditOpen}
                     >
                       {plan.lifetime_contribution_limit === null ? 'Not set' : formatCurrency(plan.lifetime_contribution_limit, plan.currency)}
+                    </motion.p>
+                  </div>
+                </div>
+
+                <div className="relative h-14 min-w-0 overflow-hidden">
+                  <p className={CATEGORY_SUMMARY_LABEL_CLASS}>Accrued Contributions</p>
+                  <div className="relative h-6 min-w-0">
+                    <motion.div
+                      className={`absolute inset-0 ${categoryEditOpen ? '' : 'pointer-events-none'}`}
+                      animate={{ opacity: categoryEditOpen ? 1 : 0 }}
+                      initial={false}
+                      transition={CATEGORY_FIELD_TRANSITION}
+                      aria-hidden={!categoryEditOpen}
+                    >
+                      <InlineCurrencyInput
+                        ariaLabel="Accrued contributions"
+                        currencies={currencies}
+                        currency={plan.currency}
+                        value={planForm.accrued_contributions}
+                        onChange={(value) => setPlanField('accrued_contributions', value)}
+                        placeholder="0"
+                      />
+                    </motion.div>
+                    <motion.p
+                      className={`absolute inset-0 font-financial ${CATEGORY_SUMMARY_VALUE_CLASS} ${categoryEditOpen ? 'pointer-events-none' : ''}`}
+                      animate={{ opacity: categoryEditOpen ? 0 : 1 }}
+                      initial={false}
+                      transition={CATEGORY_FIELD_TRANSITION}
+                      aria-hidden={categoryEditOpen}
+                    >
+                      {formatCurrency(plan.accrued_contributions, plan.currency)}
                     </motion.p>
                   </div>
                 </div>
@@ -973,258 +1177,131 @@ export default function TaxAdvantagedCategoryModal({
                     </div>
 
                     <div className={hasScrollableLimitRows ? 'max-h-[22rem] overflow-y-auto overflow-x-hidden pr-1' : 'overflow-hidden'}>
-                      <table className="block w-full text-left text-[0.9375rem] min-[750px]:table min-[750px]:table-fixed">
-                        <colgroup className="hidden min-[750px]:table-column-group">
-                          <col style={{ width: '6.5rem' }} />
-                          <col style={{ width: 'calc((100% - 11.5rem) / 2)' }} />
-                          <col style={{ width: 'calc((100% - 11.5rem) / 2)' }} />
-                          <col style={{ width: '5rem' }} />
-                        </colgroup>
-                        <thead className="hidden min-[750px]:table-header-group">
-                          <tr style={{ color: 'var(--app-text-muted)', borderBottom: '1px solid var(--app-border)' }}>
-                            <th
-                              className="sticky top-0 z-10 py-2 pr-4 font-medium"
-                              style={{ background: 'var(--app-bg)' }}
-                            >
-                              Year
-                            </th>
-                            <th
-                              className="sticky top-0 z-10 py-2 pl-0 pr-4 font-medium"
-                              style={{ background: 'var(--app-bg)' }}
-                            >
-                              Contribution limit
-                            </th>
-                            <th
-                              className="sticky top-0 z-10 py-2 pl-4 pr-0 font-medium"
-                              style={{ background: 'var(--app-bg)' }}
-                            >
-                              Withdrawal limit
-                            </th>
-                            <th
-                              className="sticky top-0 z-10 py-2 pl-2 font-medium"
-                              style={{ background: 'var(--app-bg)' }}
-                              aria-label="Actions"
-                            />
-                          </tr>
-                        </thead>
-                        <tbody className="block space-y-3 min-[750px]:table-row-group min-[750px]:space-y-0">
-                          {showAddTaxYear && (
-                            <tr
-                              className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-3 rounded-xl border p-3 min-[750px]:table-row min-[750px]:rounded-none min-[750px]:border-x-0 min-[750px]:border-t-0 min-[750px]:p-0"
-                              style={{ borderColor: 'var(--app-border)' }}
-                            >
-                              <td className="col-start-1 row-start-1 min-w-0 py-0 pr-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pr-5">
-                                <span className="app-label mb-1 block min-[750px]:hidden">Year</span>
-                                <div
-                                  className="group flex h-9 w-full items-center gap-1.5 rounded-md border border-transparent px-2 transition-colors duration-150 hover:border-[var(--app-border)] focus-within:border-[var(--app-accent-border)] min-[750px]:w-20"
-                                  style={{ background: 'color-mix(in srgb, var(--app-input-bg) 55%, var(--app-bg))' }}
-                                >
-                                  <input
-                                    aria-label="New tax year"
-                                    className="block h-8 min-w-0 flex-1 bg-transparent text-[0.9375rem] font-medium leading-8 outline-none"
-                                    inputMode="numeric"
-                                    pattern="[0-9]*"
-                                    type="text"
-                                    value={newLimitForm.year}
-                                    onChange={(event) => setNewLimitField('year', event.target.value.replace(/\D/g, '').slice(0, 4))}
-                                    style={{ color: 'var(--app-text)' }}
-                                  />
-                                  <Pencil
-                                    size={13}
-                                    className="shrink-0 opacity-45 transition-opacity duration-150 group-hover:opacity-70 group-focus-within:opacity-80"
-                                    style={{ color: 'var(--app-text-subtle)' }}
-                                    aria-hidden
-                                  />
-                                </div>
-                              </td>
-                              <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-0 min-[750px]:pr-4">
-                                <span className="app-label mb-1 block min-[750px]:hidden">Contribution limit</span>
-                                <CompactCurrencyInput
-                                  ariaLabel="New tax-year contribution limit"
-                                  currencies={currencies}
-                                  currency={plan.currency}
-                                  value={newLimitForm.contribution_limit}
-                                  onChange={(value) => setNewLimitField('contribution_limit', value)}
-                                  placeholder="Contribution limit"
-                                />
-                              </td>
-                              <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
-                                <span className="app-label mb-1 block min-[750px]:hidden">Withdrawal limit</span>
-                                <CompactCurrencyInput
-                                  ariaLabel="New tax-year withdrawal limit"
-                                  currencies={currencies}
-                                  currency={plan.currency}
-                                  value={newLimitForm.withdrawal_limit}
-                                  onChange={(value) => setNewLimitField('withdrawal_limit', value)}
-                                  placeholder="Optional"
-                                />
-                              </td>
-                              <td className="col-start-2 row-start-1 py-0 pl-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-2">
-                                <div className="flex items-center justify-center gap-1">
-                                  <button
-                                    type="button"
-                                    className="app-icon-button shrink-0"
-                                    onClick={() => { void handleCreateLimit() }}
-                                    disabled={creatingLimit}
-                                    aria-label="Save new tax year"
-                                  >
-                                    {creatingLimit ? (
-                                      <LoaderCircle size={14} className="animate-spin" aria-hidden />
-                                    ) : (
-                                      <Check size={14} aria-hidden />
-                                    )}
-                                  </button>
-                                  <button
-                                    type="button"
-                                    className="app-icon-button shrink-0"
-                                    onClick={resetNewLimitForm}
-                                    disabled={creatingLimit}
-                                    aria-label="Cancel new tax year"
-                                  >
-                                    <X size={14} aria-hidden />
-                                  </button>
-                                </div>
-                              </td>
+                        <table className="block w-full text-left text-[0.9375rem] min-[750px]:table min-[750px]:table-fixed">
+                          <colgroup className="hidden min-[750px]:table-column-group">
+                            <col style={{ width: '5rem' }} />
+                            <col style={{ width: '25%' }} />
+                            <col style={{ width: '25%' }} />
+                            <col style={{ width: 'auto' }} />
+                            <col style={{ width: '3.5rem' }} />
+                          </colgroup>
+                          <thead className="hidden min-[750px]:table-header-group">
+                            <tr style={{ color: 'var(--app-text-muted)', borderBottom: '1px solid var(--app-border)' }}>
+                              <th className="sticky top-0 z-10 py-2 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Year</th>
+                              <th className="sticky top-0 z-10 py-2 pl-0 pr-4 font-medium" style={{ background: 'var(--app-bg)' }}>Contribution limit</th>
+                              <th className="sticky top-0 z-10 py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Withdrawal limit</th>
+                              <th className="sticky top-0 z-10 py-2 pl-4 pr-0 font-medium" style={{ background: 'var(--app-bg)' }}>Prior activity</th>
+                              <th className="sticky top-0 z-10 py-2 pl-2 font-medium" style={{ background: 'var(--app-bg)' }} aria-label="Actions" />
                             </tr>
-                          )}
-                          {limitsLoading ? null : sortedLimits.length === 0 && !showAddTaxYear ? (
-                            <tr className="block min-[750px]:table-row">
-                              <td className="block py-4 text-sm italic min-[750px]:table-cell" colSpan={4} style={{ color: 'var(--app-text-subtle)' }}>
-                                No limit entries yet.
-                              </td>
-                            </tr>
-                          ) : (
-                            sortedLimits.map((limit, index) => {
-                              const draft = limitDraft(limit.year)
-                              const confirmingDelete = deleteConfirmYear === limit.year
-                              const deletingLimit = pendingDeleteLimitYear === limit.year
-                              const savingLimit = updateLimit.isPending && updateLimit.variables?.year === limit.year
-                              const contributionDirty = limitFieldDirty(limit.year, 'contribution_limit')
-                              const withdrawalDirty = limitFieldDirty(limit.year, 'withdrawal_limit')
-                              return (
-                                <tr
-                                  key={limit.year}
-                                  className={`grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-3 rounded-xl border p-3 min-[750px]:table-row min-[750px]:rounded-none min-[750px]:border-x-0 min-[750px]:border-t-0 min-[750px]:p-0 ${index === sortedLimits.length - 1 ? 'min-[750px]:border-b-0' : 'min-[750px]:border-b'}`}
-                                  style={{ borderColor: 'var(--app-border)' }}
-                                >
-                                  <td className="col-start-1 row-start-1 py-0 pr-0 font-medium min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pr-4">
-                                    <span className="app-label mb-1 block min-[750px]:hidden">Year</span>
-                                    {limit.year}
-                                  </td>
-                                  <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-0 min-[750px]:pr-4">
-                                    <span className="app-label mb-1 block min-[750px]:hidden">Contribution limit</span>
-                                    <LimitInputShell
-                                      dirty={contributionDirty}
-                                      disabled={updateLimit.isPending}
-                                      saving={savingLimit}
-                                      onSave={() => handleSaveLimit(limit.year)}
-                                      onDiscard={() => discardLimitField(limit.year, 'contribution_limit')}
-                                      saveLabel={`Save ${limit.year} contribution limit`}
-                                      discardLabel={`Discard ${limit.year} contribution limit changes`}
+                          </thead>
+                          <tbody className="block space-y-3 min-[750px]:table-row-group min-[750px]:space-y-0">
+                            {limitsLoading ? null : sortedLimits.length === 0 ? (
+                              <tr className="block min-[750px]:table-row">
+                                <td className="block py-4 text-sm italic min-[750px]:table-cell" colSpan={5} style={{ color: 'var(--app-text-subtle)' }}>
+                                  No limit entries yet.
+                                </td>
+                              </tr>
+                            ) : (
+                              sortedLimits.map((limit, index) => {
+                                const isSelected = selectedLimit?.year === limit.year && !showAddTaxYear
+                                const confirmingDelete = deleteConfirmYear === limit.year
+                                const deletingLimit = pendingDeleteLimitYear === limit.year
+                                const hasPriorActivity = limit.accrued_contributions > 0 || limit.accrued_withdrawals > 0
+                                return (
+                                  <tr
+                                    key={limit.year}
+                                    className={`grid cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-3 rounded-xl border p-3 transition-colors duration-150 hover:bg-[var(--app-accent-soft)] min-[750px]:table-row min-[750px]:rounded-none min-[750px]:border-x-0 min-[750px]:border-t-0 min-[750px]:p-0 ${index === sortedLimits.length - 1 ? 'min-[750px]:border-b-0' : 'min-[750px]:border-b'}`}
+                                    style={{
+                                      borderColor: isSelected ? 'var(--app-accent-border)' : 'var(--app-border)',
+                                      background: isSelected ? 'var(--app-accent-soft)' : undefined,
+                                    }}
+                                    tabIndex={0}
+                                    aria-selected={isSelected}
+                                    onClick={() => selectLimitYear(limit.year)}
+                                    onKeyDown={(event) => {
+                                      if (event.key === 'Enter' || event.key === ' ') {
+                                        event.preventDefault()
+                                        selectLimitYear(limit.year)
+                                      }
+                                    }}
+                                  >
+                                    <td className="col-start-1 row-start-1 py-0 pr-0 font-medium min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pr-4">
+                                      <span className="app-label mb-1 block min-[750px]:hidden">Year</span>
+                                      {limit.year}
+                                    </td>
+                                    <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 font-financial min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-0 min-[750px]:pr-4">
+                                      <span className="app-label mb-1 block min-[750px]:hidden">Contribution limit</span>
+                                      {formatCurrency(limit.contribution_limit, plan.currency)}
+                                    </td>
+                                    <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 font-financial min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
+                                      <span className="app-label mb-1 block min-[750px]:hidden">Withdrawal limit</span>
+                                      {limit.withdrawal_limit === null ? (
+                                        <span className="font-sans text-sm" style={{ color: 'var(--app-text-muted)' }}>No limit</span>
+                                      ) : (
+                                        formatCurrency(limit.withdrawal_limit, plan.currency)
+                                      )}
+                                    </td>
+                                    <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
+                                      <span className="app-label mb-1 block min-[750px]:hidden">Prior activity</span>
+                                      {hasPriorActivity ? (
+                                        <span className="block truncate text-sm font-medium">
+                                          Prior activity noted
+                                        </span>
+                                      ) : (
+                                        <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>No prior activity</span>
+                                      )}
+                                    </td>
+                                    <td
+                                      className="col-start-2 row-start-1 py-0 pl-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-2"
+                                      onClick={(event) => event.stopPropagation()}
+                                      onKeyDown={(event) => event.stopPropagation()}
                                     >
-                                      <CompactCurrencyInput
-                                        ariaLabel={`${limit.year} contribution limit`}
-                                        currencies={currencies}
-                                        currency={plan.currency}
-                                        value={draft.contribution_limit}
-                                        onChange={(value) => setLimitField(limit.year, 'contribution_limit', value)}
-                                      />
-                                    </LimitInputShell>
-                                  </td>
-                                  <td className="col-span-2 min-w-0 py-0 pl-0 pr-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
-                                    <span className="app-label mb-1 block min-[750px]:hidden">Withdrawal limit</span>
-                                    <LimitInputShell
-                                      dirty={withdrawalDirty}
-                                      disabled={updateLimit.isPending}
-                                      saving={savingLimit}
-                                      onSave={() => handleSaveLimit(limit.year)}
-                                      onDiscard={() => discardLimitField(limit.year, 'withdrawal_limit')}
-                                      saveLabel={`Save ${limit.year} withdrawal limit`}
-                                      discardLabel={`Discard ${limit.year} withdrawal limit changes`}
-                                    >
-                                      <CompactCurrencyInput
-                                        ariaLabel={`${limit.year} withdrawal limit`}
-                                        currencies={currencies}
-                                        currency={plan.currency}
-                                        value={draft.withdrawal_limit}
-                                        onChange={(value) => setLimitField(limit.year, 'withdrawal_limit', value)}
-                                        placeholder="Optional"
-                                      />
-                                    </LimitInputShell>
-                                  </td>
-                                  <td className="col-start-2 row-start-1 py-0 pl-0 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-2">
-                                    <div className="flex items-center justify-center">
-                                      <button
-                                        ref={confirmingDelete ? limitDeleteButtonRef : undefined}
-                                        type="button"
-                                        className="inline-flex h-7 min-w-7 items-center justify-center rounded-md px-2 text-xs font-medium transition-colors duration-150 hover:bg-[var(--app-negative-soft)]"
-                                        onClick={() => { void handleDeleteLimit(limit) }}
-                                        disabled={pendingDeleteLimitYear !== null}
-                                        style={{ color: confirmingDelete || deletingLimit ? 'var(--app-negative)' : 'var(--app-text-subtle)' }}
-                                        aria-label={confirmingDelete ? `Confirm deleting ${limit.year} limits` : `Delete ${limit.year} limits`}
-                                      >
-                                        <span
-                                          className="relative block"
-                                          style={{
-                                            width: limitDeleteLabelWidths
-                                              ? `${confirmingDelete || deletingLimit ? limitDeleteLabelWidths.confirm : limitDeleteLabelWidths.idle}px`
-                                              : 'auto',
-                                            height: '1rem',
-                                            transition: 'width 150ms ease-out',
-                                          }}
+                                      <div className="flex items-center justify-center">
+                                        <button
+                                          ref={confirmingDelete ? limitDeleteButtonRef : undefined}
+                                          type="button"
+                                          className="inline-flex h-7 min-w-7 items-center justify-center rounded-md px-2 text-xs font-medium transition-colors duration-150 hover:bg-[var(--app-negative-soft)]"
+                                          onClick={() => { void handleDeleteLimit(limit) }}
+                                          disabled={pendingDeleteLimitYear !== null}
+                                          style={{ color: confirmingDelete || deletingLimit ? 'var(--app-negative)' : 'var(--app-text-subtle)' }}
+                                          aria-label={confirmingDelete ? `Confirm deleting ${limit.year} limits` : `Delete ${limit.year} limits`}
                                         >
                                           <span
-                                            ref={limitDeleteIdleLabelRef}
-                                            className="invisible absolute inline-flex items-center whitespace-nowrap"
-                                            aria-hidden
+                                            className="relative block"
+                                            style={{
+                                              width: limitDeleteLabelWidths
+                                                ? `${confirmingDelete || deletingLimit ? limitDeleteLabelWidths.confirm : limitDeleteLabelWidths.idle}px`
+                                                : 'auto',
+                                              height: '1rem',
+                                              transition: 'width 150ms ease-out',
+                                            }}
                                           >
-                                            <Trash2 size={14} aria-hidden />
+                                            <span ref={limitDeleteIdleLabelRef} className="invisible absolute inline-flex items-center whitespace-nowrap" aria-hidden>
+                                              <Trash2 size={14} aria-hidden />
+                                            </span>
+                                            <span ref={limitDeleteConfirmLabelRef} className="invisible absolute inline-flex items-center whitespace-nowrap" aria-hidden>
+                                              Confirm
+                                            </span>
+                                            <motion.span className="absolute inset-0 inline-flex items-center justify-center" animate={{ opacity: deletingLimit ? 1 : 0 }} initial={false} transition={LIMIT_DELETE_BUTTON_TRANSITION} aria-hidden={!deletingLimit}>
+                                              <LoaderCircle size={14} className="animate-spin" aria-hidden />
+                                            </motion.span>
+                                            <motion.span className="absolute inset-0 inline-flex items-center justify-center" animate={{ opacity: confirmingDelete && !deletingLimit ? 1 : 0 }} initial={false} transition={LIMIT_DELETE_BUTTON_TRANSITION} aria-hidden={!confirmingDelete || deletingLimit}>
+                                              Confirm
+                                            </motion.span>
+                                            <motion.span className="absolute inset-0 inline-flex items-center justify-center" animate={{ opacity: confirmingDelete || deletingLimit ? 0 : 1 }} initial={false} transition={LIMIT_DELETE_BUTTON_TRANSITION} aria-hidden={confirmingDelete || deletingLimit}>
+                                              <Trash2 size={14} aria-hidden />
+                                            </motion.span>
                                           </span>
-                                          <span
-                                            ref={limitDeleteConfirmLabelRef}
-                                            className="invisible absolute inline-flex items-center whitespace-nowrap"
-                                            aria-hidden
-                                          >
-                                            Confirm
-                                          </span>
-                                          <motion.span
-                                            className="absolute inset-0 inline-flex items-center justify-center"
-                                            animate={{ opacity: deletingLimit ? 1 : 0 }}
-                                            initial={false}
-                                            transition={LIMIT_DELETE_BUTTON_TRANSITION}
-                                            aria-hidden={!deletingLimit}
-                                          >
-                                            <LoaderCircle size={14} className="animate-spin" aria-hidden />
-                                          </motion.span>
-                                          <motion.span
-                                            className="absolute inset-0 inline-flex items-center justify-center"
-                                            animate={{ opacity: confirmingDelete && !deletingLimit ? 1 : 0 }}
-                                            initial={false}
-                                            transition={LIMIT_DELETE_BUTTON_TRANSITION}
-                                            aria-hidden={!confirmingDelete || deletingLimit}
-                                          >
-                                            Confirm
-                                          </motion.span>
-                                          <motion.span
-                                            className="absolute inset-0 inline-flex items-center justify-center"
-                                            animate={{ opacity: confirmingDelete || deletingLimit ? 0 : 1 }}
-                                            initial={false}
-                                            transition={LIMIT_DELETE_BUTTON_TRANSITION}
-                                            aria-hidden={confirmingDelete || deletingLimit}
-                                          >
-                                            <Trash2 size={14} aria-hidden />
-                                          </motion.span>
-                                        </span>
-                                      </button>
-                                    </div>
-                                  </td>
-                                </tr>
-                              )
-                            })
-                          )}
-                        </tbody>
-                      </table>
-                    </div>
+                                        </button>
+                                      </div>
+                                    </td>
+                                  </tr>
+                                )
+                              })
+                            )}
+                          </tbody>
+                        </table>
+                      </div>
 
                     {limitError && (
                       <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
@@ -1307,6 +1384,152 @@ export default function TaxAdvantagedCategoryModal({
           </div>
         </div>
       </motion.div>
+
+      <AnimatePresence>
+        {(showAddTaxYear || (selectedLimit && selectedDraft)) && (
+          <>
+            <motion.div
+              className="fixed inset-0 z-[60]"
+              style={{ background: 'rgba(0, 0, 0, 0.28)' }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.16 }}
+              onClick={closeLimitDetailsModal}
+              aria-hidden
+            />
+            <motion.div
+              className="fixed inset-0 z-[61] flex items-center justify-center p-4"
+              initial={{ opacity: 0, scale: 0.97, y: 8 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.97, y: 8 }}
+              transition={{ duration: 0.18, ease: [0.25, 0.1, 0.25, 1] }}
+              onClick={closeLimitDetailsModal}
+            >
+              <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="tax-year-limit-title"
+                className="app-modal-panel w-full max-w-[38rem] rounded-2xl p-5"
+                style={{
+                  background: 'var(--app-bg)',
+                  border: '1px solid var(--app-border-strong)',
+                  boxShadow: 'var(--app-shadow-soft)',
+                }}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <div className="mb-5 flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <h4 id="tax-year-limit-title" className="font-serif text-2xl font-medium tracking-tight">
+                      {showAddTaxYear ? 'New Year' : selectedLimit?.year}
+                    </h4>
+                    <p className="mt-1 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                      {showAddTaxYear ? 'Configure annual limits and prior activity.' : 'Edit annual limits and prior activity.'}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="app-icon-button shrink-0"
+                    onClick={closeLimitDetailsModal}
+                    disabled={creatingLimit || updateLimit.isPending}
+                    aria-label="Close tax year details"
+                  >
+                    <X size={18} aria-hidden />
+                  </button>
+                </div>
+
+                {showAddTaxYear ? (
+                  <div className="space-y-4">
+                    <div>
+                      <span className="app-label mb-1 block text-xs">Year</span>
+                      <div
+                        className="group flex h-9 w-full items-center gap-1.5 rounded-md border border-transparent px-2 transition-colors duration-150 hover:border-[var(--app-border)] focus-within:border-[var(--app-accent-border)]"
+                        style={{ background: 'color-mix(in srgb, var(--app-input-bg) 55%, var(--app-bg))' }}
+                      >
+                        <input
+                          aria-label="New tax year"
+                          className="block h-8 min-w-0 flex-1 bg-transparent text-[0.9375rem] font-medium leading-8 outline-none"
+                          inputMode="numeric"
+                          pattern="[0-9]*"
+                          type="text"
+                          value={newLimitForm.year}
+                          onChange={(event) => setNewLimitField('year', event.target.value.replace(/\D/g, '').slice(0, 4))}
+                          style={{ color: 'var(--app-text)' }}
+                        />
+                        <Pencil
+                          size={13}
+                          className="shrink-0 opacity-45 transition-opacity duration-150 group-hover:opacity-70 group-focus-within:opacity-80"
+                          style={{ color: 'var(--app-text-subtle)' }}
+                          aria-hidden
+                        />
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">Contribution</p>
+                      <div className="grid grid-cols-2 gap-3">
+                        {renderNewLimitEditorField('contribution_limit', 'Limit', 'New tax-year contribution limit', 'Required')}
+                        {renderNewLimitEditorField('accrued_contributions', 'Prior', 'New tax-year prior contributions', '0')}
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">Withdrawal</p>
+                      <div className="grid grid-cols-2 gap-3">
+                        {renderNewLimitEditorField('withdrawal_limit', 'Limit', 'New tax-year withdrawal limit', 'Optional')}
+                        {renderNewLimitEditorField('accrued_withdrawals', 'Prior', 'New tax-year prior withdrawals', '0')}
+                      </div>
+                    </div>
+                    {limitError && (
+                      <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
+                        {limitError}
+                      </p>
+                    )}
+                    <div className="grid grid-cols-2 gap-2 pt-1">
+                      <button
+                        type="button"
+                        className="app-secondary-button justify-center"
+                        onClick={closeLimitDetailsModal}
+                        disabled={creatingLimit}
+                      >
+                        Cancel
+                      </button>
+                      <button
+                        type="button"
+                        className="app-primary-button justify-center"
+                        onClick={() => { void handleCreateLimit() }}
+                        disabled={creatingLimit}
+                      >
+                        {creatingLimit ? <div className="app-spinner" aria-label="Saving" /> : 'Save'}
+                      </button>
+                    </div>
+                  </div>
+                ) : selectedLimit && selectedDraft ? (
+                  <div className="space-y-4">
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">Contribution</p>
+                      <div className="grid grid-cols-2 gap-3">
+                        {renderLimitEditorField(selectedLimit.year, 'contribution_limit', 'Limit', 'Contribution limit', selectedDraft.contribution_limit, selectedContributionDirty, selectedSavingLimit)}
+                        {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Prior', 'Prior contributions', selectedDraft.accrued_contributions, selectedPriorContributionDirty, selectedSavingLimit, '0')}
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <p className="text-sm font-medium">Withdrawal</p>
+                      <div className="grid grid-cols-2 gap-3">
+                        {renderLimitEditorField(selectedLimit.year, 'withdrawal_limit', 'Limit', 'Withdrawal limit', selectedDraft.withdrawal_limit, selectedWithdrawalDirty, selectedSavingLimit, 'Optional')}
+                        {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Prior', 'Prior withdrawals', selectedDraft.accrued_withdrawals, selectedPriorWithdrawalDirty, selectedSavingLimit, '0')}
+                      </div>
+                    </div>
+                    {limitError && (
+                      <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
+                        {limitError}
+                      </p>
+                    )}
+                  </div>
+                ) : null}
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
     </>
   )
 }

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -942,16 +942,16 @@ export default function TaxAdvantagedCategoryModal({
                         </table>
                       </div>
 
-                      <div className={hasScrollableLimitRows ? 'max-h-[22rem] overflow-y-auto overflow-x-hidden pr-1' : 'overflow-hidden'}>
-                        <table className="block w-full text-left text-[0.9375rem] min-[750px]:table min-[750px]:table-fixed">
-                          <colgroup className="hidden min-[750px]:table-column-group">
+                      <div className={hasScrollableLimitRows ? 'hidden max-h-[22rem] overflow-y-auto overflow-x-hidden pr-1 min-[750px]:block' : 'hidden overflow-hidden min-[750px]:block'}>
+                        <table className="w-full table-fixed text-left text-[0.9375rem]">
+                          <colgroup>
                             <col style={{ width: '5rem' }} />
                             <col style={{ width: '25%' }} />
                             <col style={{ width: '25%' }} />
                             <col style={{ width: 'auto' }} />
                             <col style={{ width: '3.5rem' }} />
                           </colgroup>
-                          <tbody className="block space-y-3 min-[750px]:table-row-group min-[750px]:space-y-0">
+                          <tbody>
                             {limitsLoading ? null : sortedLimits.length === 0 ? (
                               <tr className="block min-[750px]:table-row">
                                 <td className="block py-4 text-sm italic min-[750px]:table-cell" colSpan={5} style={{ color: 'var(--app-text-subtle)' }}>
@@ -1067,6 +1067,69 @@ export default function TaxAdvantagedCategoryModal({
                             )}
                           </tbody>
                         </table>
+                      </div>
+                      <div className="space-y-3 min-[750px]:hidden">
+                        {limitsLoading ? null : sortedLimits.length === 0 ? (
+                          <p className="py-4 text-sm italic" style={{ color: 'var(--app-text-subtle)' }}>
+                            No limit entries yet.
+                          </p>
+                        ) : (
+                          sortedLimits.map((limit) => {
+                            const isSelected = selectedLimit?.year === limit.year && !showAddTaxYear
+                            const hasPriorActivity = limit.accrued_contributions > 0 || limit.accrued_withdrawals > 0
+                            return (
+                              <button
+                                key={limit.year}
+                                type="button"
+                                className="grid w-full min-w-0 cursor-pointer grid-cols-[minmax(0,1fr)_auto] gap-x-3 rounded-xl border bg-transparent px-3.5 py-3 text-left transition-colors duration-150 hover:bg-[var(--app-accent-soft)]"
+                                style={{
+                                  borderColor: isSelected ? 'var(--app-accent-border)' : 'var(--app-border)',
+                                  background: isSelected ? 'var(--app-accent-soft)' : undefined,
+                                  color: 'var(--app-text)',
+                                }}
+                                aria-label={`Edit ${limit.year} limits`}
+                                onClick={() => selectLimitYear(limit.year)}
+                              >
+                                <span className="col-start-1 row-start-1 min-w-0 truncate text-base font-medium">
+                                  {limit.year}
+                                </span>
+                                <ChevronRight size={16} className="col-start-2 row-start-1 self-center" style={{ color: 'var(--app-text-subtle)' }} aria-hidden />
+                                <span className="col-span-2 row-start-2 mt-3 grid min-w-0 grid-cols-2 items-center gap-3 border-t pt-3 text-sm">
+                                  <span className="min-w-0 truncate font-medium" style={{ color: 'var(--app-text-muted)' }}>
+                                    Contribution
+                                  </span>
+                                  <span className="min-w-0 justify-self-end truncate text-right font-financial font-medium">
+                                    {formatCurrency(limit.contribution_limit, plan.currency)}
+                                  </span>
+                                </span>
+                                <span className="col-span-2 row-start-3 grid min-w-0 grid-cols-2 items-center gap-3 pt-2 text-sm">
+                                  <span className="min-w-0 truncate font-medium" style={{ color: 'var(--app-text-muted)' }}>
+                                    Withdrawal
+                                  </span>
+                                  <span className="min-w-0 justify-self-end truncate text-right font-financial font-medium">
+                                    {limit.withdrawal_limit === null ? (
+                                      <span className="font-sans text-sm font-normal" style={{ color: 'var(--app-text-muted)' }}>No limit</span>
+                                    ) : (
+                                      formatCurrency(limit.withdrawal_limit, plan.currency)
+                                    )}
+                                  </span>
+                                </span>
+                                <span className="col-span-2 row-start-4 grid min-w-0 grid-cols-2 items-center gap-3 pt-2 text-sm">
+                                  <span className="min-w-0 truncate font-medium" style={{ color: 'var(--app-text-muted)' }}>
+                                    Opening usage
+                                  </span>
+                                  {hasPriorActivity ? (
+                                    <span className="min-w-0 justify-self-end truncate text-right font-medium">
+                                      Noted
+                                    </span>
+                                  ) : (
+                                    <span className="min-w-0 justify-self-end truncate text-right" style={{ color: 'var(--app-text-muted)' }}>No opening usage</span>
+                                  )}
+                                </span>
+                              </button>
+                            )
+                          })
+                        )}
                       </div>
                     </div>
 

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -14,6 +14,7 @@ import {
   type TaxAdvantagedPlanLimit,
 } from '@/api/taxAdvantagedPlans'
 import ActionFeedbackButton from '@/components/ActionFeedbackButton'
+import Dropdown from '@/components/Dropdown'
 import IconTooltip from '@/components/IconTooltip'
 import { formatCurrency } from '@/utils/formatCurrency'
 import type {
@@ -1316,30 +1317,12 @@ export default function TaxAdvantagedCategoryModal({
                   <div className="grid grid-cols-1 gap-3 min-[620px]:grid-cols-[minmax(0,3fr)_minmax(0,7fr)]">
                     <div className="min-w-0">
                       <span className="app-label mb-1 block text-xs">Type</span>
-                      <div
-                        className="group flex h-9 w-full items-center gap-1.5 rounded-md border border-transparent px-2 transition-colors duration-150 hover:border-[var(--app-border)] focus-within:border-[var(--app-accent-border)]"
-                        style={{ background: 'color-mix(in srgb, var(--app-input-bg) 55%, var(--app-bg))' }}
-                      >
-                        <select
-                          aria-label="TAC type"
-                          className="block h-8 min-w-0 flex-1 appearance-none bg-transparent text-[0.9375rem] font-medium leading-8 outline-none"
-                          onChange={(event) => setPlanField('tax_treatment', event.target.value as TaxPlanFormState['tax_treatment'])}
-                          style={{ color: 'var(--app-text)' }}
-                          value={planForm.tax_treatment}
-                        >
-                          {TAX_TREATMENT_OPTIONS.map((option) => (
-                            <option key={option.value} value={option.value}>
-                              {option.label}
-                            </option>
-                          ))}
-                        </select>
-                        <Pencil
-                          size={13}
-                          className="shrink-0 opacity-45 transition-opacity duration-150 group-hover:opacity-70 group-focus-within:opacity-80"
-                          style={{ color: 'var(--app-text-subtle)' }}
-                          aria-hidden
-                        />
-                      </div>
+                      <Dropdown
+                        className="h-9 w-full rounded-md border border-transparent bg-[color-mix(in_srgb,var(--app-input-bg)_55%,var(--app-bg))] px-2 py-0 text-[0.9375rem] font-medium outline-none transition-colors duration-150 hover:border-[var(--app-border)] focus:border-[var(--app-accent-border)]"
+                        options={TAX_TREATMENT_OPTIONS}
+                        value={planForm.tax_treatment}
+                        onChange={(value) => setPlanField('tax_treatment', value as TaxPlanFormState['tax_treatment'])}
+                      />
                     </div>
                     <div className="grid min-w-0 grid-cols-1 gap-3 min-[620px]:grid-cols-2">
                       <div className="min-w-0">

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -388,6 +388,7 @@ export default function TaxAdvantagedCategoryModal({
   )
   const linkedAccountsCount = bindableAccounts.filter((account) => account.tax_advantaged_plan_id === plan.id).length
   const linkedAccountsSummary = `${linkedAccountsCount} linked`
+  const linkedAccountsMobileSummary = `${linkedAccountsCount} ${linkedAccountsCount === 1 ? 'acct' : 'accts'} linked`
 
   const limitDraft = (year: number) => {
     const limit = limits.find((row) => row.year === year)
@@ -742,12 +743,9 @@ export default function TaxAdvantagedCategoryModal({
                   <span className="truncate">
                     {plan.group_id ? 'Group' : 'Personal'}
                   </span>
-                </div>
-
-                <div className="grid min-w-0 grid-cols-[minmax(0,1fr)_auto] items-center gap-4 border-t pt-2.5" style={{ borderColor: 'var(--app-border)' }}>
-                  <span className="app-label min-w-0">Linked Accounts</span>
-                  <span className="text-sm font-medium">
-                    {linkedAccountsSummary}
+                  <span aria-hidden style={{ color: 'var(--app-text-subtle)' }}>·</span>
+                  <span className="truncate">
+                    {linkedAccountsMobileSummary}
                   </span>
                 </div>
               </div>

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -299,10 +299,10 @@ export default function TaxAdvantagedCategoryModal({
       return 'Name is required.'
     }
     if (!isValidMoneyInput(form.lifetime_contribution_limit)) {
-      return 'Lifetime contribution limit must be zero or higher.'
+      return 'Lifetime limit must be zero or higher.'
     }
     if (!isValidMoneyInput(form.accrued_contributions)) {
-      return 'Accrued contributions must be zero or higher.'
+      return 'Opening usage must be zero or higher.'
     }
     return null
   }
@@ -1240,7 +1240,8 @@ export default function TaxAdvantagedCategoryModal({
                 role="dialog"
                 aria-modal="true"
                 aria-labelledby="tax-category-details-title"
-                className="app-modal-panel flex max-h-[100dvh] min-h-[100dvh] w-full flex-col overflow-hidden rounded-none min-[620px]:min-h-0 min-[620px]:max-h-[calc(100dvh-2rem)] min-[620px]:max-w-[38rem] min-[620px]:rounded-2xl"
+                data-tooltip-bounds
+                className="app-modal-panel flex max-h-[100dvh] min-h-[100dvh] w-full flex-col overflow-hidden rounded-none min-[620px]:min-h-0 min-[620px]:max-h-[calc(100dvh-2rem)] min-[620px]:max-w-[38rem] min-[620px]:overflow-visible min-[620px]:rounded-2xl"
                 style={{
                   background: 'var(--app-bg)',
                   border: '1px solid var(--app-border-strong)',
@@ -1254,7 +1255,7 @@ export default function TaxAdvantagedCategoryModal({
                       TAC Details
                     </h4>
                     <p className="mt-1 text-sm" style={{ color: 'var(--app-text-muted)' }}>
-                      Edit category identity and lifetime contribution settings.
+                      Edit category identity and lifetime contribution room.
                     </p>
                   </div>
                   <button
@@ -1268,7 +1269,7 @@ export default function TaxAdvantagedCategoryModal({
                   </button>
                 </div>
 
-                <div className="min-h-0 flex-1 overflow-y-auto p-5">
+                <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden p-5 min-[620px]:overflow-visible">
                   <div className="space-y-4">
                   <div className="grid grid-cols-1 gap-3 min-[620px]:grid-cols-[minmax(0,3fr)_minmax(0,7fr)]">
                     <div className="grid min-w-0 grid-cols-2 gap-2">
@@ -1342,9 +1343,9 @@ export default function TaxAdvantagedCategoryModal({
                     </div>
                     <div className="grid min-w-0 grid-cols-1 gap-3 min-[620px]:grid-cols-2">
                       <div className="min-w-0">
-                        <span className="app-label mb-1 block text-xs">Lifetime Contribution Limit</span>
+                        <span className="app-label mb-1 block text-xs">Lifetime limit</span>
                         <CompactCurrencyInput
-                          ariaLabel="Lifetime contribution limit"
+                          ariaLabel="Lifetime limit"
                           currencies={currencies}
                           currency={plan.currency}
                           value={planForm.lifetime_contribution_limit}
@@ -1353,9 +1354,11 @@ export default function TaxAdvantagedCategoryModal({
                         />
                       </div>
                       <div className="min-w-0">
-                        <span className="app-label mb-1 block text-xs">Accrued Contributions</span>
+                        <span className="app-label mb-1 block text-xs">
+                          <OpeningUsageLabel />
+                        </span>
                         <CompactCurrencyInput
-                          ariaLabel="Accrued contributions"
+                          ariaLabel="Opening usage"
                           currencies={currencies}
                           currency={plan.currency}
                           value={planForm.accrued_contributions}

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -1007,7 +1007,7 @@ export default function TaxAdvantagedCategoryModal({
                                     <td className="col-span-2 row-start-4 min-w-0 pt-2 min-[750px]:table-cell min-[750px]:py-3 min-[750px]:pl-4 min-[750px]:pr-0">
                                       {hasPriorActivity ? (
                                         <span className="block truncate text-sm font-medium">
-                                          Opening usage noted
+                                          Noted
                                         </span>
                                       ) : (
                                         <span className="text-sm" style={{ color: 'var(--app-text-muted)' }}>No opening usage</span>

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -28,7 +28,6 @@ import { autosaveNoticeColor } from '@/settings/components/tax-advantaged/TaxAdv
 import {
   ACCOUNT_LINK_SAVE_MIN_LOADING_MS,
   ACCOUNT_LINK_SAVE_NOTICE_DELAY_MS,
-  CATEGORY_FIELD_TRANSITION,
   CATEGORY_SUMMARY_LABEL_CLASS,
   CATEGORY_SUMMARY_VALUE_CLASS,
   DEFAULT_NEW_LIMIT_YEAR,
@@ -37,6 +36,7 @@ import {
   LIMIT_DELETE_FEEDBACK_MS,
   LIMIT_SAVE_FEEDBACK_MS,
   MAX_VISIBLE_LIMIT_ROWS,
+  TAX_TREATMENT_OPTIONS,
 } from '@/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/taxAdvantagedCategoryConstants'
 import {
   formatTaxTreatment,
@@ -47,8 +47,6 @@ import {
 } from '@/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/taxAdvantagedCategoryUtils'
 import {
   CompactCurrencyInput,
-  InlineCurrencyInput,
-  InlineTaxTreatmentSelect,
   TaxAdvantagedCurrencyWarning,
 } from '@/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedFormControls'
 
@@ -354,13 +352,25 @@ export default function TaxAdvantagedCategoryModal({
     return null
   }
 
-  const handleCategoryEditClick = async () => {
-    if (updatePlan.isPending || planSaveStatus !== 'idle') return
-    if (!categoryEditOpen) {
-      setCategoryEditOpen(true)
-      return
-    }
+  const openCategoryDetailsModal = () => {
+    if (planSaveStatus !== 'idle') return
+    setPlanOverrides({})
+    setPlanError(null)
+    setShowAddTaxYear(false)
+    setSelectedLimitYear(null)
+    setDeleteConfirmYear(null)
+    setCategoryEditOpen(true)
+  }
 
+  const closeCategoryDetailsModal = () => {
+    if (updatePlan.isPending || planSaveStatus !== 'idle') return
+    setCategoryEditOpen(false)
+    setPlanOverrides({})
+    setPlanError(null)
+  }
+
+  const handleSaveCategoryDetails = async () => {
+    if (updatePlan.isPending || planSaveStatus !== 'idle') return
     const validationError = validatePlanForm(planForm)
     if (validationError) {
       setPlanError(validationError)
@@ -383,8 +393,8 @@ export default function TaxAdvantagedCategoryModal({
       }
       await minimumLoading
       setPlanSaveStatus('success')
+      await delay(600)
       setCategoryEditOpen(false)
-      await new Promise((resolve) => window.setTimeout(resolve, 1200))
       setPlanSaveStatus('idle')
     } catch (error) {
       await minimumLoading
@@ -413,9 +423,6 @@ export default function TaxAdvantagedCategoryModal({
   }, [limits, pendingCreateLimitYear, pendingDeletedLimit])
   const hasScrollableLimitRows = sortedLimits.length > MAX_VISIBLE_LIMIT_ROWS
   const creatingLimit = pendingCreateLimitYear !== null || createLimit.isPending
-  const mobileTaxTreatmentLabel = categoryEditOpen
-    ? formatTaxTreatment(planForm.tax_treatment)
-    : formatTaxTreatment(plan.tax_treatment)
   const bindableAccounts = accounts.filter(
     (account) =>
       account.closed_at === null
@@ -791,43 +798,8 @@ export default function TaxAdvantagedCategoryModal({
             >
               <div className="flex min-w-0 items-start justify-between gap-4">
                 <div className="h-10 min-w-0 flex-1 overflow-hidden">
-                  <h3 id="tax-advantaged-category-title" className="h-10 font-serif text-3xl font-medium leading-10 tracking-tight">
-                    <div className="relative h-10 min-w-0">
-                      <motion.div
-                        className={`absolute inset-0 group flex h-10 min-w-0 items-center gap-2 ${categoryEditOpen ? '' : 'pointer-events-none'}`}
-                        style={{ borderBottom: '1px solid var(--app-border-strong)' }}
-                        animate={{ opacity: categoryEditOpen ? 1 : 0 }}
-                        initial={false}
-                        transition={CATEGORY_FIELD_TRANSITION}
-                        aria-hidden={!categoryEditOpen}
-                      >
-                        <input
-                          aria-label="Category name"
-                          className="block h-10 min-w-0 flex-1 bg-transparent font-serif text-3xl font-medium leading-10 tracking-tight outline-none"
-                          maxLength={256}
-                          onChange={(event) => setPlanField('name', event.target.value)}
-                          required
-                          style={{ color: 'var(--app-text)' }}
-                          tabIndex={categoryEditOpen ? undefined : -1}
-                          value={planForm.name}
-                        />
-                        <Pencil
-                          size={15}
-                          className="shrink-0 opacity-45 transition-opacity duration-150 group-hover:opacity-70 group-focus-within:opacity-80"
-                          style={{ color: 'var(--app-text-subtle)' }}
-                          aria-hidden
-                        />
-                      </motion.div>
-                      <motion.span
-                        className={`absolute inset-0 block h-10 truncate leading-10 ${categoryEditOpen ? 'pointer-events-none' : ''}`}
-                        animate={{ opacity: categoryEditOpen ? 0 : 1 }}
-                        initial={false}
-                        transition={CATEGORY_FIELD_TRANSITION}
-                        aria-hidden={categoryEditOpen}
-                      >
-                        {planForm.name.trim() || plan.name}
-                      </motion.span>
-                    </div>
+                  <h3 id="tax-advantaged-category-title" className="h-10 truncate font-serif text-3xl font-medium leading-10 tracking-tight">
+                    {plan.name}
                   </h3>
                 </div>
                 <button
@@ -842,32 +814,8 @@ export default function TaxAdvantagedCategoryModal({
 
               <div className="space-y-3 min-[750px]:hidden">
                 <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1 text-[0.9375rem] font-medium">
-                  <span className="relative inline-block h-6 min-w-0 max-w-[8rem] align-bottom">
-                    <span className={`invisible flex h-6 items-center leading-6 ${categoryEditOpen ? 'gap-1' : ''}`} aria-hidden>
-                      <span className="truncate">{mobileTaxTreatmentLabel}</span>
-                      {categoryEditOpen && <Pencil size={13} className="shrink-0" />}
-                    </span>
-                    <motion.span
-                      className={`absolute inset-0 ${categoryEditOpen ? '' : 'pointer-events-none'}`}
-                      animate={{ opacity: categoryEditOpen ? 1 : 0 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={!categoryEditOpen}
-                    >
-                      <InlineTaxTreatmentSelect
-                        value={planForm.tax_treatment}
-                        onChange={(value) => setPlanField('tax_treatment', value)}
-                      />
-                    </motion.span>
-                    <motion.span
-                      className={`absolute inset-0 flex h-6 items-center truncate leading-6 ${categoryEditOpen ? 'pointer-events-none' : ''}`}
-                      animate={{ opacity: categoryEditOpen ? 0 : 1 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={categoryEditOpen}
-                    >
-                      {formatTaxTreatment(plan.tax_treatment)}
-                    </motion.span>
+                  <span className="truncate">
+                    {formatTaxTreatment(plan.tax_treatment)}
                   </span>
                   <span aria-hidden style={{ color: 'var(--app-text-subtle)' }}>·</span>
                   <span className="inline-flex min-w-0 items-center gap-1">
@@ -882,94 +830,20 @@ export default function TaxAdvantagedCategoryModal({
 
                 <div className="flex min-w-0 items-center justify-between gap-4 border-t pt-3" style={{ borderColor: 'var(--app-border)' }}>
                   <span className="app-label min-w-0">Lifetime Contribution Limit</span>
-                  <span className="relative block h-6 min-w-[7rem] flex-1">
-                    <motion.span
-                      className={`absolute inset-y-0 right-0 w-full max-w-[10rem] ${categoryEditOpen ? '' : 'pointer-events-none'}`}
-                      animate={{ opacity: categoryEditOpen ? 1 : 0 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={!categoryEditOpen}
-                    >
-                      <InlineCurrencyInput
-                        ariaLabel="Lifetime contribution limit"
-                        currencies={currencies}
-                        currency={plan.currency}
-                        value={planForm.lifetime_contribution_limit}
-                        onChange={(value) => setPlanField('lifetime_contribution_limit', value)}
-                        placeholder="Optional"
-                      />
-                    </motion.span>
-                    <motion.span
-                      className={`flex h-6 items-center justify-end truncate text-right text-[0.9375rem] font-medium leading-6 ${categoryEditOpen ? 'pointer-events-none' : ''}`}
-                      animate={{ opacity: categoryEditOpen ? 0 : 1 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={categoryEditOpen}
-                    >
-                      {plan.lifetime_contribution_limit === null ? 'Not set' : formatCurrency(plan.lifetime_contribution_limit, plan.currency)}
-                    </motion.span>
+                  <span className="font-financial text-[0.9375rem] font-medium">
+                    {plan.lifetime_contribution_limit === null ? 'Not set' : formatCurrency(plan.lifetime_contribution_limit, plan.currency)}
                   </span>
                 </div>
                 <div className="flex min-w-0 items-center justify-between gap-4">
                   <span className="app-label min-w-0">Accrued Contributions</span>
-                  <span className="relative block h-6 min-w-[7rem] flex-1">
-                    <motion.span
-                      className={`absolute inset-y-0 right-0 w-full max-w-[10rem] ${categoryEditOpen ? '' : 'pointer-events-none'}`}
-                      animate={{ opacity: categoryEditOpen ? 1 : 0 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={!categoryEditOpen}
-                    >
-                      <InlineCurrencyInput
-                        ariaLabel="Accrued contributions"
-                        currencies={currencies}
-                        currency={plan.currency}
-                        value={planForm.accrued_contributions}
-                        onChange={(value) => setPlanField('accrued_contributions', value)}
-                        placeholder="0"
-                      />
-                    </motion.span>
-                    <motion.span
-                      className={`flex h-6 items-center justify-end truncate text-right text-[0.9375rem] font-medium leading-6 ${categoryEditOpen ? 'pointer-events-none' : ''}`}
-                      animate={{ opacity: categoryEditOpen ? 0 : 1 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={categoryEditOpen}
-                    >
-                      {formatCurrency(plan.accrued_contributions, plan.currency)}
-                    </motion.span>
+                  <span className="font-financial text-[0.9375rem] font-medium">
+                    {formatCurrency(plan.accrued_contributions, plan.currency)}
                   </span>
                 </div>
               </div>
 
               <div className="hidden min-[750px]:grid min-[750px]:grid-cols-4 min-[750px]:gap-x-4 min-[750px]:gap-y-3 min-[1050px]:block min-[1050px]:space-y-4">
-                <div className="relative h-14 min-w-0 overflow-hidden">
-                  <p className={CATEGORY_SUMMARY_LABEL_CLASS}>Type</p>
-                  <div className="relative h-6 min-w-0">
-                    <motion.div
-                      className={`absolute inset-0 ${categoryEditOpen ? '' : 'pointer-events-none'}`}
-                      animate={{ opacity: categoryEditOpen ? 1 : 0 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={!categoryEditOpen}
-                    >
-                      <InlineTaxTreatmentSelect
-                        value={planForm.tax_treatment}
-                        onChange={(value) => setPlanField('tax_treatment', value)}
-                      />
-                    </motion.div>
-                    <motion.p
-                      className={`absolute inset-0 ${CATEGORY_SUMMARY_VALUE_CLASS} ${categoryEditOpen ? 'pointer-events-none' : ''}`}
-                      animate={{ opacity: categoryEditOpen ? 0 : 1 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={categoryEditOpen}
-                    >
-                      {formatTaxTreatment(plan.tax_treatment)}
-                    </motion.p>
-                  </div>
-                </div>
-
+                <InfoItem label="Type" value={formatTaxTreatment(plan.tax_treatment)} />
                 <InfoItem
                   label="Currency"
                   labelAccessory={<TaxAdvantagedCurrencyWarning />}
@@ -979,64 +853,16 @@ export default function TaxAdvantagedCategoryModal({
 
                 <div className="relative h-14 min-w-0 overflow-hidden">
                   <p className={CATEGORY_SUMMARY_LABEL_CLASS}>Lifetime Contribution Limit</p>
-                  <div className="relative h-6 min-w-0">
-                    <motion.div
-                      className={`absolute inset-0 ${categoryEditOpen ? '' : 'pointer-events-none'}`}
-                      animate={{ opacity: categoryEditOpen ? 1 : 0 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={!categoryEditOpen}
-                    >
-                      <InlineCurrencyInput
-                        ariaLabel="Lifetime contribution limit"
-                        currencies={currencies}
-                        currency={plan.currency}
-                        value={planForm.lifetime_contribution_limit}
-                        onChange={(value) => setPlanField('lifetime_contribution_limit', value)}
-                        placeholder="Optional"
-                      />
-                    </motion.div>
-                    <motion.p
-                      className={`absolute inset-0 font-financial ${CATEGORY_SUMMARY_VALUE_CLASS} ${categoryEditOpen ? 'pointer-events-none' : ''}`}
-                      animate={{ opacity: categoryEditOpen ? 0 : 1 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={categoryEditOpen}
-                    >
-                      {plan.lifetime_contribution_limit === null ? 'Not set' : formatCurrency(plan.lifetime_contribution_limit, plan.currency)}
-                    </motion.p>
-                  </div>
+                  <p className={`font-financial ${CATEGORY_SUMMARY_VALUE_CLASS}`}>
+                    {plan.lifetime_contribution_limit === null ? 'Not set' : formatCurrency(plan.lifetime_contribution_limit, plan.currency)}
+                  </p>
                 </div>
 
                 <div className="relative h-14 min-w-0 overflow-hidden">
                   <p className={CATEGORY_SUMMARY_LABEL_CLASS}>Accrued Contributions</p>
-                  <div className="relative h-6 min-w-0">
-                    <motion.div
-                      className={`absolute inset-0 ${categoryEditOpen ? '' : 'pointer-events-none'}`}
-                      animate={{ opacity: categoryEditOpen ? 1 : 0 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={!categoryEditOpen}
-                    >
-                      <InlineCurrencyInput
-                        ariaLabel="Accrued contributions"
-                        currencies={currencies}
-                        currency={plan.currency}
-                        value={planForm.accrued_contributions}
-                        onChange={(value) => setPlanField('accrued_contributions', value)}
-                        placeholder="0"
-                      />
-                    </motion.div>
-                    <motion.p
-                      className={`absolute inset-0 font-financial ${CATEGORY_SUMMARY_VALUE_CLASS} ${categoryEditOpen ? 'pointer-events-none' : ''}`}
-                      animate={{ opacity: categoryEditOpen ? 0 : 1 }}
-                      initial={false}
-                      transition={CATEGORY_FIELD_TRANSITION}
-                      aria-hidden={categoryEditOpen}
-                    >
-                      {formatCurrency(plan.accrued_contributions, plan.currency)}
-                    </motion.p>
-                  </div>
+                  <p className={`font-financial ${CATEGORY_SUMMARY_VALUE_CLASS}`}>
+                    {formatCurrency(plan.accrued_contributions, plan.currency)}
+                  </p>
                 </div>
               </div>
 
@@ -1047,16 +873,14 @@ export default function TaxAdvantagedCategoryModal({
               )}
 
               <div className="flex items-center justify-between border-t pt-4 min-[1050px]:mt-auto" style={{ borderColor: 'var(--app-border)' }}>
-                <ActionFeedbackButton
+                <button
                   type="button"
                   className="app-secondary-button w-[72px]"
                   disabled={planSaveStatus !== 'idle'}
-                  loadingLabel="Saving"
-                  onClick={() => { void handleCategoryEditClick() }}
-                  status={planSaveStatus}
+                  onClick={openCategoryDetailsModal}
                 >
-                  {categoryEditOpen ? 'Done' : 'Edit'}
-                </ActionFeedbackButton>
+                  Edit
+                </button>
                 <button
                   ref={planDeleteButtonRef}
                   type="button"
@@ -1384,6 +1208,190 @@ export default function TaxAdvantagedCategoryModal({
           </div>
         </div>
       </motion.div>
+
+      <AnimatePresence>
+        {categoryEditOpen && (
+          <>
+            <motion.div
+              className="fixed inset-0 z-[60]"
+              style={{ background: 'rgba(0, 0, 0, 0.28)' }}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: 0.16 }}
+              onClick={closeCategoryDetailsModal}
+              aria-hidden
+            />
+            <motion.div
+              className="fixed inset-0 z-[61] flex items-stretch justify-center p-0 min-[620px]:items-center min-[620px]:p-4"
+              initial={{ opacity: 0, scale: 0.97, y: 8 }}
+              animate={{ opacity: 1, scale: 1, y: 0 }}
+              exit={{ opacity: 0, scale: 0.97, y: 8 }}
+              transition={{ duration: 0.18, ease: [0.25, 0.1, 0.25, 1] }}
+              onClick={closeCategoryDetailsModal}
+            >
+              <div
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="tax-category-details-title"
+                className="app-modal-panel flex max-h-[100dvh] min-h-[100dvh] w-full flex-col overflow-hidden rounded-none min-[620px]:min-h-0 min-[620px]:max-h-[calc(100dvh-2rem)] min-[620px]:max-w-[38rem] min-[620px]:rounded-2xl"
+                style={{
+                  background: 'var(--app-bg)',
+                  border: '1px solid var(--app-border-strong)',
+                  boxShadow: 'var(--app-shadow-soft)',
+                }}
+                onClick={(event) => event.stopPropagation()}
+              >
+                <div className="flex shrink-0 items-start justify-between gap-4 border-b p-5" style={{ borderColor: 'var(--app-border)' }}>
+                  <div className="min-w-0">
+                    <h4 id="tax-category-details-title" className="font-serif text-2xl font-medium tracking-tight">
+                      TAC Details
+                    </h4>
+                    <p className="mt-1 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                      Edit category identity and lifetime contribution settings.
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="app-icon-button shrink-0"
+                    onClick={closeCategoryDetailsModal}
+                    disabled={updatePlan.isPending || planSaveStatus !== 'idle'}
+                    aria-label="Close TAC details"
+                  >
+                    <X size={18} aria-hidden />
+                  </button>
+                </div>
+
+                <div className="min-h-0 flex-1 overflow-y-auto p-5">
+                  <div className="space-y-4">
+                  <div className="grid grid-cols-1 gap-3 min-[620px]:grid-cols-[minmax(0,3fr)_minmax(0,7fr)]">
+                    <div className="grid min-w-0 grid-cols-2 gap-2">
+                      <div className="min-w-0">
+                        <span className="app-label mb-0.5 block text-xs">Scope</span>
+                        <span className="block h-8 truncate text-[0.9375rem] font-medium leading-8">
+                          {plan.group_id ? 'Group' : 'Personal'}
+                        </span>
+                      </div>
+                      <div className="min-w-0">
+                        <span className="app-label mb-0.5 block text-xs">Currency</span>
+                        <span className="inline-flex h-8 min-w-0 items-center gap-1 text-[0.9375rem] font-medium">
+                          <span className="truncate">{plan.currency}</span>
+                          <TaxAdvantagedCurrencyWarning />
+                        </span>
+                      </div>
+                    </div>
+                    <div className="min-w-0">
+                      <span className="app-label mb-0.5 block text-xs">Name</span>
+                      <div
+                        className="group flex h-8 w-full items-center gap-1.5 rounded-md border border-transparent px-2 transition-colors duration-150 hover:border-[var(--app-border)] focus-within:border-[var(--app-accent-border)]"
+                        style={{ background: 'color-mix(in srgb, var(--app-input-bg) 55%, var(--app-bg))' }}
+                      >
+                        <input
+                          aria-label="TAC name"
+                          className="block h-7 min-w-0 flex-1 bg-transparent text-[0.9375rem] font-medium leading-7 outline-none"
+                          maxLength={256}
+                          onChange={(event) => setPlanField('name', event.target.value)}
+                          required
+                          style={{ color: 'var(--app-text)' }}
+                          type="text"
+                          value={planForm.name}
+                        />
+                        <Pencil
+                          size={13}
+                          className="shrink-0 opacity-45 transition-opacity duration-150 group-hover:opacity-70 group-focus-within:opacity-80"
+                          style={{ color: 'var(--app-text-subtle)' }}
+                          aria-hidden
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  <div className="grid grid-cols-1 gap-3 min-[620px]:grid-cols-[minmax(0,3fr)_minmax(0,7fr)]">
+                    <div className="min-w-0">
+                      <span className="app-label mb-1 block text-xs">Type</span>
+                      <div
+                        className="group flex h-9 w-full items-center gap-1.5 rounded-md border border-transparent px-2 transition-colors duration-150 hover:border-[var(--app-border)] focus-within:border-[var(--app-accent-border)]"
+                        style={{ background: 'color-mix(in srgb, var(--app-input-bg) 55%, var(--app-bg))' }}
+                      >
+                        <select
+                          aria-label="TAC type"
+                          className="block h-8 min-w-0 flex-1 appearance-none bg-transparent text-[0.9375rem] font-medium leading-8 outline-none"
+                          onChange={(event) => setPlanField('tax_treatment', event.target.value as TaxPlanFormState['tax_treatment'])}
+                          style={{ color: 'var(--app-text)' }}
+                          value={planForm.tax_treatment}
+                        >
+                          {TAX_TREATMENT_OPTIONS.map((option) => (
+                            <option key={option.value} value={option.value}>
+                              {option.label}
+                            </option>
+                          ))}
+                        </select>
+                        <Pencil
+                          size={13}
+                          className="shrink-0 opacity-45 transition-opacity duration-150 group-hover:opacity-70 group-focus-within:opacity-80"
+                          style={{ color: 'var(--app-text-subtle)' }}
+                          aria-hidden
+                        />
+                      </div>
+                    </div>
+                    <div className="grid min-w-0 grid-cols-1 gap-3 min-[620px]:grid-cols-2">
+                      <div className="min-w-0">
+                        <span className="app-label mb-1 block text-xs">Lifetime Contribution Limit</span>
+                        <CompactCurrencyInput
+                          ariaLabel="Lifetime contribution limit"
+                          currencies={currencies}
+                          currency={plan.currency}
+                          value={planForm.lifetime_contribution_limit}
+                          onChange={(value) => setPlanField('lifetime_contribution_limit', value)}
+                          placeholder="Optional"
+                        />
+                      </div>
+                      <div className="min-w-0">
+                        <span className="app-label mb-1 block text-xs">Accrued Contributions</span>
+                        <CompactCurrencyInput
+                          ariaLabel="Accrued contributions"
+                          currencies={currencies}
+                          currency={plan.currency}
+                          value={planForm.accrued_contributions}
+                          onChange={(value) => setPlanField('accrued_contributions', value)}
+                          placeholder="0"
+                        />
+                      </div>
+                    </div>
+                  </div>
+
+                  {planError && (
+                    <p className="text-sm" style={{ color: 'var(--app-negative)' }}>
+                      {planError}
+                    </p>
+                  )}
+                  </div>
+                </div>
+                <div className="grid shrink-0 grid-cols-2 gap-2 border-t px-5 py-4" style={{ borderColor: 'var(--app-border)' }}>
+                  <button
+                    type="button"
+                    className="app-secondary-button justify-center"
+                    onClick={closeCategoryDetailsModal}
+                    disabled={updatePlan.isPending || planSaveStatus !== 'idle'}
+                  >
+                    Cancel
+                  </button>
+                  <ActionFeedbackButton
+                    type="button"
+                    className="app-primary-button justify-center"
+                    disabled={planSaveStatus !== 'idle'}
+                    loadingLabel="Saving"
+                    onClick={() => { void handleSaveCategoryDetails() }}
+                    status={planSaveStatus}
+                  >
+                    Save
+                  </ActionFeedbackButton>
+                </div>
+              </div>
+            </motion.div>
+          </>
+        )}
+      </AnimatePresence>
 
       <AnimatePresence>
         {(showAddTaxYear || (selectedLimit && selectedDraft)) && (

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedFormControls.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedFormControls.tsx
@@ -13,13 +13,17 @@ import {
 
 export function TaxAdvantagedCurrencyWarning() {
   return (
-    <IconTooltip
-      label="Tax-advantaged category currency limitation"
-      level="important"
-      widthClassName="w-56"
-    >
-      Tax-advantaged categories currently link only accounts in the same currency.
-    </IconTooltip>
+    <span className="inline-flex h-4 items-center align-middle leading-none">
+      <IconTooltip
+        label="Tax-advantaged category currency limitation"
+        level="important"
+        widthClassName="w-56"
+        size={14}
+        strokeWidth={2.4}
+      >
+        Tax-advantaged categories currently link only accounts in the same currency.
+      </IconTooltip>
+    </span>
   )
 }
 
@@ -226,4 +230,3 @@ export function InlineTaxTreatmentSelect({
     </div>
   )
 }
-

--- a/frontend/src/settings/components/tax-advantaged/taxAdvantagedTypes.ts
+++ b/frontend/src/settings/components/tax-advantaged/taxAdvantagedTypes.ts
@@ -5,12 +5,15 @@ export interface TaxPlanFormState {
   tax_treatment: TaxTreatment
   currency: string
   lifetime_contribution_limit: string
+  accrued_contributions: string
 }
 
 export interface TaxPlanLimitFormState {
   year: string
   contribution_limit: string
   withdrawal_limit: string
+  accrued_contributions: string
+  accrued_withdrawals: string
 }
 
 export interface AutosaveNotice {

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -343,6 +343,7 @@
 
   .app-danger-button {
     @apply inline-flex h-10 items-center justify-center gap-2 rounded-lg px-3.5 font-medium transition-all duration-150 motion-reduce:transition-none;
+    font-size: 0.9375rem;
     background: var(--app-negative);
     border: 1px solid var(--app-negative-border);
     color: white;


### PR DESCRIPTION
- Adds TAC opening usage fields for lifetime and annual contribution/withdrawal limits
- Updates TAC limit room calculations and account overview visuals to account for opening usage
- Refines TAC settings modals for editing category details, annual limits, linked accounts, and explanatory tooltips
- Improves TAC modal mobile and desktop layouts, including account-list sizing, tab spacing, and currency warning alignment

CU-86baaprt7