### PR TITLE
Fix Insights calendar preset comparisons

### DIFF
--- a/backend/app/routes/insights.py
+++ b/backend/app/routes/insights.py
@@ -12,6 +12,7 @@ from app.dependencies import get_current_user
 from app.models.user import User
 from app.schemas.insights import (
     InsightsCashFlowResponse,
+    InsightsComparisonPeriod,
     InsightsFundFlowResponse,
     InsightsIncomeExpenseBreakdownResponse,
     InsightsMerchantDistributionResponse,
@@ -53,10 +54,11 @@ async def get_period_glance_route(
     db: Annotated[AsyncSession, Depends(get_db)],
     from_date: Annotated[date, Query()],
     to_date: Annotated[date, Query()],
+    comparison_period: Annotated[InsightsComparisonPeriod, Query()] = "same_length",
 ):
     """Return compact metrics for the insights top summary card."""
     _validate_date_range(from_date, to_date)
-    return await get_period_glance(db, user, from_date, to_date)
+    return await get_period_glance(db, user, from_date, to_date, comparison_period)
 
 
 @router.get("/fund-flow", response_model=InsightsFundFlowResponse)
@@ -77,10 +79,11 @@ async def get_income_expense_breakdown_route(
     db: Annotated[AsyncSession, Depends(get_db)],
     from_date: Annotated[date, Query()],
     to_date: Annotated[date, Query()],
+    comparison_period: Annotated[InsightsComparisonPeriod, Query()] = "same_length",
 ):
     """Return category breakdown and trend rows for the insights breakdown card."""
     _validate_date_range(from_date, to_date)
-    return await get_income_expense_breakdown(db, user, from_date, to_date)
+    return await get_income_expense_breakdown(db, user, from_date, to_date, comparison_period)
 
 
 @router.get("/cash-flow", response_model=InsightsCashFlowResponse)
@@ -122,10 +125,11 @@ async def get_merchant_distribution_route(
     db: Annotated[AsyncSession, Depends(get_db)],
     from_date: Annotated[date, Query()],
     to_date: Annotated[date, Query()],
+    comparison_period: Annotated[InsightsComparisonPeriod, Query()] = "same_length",
 ):
     """Return merchant spend rows for the insights merchant distribution card."""
     _validate_date_range(from_date, to_date)
-    return await get_merchant_distribution(db, user, from_date, to_date)
+    return await get_merchant_distribution(db, user, from_date, to_date, comparison_period)
 
 
 @router.get("/merchant-ranking", response_model=InsightsMerchantRankingResponse)
@@ -134,10 +138,11 @@ async def get_merchant_ranking_route(
     db: Annotated[AsyncSession, Depends(get_db)],
     from_date: Annotated[date, Query()],
     to_date: Annotated[date, Query()],
+    comparison_period: Annotated[InsightsComparisonPeriod, Query()] = "same_length",
 ):
     """Return merchant ranking rows for the insights merchant ranking card."""
     _validate_date_range(from_date, to_date)
-    return await get_merchant_ranking(db, user, from_date, to_date)
+    return await get_merchant_ranking(db, user, from_date, to_date, comparison_period)
 
 
 @router.get("/merchants", response_model=InsightsMerchantsResponse)
@@ -146,7 +151,8 @@ async def get_merchants_route(
     db: Annotated[AsyncSession, Depends(get_db)],
     from_date: Annotated[date, Query()],
     to_date: Annotated[date, Query()],
+    comparison_period: Annotated[InsightsComparisonPeriod, Query()] = "same_length",
 ):
     """Return shared merchant spend rows for the insights merchant cards."""
     _validate_date_range(from_date, to_date)
-    return await get_merchants(db, user, from_date, to_date)
+    return await get_merchants(db, user, from_date, to_date, comparison_period)

--- a/backend/app/schemas/insights.py
+++ b/backend/app/schemas/insights.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, Field
 from app.schemas.fx import FxStatus
 
 NetWorthGroupKind = Literal["asset", "debt"]
+InsightsComparisonPeriod = Literal["same_length", "previous_month", "previous_year"]
 
 
 class InsightsPeriodGlanceResponse(BaseModel):

--- a/backend/app/services/insights/common.py
+++ b/backend/app/services/insights/common.py
@@ -1,11 +1,13 @@
 """Shared helpers for insights card services."""
 
+from calendar import monthrange
 from datetime import date, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
 from app.models.user import User
+from app.schemas.insights import InsightsComparisonPeriod
 from app.services.dashboard import get_accessible_accounts
 
 
@@ -15,6 +17,33 @@ def previous_period_bounds(from_date: date, to_date: date) -> tuple[date, date]:
     previous_to_date = from_date - timedelta(days=1)
     previous_from_date = previous_to_date - timedelta(days=period_days - 1)
     return previous_from_date, previous_to_date
+
+
+def comparison_period_bounds(
+    from_date: date,
+    to_date: date,
+    comparison_period: InsightsComparisonPeriod,
+) -> tuple[date, date]:
+    """Return comparison bounds for the requested insights comparison mode."""
+    if comparison_period == "previous_month":
+        return _previous_calendar_month_bounds(from_date)
+    if comparison_period == "previous_year":
+        return _previous_calendar_year_bounds(from_date)
+    return previous_period_bounds(from_date, to_date)
+
+
+def _previous_calendar_month_bounds(from_date: date) -> tuple[date, date]:
+    month = from_date.month - 1
+    year = from_date.year
+    if month == 0:
+        month = 12
+        year -= 1
+    return date(year, month, 1), date(year, month, monthrange(year, month)[1])
+
+
+def _previous_calendar_year_bounds(from_date: date) -> tuple[date, date]:
+    year = from_date.year - 1
+    return date(year, 1, 1), date(year, 12, 31)
 
 
 async def get_base_currency_accounts(db: AsyncSession, user: User) -> list[Account]:

--- a/backend/app/services/insights/income_expense_breakdown.py
+++ b/backend/app/services/insights/income_expense_breakdown.py
@@ -14,10 +14,10 @@ from app.models.currency import Currency
 from app.models.transaction import Transaction
 from app.models.user import User
 from app.schemas.fx import FxStatus
-from app.schemas.insights import InsightsIncomeExpenseBreakdownResponse
+from app.schemas.insights import InsightsComparisonPeriod, InsightsIncomeExpenseBreakdownResponse
 from app.services.dashboard import get_accessible_accounts
 from app.services.fx import FxConverter
-from app.services.insights.common import previous_period_bounds
+from app.services.insights.common import comparison_period_bounds
 
 CATEGORY_TREND_LIMIT = 3
 
@@ -308,9 +308,10 @@ async def get_income_expense_breakdown(
     user: User,
     from_date: date,
     to_date: date,
+    comparison_period: InsightsComparisonPeriod = "same_length",
 ) -> InsightsIncomeExpenseBreakdownResponse:
     """Return category breakdown and trend rows for the income/expense card."""
-    previous_from_date, previous_to_date = previous_period_bounds(from_date, to_date)
+    previous_from_date, previous_to_date = comparison_period_bounds(from_date, to_date, comparison_period)
     accounts = await get_accessible_accounts(db, user)
 
     if not accounts:

--- a/backend/app/services/insights/merchants.py
+++ b/backend/app/services/insights/merchants.py
@@ -16,13 +16,14 @@ from app.models.transaction import Transaction
 from app.models.user import User
 from app.schemas.fx import FxStatus
 from app.schemas.insights import (
+    InsightsComparisonPeriod,
     InsightsMerchantDistributionResponse,
     InsightsMerchantRankingResponse,
     InsightsMerchantsResponse,
 )
 from app.services.dashboard import get_accessible_accounts
 from app.services.fx import FxConverter
-from app.services.insights.common import previous_period_bounds
+from app.services.insights.common import comparison_period_bounds
 
 MERCHANT_DISTRIBUTION_LIMIT = 8
 MERCHANT_RANKING_LIMIT = 10
@@ -229,9 +230,10 @@ async def get_merchants(
     user: User,
     from_date: date,
     to_date: date,
+    comparison_period: InsightsComparisonPeriod = "same_length",
 ) -> InsightsMerchantsResponse:
     """Return shared merchant spend data for the insights merchant cards."""
-    previous_from_date, previous_to_date = previous_period_bounds(from_date, to_date)
+    previous_from_date, previous_to_date = comparison_period_bounds(from_date, to_date, comparison_period)
     accounts = await get_accessible_accounts(db, user)
 
     if not accounts:
@@ -264,9 +266,10 @@ async def get_merchant_distribution(
     user: User,
     from_date: date,
     to_date: date,
+    comparison_period: InsightsComparisonPeriod = "same_length",
 ) -> InsightsMerchantDistributionResponse:
     """Return merchant spend rows for the insights merchant distribution card."""
-    merchants = await get_merchants(db, user, from_date, to_date)
+    merchants = await get_merchants(db, user, from_date, to_date, comparison_period)
     return InsightsMerchantDistributionResponse(merchants=merchants.distribution)
 
 
@@ -275,7 +278,8 @@ async def get_merchant_ranking(
     user: User,
     from_date: date,
     to_date: date,
+    comparison_period: InsightsComparisonPeriod = "same_length",
 ) -> InsightsMerchantRankingResponse:
     """Return merchant ranking rows for the insights merchant ranking card."""
-    merchants = await get_merchants(db, user, from_date, to_date)
+    merchants = await get_merchants(db, user, from_date, to_date, comparison_period)
     return InsightsMerchantRankingResponse(merchants=merchants.ranking)

--- a/backend/app/services/insights/period_glance.py
+++ b/backend/app/services/insights/period_glance.py
@@ -13,10 +13,10 @@ from app.models.currency import Currency
 from app.models.transaction import Transaction
 from app.models.user import User
 from app.schemas.fx import FxStatus
-from app.schemas.insights import InsightsPeriodGlanceResponse
+from app.schemas.insights import InsightsComparisonPeriod, InsightsPeriodGlanceResponse
 from app.services.dashboard import get_accessible_accounts
 from app.services.fx import FxConverter
-from app.services.insights.common import previous_period_bounds
+from app.services.insights.common import comparison_period_bounds
 
 CategoryNetTotals = dict[uuid.UUID, tuple[str, CategoryKind, int]]
 
@@ -388,9 +388,10 @@ async def get_period_glance(
     user: User,
     from_date: date,
     to_date: date,
+    comparison_period: InsightsComparisonPeriod = "same_length",
 ) -> InsightsPeriodGlanceResponse:
     """Return compact insight totals for the top period-glance card."""
-    previous_from_date, previous_to_date = previous_period_bounds(from_date, to_date)
+    previous_from_date, previous_to_date = comparison_period_bounds(from_date, to_date, comparison_period)
     all_accounts = await get_accessible_accounts(db, user)
 
     if not all_accounts:

--- a/backend/tests/routes/test_insights_income_expense_breakdown.py
+++ b/backend/tests/routes/test_insights_income_expense_breakdown.py
@@ -488,6 +488,38 @@ async def test_income_expense_breakdown_uses_stable_tie_breakers(client):
     ]
 
 
+async def test_income_expense_breakdown_compares_previous_calendar_month(client):
+    """Calendar-month presets compare against the previous full month."""
+    signup_resp = await _create_user(client)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
+    groceries_id, groceries = _category(user_id, "Groceries", CategoryKind.EXPENSE)
+
+    async with TestSession() as session:
+        session.add_all([
+            groceries,
+            _transaction(user_id, account_id, groceries_id, date(2026, 5, 15), -100_000),
+            _transaction(user_id, account_id, groceries_id, date(2026, 4, 10), -40_000),
+            _transaction(user_id, account_id, groceries_id, date(2026, 3, 31), -60_000),
+        ])
+        await session.commit()
+
+    resp = await client.get(
+        "/insights/income-expense-breakdown",
+        params={
+            "from_date": "2026-05-01",
+            "to_date": "2026-05-31",
+            "comparison_period": "previous_month",
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["expense_increases"] == [[str(groceries_id), "Groceries", 100_000, 40_000, 150, 1]]
+
+
 async def test_income_expense_breakdown_rejects_invalid_date_range(client):
     """The endpoint rejects a start date after the end date."""
     signup_resp = await _create_user(client)

--- a/backend/tests/routes/test_insights_merchants.py
+++ b/backend/tests/routes/test_insights_merchants.py
@@ -215,6 +215,47 @@ async def test_merchants_reports_incomplete_fx_with_missing_pairs(client, monkey
     }
 
 
+async def test_merchants_compare_previous_calendar_month(client):
+    """Merchant deltas can compare against the previous full calendar month."""
+    signup_resp = await _create_user(client)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
+    expense_id, expense = _category(user_id, "Shopping", CategoryKind.EXPENSE)
+    alpha_id, alpha = _merchant(user_id, "Alpha Market")
+
+    async with TestSession() as session:
+        session.add_all([
+            expense,
+            alpha,
+            _transaction(user_id, account_id, expense_id, date(2026, 5, 10), -100_000, alpha_id),
+            _transaction(user_id, account_id, expense_id, date(2026, 4, 10), -40_000, alpha_id),
+            _transaction(user_id, account_id, expense_id, date(2026, 3, 31), -60_000, alpha_id),
+        ])
+        await session.commit()
+
+    resp = await client.get(
+        "/insights/merchants",
+        params={
+            "from_date": "2026-05-01",
+            "to_date": "2026-05-31",
+            "comparison_period": "previous_month",
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "distribution": [
+            [str(alpha_id), "Alpha Market", 100_000, 150, 60_000],
+        ],
+        "ranking": [
+            [str(alpha_id), "Alpha Market", 100_000, 1, 150],
+        ],
+        "fx_status": {"state": "none", "missing_pairs": []},
+    }
+
+
 async def test_merchants_rejects_invalid_date_range(client):
     """The shared endpoint rejects a start date after the end date."""
     signup_resp = await _create_user(client)

--- a/backend/tests/routes/test_insights_period_glance.py
+++ b/backend/tests/routes/test_insights_period_glance.py
@@ -771,6 +771,39 @@ async def test_period_glance_returns_net_worth_change_without_period_transaction
     assert "biggest_change_name" not in data
 
 
+async def test_period_glance_compares_previous_calendar_year(client):
+    """Year-to-date presets can compare against the previous full calendar year."""
+    signup_resp = await _create_user(client)
+    user_id = UUID(signup_resp.json()["user"]["id"])
+    headers = _get_auth_header(signup_resp)
+    account_id = UUID((await _create_account(client, headers, name="Main Cash")).json()["id"])
+    groceries_id, groceries = _category(user_id, "Groceries", CategoryKind.EXPENSE)
+
+    async with TestSession() as session:
+        session.add_all([
+            groceries,
+            _transaction(user_id, account_id, groceries_id, date(2026, 2, 15), -100_000),
+            _transaction(user_id, account_id, groceries_id, date(2025, 2, 15), -40_000),
+        ])
+        await session.commit()
+
+    resp = await client.get(
+        "/insights/period-glance",
+        params={
+            "from_date": "2026-01-01",
+            "to_date": "2026-06-06",
+            "comparison_period": "previous_year",
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["biggest_change_name"] == "Groceries"
+    assert data["biggest_change_amount"] == 60_000
+    assert data["biggest_change_pct"] == 150
+
+
 async def test_period_glance_rejects_invalid_date_range(client):
     """The endpoint rejects a start date after the end date."""
     signup_resp = await _create_user(client)

--- a/frontend/src/api/insights.ts
+++ b/frontend/src/api/insights.ts
@@ -3,6 +3,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { authenticatedFetch } from '@/api/client';
 import type { FxStatus } from '@/api/dashboard';
 import { insightsKeys } from '@/api/queryKeys';
+import type { InsightsComparisonPeriod } from '@/insights/types/range';
 
 export interface InsightsPeriodGlanceResponse {
   income: number;
@@ -81,13 +82,29 @@ export interface InsightsMerchantsResponse {
   fx_status: FxStatus;
 }
 
-export function useInsightsPeriodGlance(fromDate: string, toDate: string, enabled = true) {
+function rangeQueryString(fromDate: string, toDate: string, comparisonPeriod?: InsightsComparisonPeriod) {
+  const params = new URLSearchParams({
+    from_date: fromDate,
+    to_date: toDate,
+  });
+  if (comparisonPeriod) {
+    params.set('comparison_period', comparisonPeriod);
+  }
+  return params.toString();
+}
+
+export function useInsightsPeriodGlance(
+  fromDate: string,
+  toDate: string,
+  comparisonPeriod: InsightsComparisonPeriod = 'same_length',
+  enabled = true,
+) {
   const { accessToken } = useAuth();
   return useQuery({
-    queryKey: insightsKeys.periodGlance(fromDate, toDate),
+    queryKey: insightsKeys.periodGlance(fromDate, toDate, comparisonPeriod),
     queryFn: () =>
       authenticatedFetch<InsightsPeriodGlanceResponse>(
-        `/insights/period-glance?from_date=${encodeURIComponent(fromDate)}&to_date=${encodeURIComponent(toDate)}`,
+        `/insights/period-glance?${rangeQueryString(fromDate, toDate, comparisonPeriod)}`,
       ),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
     staleTime: 5 * 60 * 1000,
@@ -100,7 +117,7 @@ export function useInsightsNetWorth(fromDate: string, toDate: string, enabled = 
     queryKey: insightsKeys.netWorth(fromDate, toDate),
     queryFn: () =>
       authenticatedFetch<InsightsNetWorthResponse>(
-        `/insights/net-worth?from_date=${encodeURIComponent(fromDate)}&to_date=${encodeURIComponent(toDate)}`,
+        `/insights/net-worth?${rangeQueryString(fromDate, toDate)}`,
       ),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
     staleTime: 5 * 60 * 1000,
@@ -118,13 +135,18 @@ export function useInsightsSavingsRateTrend(enabled = true) {
   });
 }
 
-export function useInsightsIncomeExpenseBreakdown(fromDate: string, toDate: string, enabled = true) {
+export function useInsightsIncomeExpenseBreakdown(
+  fromDate: string,
+  toDate: string,
+  comparisonPeriod: InsightsComparisonPeriod = 'same_length',
+  enabled = true,
+) {
   const { accessToken } = useAuth();
   return useQuery({
-    queryKey: insightsKeys.incomeExpenseBreakdown(fromDate, toDate),
+    queryKey: insightsKeys.incomeExpenseBreakdown(fromDate, toDate, comparisonPeriod),
     queryFn: () =>
       authenticatedFetch<InsightsIncomeExpenseBreakdownResponse>(
-        `/insights/income-expense-breakdown?from_date=${encodeURIComponent(fromDate)}&to_date=${encodeURIComponent(toDate)}`,
+        `/insights/income-expense-breakdown?${rangeQueryString(fromDate, toDate, comparisonPeriod)}`,
       ),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
     staleTime: 5 * 60 * 1000,
@@ -137,7 +159,7 @@ export function useInsightsCashFlow(fromDate: string, toDate: string, enabled = 
     queryKey: insightsKeys.cashFlow(fromDate, toDate),
     queryFn: () =>
       authenticatedFetch<InsightsCashFlowResponse>(
-        `/insights/cash-flow?from_date=${encodeURIComponent(fromDate)}&to_date=${encodeURIComponent(toDate)}`,
+        `/insights/cash-flow?${rangeQueryString(fromDate, toDate)}`,
       ),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
     staleTime: 5 * 60 * 1000,
@@ -150,20 +172,25 @@ export function useInsightsFundFlow(fromDate: string, toDate: string, enabled = 
     queryKey: insightsKeys.fundFlow(fromDate, toDate),
     queryFn: () =>
       authenticatedFetch<InsightsFundFlowResponse>(
-        `/insights/fund-flow?from_date=${encodeURIComponent(fromDate)}&to_date=${encodeURIComponent(toDate)}`,
+        `/insights/fund-flow?${rangeQueryString(fromDate, toDate)}`,
       ),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
     staleTime: 5 * 60 * 1000,
   });
 }
 
-export function useInsightsMerchants(fromDate: string, toDate: string, enabled = true) {
+export function useInsightsMerchants(
+  fromDate: string,
+  toDate: string,
+  comparisonPeriod: InsightsComparisonPeriod = 'same_length',
+  enabled = true,
+) {
   const { accessToken } = useAuth();
   return useQuery({
-    queryKey: insightsKeys.merchants(fromDate, toDate),
+    queryKey: insightsKeys.merchants(fromDate, toDate, comparisonPeriod),
     queryFn: () =>
       authenticatedFetch<InsightsMerchantsResponse>(
-        `/insights/merchants?from_date=${encodeURIComponent(fromDate)}&to_date=${encodeURIComponent(toDate)}`,
+        `/insights/merchants?${rangeQueryString(fromDate, toDate, comparisonPeriod)}`,
       ),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
     staleTime: 5 * 60 * 1000,

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -75,11 +75,13 @@ export const dashboardKeys = {
 
 export const insightsKeys = {
   periodGlanceAll: ['insights-period-glance'] as const,
-  periodGlance: (fromDate: string, toDate: string) => ['insights-period-glance', fromDate, toDate] as const,
+  periodGlance: (fromDate: string, toDate: string, comparisonPeriod = 'same_length') =>
+    ['insights-period-glance', fromDate, toDate, comparisonPeriod] as const,
   fundFlowAll: ['insights-fund-flow'] as const,
   fundFlow: (fromDate: string, toDate: string) => ['insights-fund-flow', fromDate, toDate] as const,
   incomeExpenseBreakdownAll: ['insights-income-expense-breakdown'] as const,
-  incomeExpenseBreakdown: (fromDate: string, toDate: string) => ['insights-income-expense-breakdown', fromDate, toDate] as const,
+  incomeExpenseBreakdown: (fromDate: string, toDate: string, comparisonPeriod = 'same_length') =>
+    ['insights-income-expense-breakdown', fromDate, toDate, comparisonPeriod] as const,
   cashFlowAll: ['insights-cash-flow'] as const,
   cashFlow: (fromDate: string, toDate: string) => ['insights-cash-flow', fromDate, toDate] as const,
   netWorthAll: ['insights-net-worth'] as const,
@@ -87,7 +89,8 @@ export const insightsKeys = {
   savingsRateTrendAll: ['insights-savings-rate-trend'] as const,
   savingsRateTrend: () => ['insights-savings-rate-trend'] as const,
   merchantsAll: ['insights-merchants'] as const,
-  merchants: (fromDate: string, toDate: string) => ['insights-merchants', fromDate, toDate] as const,
+  merchants: (fromDate: string, toDate: string, comparisonPeriod = 'same_length') =>
+    ['insights-merchants', fromDate, toDate, comparisonPeriod] as const,
 };
 
 export const budgetKeys = {

--- a/frontend/src/insights/InsightsPage.tsx
+++ b/frontend/src/insights/InsightsPage.tsx
@@ -44,6 +44,7 @@ export default function InsightsPage() {
   const [merchantRankingCardRef, merchantRankingCardVisible] = useInsightCardVisibility()
   const queries = useInsightsCardQueries({
     rangeInputDates: range.rangeInputDates,
+    comparisonPeriod: range.comparisonPeriod,
     cardQueriesEnabled: range.cardQueriesEnabled,
     visibility: {
       periodGlance: periodGlanceCardVisible,

--- a/frontend/src/insights/hooks/useInsightsCardQueries.ts
+++ b/frontend/src/insights/hooks/useInsightsCardQueries.ts
@@ -7,7 +7,7 @@ import {
   useInsightsPeriodGlance,
   useInsightsSavingsRateTrend,
 } from '@/api/insights'
-import type { InsightsRangeInputDates } from '../types/range'
+import type { InsightsComparisonPeriod, InsightsRangeInputDates } from '../types/range'
 
 type InsightsCardQueryVisibility = {
   periodGlance: boolean
@@ -22,18 +22,21 @@ type InsightsCardQueryVisibility = {
 
 type UseInsightsCardQueriesParams = {
   rangeInputDates: InsightsRangeInputDates
+  comparisonPeriod: InsightsComparisonPeriod
   cardQueriesEnabled: boolean
   visibility: InsightsCardQueryVisibility
 }
 
 export function useInsightsCardQueries({
   rangeInputDates,
+  comparisonPeriod,
   cardQueriesEnabled,
   visibility,
 }: UseInsightsCardQueriesParams) {
   const periodGlance = useInsightsPeriodGlance(
     rangeInputDates.from,
     rangeInputDates.to,
+    comparisonPeriod,
     cardQueriesEnabled && visibility.periodGlance,
   )
   const fundFlow = useInsightsFundFlow(
@@ -44,6 +47,7 @@ export function useInsightsCardQueries({
   const incomeExpenseBreakdown = useInsightsIncomeExpenseBreakdown(
     rangeInputDates.from,
     rangeInputDates.to,
+    comparisonPeriod,
     cardQueriesEnabled && visibility.breakdown,
   )
   const netWorth = useInsightsNetWorth(
@@ -59,6 +63,7 @@ export function useInsightsCardQueries({
   const merchants = useInsightsMerchants(
     rangeInputDates.from,
     rangeInputDates.to,
+    comparisonPeriod,
     cardQueriesEnabled && (visibility.merchantDistribution || visibility.merchantRanking),
   )
   const savingsRateTrend = useInsightsSavingsRateTrend(visibility.savingsRate)

--- a/frontend/src/insights/hooks/useInsightsRange.ts
+++ b/frontend/src/insights/hooks/useInsightsRange.ts
@@ -1,8 +1,10 @@
 import { useMemo, useState } from 'react'
-import type { InsightsRangeInputDates, InsightsRangePreset } from '../types/range'
+import type { InsightsComparisonPeriod, InsightsRangeInputDates, InsightsRangePreset } from '../types/range'
 import {
   getCustomRangeDays,
   getDefaultCustomRange,
+  getRangeComparisonPeriod,
+  getRangeDisplayDates,
   getRangeInputDates,
 } from '../utils/range'
 
@@ -16,6 +18,7 @@ export type InsightsRangeState = {
   commitCustomRange: () => void
   customInvalid: boolean
   rangeInputDates: InsightsRangeInputDates
+  comparisonPeriod: InsightsComparisonPeriod
   cardTransitionKey: string
   cardQueriesEnabled: boolean
 }
@@ -26,18 +29,23 @@ export function useInsightsRange(): InsightsRangeState {
     () => getRangeInputDates('THIS_MONTH', defaultCustomRange.from, defaultCustomRange.to),
     [defaultCustomRange],
   )
+  const initialRangeDisplayDates = useMemo(
+    () => getRangeDisplayDates('THIS_MONTH', defaultCustomRange.from, defaultCustomRange.to),
+    [defaultCustomRange],
+  )
   const [rangePreset, setRangePresetState] = useState<InsightsRangePreset>('THIS_MONTH')
   const [committedCustomFrom, setCommittedCustomFrom] = useState(defaultCustomRange.from)
   const [committedCustomTo, setCommittedCustomTo] = useState(defaultCustomRange.to)
-  const [customFrom, setCustomFromState] = useState(initialRangeInputDates.from)
-  const [customTo, setCustomToState] = useState(initialRangeInputDates.to)
+  const [customFrom, setCustomFromState] = useState(initialRangeDisplayDates.from)
+  const [customTo, setCustomToState] = useState(initialRangeDisplayDates.to)
   const [rangeInputDates, setRangeInputDates] = useState<InsightsRangeInputDates>(initialRangeInputDates)
+  const [comparisonPeriod, setComparisonPeriod] = useState<InsightsComparisonPeriod>(getRangeComparisonPeriod('THIS_MONTH'))
 
   const customInvalid = rangePreset === 'CUSTOM'
     && customFrom !== ''
     && customTo !== ''
     && getCustomRangeDays(customFrom, customTo) === null
-  const cardTransitionKey = `${rangeInputDates.from}:${rangeInputDates.to}`
+  const cardTransitionKey = `${rangeInputDates.from}:${rangeInputDates.to}:${comparisonPeriod}`
   const cardQueriesEnabled = rangeInputDates.from !== '' && rangeInputDates.to !== ''
 
   function setRangePreset(value: InsightsRangePreset) {
@@ -48,13 +56,16 @@ export function useInsightsRange(): InsightsRangeState {
       setCustomFromState(nextRange.from)
       setCustomToState(nextRange.to)
       setRangeInputDates(nextRange)
+      setComparisonPeriod(getRangeComparisonPeriod(value))
       return
     }
 
-    const nextRange = getRangeInputDates(value, committedCustomFrom, committedCustomTo)
-    setCustomFromState(nextRange.from)
-    setCustomToState(nextRange.to)
-    setRangeInputDates(nextRange)
+    const nextInputRange = getRangeInputDates(value, committedCustomFrom, committedCustomTo)
+    const nextDisplayRange = getRangeDisplayDates(value, committedCustomFrom, committedCustomTo)
+    setCustomFromState(nextDisplayRange.from)
+    setCustomToState(nextDisplayRange.to)
+    setRangeInputDates(nextInputRange)
+    setComparisonPeriod(getRangeComparisonPeriod(value))
   }
 
   function setCustomFrom(value: string) {
@@ -75,6 +86,7 @@ export function useInsightsRange(): InsightsRangeState {
     setCommittedCustomFrom(customFrom)
     setCommittedCustomTo(customTo)
     setRangeInputDates({ from: customFrom, to: customTo })
+    setComparisonPeriod(getRangeComparisonPeriod('CUSTOM'))
   }
 
   return {
@@ -87,6 +99,7 @@ export function useInsightsRange(): InsightsRangeState {
     commitCustomRange,
     customInvalid,
     rangeInputDates,
+    comparisonPeriod,
     cardTransitionKey,
     cardQueriesEnabled,
   }

--- a/frontend/src/insights/types/range.ts
+++ b/frontend/src/insights/types/range.ts
@@ -1,5 +1,7 @@
 export type InsightsRangePreset = 'THIS_MONTH' | 'LAST_MONTH' | 'LAST_30_DAYS' | 'LAST_90_DAYS' | 'THIS_YEAR' | 'CUSTOM'
 
+export type InsightsComparisonPeriod = 'same_length' | 'previous_month' | 'previous_year'
+
 export type InsightsRangeInputDates = {
   from: string
   to: string

--- a/frontend/src/insights/utils/range.ts
+++ b/frontend/src/insights/utils/range.ts
@@ -1,54 +1,68 @@
-import type { InsightsRangeInputDates, InsightsRangePreset } from '../types/range'
+import type { InsightsComparisonPeriod, InsightsRangeInputDates, InsightsRangePreset } from '../types/range'
 import {
   addDays,
   formatYmd,
   parseYmd,
 } from './date'
 
-function getRangeDates(preset: InsightsRangePreset, customFrom: string, customTo: string) {
-  if (preset === 'CUSTOM') {
-    const fromDate = parseYmd(customFrom)
-    const toDate = parseYmd(customTo)
-    if (fromDate && toDate && fromDate <= toDate) {
-      const dates: Date[] = []
-      let cursor = fromDate
-      while (cursor <= toDate) {
-        dates.push(cursor)
-        cursor = addDays(cursor, 1)
-      }
-      return dates
-    }
-  }
-
+function getEffectiveRangeBounds(
+  preset: InsightsRangePreset,
+  customFrom: string,
+  customTo: string,
+): { start: Date; end: Date } {
   const today = new Date()
-  const rangeBoundary = (() => {
-    switch (preset) {
-      case 'THIS_MONTH':
-        return { start: new Date(today.getFullYear(), today.getMonth(), 1), end: today }
-      case 'THIS_YEAR':
-        return { start: new Date(today.getFullYear(), 0, 1), end: today }
-      case 'LAST_MONTH': {
-        const start = new Date(today.getFullYear(), today.getMonth() - 1, 1)
-        return { start, end: new Date(today.getFullYear(), today.getMonth(), 0) }
-      }
-      case 'LAST_30_DAYS':
-        return { start: addDays(today, -29), end: today }
-      case 'LAST_90_DAYS':
-        return { start: addDays(today, -89), end: today }
-      case 'CUSTOM':
-        return { start: addDays(today, -29), end: today }
-      default:
-        return { start: addDays(today, -29), end: today }
-    }
-  })()
 
-  const dates: Date[] = []
-  let cursor = rangeBoundary.start
-  while (cursor <= rangeBoundary.end) {
-    dates.push(cursor)
-    cursor = addDays(cursor, 1)
+  switch (preset) {
+    case 'THIS_MONTH':
+      return { start: new Date(today.getFullYear(), today.getMonth(), 1), end: today }
+    case 'THIS_YEAR':
+      return { start: new Date(today.getFullYear(), 0, 1), end: today }
+    case 'LAST_MONTH': {
+      const start = new Date(today.getFullYear(), today.getMonth() - 1, 1)
+      return { start, end: new Date(today.getFullYear(), today.getMonth(), 0) }
+    }
+    case 'LAST_30_DAYS':
+      return { start: addDays(today, -29), end: today }
+    case 'LAST_90_DAYS':
+      return { start: addDays(today, -89), end: today }
+    case 'CUSTOM': {
+      const fromDate = parseYmd(customFrom)
+      const toDate = parseYmd(customTo)
+      if (fromDate && toDate && fromDate <= toDate) {
+        return { start: fromDate, end: toDate }
+      }
+      return { start: addDays(today, -29), end: today }
+    }
+    default:
+      return { start: addDays(today, -29), end: today }
   }
-  return dates
+}
+
+function getDisplayRangeBounds(
+  preset: InsightsRangePreset,
+  customFrom: string,
+  customTo: string,
+): { start: Date; end: Date } {
+  const today = new Date()
+
+  switch (preset) {
+    case 'THIS_MONTH':
+      return {
+        start: new Date(today.getFullYear(), today.getMonth(), 1),
+        end: new Date(today.getFullYear(), today.getMonth() + 1, 0),
+      }
+    case 'THIS_YEAR':
+      return {
+        start: new Date(today.getFullYear(), 0, 1),
+        end: new Date(today.getFullYear(), 11, 31),
+      }
+    default:
+      return getEffectiveRangeBounds(preset, customFrom, customTo)
+  }
+}
+
+function formatRangeBounds({ start, end }: { start: Date; end: Date }): InsightsRangeInputDates {
+  return { from: formatYmd(start), to: formatYmd(end) }
 }
 
 export function getDefaultCustomRange(): InsightsRangeInputDates {
@@ -71,15 +85,25 @@ export function getRangeInputDates(
   customFrom: string,
   customTo: string,
 ): InsightsRangeInputDates {
-  if (preset === 'CUSTOM') {
-    return { from: customFrom, to: customTo }
-  }
+  return formatRangeBounds(getEffectiveRangeBounds(preset, customFrom, customTo))
+}
 
-  const dates = getRangeDates(preset, customFrom, customTo)
-  const firstDate = dates[0]
-  const lastDate = dates.at(-1)
-  return {
-    from: firstDate ? formatYmd(firstDate) : customFrom,
-    to: lastDate ? formatYmd(lastDate) : customTo,
+export function getRangeDisplayDates(
+  preset: InsightsRangePreset,
+  customFrom: string,
+  customTo: string,
+): InsightsRangeInputDates {
+  return formatRangeBounds(getDisplayRangeBounds(preset, customFrom, customTo))
+}
+
+export function getRangeComparisonPeriod(preset: InsightsRangePreset): InsightsComparisonPeriod {
+  switch (preset) {
+    case 'THIS_MONTH':
+    case 'LAST_MONTH':
+      return 'previous_month'
+    case 'THIS_YEAR':
+      return 'previous_year'
+    default:
+      return 'same_length'
   }
 }


### PR DESCRIPTION
- Compare MTD and last-month Insights deltas against the previous calendar month
- Compare YTD Insights deltas against the previous calendar year
- Show full calendar bounds for MTD and YTD in the Insights range selector while still calculating the current period through today
- Leave the behaviour of 30D, 90D, and custom ranges unchanged

CU-86baa6m18
CU-86baaefuk