### PR TITLE
fix: animate app page after login

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -152,9 +152,12 @@ function AnimatedRoutes() {
     let exitTimer: number | undefined;
 
     const transitionTimer = window.setTimeout(() => {
-      if (!isProtectedPath(location.pathname) || !isProtectedPath(displayLocation.pathname)) {
+      const nextPathIsProtected = isProtectedPath(location.pathname);
+      const displayedPathIsProtected = isProtectedPath(displayLocation.pathname);
+
+      if (!nextPathIsProtected || !displayedPathIsProtected) {
         setDisplayLocation(location);
-        setPageTransitionPhase('idle');
+        setPageTransitionPhase(nextPathIsProtected ? 'entering' : 'idle');
         return;
       }
 


### PR DESCRIPTION
- Animates the app page when login moves the user from the auth screen into the app
- Keeps existing page transitions unchanged for protected app navigation