### PR TITLE
Fix insights page responsive layout issues

### DIFF
--- a/frontend/src/insights/components/IncomeExpenseBreakdownCard.tsx
+++ b/frontend/src/insights/components/IncomeExpenseBreakdownCard.tsx
@@ -305,10 +305,10 @@ export function IncomeExpenseBreakdownCard({
       <div className="relative overflow-visible" data-tooltip-bounds>
         <InsightLoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           <div className="grid gap-6 min-[1350px]:grid-cols-[minmax(0,0.95fr)_minmax(360px,1.05fr)]">
-            <div className="flex min-h-[620px] flex-col">
+            <div className="flex flex-col min-[1350px]:min-h-[620px]">
               <div
                 ref={breakdownChartRef}
-                className="relative h-[450px] shrink-0"
+                className="relative aspect-square max-h-[450px] w-full shrink-0"
                 onMouseLeave={hideBreakdownTooltip}
               >
                 <div className="pointer-events-none absolute inset-0 z-10 flex flex-col items-center justify-center">
@@ -409,7 +409,7 @@ export function IncomeExpenseBreakdownCard({
               </div>
             </div>
 
-            <div className="flex min-h-[620px] flex-col border-t border-[var(--app-border)] pt-3 min-[1350px]:border-t-0 min-[1350px]:pt-0">
+            <div className="flex flex-col border-t border-[var(--app-border)] pt-3 min-[1350px]:min-h-[620px] min-[1350px]:border-t-0 min-[1350px]:pt-0">
               <div className="grid gap-4 min-[1350px]:min-h-0 min-[1350px]:flex-1 min-[1350px]:grid-rows-2">
                 {displaySnapshot.trendSections.map((section) => (
                   <div

--- a/frontend/src/insights/components/IncomeExpenseBreakdownCard.tsx
+++ b/frontend/src/insights/components/IncomeExpenseBreakdownCard.tsx
@@ -409,14 +409,14 @@ export function IncomeExpenseBreakdownCard({
               </div>
             </div>
 
-            <div className="flex flex-col border-t border-[var(--app-border)] pt-3 min-[1350px]:min-h-[620px] min-[1350px]:border-t-0 min-[1350px]:pt-0">
-              <div className="grid gap-4 min-[1350px]:min-h-0 min-[1350px]:flex-1 min-[1350px]:grid-rows-2">
+            <div className="flex flex-col border-t border-[var(--app-border)] pt-4 min-[1350px]:min-h-[620px] min-[1350px]:border-t-0 min-[1350px]:pt-0">
+              <div className="grid gap-5 min-[1350px]:min-h-0 min-[1350px]:flex-1 min-[1350px]:grid-rows-2 min-[1350px]:gap-4">
                 {displaySnapshot.trendSections.map((section) => (
                   <div
                     key={section.id}
                     className="flex min-h-0 flex-col"
                   >
-                    <p className="app-label mb-2 inline-flex items-center gap-2">
+                    <p className="app-label mb-3 inline-flex items-center gap-2 min-[1350px]:mb-2">
                       {section.label}
                       <IconTooltip
                         label={`${section.label} calculation`}

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -86,6 +86,7 @@
 
   html {
     min-height: 100dvh;
+    overflow-x: clip;
     scrollbar-gutter: stable;
     background-color: var(--app-bg);
     color: var(--app-text);
@@ -99,9 +100,17 @@
   body {
     min-height: 100dvh;
     margin: 0;
+    overflow-x: clip;
     background-color: var(--app-bg);
     color: var(--app-text);
     font-family: "DM Sans", system-ui, sans-serif;
+  }
+
+  @supports not (overflow: clip) {
+    html,
+    body {
+      overflow-x: hidden;
+    }
   }
 
   html,


### PR DESCRIPTION
- Prevent horizontal overflow from making the insights page scroll sideways
- Let the income/expense breakdown donut shrink with narrow viewports
- Rebalance stacked spacing in the breakdown trend sections