### PR TITLE
fix: cache app version text

### DIFF
--- a/frontend/src/api/queryKeys.ts
+++ b/frontend/src/api/queryKeys.ts
@@ -112,6 +112,10 @@ export const userKeys = {
   runway: () => ['me', 'runway'] as const,
 };
 
+export const appVersionKeys = {
+  version: () => ['app-version'] as const,
+};
+
 export const categoryKeys = {
   list: () => ['categories'] as const,
 };

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -1,4 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
 import { API_BASE } from './config';
+import { appVersionKeys } from './queryKeys';
 
 function getBuildValue(value: string | undefined) {
   return value?.trim() ?? '';
@@ -42,4 +44,13 @@ export async function fetchAppVersion(): Promise<AppVersionInfo> {
         }
       : null,
   };
+}
+
+export function useAppVersion() {
+  return useQuery({
+    queryKey: appVersionKeys.version(),
+    queryFn: fetchAppVersion,
+    staleTime: 15 * 60 * 1000,
+    gcTime: Infinity,
+  });
 }

--- a/frontend/src/components/Navigation.tsx
+++ b/frontend/src/components/Navigation.tsx
@@ -15,7 +15,7 @@ import {
   Sun,
   type LucideIcon,
 } from 'lucide-react';
-import { CURRENT_APP_VERSION, fetchAppVersion, type AppUpdateNotice } from '@/api/version';
+import { CURRENT_APP_VERSION, useAppVersion } from '@/api/version';
 import { useAuth } from '@/hooks/useAuth';
 import { useTheme } from '@/hooks/useTheme';
 import type { Theme } from '@/types';
@@ -210,25 +210,10 @@ function getCurrentVersionLabel(version: string) {
 }
 
 function VersionIndicator() {
-  const [version, setVersion] = useState(CURRENT_APP_VERSION);
-  const [updateNotice, setUpdateNotice] = useState<AppUpdateNotice | null>(null);
+  const { data: appVersion } = useAppVersion();
+  const version = appVersion?.version ?? CURRENT_APP_VERSION;
+  const updateNotice = appVersion?.update ?? null;
   const currentVersionLabel = getCurrentVersionLabel(version);
-
-  useEffect(() => {
-    let isMounted = true;
-
-    fetchAppVersion()
-      .then((appVersion) => {
-        if (!isMounted) return;
-        setVersion(appVersion.version.trim());
-        setUpdateNotice(appVersion.update);
-      })
-      .catch(() => undefined);
-
-    return () => {
-      isMounted = false;
-    };
-  }, []);
 
   return (
     <div className="mt-2 px-2 text-center" aria-label={currentVersionLabel}>


### PR DESCRIPTION
- Cache app version metadata through the shared query client for 15 minutes
- Keep the sidebar version text and update notification stable across navigation pane remounts
- Fall back to the build version only before fetch has returned any data

CU-86badpu9u