### PR TITLE
fix: include archived account history in runway

### DIFF
--- a/backend/app/routes/runway/account_helpers.py
+++ b/backend/app/routes/runway/account_helpers.py
@@ -27,22 +27,21 @@ def get_runway_thresholds_from_user(user: User) -> RunwayThresholds:
     return thresholds
 
 
-async def get_readable_non_archived_accounts_for_runway(
+async def get_readable_accounts_for_runway(
     db: AsyncSession,
     user: User,
 ) -> list[Account]:
-    """Return readable non-archived accounts for runway calculations
+    """Return readable accounts for runway calculations
 
     Args:
         db: Active database session
         user: Authenticated user
 
     Returns:
-        Readable non-archived accounts
+        Readable accounts
     """
     readable_accounts = await get_accessible_accounts(db, user, include_archived=True)
-    non_archived_accounts = [account for account in readable_accounts if not account.is_archived]
-    return non_archived_accounts
+    return readable_accounts
 
 
 async def get_runway_account_ids_by_archive_state(

--- a/backend/app/routes/runway/response_helpers.py
+++ b/backend/app/routes/runway/response_helpers.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.user import User
 from app.routes.runway.account_helpers import (
     get_active_runway_account_ids,
-    get_readable_non_archived_accounts_for_runway,
+    get_readable_accounts_for_runway,
     get_runway_thresholds_from_user,
 )
 from app.routes.runway.expense_helpers import (
@@ -43,7 +43,7 @@ async def get_runway_response(
     Returns:
         Cash runway response for the user
     """
-    readable_accounts = await get_readable_non_archived_accounts_for_runway(db, user)
+    readable_accounts = await get_readable_accounts_for_runway(db, user)
     account_by_id = {account.id: account for account in readable_accounts}
     readable_account_ids = set(account_by_id)
     active_runway_account_ids = await get_active_runway_account_ids(db, user)

--- a/backend/tests/routes/runway/test_runway.py
+++ b/backend/tests/routes/runway/test_runway.py
@@ -262,8 +262,8 @@ async def test_get_runway_includes_threshold_settings(client):
     assert resp.json()["thresholds"] == {"risky_below_months": 2, "healthy_at_months": 8}
 
 
-async def test_archived_runway_selection_is_inactive_but_restorable(client, monkeypatch):
-    """Archived selected accounts are omitted from runway responses without deleting the stored pick."""
+async def test_archived_runway_selection_excludes_current_balance_but_keeps_history(client, monkeypatch):
+    """Archived selected accounts keep historical expenses while their current balance stays inactive"""
     from app.routes.users import date_helpers as user_routes
 
     class FixedDateTime(datetime):
@@ -339,7 +339,8 @@ async def test_archived_runway_selection_is_inactive_but_restorable(client, monk
     assert archived_runway["liquid_balance"] == 120_000
     assert archived_runway["account_balances"] == [{"account_id": visible_account_id, "balance": 120_000}]
     assert archived_runway["months_covered"] == 1
-    assert archived_runway["avg_monthly_expense"] == 12_000
+    assert archived_runway["avg_monthly_expense"] == 36_000
+    assert archived_runway["months"] == pytest.approx(120_000 / 36_000)
 
     await client.patch(f"/accounts/{archived_account_id}", json={"is_archived": False}, headers=headers)
 


### PR DESCRIPTION
- Keeps archived (and accessible) accounts in the runway historical expense's scope
- Updates the runway tests related to archived accounts for the corrected behaviour

CU-86bab3nck