### PR TITLE
fix: stabilize settings secondary menu

### DIFF
--- a/frontend/src/components/CreateCategoryModal.tsx
+++ b/frontend/src/components/CreateCategoryModal.tsx
@@ -5,6 +5,7 @@ import { AnimatePresence, motion } from 'motion/react'
 import { Tag, X } from 'lucide-react'
 import { useCreateCategory, type Category } from '@/api/categories'
 import Dropdown from '@/components/Dropdown'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 
 type CategoryKind = Category['kind']
 type CreateCategoryField = 'icon' | 'name'
@@ -127,11 +128,7 @@ export default function CreateCategoryModal({
   const isCreating = createCategory.isPending || createInProgress
   const isSecondary = variant === 'secondary'
 
-  useEffect(() => {
-    if (!open || isSecondary) return
-    document.body.style.overflow = 'hidden'
-    return () => { document.body.style.overflow = '' }
-  }, [isSecondary, open])
+  useBodyScrollLock(open && !isSecondary)
 
   useEffect(() => {
     if (!open) return

--- a/frontend/src/components/CreateMerchantModal.tsx
+++ b/frontend/src/components/CreateMerchantModal.tsx
@@ -5,6 +5,7 @@ import { Store, X } from 'lucide-react'
 import { ApiError } from '@/api/auth'
 import { useCreateMerchant, type Merchant } from '@/api/merchants'
 import Dropdown, { type DropdownOption } from '@/components/Dropdown'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 
 const EASE = [0.25, 0.1, 0.25, 1] as const
 const CREATE_MERCHANT_MIN_LOADING_MS = 800
@@ -54,11 +55,7 @@ export default function CreateMerchantModal({
   const isCreating = createMerchant.isPending || createInProgress
   const isSecondary = variant === 'secondary'
 
-  useEffect(() => {
-    if (!open || isSecondary) return
-    document.body.style.overflow = 'hidden'
-    return () => { document.body.style.overflow = '' }
-  }, [isSecondary, open])
+  useBodyScrollLock(open && !isSecondary)
 
   useEffect(() => {
     if (!open) return

--- a/frontend/src/components/CreateTagModal.tsx
+++ b/frontend/src/components/CreateTagModal.tsx
@@ -4,6 +4,7 @@ import { AnimatePresence, motion } from 'motion/react'
 import { Tag as TagIcon, X } from 'lucide-react'
 import { ApiError } from '@/api/auth'
 import { useCreateTag, type Tag } from '@/api/tags'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 
 const EASE = [0.25, 0.1, 0.25, 1] as const
 const CREATE_TAG_MIN_LOADING_MS = 800
@@ -40,14 +41,7 @@ export default function CreateTagModal({
   const isSubmitting = createTag.isPending || createInProgress
   const isSecondary = variant === 'secondary'
 
-  useEffect(() => {
-    if (!open || isSecondary) return undefined
-
-    document.body.style.overflow = 'hidden'
-    return () => {
-      document.body.style.overflow = ''
-    }
-  }, [isSecondary, open])
+  useBodyScrollLock(open && !isSecondary)
 
   useEffect(() => {
     if (!open) return undefined

--- a/frontend/src/hooks/useBodyScrollLock.ts
+++ b/frontend/src/hooks/useBodyScrollLock.ts
@@ -1,0 +1,27 @@
+import { useEffect } from 'react'
+
+let lockCount = 0
+let previousOverflow = ''
+
+export function useBodyScrollLock(locked: boolean) {
+  useEffect(() => {
+    if (!locked) return undefined
+
+    if (lockCount === 0) {
+      previousOverflow = document.body.style.overflow
+      document.body.classList.add('app-body-scroll-locked')
+      document.body.style.overflow = 'hidden'
+    }
+
+    lockCount += 1
+
+    return () => {
+      lockCount -= 1
+      if (lockCount > 0) return
+
+      document.body.style.overflow = previousOverflow
+      document.body.classList.remove('app-body-scroll-locked')
+      previousOverflow = ''
+    }
+  }, [locked])
+}

--- a/frontend/src/settings/SettingsPage.tsx
+++ b/frontend/src/settings/SettingsPage.tsx
@@ -400,9 +400,10 @@ export default function SettingsPage() {
       </header>
 
       <div ref={mobileSettingsStickySentinelRef} aria-hidden className="h-px min-[1200px]:hidden" />
+      <div className="settings-mobile-section-menu-lock-spacer hidden min-[1200px]:hidden" aria-hidden />
 
       <div
-        className="sticky top-0 z-20 -mx-2 -mt-4 mb-4 px-2 pt-4 min-[1050px]:-mt-5 min-[1050px]:pt-5 min-[1200px]:hidden"
+        className="settings-mobile-section-menu-shell sticky top-0 z-20 -mx-2 -mt-4 mb-4 min-h-[3.75rem] px-2 pt-4 min-[1050px]:-mt-5 min-[1050px]:min-h-16 min-[1050px]:pt-5 min-[1200px]:hidden"
         style={{
           background: 'color-mix(in srgb, var(--app-bg) 72%, transparent)',
           backdropFilter: 'blur(10px)',

--- a/frontend/src/settings/SettingsPage.tsx
+++ b/frontend/src/settings/SettingsPage.tsx
@@ -482,7 +482,7 @@ export default function SettingsPage() {
       <div className="min-[1200px]:grid min-[1200px]:grid-cols-[260px_minmax(0,1fr)] min-[1200px]:gap-10 min-[1200px]:items-start">
         {/* Sidebar — sticky on desktop, hidden on mobile (sections just stack) */}
         <aside className="hidden w-[260px] self-stretch min-[1200px]:grid min-[1200px]:min-h-[calc(100vh-3rem)] min-[1200px]:grid-rows-[auto_minmax(0,1fr)_auto]">
-          <nav className="sticky top-6 row-start-1 space-y-0.5" aria-label="Settings sections">
+          <nav className="settings-desktop-section-nav sticky top-6 row-start-1 space-y-0.5" aria-label="Settings sections">
           {SETTINGS_SECTIONS.map((s) => {
               const Icon = s.icon
               const isActive = activeSection === s.id

--- a/frontend/src/settings/SettingsPage.tsx
+++ b/frontend/src/settings/SettingsPage.tsx
@@ -481,8 +481,8 @@ export default function SettingsPage() {
 
       <div className="min-[1200px]:grid min-[1200px]:grid-cols-[260px_minmax(0,1fr)] min-[1200px]:gap-10 min-[1200px]:items-start">
         {/* Sidebar — sticky on desktop, hidden on mobile (sections just stack) */}
-        <aside className="sticky top-6 hidden min-[1200px]:block">
-          <nav className="space-y-0.5" aria-label="Settings sections">
+        <aside className="hidden w-[260px] self-stretch min-[1200px]:grid min-[1200px]:min-h-[calc(100vh-3rem)] min-[1200px]:grid-rows-[auto_minmax(0,1fr)_auto]">
+          <nav className="sticky top-6 row-start-1 space-y-0.5" aria-label="Settings sections">
           {SETTINGS_SECTIONS.map((s) => {
               const Icon = s.icon
               const isActive = activeSection === s.id
@@ -500,7 +500,7 @@ export default function SettingsPage() {
             })}
 
           </nav>
-          <div className="fixed bottom-6 left-[calc(260px+1.5rem)] w-[260px]">
+          <div className="sticky bottom-6 row-start-3">
             <button
               type="button"
               onClick={() => navigate('/settings/imports')}

--- a/frontend/src/settings/components/CategorySettingsSection/MergeDeleteCategoryModal.tsx
+++ b/frontend/src/settings/components/CategorySettingsSection/MergeDeleteCategoryModal.tsx
@@ -4,6 +4,7 @@ import { motion } from 'motion/react'
 import { Tag, X } from 'lucide-react'
 import type { Category } from '@/api/categories'
 import Dropdown from '@/components/Dropdown'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import {
   DELETE_SPINNER_MS,
   EASE,
@@ -35,14 +36,14 @@ export default function MergeDeleteCategoryModal({
     : options[0]?.value ?? ''
   const isSubmitting = isPending || mergeInProgress
 
+  useBodyScrollLock(true)
+
   useEffect(() => {
-    document.body.style.overflow = 'hidden'
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && !isSubmitting) onClose()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => {
-      document.body.style.overflow = ''
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [isSubmitting, onClose])

--- a/frontend/src/settings/components/MerchantSettingsSection/MergeDeleteMerchantModal.tsx
+++ b/frontend/src/settings/components/MerchantSettingsSection/MergeDeleteMerchantModal.tsx
@@ -7,6 +7,7 @@ import {
   type Merchant,
 } from '@/api/merchants'
 import Dropdown from '@/components/Dropdown'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import {
   DELETE_SPINNER_MS,
   EASE,
@@ -52,14 +53,14 @@ export default function MergeDeleteMerchantModal({
     : options[0]?.value ?? ''
   const isSubmitting = isPending || mergeInProgress
 
+  useBodyScrollLock(true)
+
   useEffect(() => {
-    document.body.style.overflow = 'hidden'
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && !isSubmitting) onClose()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => {
-      document.body.style.overflow = ''
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [isSubmitting, onClose])

--- a/frontend/src/settings/components/TagSettingsSection/MergeDeleteTagModal.tsx
+++ b/frontend/src/settings/components/TagSettingsSection/MergeDeleteTagModal.tsx
@@ -4,6 +4,7 @@ import { Tag as TagIcon, X } from 'lucide-react'
 import { motion } from 'motion/react'
 import { useInfiniteTags, type Tag } from '@/api/tags'
 import Dropdown from '@/components/Dropdown'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import {
   DELETE_SPINNER_MS,
   EASE,
@@ -49,14 +50,14 @@ export default function MergeDeleteTagModal({
     : options[0]?.value ?? ''
   const isSubmitting = isPending || mergeInProgress
 
+  useBodyScrollLock(true)
+
   useEffect(() => {
-    document.body.style.overflow = 'hidden'
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && !isSubmitting) onClose()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => {
-      document.body.style.overflow = ''
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [isSubmitting, onClose])

--- a/frontend/src/settings/components/TagSettingsSection/TagCreateModal.tsx
+++ b/frontend/src/settings/components/TagSettingsSection/TagCreateModal.tsx
@@ -4,6 +4,7 @@ import { Tag as TagIcon, X } from 'lucide-react'
 import { AnimatePresence, motion } from 'motion/react'
 import { ApiError } from '@/api/auth'
 import { useCreateTag, type Tag } from '@/api/tags'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import {
   CREATE_TAG_MIN_LOADING_MS,
   EASE,
@@ -25,16 +26,16 @@ export default function TagCreateModal({
   const [createInProgress, setCreateInProgress] = useState(false)
   const isSubmitting = createTag.isPending || createInProgress
 
+  useBodyScrollLock(open)
+
   useEffect(() => {
     if (!open) return undefined
 
-    document.body.style.overflow = 'hidden'
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape' && !isSubmitting) onClose()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => {
-      document.body.style.overflow = ''
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [isSubmitting, onClose, open])

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/CreateTaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/CreateTaxAdvantagedCategoryModal.tsx
@@ -6,6 +6,7 @@ import { Landmark, X } from 'lucide-react'
 import type { Currency } from '@/api/currency'
 import { useCreateTaxAdvantagedPlan, type TaxTreatment } from '@/api/taxAdvantagedPlans'
 import Dropdown from '@/components/Dropdown'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import type { TaxPlanFormState } from '@/settings/components/tax-advantaged/taxAdvantagedTypes'
 import {
   CREATE_TAX_CATEGORY_MIN_LOADING_MS,
@@ -45,14 +46,14 @@ export default function CreateTaxAdvantagedCategoryModal({
   const options = useMemo(() => currencyOptions(currencies), [currencies])
   const isCreating = createPlan.isPending || createInProgress
 
+  useBodyScrollLock(true)
+
   useEffect(() => {
-    document.body.style.overflow = 'hidden'
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onClose()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => {
-      document.body.style.overflow = ''
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [onClose])

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -16,6 +16,7 @@ import {
 import ActionFeedbackButton from '@/components/ActionFeedbackButton'
 import Dropdown from '@/components/Dropdown'
 import IconTooltip from '@/components/IconTooltip'
+import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import { formatCurrency } from '@/utils/formatCurrency'
 import type {
   AutosaveNotice,
@@ -151,14 +152,14 @@ export default function TaxAdvantagedCategoryModal({
     }
   }
 
+  useBodyScrollLock(true)
+
   useEffect(() => {
-    document.body.style.overflow = 'hidden'
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') onClose()
     }
     window.addEventListener('keydown', onKeyDown)
     return () => {
-      document.body.style.overflow = ''
       window.removeEventListener('keydown', onKeyDown)
     }
   }, [onClose])

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -181,6 +181,14 @@
     color: var(--app-accent);
   }
 
+  @media (min-width: 1200px) {
+    .app-body-scroll-locked .settings-desktop-section-nav {
+      position: fixed;
+      top: 1.5rem;
+      width: 260px;
+    }
+  }
+
   .app-input {
     @apply h-10 min-w-0 w-full rounded-lg border px-4 py-0 outline-none transition-colors duration-200;
     font-size: 0.9375rem;

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -189,6 +189,36 @@
     }
   }
 
+  @media (max-width: 1049.98px) {
+    .app-body-scroll-locked .settings-mobile-section-menu-lock-spacer {
+      display: block;
+      height: 3.75rem;
+    }
+
+    .app-body-scroll-locked .settings-mobile-section-menu-shell {
+      position: fixed;
+      top: 0;
+      left: 0.5rem;
+      right: 0.5rem;
+      margin: 0;
+    }
+  }
+
+  @media (min-width: 1050px) and (max-width: 1199.98px) {
+    .app-body-scroll-locked .settings-mobile-section-menu-lock-spacer {
+      display: block;
+      height: 3.75rem;
+    }
+
+    .app-body-scroll-locked .settings-mobile-section-menu-shell {
+      position: fixed;
+      top: 0;
+      left: calc(260px + 1rem);
+      right: 1rem;
+      margin: 0;
+    }
+  }
+
   .app-input {
     @apply h-10 min-w-0 w-full rounded-lg border px-4 py-0 outline-none transition-colors duration-200;
     font-size: 0.9375rem;


### PR DESCRIPTION
- Keeps the settings Import action aligned with the secondary menu instead of snapping in separately
- Preserves desktop secondary menu position when settings modals lock page scrolling
- Keeps the mobile settings dropdown stable during modal open without changing width or shifting page content