### PR TITLE
fix: align tax advantaged category API and schema

### DIFF
--- a/backend/alembic/versions/2b6c4a9f1e32_rename_tax_advantaged_plans_to_categories.py
+++ b/backend/alembic/versions/2b6c4a9f1e32_rename_tax_advantaged_plans_to_categories.py
@@ -8,8 +8,8 @@ Create Date: 2026-06-10 00:00:00.000000
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-from alembic import op
 
+from alembic import op
 
 revision: str = "2b6c4a9f1e32"
 down_revision: str | Sequence[str] | None = "c9e5d4a1b2f0"
@@ -21,6 +21,8 @@ def upgrade() -> None:
     """Rename TAC storage to tax-advantaged category naming"""
     op.rename_table("tax_advantaged_plans", "tax_advantaged_categories")
     op.rename_table("tax_advantaged_plan_limits", "tax_advantaged_category_limits")
+
+    # Rename the account link so storage matches the tax-advantaged category API
     op.alter_column(
         "accounts",
         "tax_advantaged_plan_id",
@@ -28,6 +30,8 @@ def upgrade() -> None:
         existing_type=sa.UUID(),
         existing_nullable=True,
     )
+
+    # Rename the limit link so storage matches the tax-advantaged category API
     op.alter_column(
         "tax_advantaged_category_limits",
         "plan_id",
@@ -36,9 +40,28 @@ def upgrade() -> None:
         existing_nullable=False,
     )
 
+    # Rename the owner foreign key so storage matches the tax-advantaged category API
+    op.alter_column(
+        "tax_advantaged_categories",
+        "plan_owner_user_id",
+        new_column_name="category_owner_user_id",
+        existing_type=sa.UUID(),
+        existing_nullable=False,
+    )
+
 
 def downgrade() -> None:
     """Rename TAC storage back to tax-advantaged plan naming"""
+    # Restore the prior owner foreign key name used by the plan storage
+    op.alter_column(
+        "tax_advantaged_categories",
+        "category_owner_user_id",
+        new_column_name="plan_owner_user_id",
+        existing_type=sa.UUID(),
+        existing_nullable=False,
+    )
+
+    # Restore the prior limit link name used by the plan storage
     op.alter_column(
         "tax_advantaged_category_limits",
         "tax_advantaged_category_id",
@@ -46,6 +69,8 @@ def downgrade() -> None:
         existing_type=sa.UUID(),
         existing_nullable=False,
     )
+
+    # Restore the prior account link name used by the plan storage
     op.alter_column(
         "accounts",
         "tax_advantaged_category_id",

--- a/backend/tests/migrations/test_schema_parity.py
+++ b/backend/tests/migrations/test_schema_parity.py
@@ -1,0 +1,145 @@
+"""Alembic schema parity tests"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.models.base import Base
+from tests.conftest import (
+    TEST_DB_HOST,
+    TEST_DB_PASSWORD,
+    TEST_DB_PORT,
+    TEST_DB_USER,
+    WORKER_DB_NAME,
+)
+
+_BACKEND_DIR = Path(__file__).resolve().parents[2]
+_ALEMBIC_TEST_DB_NAME = f"{WORKER_DB_NAME}_alembic_schema"
+
+
+async def test_alembic_schema_columns_match_model_metadata() -> None:
+    """Verify Alembic creates the same table columns expected by the models"""
+    await _recreate_database(_ALEMBIC_TEST_DB_NAME)
+    try:
+        _run_alembic_upgrade(_ALEMBIC_TEST_DB_NAME)
+        actual_columns = await _get_database_columns(_ALEMBIC_TEST_DB_NAME)
+        expected_columns = _get_model_columns()
+        assert actual_columns == expected_columns
+    finally:
+        await _drop_database(_ALEMBIC_TEST_DB_NAME)
+
+
+async def _recreate_database(database_name: str) -> None:
+    """Drop and recreate the database used for Alembic schema parity"""
+    maintenance_engine = _create_engine_for_database("postgres", isolation_level="AUTOCOMMIT")
+    try:
+        async with maintenance_engine.connect() as conn:
+            await _terminate_database_connections(conn, database_name)
+
+            # Drop any stale parity database left by an interrupted test run
+            await conn.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+
+            # Create a clean database that Alembic will build from its base revision
+            await conn.execute(text(f'CREATE DATABASE "{database_name}"'))
+    finally:
+        await maintenance_engine.dispose()
+
+
+async def _drop_database(database_name: str) -> None:
+    """Drop the database used for Alembic schema parity"""
+    maintenance_engine = _create_engine_for_database("postgres", isolation_level="AUTOCOMMIT")
+    try:
+        async with maintenance_engine.connect() as conn:
+            await _terminate_database_connections(conn, database_name)
+
+            # Drop the parity database so repeated test runs start clean
+            await conn.execute(text(f'DROP DATABASE IF EXISTS "{database_name}"'))
+    finally:
+        await maintenance_engine.dispose()
+
+
+async def _terminate_database_connections(conn: AsyncConnection, database_name: str) -> None:
+    """Terminate open connections to a generated parity database"""
+    # Close active connections so PostgreSQL can drop the generated database
+    await conn.execute(
+        text(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = :database_name
+              AND pid <> pg_backend_pid()
+            """,
+        ),
+        {"database_name": database_name},
+    )
+
+
+def _run_alembic_upgrade(database_name: str) -> None:
+    """Run Alembic upgrade head against a generated parity database"""
+    environment = os.environ.copy()
+    environment.update(
+        {
+            "DB_HOST": TEST_DB_HOST,
+            "DB_PORT": TEST_DB_PORT,
+            "DB_NAME": database_name,
+            "DB_USER": TEST_DB_USER,
+            "DB_PASSWORD": TEST_DB_PASSWORD,
+        },
+    )
+
+    completed = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=_BACKEND_DIR,
+        env=environment,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+
+
+async def _get_database_columns(database_name: str) -> dict[str, set[str]]:
+    """Return public table columns from a generated parity database"""
+    engine = _create_engine_for_database(database_name)
+    try:
+        async with engine.connect() as conn:
+
+            # Fetch public schema columns created by Alembic for comparison with model metadata
+            result = await conn.execute(
+                text(
+                    """
+                    SELECT table_name, column_name
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name <> 'alembic_version'
+                    ORDER BY table_name, ordinal_position
+                    """,
+                ),
+            )
+            columns_by_table: dict[str, set[str]] = {}
+            for row in result:
+                columns_by_table.setdefault(row.table_name, set()).add(row.column_name)
+            return columns_by_table
+    finally:
+        await engine.dispose()
+
+
+def _get_model_columns() -> dict[str, set[str]]:
+    """Return SQLAlchemy model columns keyed by table name"""
+    columns_by_table = {
+        table.name: {column.name for column in table.columns}
+        for table in Base.metadata.sorted_tables
+    }
+    return columns_by_table
+
+
+def _create_engine_for_database(database_name: str, *, isolation_level: str | None = None):
+    """Create an async engine for a test database"""
+    database_url = f"postgresql+asyncpg://{TEST_DB_USER}:{TEST_DB_PASSWORD}@{TEST_DB_HOST}:{TEST_DB_PORT}/{database_name}"
+    engine = create_async_engine(database_url, poolclass=NullPool, isolation_level=isolation_level)
+    return engine

--- a/db/db.dbml
+++ b/db/db.dbml
@@ -156,9 +156,9 @@ Table account_balance_snapshots [note: "end-of-day balance records; backend-main
   ts timestamptz pk [not null, note: "midnight UTC of the snapshot's day"]
 }
 
-Table tax_advantaged_categories [note: "individual-owned limit trackers; group_id is household context, not pooled ownership"] {
+Table tax_advantaged_categories [note: "individual-owned limit trackers; group_id adds household context, not pooled ownership"] {
   id uuid pk
-  category_owner_user_id uuid [not null, ref: > users.id, note: "ON DELETE CASCADE"]
+  category_owner_user_id uuid [not null, ref: > users.id, note: "individual owner whose limits this category tracks; ON DELETE CASCADE"]
   group_id uuid [ref: > groups.id, note: "ON DELETE CASCADE"]
   name varchar(256) [not null]
   tax_treatment tax_treatment [not null, note: "must be non-taxable"]

--- a/db/schema-reference.md
+++ b/db/schema-reference.md
@@ -183,12 +183,12 @@ End-of-day balance records for historical charts and net worth tracking. Backend
 
 ### `tax_advantaged_categories`
 
-Individual-owned contribution/withdrawal limit trackers. `group_id` provides household visibility/context only; limits are not pooled.
+Individual-owned contribution/withdrawal limit trackers. `category_owner_user_id` is the person whose limits are tracked; `group_id` provides household context only, and limits are not pooled.
 
 | Column                        | Type         | Constraints                                 | Description                                         |
 | ----------------------------- | ------------ | ------------------------------------------- | --------------------------------------------------- |
 | `id`                          | uuid         | PK                                          |                                                     |
-| `category_owner_user_id`      | uuid         | NOT NULL, FK → `users.id` ON DELETE CASCADE | User whose limits this category tracks              |
+| `category_owner_user_id`      | uuid         | NOT NULL, FK → `users.id` ON DELETE CASCADE | Individual owner whose limits this category tracks  |
 | `group_id`                    | uuid         | FK → `groups.id` ON DELETE CASCADE          | Optional group context                              |
 | `name`                        | varchar(256) | NOT NULL                                    | User-facing category name, e.g. TFSA or RRSP        |
 | `tax_treatment`               | enum         | NOT NULL                                    | Must be non-`taxable`                               |

--- a/frontend/src/accounts/components/AccountRow.tsx
+++ b/frontend/src/accounts/components/AccountRow.tsx
@@ -80,8 +80,8 @@ export default function AccountRow({
         : account.current_balance < 0
           ? 'var(--app-negative)'
           : 'var(--app-text)'
-  const linkedPlan = account.group_id === null && account.tax_advantaged_plan_id
-    ? taxAdvantagedPlanById.get(account.tax_advantaged_plan_id)
+  const linkedPlan = account.group_id === null && account.tax_advantaged_category_id
+    ? taxAdvantagedPlanById.get(account.tax_advantaged_category_id)
     : undefined
   const metadataLabel = `${humanizeAccountType(account.account_type)}${account.institution ? ` · ${account.institution.name}` : ''}`
   const fxStatus = account.current_balance_fx_status

--- a/frontend/src/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/accounts/detail/AccountDetailPage.tsx
@@ -29,7 +29,7 @@ export default function AccountDetailPage() {
   const [deletedAccountSnapshot, setDeletedAccountSnapshot] = useState<Account | null>(null)
 
   const visibleAccount = account ?? (deleteExitPhase !== 'idle' ? deletedAccountSnapshot : null)
-  const linkedTaxAdvantagedPlanId = visibleAccount?.group_id === null ? visibleAccount.tax_advantaged_plan_id : null
+  const linkedTaxAdvantagedPlanId = visibleAccount?.group_id === null ? visibleAccount.tax_advantaged_category_id : null
   const {
     data: linkedTaxAdvantagedPlan,
     error: linkedTaxAdvantagedPlanError,

--- a/frontend/src/accounts/detail/components/AccountIdentityCard.tsx
+++ b/frontend/src/accounts/detail/components/AccountIdentityCard.tsx
@@ -191,7 +191,7 @@ export default function AccountIdentityCard({
   linkedTaxAdvantagedPlanError: unknown
   onEdit: () => void
 }) {
-  const linkedTaxAdvantagedPlanId = account.group_id === null ? account.tax_advantaged_plan_id : null
+  const linkedTaxAdvantagedPlanId = account.group_id === null ? account.tax_advantaged_category_id : null
   const closedLabel = account.closed_at
     ? ' · Closed ' + new Date(account.closed_at).toLocaleDateString()
     : ''

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -59,7 +59,7 @@ function FieldLabelRow({
 interface AccountIdentityForm {
   name: string
   institution_id: string
-  tax_advantaged_plan_id: string
+  tax_advantaged_category_id: string
   credit_limit: string
   is_archived: boolean
 }
@@ -133,7 +133,7 @@ export default function EditAccountIdentityModal({
   const [form, setForm] = useState<AccountIdentityForm>({
     name: account.name,
     institution_id: account.institution?.id ?? '',
-    tax_advantaged_plan_id: account.tax_advantaged_plan_id ?? '',
+    tax_advantaged_category_id: account.tax_advantaged_category_id ?? '',
     credit_limit: fromMinorUnits(account.credit_limit, currencies, account.currency),
     is_archived: account.is_archived,
   })
@@ -218,7 +218,7 @@ export default function EditAccountIdentityModal({
             ? { credit_limit: toMinorUnits(form.credit_limit, currencies, account.currency) }
             : {}),
           ...(canLinkTaxAdvantagedCategory
-            ? { tax_advantaged_plan_id: form.tax_advantaged_plan_id || null }
+            ? { tax_advantaged_category_id: form.tax_advantaged_category_id || null }
             : {}),
         },
       })
@@ -433,8 +433,8 @@ export default function EditAccountIdentityModal({
                                 <FieldLabelRow label="Tax-Advantaged Plan" />
                                 <Dropdown
                                   options={taxAdvantagedCategoryOptions}
-                                  value={form.tax_advantaged_plan_id}
-                                  onChange={(value) => setField('tax_advantaged_plan_id', value)}
+                                  value={form.tax_advantaged_category_id}
+                                  onChange={(value) => setField('tax_advantaged_category_id', value)}
                                   placeholder="Select plan..."
                                   searchable
                                   searchPlaceholder="Search plans..."

--- a/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
+++ b/frontend/src/accounts/detail/components/EditAccountIdentityModal.tsx
@@ -430,14 +430,14 @@ export default function EditAccountIdentityModal({
 
                             {canLinkTaxAdvantagedCategory && (
                               <div>
-                                <FieldLabelRow label="Tax-Advantaged Plan" />
+                                <FieldLabelRow label="Tax-Advantaged Category" />
                                 <Dropdown
                                   options={taxAdvantagedCategoryOptions}
                                   value={form.tax_advantaged_category_id}
                                   onChange={(value) => setField('tax_advantaged_category_id', value)}
-                                  placeholder="Select plan..."
+                                  placeholder="Select category..."
                                   searchable
-                                  searchPlaceholder="Search plans..."
+                                  searchPlaceholder="Search categories..."
                                 />
                               </div>
                             )}

--- a/frontend/src/accounts/hooks/useTaxAdvantagedLimitSummaries.ts
+++ b/frontend/src/accounts/hooks/useTaxAdvantagedLimitSummaries.ts
@@ -20,11 +20,11 @@ export function useTaxAdvantagedLimitSummaries({
   const linkedAccountCountByPlanId = useMemo(() => {
     const counts = new Map<string, number>()
     for (const account of rows) {
-      if (account.group_id !== null || !account.tax_advantaged_plan_id) continue
-      if (!taxAdvantagedPlanById.has(account.tax_advantaged_plan_id)) continue
+      if (account.group_id !== null || !account.tax_advantaged_category_id) continue
+      if (!taxAdvantagedPlanById.has(account.tax_advantaged_category_id)) continue
       counts.set(
-        account.tax_advantaged_plan_id,
-        (counts.get(account.tax_advantaged_plan_id) ?? 0) + 1,
+        account.tax_advantaged_category_id,
+        (counts.get(account.tax_advantaged_category_id) ?? 0) + 1,
       )
     }
     return counts
@@ -33,8 +33,8 @@ export function useTaxAdvantagedLimitSummaries({
   const taxAdvantagedLimitSummaries = useMemo<TaxAdvantagedLimitSummary[]>(() => {
     const visiblePlanIds = new Set<string>()
     for (const account of filteredRows) {
-      if (account.group_id !== null || !account.tax_advantaged_plan_id) continue
-      visiblePlanIds.add(account.tax_advantaged_plan_id)
+      if (account.group_id !== null || !account.tax_advantaged_category_id) continue
+      visiblePlanIds.add(account.tax_advantaged_category_id)
     }
 
     return (taxAdvantagedPlans ?? [])

--- a/frontend/src/api/accounts.ts
+++ b/frontend/src/api/accounts.ts
@@ -58,7 +58,7 @@ export interface AccountsOverview {
   group_id: string | null;
   account_kind: AccountKind;
   account_type: AccountType;
-  tax_advantaged_plan_id: string | null;
+  tax_advantaged_category_id: string | null;
   name: string;
   institution: Institution | null;
   currency: string;
@@ -103,7 +103,7 @@ export interface Account extends AccountsOverview {
 export interface CreateAccountPayload {
   account_kind: AccountKind;
   account_type: AccountType;
-  tax_advantaged_plan_id: string | null;
+  tax_advantaged_category_id: string | null;
   name: string;
   institution_id: string | null;
   currency: string;
@@ -113,7 +113,7 @@ export interface CreateAccountPayload {
 }
 
 export interface UpdateAccountPayload {
-  tax_advantaged_plan_id?: string | null;
+  tax_advantaged_category_id?: string | null;
   name?: string;
   institution_id?: string | null;
   credit_limit?: number | null;
@@ -190,7 +190,7 @@ function invalidateAccountTaxPlanData(
 function invalidateAccountAggregateData(
   queryClient: QueryClient,
   accountId: string,
-  account: Pick<AccountsOverview, 'account_kind' | 'tax_advantaged_plan_id'> | undefined,
+  account: Pick<AccountsOverview, 'account_kind' | 'tax_advantaged_category_id'> | undefined,
 ) {
   invalidateAccountData(queryClient, [accountId]);
   invalidateTransactions(queryClient);
@@ -205,7 +205,7 @@ function invalidateAccountAggregateData(
   invalidateBudgets(queryClient);
   invalidateDashboardBudgets(queryClient);
   invalidateRunwaySettings(queryClient);
-  invalidateAccountTaxPlanData(queryClient, [account?.tax_advantaged_plan_id]);
+  invalidateAccountTaxPlanData(queryClient, [account?.tax_advantaged_category_id]);
 }
 
 export function useCreateAccount() {
@@ -226,8 +226,8 @@ export function useCreateAccount() {
       if (!account.is_archived && payload.credit_limit !== null) {
         invalidateAccountCreditData(queryClient, account);
       }
-      if (account.tax_advantaged_plan_id) {
-        invalidateAccountTaxPlanData(queryClient, [account.tax_advantaged_plan_id]);
+      if (account.tax_advantaged_category_id) {
+        invalidateAccountTaxPlanData(queryClient, [account.tax_advantaged_category_id]);
       }
     },
   });
@@ -239,7 +239,7 @@ export function useUpdateAccount() {
     mutationFn: updateAccount,
     onSuccess: (account, variables) => {
       const previousAccount = getCachedAccount(queryClient, account.id);
-      const previousPlanId = previousAccount?.tax_advantaged_plan_id;
+      const previousPlanId = previousAccount?.tax_advantaged_category_id;
       const previousIsArchived = previousAccount?.is_archived;
       const previousCreditLimit = previousAccount?.credit_limit;
 
@@ -258,12 +258,12 @@ export function useUpdateAccount() {
       }
 
       if (
-        'tax_advantaged_plan_id' in variables.payload
-        && previousPlanId !== account.tax_advantaged_plan_id
+        'tax_advantaged_category_id' in variables.payload
+        && previousPlanId !== account.tax_advantaged_category_id
       ) {
         invalidateAccountTaxPlanData(queryClient, [
           previousPlanId,
-          account.tax_advantaged_plan_id,
+          account.tax_advantaged_category_id,
         ]);
       }
     },

--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -58,10 +58,10 @@ export const transactionOverviewKeys = {
 };
 
 export const taxAdvantagedPlanKeys = {
-  all: ['tax-advantaged-plans'] as const,
-  list: () => ['tax-advantaged-plans'] as const,
-  detail: (planId: string | null | undefined) => ['tax-advantaged-plans', planId] as const,
-  limits: (planId: string | undefined) => ['tax-advantaged-plans', planId, 'limits'] as const,
+  all: ['tax-advantaged-categories'] as const,
+  list: () => ['tax-advantaged-categories'] as const,
+  detail: (planId: string | null | undefined) => ['tax-advantaged-categories', planId] as const,
+  limits: (planId: string | undefined) => ['tax-advantaged-categories', planId, 'limits'] as const,
 };
 
 export const dashboardKeys = {

--- a/frontend/src/api/taxAdvantagedPlans.ts
+++ b/frontend/src/api/taxAdvantagedPlans.ts
@@ -12,7 +12,7 @@ export type TaxTreatment = 'tax_free' | 'tax_deferred' | 'tax_assisted';
 
 export interface TaxAdvantagedPlan {
   id: string;
-  plan_owner_user_id: string;
+  category_owner_user_id: string;
   group_id: string | null;
   name: string;
   tax_treatment: TaxTreatment;
@@ -30,7 +30,7 @@ export interface TaxAdvantagedPlan {
 }
 
 export interface TaxAdvantagedPlanLimit {
-  plan_id: string;
+  tax_advantaged_category_id: string;
   year: number;
   contribution_limit: number;
   withdrawal_limit: number | null;
@@ -99,7 +99,7 @@ function upsertTaxAdvantagedPlanLimit(
   limit: TaxAdvantagedPlanLimit,
 ) {
   queryClient.setQueryData<TaxAdvantagedPlanLimit[]>(
-    taxAdvantagedPlanKeys.limits(limit.plan_id),
+    taxAdvantagedPlanKeys.limits(limit.tax_advantaged_category_id),
     (limits) => {
       if (!limits) return [limit];
       const index = limits.findIndex((item) => item.year === limit.year);
@@ -128,23 +128,23 @@ function removeTaxAdvantagedPlanLimit(
 function clearLinkedAccountPlanCaches(queryClient: QueryClient, planId: string) {
   const accounts = queryClient.getQueryData<AccountsOverview[]>(accountKeys.list()) ?? [];
   const linkedAccountIds = accounts
-    .filter((account) => account.tax_advantaged_plan_id === planId)
+    .filter((account) => account.tax_advantaged_category_id === planId)
     .map((account) => account.id);
 
   queryClient.setQueryData<AccountsOverview[]>(
     accountKeys.list(),
     (currentAccounts) =>
       currentAccounts?.map((account) =>
-        account.tax_advantaged_plan_id === planId
-          ? { ...account, tax_advantaged_plan_id: null }
+        account.tax_advantaged_category_id === planId
+          ? { ...account, tax_advantaged_category_id: null }
           : account,
       ),
   );
 
   for (const accountId of linkedAccountIds) {
     queryClient.setQueryData<Account>(accountKeys.detail(accountId), (account) =>
-      account?.tax_advantaged_plan_id === planId
-        ? { ...account, tax_advantaged_plan_id: null }
+      account?.tax_advantaged_category_id === planId
+        ? { ...account, tax_advantaged_category_id: null }
         : account,
     );
   }
@@ -157,7 +157,7 @@ export function useTaxAdvantagedPlans() {
   const { accessToken } = useAuth();
   return useQuery({
     queryKey: taxAdvantagedPlanKeys.list(),
-    queryFn: () => authenticatedFetch<TaxAdvantagedPlan[]>('/tax-advantaged-plans'),
+    queryFn: () => authenticatedFetch<TaxAdvantagedPlan[]>('/tax-advantaged-categories'),
     enabled: !!accessToken,
     staleTime: 10 * 60 * 1000,
   });
@@ -167,7 +167,7 @@ export function useCreateTaxAdvantagedPlan() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (payload: CreateTaxAdvantagedPlanPayload) =>
-      authenticatedFetch<TaxAdvantagedPlan>('/tax-advantaged-plans', {
+      authenticatedFetch<TaxAdvantagedPlan>('/tax-advantaged-categories', {
         method: 'POST',
         body: JSON.stringify(payload),
       }),
@@ -182,7 +182,7 @@ export function useUpdateTaxAdvantagedPlan(planId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (payload: UpdateTaxAdvantagedPlanPayload) =>
-      authenticatedFetch<TaxAdvantagedPlan>(`/tax-advantaged-plans/${planId}`, {
+      authenticatedFetch<TaxAdvantagedPlan>(`/tax-advantaged-categories/${planId}`, {
         method: 'PATCH',
         body: JSON.stringify(payload),
       }),
@@ -199,7 +199,7 @@ export function useDeleteTaxAdvantagedPlan({ minimumPendingMs = 0 }: { minimumPe
     mutationFn: async (planId: string) => {
       const minimumPending = delay(minimumPendingMs);
       try {
-        const result = await authenticatedFetch<void>(`/tax-advantaged-plans/${planId}`, {
+        const result = await authenticatedFetch<void>(`/tax-advantaged-categories/${planId}`, {
           method: 'DELETE',
         });
         await minimumPending;
@@ -225,7 +225,7 @@ export function useTaxAdvantagedPlanLimits(planId: string | undefined) {
   const { accessToken } = useAuth();
   return useQuery({
     queryKey: taxAdvantagedPlanKeys.limits(planId),
-    queryFn: () => authenticatedFetch<TaxAdvantagedPlanLimit[]>(`/tax-advantaged-plans/${planId}/limits`),
+    queryFn: () => authenticatedFetch<TaxAdvantagedPlanLimit[]>(`/tax-advantaged-categories/${planId}/limits`),
     enabled: !!accessToken && !!planId,
     staleTime: 5 * 60 * 1000,
   });
@@ -235,7 +235,7 @@ export function useCreateTaxAdvantagedPlanLimit() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ planId, ...payload }: CreateTaxAdvantagedPlanLimitPayload) =>
-      authenticatedFetch<TaxAdvantagedPlanLimit>(`/tax-advantaged-plans/${planId}/limits`, {
+      authenticatedFetch<TaxAdvantagedPlanLimit>(`/tax-advantaged-categories/${planId}/limits`, {
         method: 'POST',
         body: JSON.stringify(payload),
       }),
@@ -250,7 +250,7 @@ export function useUpdateTaxAdvantagedPlanLimit() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ planId, year, ...payload }: UpdateTaxAdvantagedPlanLimitPayload) =>
-      authenticatedFetch<TaxAdvantagedPlanLimit>(`/tax-advantaged-plans/${planId}/limits/${year}`, {
+      authenticatedFetch<TaxAdvantagedPlanLimit>(`/tax-advantaged-categories/${planId}/limits/${year}`, {
         method: 'PATCH',
         body: JSON.stringify(payload),
       }),
@@ -265,7 +265,7 @@ export function useDeleteTaxAdvantagedPlanLimit() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: ({ planId, year }: { planId: string; year: number }) =>
-      authenticatedFetch<void>(`/tax-advantaged-plans/${planId}/limits/${year}`, {
+      authenticatedFetch<void>(`/tax-advantaged-categories/${planId}/limits/${year}`, {
         method: 'DELETE',
       }),
     onSuccess: (_data, variables) => {
@@ -279,7 +279,7 @@ export function useTaxAdvantagedPlan(planId: string | null | undefined) {
   const { accessToken } = useAuth();
   return useQuery({
     queryKey: taxAdvantagedPlanKeys.detail(planId),
-    queryFn: () => authenticatedFetch<TaxAdvantagedPlan>(`/tax-advantaged-plans/${planId}`),
+    queryFn: () => authenticatedFetch<TaxAdvantagedPlan>(`/tax-advantaged-categories/${planId}`),
     enabled: !!accessToken && !!planId,
     staleTime: 5 * 60 * 1000,
   });

--- a/frontend/src/api/transactions.ts
+++ b/frontend/src/api/transactions.ts
@@ -323,10 +323,10 @@ function getCachedAccountPlanId(
   accountId: string,
 ): string | null | undefined {
   const detail = queryClient.getQueryData<Account>(accountKeys.detail(accountId));
-  if (detail) return detail.tax_advantaged_plan_id;
+  if (detail) return detail.tax_advantaged_category_id;
 
   const accounts = queryClient.getQueryData<AccountsOverview[]>(accountKeys.list());
-  return accounts?.find((account) => account.id === accountId)?.tax_advantaged_plan_id;
+  return accounts?.find((account) => account.id === accountId)?.tax_advantaged_category_id;
 }
 
 function getCachedAccountKind(

--- a/frontend/src/components/CreateAccountModal.tsx
+++ b/frontend/src/components/CreateAccountModal.tsx
@@ -39,7 +39,7 @@ const INITIAL_FORM = {
   name: '',
   currency: '',
   institution_id: '',
-  tax_advantaged_plan_id: '',
+  tax_advantaged_category_id: '',
   credit_limit: '',
   starting_balance: '',
 };
@@ -212,10 +212,10 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
       if (field === 'account_type') {
         const nextKind = value ? ACCOUNT_KIND_BY_TYPE[value as AccountType] : undefined;
         if (nextKind !== 'revolving') next.credit_limit = '';
-        if (nextKind !== 'asset') next.tax_advantaged_plan_id = '';
+        if (nextKind !== 'asset') next.tax_advantaged_category_id = '';
       }
       if (field === 'currency') {
-        next.tax_advantaged_plan_id = '';
+        next.tax_advantaged_category_id = '';
       }
       return next;
     });
@@ -269,7 +269,7 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
     const payload: CreateAccountPayload = {
       account_kind: ACCOUNT_KIND_BY_TYPE[form.account_type as AccountType],
       account_type: form.account_type as AccountType,
-      tax_advantaged_plan_id: form.tax_advantaged_plan_id || null,
+      tax_advantaged_category_id: form.tax_advantaged_category_id || null,
       name: form.name.trim(),
       institution_id: form.institution_id || null,
       currency: form.currency,
@@ -529,8 +529,8 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                                       <label className="app-label mb-1.5 block text-[0.9375rem] leading-5">Tax-Advantaged Plan</label>
                                       <Dropdown
                                         options={taxPlanOptions}
-                                        value={form.tax_advantaged_plan_id}
-                                        onChange={(v) => handleChange('tax_advantaged_plan_id', v)}
+                                        value={form.tax_advantaged_category_id}
+                                        onChange={(v) => handleChange('tax_advantaged_category_id', v)}
                                         placeholder="Select plan..."
                                         searchable
                                         searchPlaceholder="Search plans..."

--- a/frontend/src/components/CreateAccountModal.tsx
+++ b/frontend/src/components/CreateAccountModal.tsx
@@ -526,14 +526,14 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                                 >
                                   {conditionalAccountField === 'tax-plan' ? (
                                     <div>
-                                      <label className="app-label mb-1.5 block text-[0.9375rem] leading-5">Tax-Advantaged Plan</label>
+                                      <label className="app-label mb-1.5 block text-[0.9375rem] leading-5">Tax-Advantaged Category</label>
                                       <Dropdown
                                         options={taxPlanOptions}
                                         value={form.tax_advantaged_category_id}
                                         onChange={(v) => handleChange('tax_advantaged_category_id', v)}
-                                        placeholder="Select plan..."
+                                        placeholder="Select category..."
                                         searchable
-                                        searchPlaceholder="Search plans..."
+                                        searchPlaceholder="Search categories..."
                                       />
                                     </div>
                                   ) : (

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -356,7 +356,7 @@ export default function TaxAdvantagedCategoryModal({
     } catch (error) {
       await minimumLoading
       setPlanSaveStatus('idle')
-      setPlanError(error instanceof Error ? error.message : 'Failed to update plan.')
+      setPlanError(error instanceof Error ? error.message : 'Failed to update category.')
     }
   }
 
@@ -366,7 +366,7 @@ export default function TaxAdvantagedCategoryModal({
       onSuccess: onClose,
       onError: (error) => {
         setConfirmingPlanDelete(false)
-        setPlanError(error instanceof Error ? error.message : 'Failed to delete plan.')
+        setPlanError(error instanceof Error ? error.message : 'Failed to delete category.')
       },
     })
   }

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/TaxAdvantagedCategoryModal.tsx
@@ -387,7 +387,7 @@ export default function TaxAdvantagedCategoryModal({
       && account.account_kind === 'asset'
       && account.currency === plan.currency,
   )
-  const linkedAccountsCount = bindableAccounts.filter((account) => account.tax_advantaged_plan_id === plan.id).length
+  const linkedAccountsCount = bindableAccounts.filter((account) => account.tax_advantaged_category_id === plan.id).length
   const linkedAccountsSummary = `${linkedAccountsCount} linked`
   const linkedAccountsMobileSummary = `${linkedAccountsCount} ${linkedAccountsCount === 1 ? 'acct' : 'accts'} linked`
 
@@ -575,7 +575,7 @@ export default function TaxAdvantagedCategoryModal({
   const handleToggleAccount = async (account: AccountsOverview) => {
     if (account.is_archived) return
 
-    const isLinked = account.tax_advantaged_plan_id === plan.id
+    const isLinked = account.tax_advantaged_category_id === plan.id
     let savingNoticeShown = false
     const savingNoticeTimer = window.setTimeout(() => {
       savingNoticeShown = true
@@ -585,7 +585,7 @@ export default function TaxAdvantagedCategoryModal({
     try {
       await updateAccount.mutateAsync({
         accountId: account.id,
-        payload: { tax_advantaged_plan_id: isLinked ? null : plan.id },
+        payload: { tax_advantaged_category_id: isLinked ? null : plan.id },
       })
       window.clearTimeout(savingNoticeTimer)
 
@@ -1163,8 +1163,8 @@ export default function TaxAdvantagedCategoryModal({
                         style={{ borderColor: 'var(--app-border)' }}
                       >
                         {bindableAccounts.map((account, index) => {
-                          const linked = account.tax_advantaged_plan_id === plan.id
-                          const linkedElsewhere = account.tax_advantaged_plan_id !== null && !linked
+                          const linked = account.tax_advantaged_category_id === plan.id
+                          const linkedElsewhere = account.tax_advantaged_category_id !== null && !linked
                           const pending = updateAccount.isPending && updateAccount.variables?.accountId === account.id
                           const disabled = account.is_archived || linkedElsewhere || pending
                           const statusParts = [

--- a/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/hooks/useTaxAdvantagedCategoryList.ts
+++ b/frontend/src/settings/components/tax-advantaged/TaxAdvantagedCategoriesSection/hooks/useTaxAdvantagedCategoryList.ts
@@ -21,8 +21,8 @@ export function useTaxAdvantagedCategoryList({
   const linkedAccountCounts = useMemo(() => {
     const counts = new Map<string, number>()
     for (const account of accounts) {
-      if (!account.tax_advantaged_plan_id) continue
-      counts.set(account.tax_advantaged_plan_id, (counts.get(account.tax_advantaged_plan_id) ?? 0) + 1)
+      if (!account.tax_advantaged_category_id) continue
+      counts.set(account.tax_advantaged_category_id, (counts.get(account.tax_advantaged_category_id) ?? 0) + 1)
     }
     return counts
   }, [accounts])


### PR DESCRIPTION
- Renames the TAC owner column during the existing Alembic table rename so migrated databases match the current model
- Adds an Alembic schema parity test to catch model/migration drift
- Updates frontend API calls and account payload fields to use tax-advantaged category routes and field names
- Updates database docs and frontend text to use tax-advantaged category wording