### PR TITLE
Fix frontend interaction bugs

### DIFF
--- a/backend/app/services/fx/frankfurter_provider.py
+++ b/backend/app/services/fx/frankfurter_provider.py
@@ -1,16 +1,25 @@
 """Frankfurter foreign exchange rate provider"""
 
+import asyncio
+from collections.abc import Awaitable, Callable
 from datetime import date
 from decimal import Decimal
+from functools import partial
+from typing import TypeVar
 
 import httpx
 
 from app.config import FRANKFURTER_URL
+from app.services.fx.errors import FxRateError
 from app.services.fx.frankfurter_request_helpers import (
     request_frankfurter_rate_response,
     request_frankfurter_rates_response,
 )
 from app.services.fx.rate_parser_helpers import parse_rate, parse_rates
+
+DEFAULT_FX_PROVIDER_RETRY_ATTEMPTS = 3
+DEFAULT_FX_PROVIDER_RETRY_DELAY_SECONDS = 0.5
+_T = TypeVar("_T")
 
 
 class FrankfurterProvider:
@@ -22,6 +31,8 @@ class FrankfurterProvider:
         url: str = FRANKFURTER_URL,
         client: httpx.AsyncClient | None = None,
         timeout: float = 5.0,
+        retry_attempts: int = DEFAULT_FX_PROVIDER_RETRY_ATTEMPTS,
+        retry_delay_seconds: float = DEFAULT_FX_PROVIDER_RETRY_DELAY_SECONDS,
     ):
         """Initialize the provider with an optional reusable HTTP client
 
@@ -29,10 +40,14 @@ class FrankfurterProvider:
             url: Base URL for the Frankfurter API
             client: Optional reusable HTTP client
             timeout: HTTP request timeout in seconds when creating a client
+            retry_attempts: Number of provider lookup attempts before surfacing an FX error
+            retry_delay_seconds: Delay between provider lookup attempts
         """
         self.url = url.rstrip("/")
         self.client = client
         self.timeout = timeout
+        self.retry_attempts = retry_attempts
+        self.retry_delay_seconds = retry_delay_seconds
 
     async def get_rate(self, base: str, quote: str, rate_date: date) -> Decimal:
         """Return quote currency units per one base currency unit
@@ -71,9 +86,9 @@ class FrankfurterProvider:
         Returns:
             Quote currency units per one base currency unit
         """
-        response = await request_frankfurter_rate_response(client, self.url, base, quote, rate_date)
-        rate = parse_rate(response.json(), expected_base=base, expected_quote=quote)
-        return rate
+        return await self._run_provider_lookup_with_retries(
+            partial(self._request_and_parse_rate, client, base, quote, rate_date),
+        )
 
     async def get_rates(self, base: str, quote: str, start_date: date, end_date: date) -> dict[date, Decimal]:
         """Return quote currency units per one base currency unit over a date range
@@ -104,6 +119,76 @@ class FrankfurterProvider:
         end_date: date,
     ) -> dict[date, Decimal]:
         """Return parsed FX rates over a date range using an HTTP client
+
+        Args:
+            client: HTTP client used for the provider request
+            base: Normalized source currency code
+            quote: Normalized target currency code
+            start_date: First date in the requested range
+            end_date: Last date in the requested range
+
+        Returns:
+            Rates keyed by calendar date
+        """
+        return await self._run_provider_lookup_with_retries(
+            partial(self._request_and_parse_rates, client, base, quote, start_date, end_date),
+        )
+
+    async def _run_provider_lookup_with_retries(self, lookup: Callable[[], Awaitable[_T]]) -> _T:
+        """Run one provider lookup with retry policy before surfacing the final FX error
+
+        Args:
+            lookup: Provider request and parser work to attempt
+
+        Returns:
+            Parsed provider lookup result
+        """
+        last_error: FxRateError | None = None
+
+        for attempt in range(1, self.retry_attempts + 1):
+            try:
+                return await lookup()
+            except FxRateError as exc:
+                last_error = exc
+                if attempt == self.retry_attempts:
+                    break
+                await asyncio.sleep(self.retry_delay_seconds)
+
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("FX provider retry attempts ended before a lookup was attempted")
+
+    async def _request_and_parse_rate(
+        self,
+        client: httpx.AsyncClient,
+        base: str,
+        quote: str,
+        rate_date: date,
+    ) -> Decimal:
+        """Request and parse one FX rate response
+
+        Args:
+            client: HTTP client used for the provider request
+            base: Normalized source currency code
+            quote: Normalized target currency code
+            rate_date: Date for the requested rate
+
+        Returns:
+            Quote currency units per one base currency unit
+        """
+        response = await request_frankfurter_rate_response(client, self.url, base, quote, rate_date)
+        rate = parse_rate(response.json(), expected_base=base, expected_quote=quote)
+        return rate
+
+    async def _request_and_parse_rates(
+        self,
+        client: httpx.AsyncClient,
+        base: str,
+        quote: str,
+        start_date: date,
+        end_date: date,
+    ) -> dict[date, Decimal]:
+        """Request and parse FX rates over a date range
 
         Args:
             client: HTTP client used for the provider request

--- a/backend/tests/services/fx/test_fx.py
+++ b/backend/tests/services/fx/test_fx.py
@@ -13,6 +13,7 @@ from app.services.fx import (
     FxRateResponseError,
     convert_minor_units,
 )
+from app.services.fx.frankfurter_provider import DEFAULT_FX_PROVIDER_RETRY_DELAY_SECONDS
 
 
 class _FakeProvider:
@@ -278,6 +279,110 @@ async def test_frankfurter_provider_uses_configured_url_for_rate_range():
     assert seen_url.params["to"] == "2026-05-30"
 
 
+async def test_frankfurter_provider_retries_single_rate_failure(monkeypatch):
+    """FrankfurterProvider retries a failed single-rate lookup before returning a successful rate"""
+    calls = 0
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        """Record retry delays without waiting"""
+        sleep_calls.append(delay)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return httpx.Response(503)
+        return httpx.Response(200, json={"date": "2026-05-30", "base": "USD", "quote": "CAD", "rate": 1.375})
+
+    monkeypatch.setattr("app.services.fx.frankfurter_provider.asyncio.sleep", fake_sleep)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        rate = await FrankfurterProvider(url="https://fx.example.test/v2/", client=client).get_rate(
+            "USD",
+            "CAD",
+            date(2026, 5, 30),
+        )
+
+    assert rate == Decimal("1.375")
+    assert calls == 2
+    assert sleep_calls == [DEFAULT_FX_PROVIDER_RETRY_DELAY_SECONDS]
+
+
+async def test_frankfurter_provider_retries_rate_range_failure(monkeypatch):
+    """FrankfurterProvider retries failed range lookups before returning successful rates"""
+    calls = 0
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        """Record retry delays without waiting"""
+        sleep_calls.append(delay)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        if calls < 3:
+            return httpx.Response(503)
+        return httpx.Response(
+            200,
+            json=[
+                {"date": "2026-05-29", "base": "USD", "quote": "CAD", "rate": 1.37},
+                {"date": "2026-05-30", "base": "USD", "quote": "CAD", "rate": 1.375},
+            ],
+        )
+
+    monkeypatch.setattr("app.services.fx.frankfurter_provider.asyncio.sleep", fake_sleep)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        rates = await FrankfurterProvider(url="https://fx.example.test/v2/", client=client).get_rates(
+            "USD",
+            "CAD",
+            date(2026, 5, 29),
+            date(2026, 5, 30),
+        )
+
+    assert rates == {
+        date(2026, 5, 29): Decimal("1.37"),
+        date(2026, 5, 30): Decimal("1.375"),
+    }
+    assert calls == 3
+    assert sleep_calls == [
+        DEFAULT_FX_PROVIDER_RETRY_DELAY_SECONDS,
+        DEFAULT_FX_PROVIDER_RETRY_DELAY_SECONDS,
+    ]
+
+
+async def test_frankfurter_provider_surfaces_final_lookup_error_after_three_attempts(monkeypatch):
+    """FrankfurterProvider surfaces the existing FX error after all retry attempts fail"""
+    calls = 0
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(delay: float) -> None:
+        """Record retry delays without waiting"""
+        sleep_calls.append(delay)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(503)
+
+    monkeypatch.setattr("app.services.fx.frankfurter_provider.asyncio.sleep", fake_sleep)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(FxProviderUnavailableError):
+            await FrankfurterProvider(url="https://fx.example.test/v2/", client=client).get_rate(
+                "USD",
+                "CAD",
+                date(2026, 5, 30),
+            )
+
+    assert calls == 3
+    assert sleep_calls == [
+        DEFAULT_FX_PROVIDER_RETRY_DELAY_SECONDS,
+        DEFAULT_FX_PROVIDER_RETRY_DELAY_SECONDS,
+    ]
+
+
 async def test_frankfurter_provider_rejects_invalid_payload():
     """FrankfurterProvider does not accept malformed rate payloads."""
 
@@ -286,7 +391,7 @@ async def test_frankfurter_provider_rejects_invalid_payload():
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         with pytest.raises(FxRateResponseError):
-            await FrankfurterProvider(client=client).get_rate("USD", "CAD", date(2026, 5, 30))
+            await FrankfurterProvider(client=client, retry_delay_seconds=0).get_rate("USD", "CAD", date(2026, 5, 30))
 
 
 async def test_frankfurter_provider_rejects_invalid_rate():
@@ -297,4 +402,4 @@ async def test_frankfurter_provider_rejects_invalid_rate():
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         with pytest.raises(FxRateResponseError):
-            await FrankfurterProvider(client=client).get_rate("USD", "CAD", date(2026, 5, 30))
+            await FrankfurterProvider(client=client, retry_delay_seconds=0).get_rate("USD", "CAD", date(2026, 5, 30))

--- a/frontend/src/api/accounts/hooks.ts
+++ b/frontend/src/api/accounts/hooks.ts
@@ -24,7 +24,10 @@ import type {
 } from '@/api/accounts/types';
 import { runWithMinimumPendingTime } from '@/api/utils/mutationFeedback';
 import { accountKeys } from '@/api/cache/queryKeys';
+import { getFxAwareStaleTime } from '@/api/shared/fxCache';
 import { useAuth } from '@/hooks/useAuth';
+
+const ACCOUNT_FX_STALE_TIME_MS = 10 * 60 * 1000;
 
 /**
  * Creates accounts and refreshes account-dependent rollups
@@ -110,7 +113,7 @@ export function useAccounts() {
     queryKey: accountKeys.list(),
     queryFn: fetchAccounts,
     enabled: !!accessToken,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(ACCOUNT_FX_STALE_TIME_MS),
   });
 }
 
@@ -123,7 +126,7 @@ export function useAccount(accountId: string | undefined) {
     queryKey: accountKeys.detail(accountId),
     queryFn: () => fetchAccount(accountId),
     enabled: !!accessToken && !!accountId,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(ACCOUNT_FX_STALE_TIME_MS),
   });
 }
 

--- a/frontend/src/api/budgets/hooks.ts
+++ b/frontend/src/api/budgets/hooks.ts
@@ -13,7 +13,10 @@ import {
 } from '@/api/budgets/requests';
 import { runWithMinimumPendingTime } from '@/api/utils/mutationFeedback';
 import { budgetKeys } from '@/api/cache/queryKeys';
+import { getFxAwareStaleTime } from '@/api/shared/fxCache';
 import { useAuth } from '@/hooks/useAuth';
+
+const BUDGET_FX_STALE_TIME_MS = 5 * 60 * 1000;
 
 /**
  * Reads base budget definitions
@@ -50,7 +53,7 @@ export function useLatestBudgetUtilizations() {
     queryKey: budgetKeys.latestUtilizations(),
     queryFn: fetchLatestBudgetUtilizations,
     enabled: !!accessToken,
-    staleTime: 5 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(BUDGET_FX_STALE_TIME_MS),
   });
 }
 
@@ -64,7 +67,7 @@ export function useBudgetUtilizations(budgetIds: string[]) {
       queryKey: budgetKeys.utilization(budgetId),
       queryFn: () => fetchBudgetUtilization(budgetId),
       enabled: !!accessToken,
-      staleTime: 5 * 60 * 1000,
+      staleTime: getFxAwareStaleTime(BUDGET_FX_STALE_TIME_MS),
     })),
   });
 }

--- a/frontend/src/api/dashboard/hooks.ts
+++ b/frontend/src/api/dashboard/hooks.ts
@@ -9,7 +9,10 @@ import {
 } from '@/api/dashboard/requests';
 import type { SpendingRange } from '@/api/dashboard/types';
 import { dashboardKeys } from '@/api/cache/queryKeys';
+import { getFxAwareStaleTime } from '@/api/shared/fxCache';
 import { useAuth } from '@/hooks/useAuth';
+
+const DASHBOARD_FX_STALE_TIME_MS = 10 * 60 * 1000;
 
 /**
  * Reads dashboard credit utilization data
@@ -20,7 +23,7 @@ export function useDashboardCredit() {
     queryKey: dashboardKeys.credit(),
     queryFn: fetchDashboardCredit,
     enabled: !!accessToken,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(DASHBOARD_FX_STALE_TIME_MS),
   });
 }
 
@@ -33,7 +36,7 @@ export function useDashboardNetWorth(windowDays = 90) {
     queryKey: dashboardKeys.netWorth(windowDays),
     queryFn: () => fetchDashboardNetWorth(windowDays),
     enabled: !!accessToken,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(DASHBOARD_FX_STALE_TIME_MS),
   });
 }
 
@@ -46,7 +49,7 @@ export function useDashboardSavingsRate() {
     queryKey: dashboardKeys.savingsRate(),
     queryFn: fetchDashboardSavingsRate,
     enabled: !!accessToken,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(DASHBOARD_FX_STALE_TIME_MS),
   });
 }
 
@@ -72,7 +75,7 @@ export function useSpendingComparison(range: SpendingRange) {
     queryKey: dashboardKeys.spendingComparison(range),
     queryFn: () => fetchSpendingComparison(range),
     enabled: !!accessToken,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(DASHBOARD_FX_STALE_TIME_MS),
   });
 }
 
@@ -85,6 +88,6 @@ export function useSpendingBreakdown(range: SpendingRange) {
     queryKey: dashboardKeys.spendingBreakdown(range),
     queryFn: () => fetchSpendingBreakdown(range),
     enabled: !!accessToken,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(DASHBOARD_FX_STALE_TIME_MS),
   });
 }

--- a/frontend/src/api/insights/hooks.ts
+++ b/frontend/src/api/insights/hooks.ts
@@ -9,8 +9,11 @@ import {
   fetchInsightsSavingsRateTrend,
 } from '@/api/insights/requests';
 import { insightsKeys } from '@/api/cache/queryKeys';
+import { getFxAwareStaleTime } from '@/api/shared/fxCache';
 import { useAuth } from '@/hooks/useAuth';
 import type { InsightsComparisonPeriod } from '@/pages/insights/types/range';
+
+const INSIGHTS_FX_STALE_TIME_MS = 5 * 60 * 1000;
 
 /**
  * Reads headline insights metrics for a comparison date range
@@ -26,7 +29,7 @@ export function useInsightsPeriodGlance(
     queryKey: insightsKeys.periodGlance(fromDate, toDate, comparisonPeriod),
     queryFn: () => fetchInsightsPeriodGlance(fromDate, toDate, comparisonPeriod),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
-    staleTime: 5 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(INSIGHTS_FX_STALE_TIME_MS),
   });
 }
 
@@ -39,7 +42,7 @@ export function useInsightsNetWorth(fromDate: string, toDate: string, enabled = 
     queryKey: insightsKeys.netWorth(fromDate, toDate),
     queryFn: () => fetchInsightsNetWorth(fromDate, toDate),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
-    staleTime: 5 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(INSIGHTS_FX_STALE_TIME_MS),
   });
 }
 
@@ -52,7 +55,7 @@ export function useInsightsSavingsRateTrend(enabled = true) {
     queryKey: insightsKeys.savingsRateTrend(),
     queryFn: fetchInsightsSavingsRateTrend,
     enabled: !!accessToken && enabled,
-    staleTime: 5 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(INSIGHTS_FX_STALE_TIME_MS),
   });
 }
 
@@ -70,7 +73,7 @@ export function useInsightsIncomeExpenseBreakdown(
     queryKey: insightsKeys.incomeExpenseBreakdown(fromDate, toDate, comparisonPeriod),
     queryFn: () => fetchInsightsIncomeExpenseBreakdown(fromDate, toDate, comparisonPeriod),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
-    staleTime: 5 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(INSIGHTS_FX_STALE_TIME_MS),
   });
 }
 
@@ -83,7 +86,7 @@ export function useInsightsCashFlow(fromDate: string, toDate: string, enabled = 
     queryKey: insightsKeys.cashFlow(fromDate, toDate),
     queryFn: () => fetchInsightsCashFlow(fromDate, toDate),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
-    staleTime: 5 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(INSIGHTS_FX_STALE_TIME_MS),
   });
 }
 
@@ -96,7 +99,7 @@ export function useInsightsFundFlow(fromDate: string, toDate: string, enabled = 
     queryKey: insightsKeys.fundFlow(fromDate, toDate),
     queryFn: () => fetchInsightsFundFlow(fromDate, toDate),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
-    staleTime: 5 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(INSIGHTS_FX_STALE_TIME_MS),
   });
 }
 
@@ -114,6 +117,6 @@ export function useInsightsMerchants(
     queryKey: insightsKeys.merchants(fromDate, toDate, comparisonPeriod),
     queryFn: () => fetchInsightsMerchants(fromDate, toDate, comparisonPeriod),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
-    staleTime: 5 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(INSIGHTS_FX_STALE_TIME_MS),
   });
 }

--- a/frontend/src/api/shared/fxCache.ts
+++ b/frontend/src/api/shared/fxCache.ts
@@ -1,0 +1,81 @@
+import type { DefaultError, Query, QueryKey } from '@tanstack/react-query';
+import type { FxStatus } from '@/api/shared/fx';
+
+const FX_CACHEABLE_STATES = new Set(['none', 'complete']);
+
+type FxStatusLike = Pick<FxStatus, 'missing_pairs'> & {
+  state: string;
+};
+
+type FxAwareStaleTime = <
+  TQueryFnData = unknown,
+  TError = DefaultError,
+  TData = TQueryFnData,
+  TQueryKey extends QueryKey = QueryKey,
+>(
+  query: Query<TQueryFnData, TError, TData, TQueryKey>
+) => number;
+
+/**
+ * Checks any response shape for an FX status that should not be cached as fresh data
+ */
+export function hasUncacheableFxStatus(value: unknown): boolean {
+  return hasUncacheableFxStatusValue(value, new WeakSet<object>());
+}
+
+/**
+ * Recursively scans JSON response data while avoiding repeated object references
+ */
+function hasUncacheableFxStatusValue(value: unknown, visited: WeakSet<object>): boolean {
+  if (value == null) return false;
+
+  if (Array.isArray(value)) {
+    if (visited.has(value)) return false;
+    visited.add(value);
+
+    return value.some((item) => hasUncacheableFxStatusValue(item, visited));
+  }
+
+  if (!isRecord(value)) return false;
+  if (visited.has(value)) return false;
+  visited.add(value);
+
+  if (isFxStatusLike(value)) return !FX_CACHEABLE_STATES.has(value.state);
+
+  return Object.values(value).some((item) => hasUncacheableFxStatusValue(item, visited));
+}
+
+/**
+ * Keeps final failed FX responses active in the UI without treating them as fresh cache entries
+ */
+export function getFxAwareStaleTime(staleTimeMs: number): FxAwareStaleTime {
+  return <
+    TQueryFnData = unknown,
+    TError = DefaultError,
+    TData = TQueryFnData,
+    TQueryKey extends QueryKey = QueryKey,
+  >(
+    query: Query<TQueryFnData, TError, TData, TQueryKey>,
+  ) => (hasUncacheableFxStatus(query.state.data) ? 0 : staleTimeMs);
+}
+
+/**
+ * Keeps persisted cache storage from saving payloads whose FX values are known to be incomplete
+ */
+export function shouldPersistFxData(data: unknown) {
+  return !hasUncacheableFxStatus(data);
+}
+
+/**
+ * Narrows plain JSON response objects before checking response fields
+ */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Detects the backend FX status contract while still rejecting future non-success states
+ */
+function isFxStatusLike(value: Record<string, unknown>): value is FxStatusLike {
+  return typeof value.state === 'string' && Array.isArray(value.missing_pairs);
+}

--- a/frontend/src/api/transactions/hooks.ts
+++ b/frontend/src/api/transactions/hooks.ts
@@ -26,7 +26,10 @@ import type {
   TransactionFilters,
   UpdateTransactionPayload,
 } from '@/api/transactions/types';
+import { getFxAwareStaleTime } from '@/api/shared/fxCache';
 import { useAuth } from '@/hooks/useAuth';
+
+const TRANSACTION_OVERVIEW_FX_STALE_TIME_MS = 10 * 60 * 1000;
 
 /**
  * Reads transactions for non-infinite consumers such as selectors
@@ -71,7 +74,7 @@ export function useTransactionsOverview(filters: OverviewFilters = {}) {
     queryKey: transactionOverviewKeys.detail(filters as Record<string, unknown>),
     queryFn: () => fetchTransactionsOverview(filters),
     enabled: !!accessToken,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(TRANSACTION_OVERVIEW_FX_STALE_TIME_MS),
   });
 }
 

--- a/frontend/src/api/user/hooks.ts
+++ b/frontend/src/api/user/hooks.ts
@@ -13,7 +13,10 @@ import {
   updateRunwaySettings,
 } from '@/api/user/requests';
 import { userKeys } from '@/api/cache/queryKeys';
+import { getFxAwareStaleTime } from '@/api/shared/fxCache';
 import { useAuth } from '@/hooks/useAuth';
+
+const RUNWAY_FX_STALE_TIME_MS = 10 * 60 * 1000;
 
 /**
  * Updates the current user's editable profile fields
@@ -89,6 +92,6 @@ export function useRunway() {
     queryKey: userKeys.runway(),
     queryFn: fetchRunway,
     enabled: !!accessToken,
-    staleTime: 10 * 60 * 1000,
+    staleTime: getFxAwareStaleTime(RUNWAY_FX_STALE_TIME_MS),
   });
 }

--- a/frontend/src/components/tooltips/FxStatusBadge.tsx
+++ b/frontend/src/components/tooltips/FxStatusBadge.tsx
@@ -5,9 +5,11 @@ import { formatMissingFxPairs, getFxStatusMessage, getFxStatusTone } from '@/uti
 type FxStatusBadgeProps = {
   label: string
   fxStatus: FxStatus | undefined
-  getMessage?: (fxStatus: FxStatus) => string
+  getMessage?: (fxStatus: FxStatus) => string | undefined
   placement?: 'top' | 'bottom'
 }
+
+const FX_STATUS_FALLBACK_MESSAGE = 'FX conversion did not complete. Values may be incomplete'
 
 /**
  * Renders the shared FX status badge and tooltip content including missing currency pair details
@@ -19,6 +21,7 @@ export function FxStatusBadge({
   placement = 'top',
 }: FxStatusBadgeProps) {
   if (!fxStatus) return null
+  const message = getMessage(fxStatus) ?? FX_STATUS_FALLBACK_MESSAGE
 
   return (
     <IconTooltip
@@ -27,7 +30,7 @@ export function FxStatusBadge({
       fxTone={getFxStatusTone(fxStatus)}
       placement={placement}
     >
-      <span className="block">{getMessage(fxStatus)}</span>
+      <span className="block">{message}</span>
       {fxStatus.missing_pairs.length > 0 && (
         <span className="mt-2 block text-xs" style={{ color: 'var(--app-text-muted)' }}>
           Missing: {formatMissingFxPairs(fxStatus.missing_pairs)}

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -136,11 +136,8 @@ export default function TransactionRow({
   return (
     <button
       type="button"
-      onClick={() => {
-        if (!readOnly) onOpen(transaction)
-      }}
-      disabled={readOnly}
-      className={`block w-full px-3 py-2.5 text-left transition-colors duration-100 focus-visible:bg-[var(--app-surface-soft)] focus-visible:outline-none ${readOnly ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--app-surface-soft)]'}`}
+      onClick={() => onOpen(transaction)}
+      className="block w-full cursor-pointer px-3 py-2.5 text-left transition-colors duration-100 hover:bg-[var(--app-surface-soft)] focus-visible:bg-[var(--app-surface-soft)] focus-visible:outline-none"
       style={{
         borderBottom: '1px solid var(--app-border)',
         opacity: readOnly ? 0.68 : 1,

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,11 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
-import { QueryClient } from '@tanstack/react-query'
+import { defaultShouldDehydrateQuery, QueryClient, type Query } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
 import '../styles/tailwind.css'
 import App from '@/App.tsx'
+import { shouldPersistFxData } from '@/api/shared/fxCache'
 
 const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000;
 
@@ -24,11 +25,22 @@ const persister = createAsyncStoragePersister({
   key: 'lumina:query-cache',
 });
 
+/**
+ * Persists successful query data while leaving failed FX responses out of local storage
+ */
+function shouldDehydrateQuery(query: Query) {
+  return defaultShouldDehydrateQuery(query) && shouldPersistFxData(query.state.data);
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <PersistQueryClientProvider
       client={queryClient}
-      persistOptions={{ persister, maxAge: SIX_MONTHS_MS }}
+      persistOptions={{
+        persister,
+        maxAge: SIX_MONTHS_MS,
+        dehydrateOptions: { shouldDehydrateQuery },
+      }}
     >
       <App />
     </PersistQueryClientProvider>

--- a/frontend/src/pages/accounts/AccountsPage.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.tsx
@@ -39,7 +39,6 @@ export default function AccountsPage() {
   const { taxAdvantagedCategoryById, taxAdvantagedLimitSummaries } =
     useTaxAdvantagedLimitSummaries({
       rows,
-      filteredRows,
       taxAdvantagedCategories,
     })
 

--- a/frontend/src/pages/accounts/components/ArchivedSection.tsx
+++ b/frontend/src/pages/accounts/components/ArchivedSection.tsx
@@ -1,9 +1,31 @@
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { ChevronDown, EyeOff } from 'lucide-react'
+import { motion, useReducedMotion } from 'motion/react'
 import type { AccountsOverview } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/taxAdvantagedCategories'
 import AccountRow from '@/pages/accounts/components/Row'
 
+const ARCHIVED_ACCOUNTS_EASE = [0.25, 0.1, 0.25, 1] as const
+const ARCHIVED_ACCOUNTS_SCROLL_OFFSET_PX = 24
+const ARCHIVED_ACCOUNTS_TRANSITION_SECONDS = 0.24
+
+/**
+ * Scrolls the archived section near the top of the viewport while allowing the page bottom to clamp the target
+ */
+function scrollArchivedAccountsIntoView(section: HTMLElement, prefersReducedMotion: boolean | null) {
+  const sectionTop = section.getBoundingClientRect().top + window.scrollY
+  const maxScrollTop = Math.max(document.documentElement.scrollHeight - window.innerHeight, 0)
+  const targetTop = Math.min(Math.max(sectionTop - ARCHIVED_ACCOUNTS_SCROLL_OFFSET_PX, 0), maxScrollTop)
+
+  window.scrollTo({
+    top: targetTop,
+    behavior: prefersReducedMotion ? 'auto' : 'smooth',
+  })
+}
+
+/**
+ * Renders archived accounts behind a collapsible section and scrolls the expanded list into view
+ */
 export default function ArchivedAccountsSection({
   accounts,
   taxAdvantagedCategoryById,
@@ -14,11 +36,49 @@ export default function ArchivedAccountsSection({
   displayCurrency: string
 }) {
   const [expanded, setExpanded] = useState(false)
+  const [rowsMounted, setRowsMounted] = useState(false)
+  const sectionRef = useRef<HTMLElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    if (!expanded) return
+
+    const animationFrameId = window.requestAnimationFrame(() => {
+      const section = sectionRef.current
+      if (!section) return
+
+      scrollArchivedAccountsIntoView(section, prefersReducedMotion)
+    })
+
+    return () => window.cancelAnimationFrame(animationFrameId)
+  }, [expanded, prefersReducedMotion])
+
+  /**
+   * Toggles archived rows while keeping closing rows mounted until their height animation finishes
+   */
+  function toggleExpanded() {
+    if (expanded) {
+      setExpanded(false)
+      return
+    }
+
+    setRowsMounted(true)
+    setExpanded(true)
+  }
+
+  /**
+   * Removes collapsed rows after their closing height animation finishes
+   */
+  function handleListAnimationComplete() {
+    if (expanded) return
+
+    setRowsMounted(false)
+  }
 
   if (accounts.length === 0) return null
 
   return (
-    <section>
+    <section ref={sectionRef}>
       <button
         type="button"
         className="flex w-full items-center gap-3 py-2 text-left transition-colors hover:text-[var(--app-text)]"
@@ -27,7 +87,7 @@ export default function ArchivedAccountsSection({
           color: 'var(--app-text-muted)',
         }}
         aria-expanded={expanded}
-        onClick={() => setExpanded((value) => !value)}
+        onClick={toggleExpanded}
       >
         <EyeOff size={16} aria-hidden />
         <span className="font-medium">Archived accounts</span>
@@ -44,21 +104,37 @@ export default function ArchivedAccountsSection({
         />
       </button>
 
-      {expanded && (
-        <div className="pt-1">
-          {accounts.map((account) => (
-            <AccountRow
-              key={account.id}
-              account={account}
-              accent={account.account_kind === 'asset' ? 'positive' : 'negative'}
-              showCreditLimit={account.account_kind === 'revolving'}
-              taxAdvantagedCategoryById={taxAdvantagedCategoryById}
-              displayCurrency={displayCurrency}
-              isArchived
-            />
-          ))}
-        </div>
-      )}
+      <motion.div
+        className="grid overflow-hidden"
+        initial={false}
+        animate={{
+          gridTemplateRows: expanded ? '1fr' : '0fr',
+          opacity: expanded ? 1 : 0,
+        }}
+        transition={{
+          duration: prefersReducedMotion || expanded ? 0 : ARCHIVED_ACCOUNTS_TRANSITION_SECONDS,
+          ease: ARCHIVED_ACCOUNTS_EASE,
+        }}
+        aria-hidden={!expanded}
+        inert={!expanded}
+        onAnimationComplete={handleListAnimationComplete}
+      >
+        {rowsMounted && (
+          <div className="min-h-0 overflow-hidden pt-1">
+            {accounts.map((account) => (
+              <AccountRow
+                key={account.id}
+                account={account}
+                accent={account.account_kind === 'asset' ? 'positive' : 'negative'}
+                showCreditLimit={account.account_kind === 'revolving'}
+                taxAdvantagedCategoryById={taxAdvantagedCategoryById}
+                displayCurrency={displayCurrency}
+                isArchived
+              />
+            ))}
+          </div>
+        )}
+      </motion.div>
     </section>
   )
 }

--- a/frontend/src/pages/accounts/components/ListSection.tsx
+++ b/frontend/src/pages/accounts/components/ListSection.tsx
@@ -7,6 +7,9 @@ import type { AccountAccent } from '@/pages/accounts/types/accounts'
 
 const ACCOUNT_ROW_EASE = [0.25, 0.1, 0.25, 1] as const
 
+/**
+ * Renders one account section with loading, empty-state, and row transition behaviour
+ */
 export default function AccountListSection({
   title,
   accent,
@@ -89,26 +92,31 @@ export default function AccountListSection({
             </motion.p>
           )}
         </AnimatePresence>
-        {!loading && accounts.map((account) => (
-          <motion.div
-            key={account.id}
-            className="overflow-hidden"
-            initial={prefersReducedMotion ? false : { opacity: 0, height: 0 }}
-            animate={{ opacity: 1, height: 'auto' }}
-            transition={{
-              duration: prefersReducedMotion ? 0 : 0.22,
-              ease: ACCOUNT_ROW_EASE,
-            }}
-          >
-            <AccountRow
-              account={account}
-              accent={accent}
-              showCreditLimit={showCreditLimit}
-              taxAdvantagedCategoryById={taxAdvantagedCategoryById}
-              displayCurrency={displayCurrency}
-            />
-          </motion.div>
-        ))}
+        <AnimatePresence initial={false}>
+          {!loading && accounts.map((account) => (
+            <motion.div
+              key={account.id}
+              layout={prefersReducedMotion ? false : 'position'}
+              className="overflow-hidden"
+              initial={prefersReducedMotion ? false : { opacity: 0, height: 0 }}
+              animate={{ opacity: 1, height: 'auto' }}
+              exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, height: 0 }}
+              transition={{
+                duration: prefersReducedMotion ? 0 : 0.22,
+                ease: ACCOUNT_ROW_EASE,
+                layout: { duration: prefersReducedMotion ? 0 : 0.22, ease: ACCOUNT_ROW_EASE },
+              }}
+            >
+              <AccountRow
+                account={account}
+                accent={accent}
+                showCreditLimit={showCreditLimit}
+                taxAdvantagedCategoryById={taxAdvantagedCategoryById}
+                displayCurrency={displayCurrency}
+              />
+            </motion.div>
+          ))}
+        </AnimatePresence>
       </div>
     </section>
   )

--- a/frontend/src/pages/accounts/components/tax-advantaged-limits/Section.tsx
+++ b/frontend/src/pages/accounts/components/tax-advantaged-limits/Section.tsx
@@ -3,7 +3,7 @@ import { hasTaxAdvantagedLimitTracking } from '@/pages/accounts/utils/taxAdvanta
 import { TaxAdvantagedLimitMeterStack } from './LimitMeterStack'
 
 /**
- * Renders tax-advantaged limit summaries for the currently visible accounts
+ * Renders tax-advantaged limit summaries for linked active accounts
  */
 export default function TaxAdvantagedLimitsSection({
   summaries,

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -45,8 +45,6 @@ export default function AccountDetailPage() {
   }
 
   const openEditTransaction = (transaction: Transaction) => {
-    if (visibleAccount?.is_archived) return
-
     setEditingTransaction(transaction)
     setTxnModalKey((key) => key + 1)
     setShowTxnModal(true)
@@ -154,6 +152,7 @@ export default function AccountDetailPage() {
             transaction={editingTransaction ?? undefined}
             defaultAccountId={visibleAccount.id}
             defaultCurrency={visibleAccount.currency}
+            readOnly={Boolean(editingTransaction && visibleAccount.is_archived)}
           />
 
           <AnimatePresence onExitComplete={handleAccountEditModalExitComplete}>

--- a/frontend/src/pages/accounts/hooks/useTaxAdvantagedLimitSummaries.ts
+++ b/frontend/src/pages/accounts/hooks/useTaxAdvantagedLimitSummaries.ts
@@ -1,15 +1,16 @@
 import { useMemo } from 'react'
 import type { AccountsOverview } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/taxAdvantagedCategories'
-import type { TaxAdvantagedLimitSummary } from '@/pages/accounts/types/accounts'
+import { getTaxAdvantagedLimitSummaries } from '@/pages/accounts/utils/taxAdvantagedLimits'
 
+/**
+ * Builds tax-advantaged lookup and limit summary data for the accounts overview
+ */
 export function useTaxAdvantagedLimitSummaries({
   rows,
-  filteredRows,
   taxAdvantagedCategories,
 }: {
   rows: AccountsOverview[]
-  filteredRows: AccountsOverview[]
   taxAdvantagedCategories?: TaxAdvantagedCategory[]
 }) {
   const taxAdvantagedCategoryById = useMemo(
@@ -17,38 +18,10 @@ export function useTaxAdvantagedLimitSummaries({
     [taxAdvantagedCategories],
   )
 
-  const linkedAccountCountByPlanId = useMemo(() => {
-    const counts = new Map<string, number>()
-    for (const account of rows) {
-      if (account.group_id !== null || !account.tax_advantaged_category_id) continue
-      if (!taxAdvantagedCategoryById.has(account.tax_advantaged_category_id)) continue
-      counts.set(
-        account.tax_advantaged_category_id,
-        (counts.get(account.tax_advantaged_category_id) ?? 0) + 1,
-      )
-    }
-    return counts
-  }, [rows, taxAdvantagedCategoryById])
-
-  const taxAdvantagedLimitSummaries = useMemo<TaxAdvantagedLimitSummary[]>(() => {
-    const visiblePlanIds = new Set<string>()
-    for (const account of filteredRows) {
-      if (account.group_id !== null || !account.tax_advantaged_category_id) continue
-      visiblePlanIds.add(account.tax_advantaged_category_id)
-    }
-
-    return (taxAdvantagedCategories ?? [])
-      .filter((plan) => visiblePlanIds.has(plan.id))
-      .filter((plan) =>
-        plan.current_year_contribution_limit !== null ||
-        plan.current_year_withdrawal_limit !== null ||
-        plan.lifetime_contribution_limit !== null ||
-        plan.accrued_lifetime_contribution_limit !== null)
-      .map((plan) => ({
-        plan,
-        linkedAccountCount: linkedAccountCountByPlanId.get(plan.id) ?? 0,
-      }))
-  }, [filteredRows, linkedAccountCountByPlanId, taxAdvantagedCategories])
+  const taxAdvantagedLimitSummaries = useMemo(
+    () => getTaxAdvantagedLimitSummaries(rows, taxAdvantagedCategories ?? []),
+    [rows, taxAdvantagedCategories],
+  )
 
   return { taxAdvantagedCategoryById, taxAdvantagedLimitSummaries }
 }

--- a/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
+++ b/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
@@ -1,4 +1,6 @@
+import type { AccountsOverview } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/taxAdvantagedCategories'
+import type { TaxAdvantagedLimitSummary } from '@/pages/accounts/types/accounts'
 
 /**
  * Chooses the usage colour for tax-advantaged contribution and withdrawal meters
@@ -135,5 +137,47 @@ export function hasTaxAdvantagedLimitTracking(plan: TaxAdvantagedCategory): bool
     plan.ytd_withdrawals !== 0 ||
     plan.lifetime_contributions !== 0 ||
     plan.lifetime_withdrawals !== 0
+  )
+}
+
+/**
+ * Builds tax-advantaged limit rows from active account links without applying page filters
+ */
+export function getTaxAdvantagedLimitSummaries(
+  rows: AccountsOverview[],
+  taxAdvantagedCategories: TaxAdvantagedCategory[],
+): TaxAdvantagedLimitSummary[] {
+  const linkedAccountCountByPlanId = new Map<string, number>()
+  const activePlanIds = new Set<string>()
+  const taxAdvantagedCategoryById = new Map(taxAdvantagedCategories.map((plan) => [plan.id, plan]))
+
+  for (const account of rows) {
+    if (account.group_id !== null || !account.tax_advantaged_category_id) continue
+    if (!taxAdvantagedCategoryById.has(account.tax_advantaged_category_id)) continue
+    activePlanIds.add(account.tax_advantaged_category_id)
+    linkedAccountCountByPlanId.set(
+      account.tax_advantaged_category_id,
+      (linkedAccountCountByPlanId.get(account.tax_advantaged_category_id) ?? 0) + 1,
+    )
+  }
+
+  return taxAdvantagedCategories
+    .filter((plan) => activePlanIds.has(plan.id))
+    .filter(hasTaxAdvantagedConfiguredLimit)
+    .map((plan) => ({
+      plan,
+      linkedAccountCount: linkedAccountCountByPlanId.get(plan.id) ?? 0,
+    }))
+}
+
+/**
+ * Checks whether a tax-advantaged category has configured limits worth summarizing
+ */
+function hasTaxAdvantagedConfiguredLimit(plan: TaxAdvantagedCategory): boolean {
+  return (
+    plan.current_year_contribution_limit !== null ||
+    plan.current_year_withdrawal_limit !== null ||
+    plan.lifetime_contribution_limit !== null ||
+    plan.accrued_lifetime_contribution_limit !== null
   )
 }

--- a/frontend/src/pages/auth/AuthPage.tsx
+++ b/frontend/src/pages/auth/AuthPage.tsx
@@ -60,7 +60,7 @@ const AuthPage = () => {
       animate={{ opacity: 1 }}
       transition={{ duration: 0.3 }}
     >
-      <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-5" noValidate>
+      <form onSubmit={handleSubmit} className="w-full max-w-sm" noValidate>
         <AuthAnimatedTitle mode={mode} />
 
         <AuthErrorBanner error={displayError} />
@@ -74,19 +74,21 @@ const AuthPage = () => {
           onFieldChange={handleChange}
         />
 
-        <AuthTextField
-          id="email"
-          label="Email"
-          type="email"
-          autoComplete="email"
-          value={form.email}
-          touched={touched.email}
-          error={fieldErrors.email}
-          onChange={(value) => handleChange('email', value)}
-          onBlur={() => handleBlur('email')}
-        />
+        <div className="mt-5">
+          <AuthTextField
+            id="email"
+            label="Email"
+            type="email"
+            autoComplete="email"
+            value={form.email}
+            touched={touched.email}
+            error={fieldErrors.email}
+            onChange={(value) => handleChange('email', value)}
+            onBlur={() => handleBlur('email')}
+          />
+        </div>
 
-        <div>
+        <div className="mt-5">
           <AuthTextField
             id="password"
             label="Password"
@@ -126,7 +128,7 @@ const AuthPage = () => {
           onFieldChange={handleChange}
         />
 
-        <div className="flex justify-center">
+        <div className="mt-5 flex justify-center">
           <button
             type="submit"
             disabled={submitDisabled}
@@ -138,7 +140,7 @@ const AuthPage = () => {
           </button>
         </div>
 
-        <p className="text-center text-sm" style={{ color: 'var(--app-text-muted)' }}>
+        <p className="mt-5 text-center text-sm" style={{ color: 'var(--app-text-muted)' }}>
           {isLogin ? "Don't have an account? " : 'Already have an account? '}
           <button
             type="button"

--- a/frontend/src/pages/auth/components/feedback/ErrorBanner.tsx
+++ b/frontend/src/pages/auth/components/feedback/ErrorBanner.tsx
@@ -15,9 +15,9 @@ export function AuthErrorBanner({ error }: { error: string }) {
             background: 'var(--app-negative-soft)',
             border: '1px solid var(--app-negative-border)',
           }}
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: 'auto' }}
-          exit={{ opacity: 0, height: 0 }}
+          initial={{ opacity: 0, height: 0, marginTop: 0 }}
+          animate={{ opacity: 1, height: 'auto', marginTop: 20 }}
+          exit={{ opacity: 0, height: 0, marginTop: 0 }}
           transition={{ duration: 0.2 }}
         >
           <AlertCircle
@@ -34,4 +34,3 @@ export function AuthErrorBanner({ error }: { error: string }) {
     </AnimatePresence>
   )
 }
-

--- a/frontend/src/pages/budgets/utils/budgetStatus.ts
+++ b/frontend/src/pages/budgets/utils/budgetStatus.ts
@@ -5,7 +5,7 @@ import { getBudgetUtilizationPercent } from '@/pages/budgets/utils/utilization'
  * Classifies the latest budget period into the status used by cards and details summaries
  */
 export function attentionState(latestPeriod: Budget | undefined, utilization: BudgetUtilization | undefined) {
-  if (!latestPeriod || !utilization) {
+  if (!latestPeriod) {
     return {
       label: 'Needs attention',
       background: 'var(--app-negative-soft)',
@@ -15,7 +15,7 @@ export function attentionState(latestPeriod: Budget | undefined, utilization: Bu
     }
   }
 
-  const usedPercent = getBudgetUtilizationPercent(utilization.total_spent, latestPeriod.overall_limit)
+  const usedPercent = getBudgetUtilizationPercent(utilization?.total_spent ?? 0, latestPeriod.overall_limit)
   if (usedPercent >= 100) {
     return {
       label: 'Needs attention',

--- a/frontend/src/pages/dashboard/DashboardPage.tsx
+++ b/frontend/src/pages/dashboard/DashboardPage.tsx
@@ -8,6 +8,7 @@ import { SpendingBreakdownWidget } from '@/pages/dashboard/widgets/spending-brea
 import { SpendingComparisonWidget } from '@/pages/dashboard/widgets/spending-comparison/Widget'
 import { TopBudgetsWidget } from '@/pages/dashboard/widgets/top-budgets/Widget'
 import { useDashboardGreeting } from '@/pages/dashboard/hooks/useDashboardGreeting'
+import { DashboardGreetingHeader } from '@/pages/dashboard/components/GreetingHeader'
 
 /**
  * Composes the dashboard greeting and financial overview widgets
@@ -19,12 +20,7 @@ export default function DashboardPage() {
 
   return (
     <div>
-      <header className="app-page-header">
-        <h1 className="app-page-title">
-          {greeting}
-        </h1>
-        <p className="app-page-description">{subtitle}</p>
-      </header>
+      <DashboardGreetingHeader greeting={greeting} subtitle={subtitle} />
 
       <div className="space-y-5">
         <div className="grid grid-cols-1 gap-4 min-[730px]:grid-cols-2 min-[1750px]:grid-cols-4">

--- a/frontend/src/pages/dashboard/components/GreetingHeader.tsx
+++ b/frontend/src/pages/dashboard/components/GreetingHeader.tsx
@@ -1,0 +1,93 @@
+import { AnimatePresence, motion } from 'motion/react'
+
+const DASHBOARD_GREETING_CHARACTER_TRANSITION = {
+  duration: 0.3,
+  ease: [0.25, 0.1, 0.25, 1.04],
+} as const
+
+const DASHBOARD_GREETING_TITLE_VARIANTS = {
+  initial: { transition: { staggerChildren: 0.03 } },
+  enter: { transition: { staggerChildren: 0.03 } },
+  exit: { transition: { staggerChildren: 0.02, staggerDirection: -1 } },
+} as const
+
+const DASHBOARD_GREETING_CHARACTER_VARIANTS = {
+  initial: { y: 40, opacity: 0 },
+  enter: { y: 0, opacity: 1 },
+  exit: { y: -40, opacity: 0 },
+} as const
+
+const DASHBOARD_GREETING_SUBTITLE_TRANSITION = {
+  duration: 0.22,
+  ease: [0.42, 0, 0.58, 1],
+} as const
+
+const DASHBOARD_GREETING_TITLE_BLEED = 'calc(var(--app-page-title-size) * 0.16)'
+const DASHBOARD_GREETING_TITLE_NEGATIVE_BLEED = 'calc(var(--app-page-title-size) * -0.16)'
+const DASHBOARD_GREETING_RESERVED_SUBTITLE = 'Your finances can wait, your sleep can\u2019t.'
+
+/**
+ * Renders the dashboard greeting with separate title and subtitle transition styles
+ */
+export function DashboardGreetingHeader({
+  greeting,
+  subtitle,
+}: {
+  greeting: string
+  subtitle: string
+}) {
+  return (
+    <header className="app-page-header">
+      <div className="relative" style={{ height: 'var(--app-page-title-size)' }}>
+        <div
+          className="absolute inset-x-0 overflow-hidden"
+          style={{
+            bottom: DASHBOARD_GREETING_TITLE_NEGATIVE_BLEED,
+            paddingTop: DASHBOARD_GREETING_TITLE_BLEED,
+            top: DASHBOARD_GREETING_TITLE_NEGATIVE_BLEED,
+          }}
+        >
+          <AnimatePresence initial={false} mode="wait">
+            <motion.h1
+              key={greeting}
+              className="app-page-title flex whitespace-nowrap"
+              initial="initial"
+              animate="enter"
+              exit="exit"
+              variants={DASHBOARD_GREETING_TITLE_VARIANTS}
+            >
+              {greeting.split('').map((char, index) => (
+                <motion.span
+                  key={`${greeting}-${index}`}
+                  className={char === ' ' ? 'inline-block w-[0.28em]' : 'inline-block'}
+                  variants={DASHBOARD_GREETING_CHARACTER_VARIANTS}
+                  transition={DASHBOARD_GREETING_CHARACTER_TRANSITION}
+                >
+                  {char}
+                </motion.span>
+              ))}
+            </motion.h1>
+          </AnimatePresence>
+        </div>
+      </div>
+
+      <div className="relative">
+        <p className="app-page-description invisible" aria-hidden>
+          {DASHBOARD_GREETING_RESERVED_SUBTITLE}
+        </p>
+        <AnimatePresence initial={false} mode="wait">
+          <motion.p
+            key={subtitle}
+            className="app-page-description absolute inset-x-0 top-0"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={DASHBOARD_GREETING_SUBTITLE_TRANSITION}
+          >
+            {subtitle}
+          </motion.p>
+        </AnimatePresence>
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/pages/dashboard/hooks/useDashboardGreeting.ts
+++ b/frontend/src/pages/dashboard/hooks/useDashboardGreeting.ts
@@ -1,18 +1,39 @@
+import { useEffect, useState } from 'react'
+
 /**
- * Returns the dashboard greeting copy for the current local hour
+ * Returns the dashboard greeting copy for a local hour
  */
-export function useDashboardGreeting() {
-  const hour = new Date().getHours()
+export function getDashboardGreetingForHour(hour: number) {
+  const isSleepHours = hour < 4 || hour >= 21
   const greeting =
-    hour >= 1 && hour < 4 ? 'Still Up?' :
-    hour < 12 ? 'Good Morning' :
-    hour < 17 ? 'Good Afternoon' :
-    'Good Evening'
+    hour < 4 ? 'Still up?' :
+    hour < 12 ? 'Good morning' :
+    hour < 16 ? 'Good afternoon' :
+    hour < 21 ? 'Good evening' :
+    'It\u2019s getting late...'
 
   const subtitle =
-    hour >= 1 && hour < 4
+    isSleepHours
       ? 'Your finances can wait, your sleep can\u2019t.'
       : 'Here is your financial overview.'
 
   return { greeting, subtitle }
+}
+
+/**
+ * Returns the dashboard greeting copy and refreshes it when the window regains focus
+ */
+export function useDashboardGreeting() {
+  const [greeting, setGreeting] = useState(() => getDashboardGreetingForHour(new Date().getHours()))
+
+  useEffect(() => {
+    const handleWindowFocus = () => {
+      setGreeting(getDashboardGreetingForHour(new Date().getHours()))
+    }
+
+    window.addEventListener('focus', handleWindowFocus)
+    return () => window.removeEventListener('focus', handleWindowFocus)
+  }, [])
+
+  return greeting
 }

--- a/frontend/src/pages/transactions/TransactionsPage.tsx
+++ b/frontend/src/pages/transactions/TransactionsPage.tsx
@@ -34,7 +34,7 @@ export default function TransactionsPage() {
   const [createModalKey, setCreateModalKey] = useState(0)
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null)
   const [openingOutlierId, setOpeningOutlierId] = useState<string | null>(null)
-  const [outlierOpenError, setOutlierOpenError] = useState<string | null>(null)
+  const [outlierLoadError, setOutlierLoadError] = useState<string | null>(null)
 
   /**
    * Opens the transaction modal in create mode and resets any previous edit state
@@ -46,12 +46,9 @@ export default function TransactionsPage() {
   }
 
   /**
-   * Opens the transaction modal in edit mode unless the owning account is archived
+   * Opens the transaction modal in edit mode, including read-only archived account transactions
    */
   const openEditModal = (transaction: Transaction) => {
-    const account = accounts?.find((item) => item.id === transaction.account_id)
-    if (account?.is_archived) return
-
     setEditingTransaction(transaction)
     setCreateModalKey((key) => key + 1)
     setShowCreateModal(true)
@@ -61,16 +58,11 @@ export default function TransactionsPage() {
    * Opens a top-band outlier transaction from the loaded list or a cached detail fetch
    */
   const openOutlierTransaction = async (transactionId: string) => {
-    setOutlierOpenError(null)
+    setOutlierLoadError(null)
 
     // Outliers may not be in the currently loaded list page, so fall back to a detail fetch
     const loadedTransaction = latestTransactionsRef.current.find((transaction) => transaction.id === transactionId)
     if (loadedTransaction) {
-      const account = accounts?.find((item) => item.id === loadedTransaction.account_id)
-      if (account?.is_archived) {
-        setOutlierOpenError('Archived account transactions are read-only')
-        return
-      }
       openEditModal(loadedTransaction)
       return
     }
@@ -82,14 +74,9 @@ export default function TransactionsPage() {
         queryFn: () => fetchTransaction(transactionId),
         staleTime: 10 * 60 * 1000,
       })
-      const account = accounts?.find((item) => item.id === transaction.account_id)
-      if (account?.is_archived) {
-        setOutlierOpenError('Archived account transactions are read-only')
-        return
-      }
       openEditModal(transaction)
     } catch {
-      setOutlierOpenError('Unable to open transaction')
+      setOutlierLoadError('Unable to open transaction')
     } finally {
       setOpeningOutlierId((current) => (current === transactionId ? null : current))
     }
@@ -130,6 +117,11 @@ export default function TransactionsPage() {
     })),
     [accounts],
   )
+  const editingTransactionReadOnly = useMemo(() => {
+    if (!editingTransaction) return false
+
+    return Boolean(accounts?.find((account) => account.id === editingTransaction.account_id)?.is_archived)
+  }, [accounts, editingTransaction])
   const handleSettledTransactionsChange = useCallback((transactions: Transaction[]) => {
     latestTransactionsRef.current = transactions
   }, [])
@@ -153,7 +145,7 @@ export default function TransactionsPage() {
             chartAnimationKey={chartAnimationKey}
             prefersReducedMotion={prefersReducedMotion}
             openingOutlierId={openingOutlierId}
-            outlierOpenError={outlierOpenError}
+            outlierLoadError={outlierLoadError}
             onOpenOutlierTransaction={(transactionId) => { void openOutlierTransaction(transactionId) }}
           />
 
@@ -184,6 +176,7 @@ export default function TransactionsPage() {
         open={showCreateModal}
         onClose={() => setShowCreateModal(false)}
         transaction={editingTransaction ?? undefined}
+        readOnly={editingTransactionReadOnly}
       />
     </div>
   )

--- a/frontend/src/pages/transactions/components/TopBand.tsx
+++ b/frontend/src/pages/transactions/components/TopBand.tsx
@@ -37,7 +37,7 @@ export default function TransactionsTopBand({
   chartAnimationKey,
   prefersReducedMotion,
   openingOutlierId,
-  outlierOpenError,
+  outlierLoadError,
   onOpenOutlierTransaction,
 }: {
   overview: TransactionsOverview | undefined
@@ -49,7 +49,7 @@ export default function TransactionsTopBand({
   chartAnimationKey: string
   prefersReducedMotion: boolean | null
   openingOutlierId: string | null
-  outlierOpenError: string | null
+  outlierLoadError: string | null
   onOpenOutlierTransaction: (transactionId: string) => void
 }) {
   const overviewOutliers = overview?.outliers ?? []
@@ -156,7 +156,7 @@ export default function TransactionsTopBand({
             fxStatus={overview?.outliers_fx_status}
             prefersReducedMotion={prefersReducedMotion}
             openingOutlierId={openingOutlierId}
-            outlierOpenError={outlierOpenError}
+            outlierLoadError={outlierLoadError}
             onOpenOutlierTransaction={onOpenOutlierTransaction}
             className="border-t border-[var(--app-border)] pt-3 min-[730px]:relative min-[730px]:pr-6 min-[730px]:after:absolute min-[730px]:after:bottom-0 min-[730px]:after:right-0 min-[730px]:after:top-3 min-[730px]:after:w-px min-[730px]:after:bg-[var(--app-border)] min-[730px]:after:content-[''] min-[1750px]:border-x min-[1750px]:border-t-0 min-[1750px]:px-6 min-[1750px]:pt-0 min-[1750px]:after:hidden"
           />

--- a/frontend/src/pages/transactions/components/top-band/MostExpensiveTransactionsPanel.tsx
+++ b/frontend/src/pages/transactions/components/top-band/MostExpensiveTransactionsPanel.tsx
@@ -23,7 +23,7 @@ export default function MostExpensiveTransactionsPanel({
   fxStatus,
   prefersReducedMotion,
   openingOutlierId,
-  outlierOpenError,
+  outlierLoadError,
   onOpenOutlierTransaction,
   className = '',
 }: {
@@ -31,7 +31,7 @@ export default function MostExpensiveTransactionsPanel({
   fxStatus: FxStatus | undefined
   prefersReducedMotion: boolean | null
   openingOutlierId: string | null
-  outlierOpenError: string | null
+  outlierLoadError: string | null
   onOpenOutlierTransaction: (transactionId: string) => void
   className?: string
 }) {
@@ -117,9 +117,9 @@ export default function MostExpensiveTransactionsPanel({
               )
             })}
         </AnimatePresence>
-        {outlierOpenError && (
+        {outlierLoadError && (
           <p className="text-xs" style={{ color: 'var(--app-negative)' }}>
-            {outlierOpenError}
+            {outlierLoadError}
           </p>
         )}
       </div>

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -64,6 +64,7 @@ export default function CreateTransactionModal({
   transaction,
   defaultAccountId,
   defaultCurrency,
+  readOnly: readOnlyProp = false,
 }: CreateTransactionModalProps) {
   const editing = !!transaction
   const queryClient = useQueryClient()
@@ -138,6 +139,7 @@ export default function CreateTransactionModal({
     () => accounts.find((account) => account.id === form.account_id),
     [accounts, form.account_id],
   )
+  const readOnly = editing && (readOnlyProp || Boolean(selectedAccount?.is_archived))
   const merchantQuery = useInfiniteMerchants(
     { q: merchantReferenceSearch.activeSearchText || undefined },
     MERCHANT_DROPDOWN_PAGE_SIZE,
@@ -325,7 +327,7 @@ export default function CreateTransactionModal({
   }
 
   const handleMakeMerchantDefaultCategory = () => {
-    if (!selectedMerchant || !selectedCategory || updateMerchantMutation.isPending) return
+    if (readOnly || !selectedMerchant || !selectedCategory || updateMerchantMutation.isPending) return
 
     setSubmitError('')
     updateMerchantMutation.mutate(
@@ -461,7 +463,7 @@ export default function CreateTransactionModal({
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (isPending) return
+    if (isPending || readOnly) return
     const errors = validateTransactionForm(form)
     setFieldErrors(errors)
     setTouched({ account_id: true, category_id: true, merchant_id: true, amount: true, currency: true, date: true })
@@ -535,7 +537,7 @@ export default function CreateTransactionModal({
   }
 
   const handleDelete = async () => {
-    if (!transaction) return false
+    if (!transaction || readOnly) return false
 
     setSubmitError('')
 
@@ -557,12 +559,14 @@ export default function CreateTransactionModal({
         open={open}
         editing={editing}
         transactionKindLabel={KIND_LABELS[form.kind]}
+        headerStatus={readOnly ? 'Archived account' : undefined}
         onClose={handleClose}
         onSubmit={handleSubmit}
         footer={(
           <TransactionModalFooter
             editing={editing}
             isPending={isPending}
+            readOnly={readOnly}
             submitLoading={submitLoading}
             deleteLoading={deleteLoading}
             keepOpenAfterCreate={keepOpenAfterCreate}
@@ -577,6 +581,7 @@ export default function CreateTransactionModal({
             kind={form.kind}
             direction={form.direction}
             editing={editing}
+            readOnly={readOnly}
             directionHighlightKey={directionHighlightKey}
             onKindChange={handleKindChange}
             onDirectionChange={(value) => handleField('direction', value)}
@@ -614,6 +619,7 @@ export default function CreateTransactionModal({
             tagHideOptionsWhileLoading={tagReference.showInitialLoading}
             tagHasMore={!!tagQuery.hasNextPage}
             selectedTags={selectedTags}
+            readOnly={readOnly}
             onAccountChange={handleAccountChange}
             onMerchantChange={handleMerchantChange}
             onMerchantSearchChange={merchantReferenceSearch.setSearch}
@@ -641,6 +647,7 @@ export default function CreateTransactionModal({
             amount={form.amount}
             amountError={showError('amount')}
             notes={form.notes}
+            readOnly={readOnly}
             onDateChange={(value) => handleField('date', value)}
             onDateBlur={() => handleBlur('date')}
             onAmountChange={handleAmountChange}

--- a/frontend/src/pages/transactions/components/transaction-modal/layout/Footer.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/layout/Footer.tsx
@@ -4,6 +4,7 @@ import { Check, Trash2 } from 'lucide-react'
 interface TransactionModalFooterProps {
   editing: boolean
   isPending: boolean
+  readOnly: boolean
   submitLoading: boolean
   deleteLoading: boolean
   keepOpenAfterCreate: boolean
@@ -18,6 +19,7 @@ interface TransactionModalFooterProps {
 export default function TransactionModalFooter({
   editing,
   isPending,
+  readOnly,
   submitLoading,
   deleteLoading,
   keepOpenAfterCreate,
@@ -78,7 +80,7 @@ export default function TransactionModalFooter({
       className="flex shrink-0 flex-col gap-3 px-6 py-4 sm:flex-row sm:items-center sm:px-8 min-[1050px]:py-5"
       style={{ borderTop: '1px solid var(--app-border)' }}
     >
-      {editing ? (
+      {editing && !readOnly ? (
         <button
           ref={deleteButtonRef}
           type="button"
@@ -134,7 +136,7 @@ export default function TransactionModalFooter({
             </span>
           )}
         </button>
-      ) : (
+      ) : !editing ? (
         <div className="min-w-0 sm:max-w-xs">
           <label
             htmlFor="txn-keep-open"
@@ -159,23 +161,25 @@ export default function TransactionModalFooter({
             </span>
           </label>
         </div>
-      )}
+      ) : null}
       <div className="grid grid-cols-2 gap-3 sm:ml-auto sm:flex sm:items-center">
         <button
           type="button"
-          className="app-secondary-button w-full sm:w-auto"
+          className={readOnly ? 'app-secondary-button col-span-2 w-full sm:w-auto' : 'app-secondary-button w-full sm:w-auto'}
           onClick={onCancel}
           disabled={isPending}
         >
-          Cancel
+          {readOnly ? 'Close' : 'Cancel'}
         </button>
-        <button
-          type="submit"
-          disabled={isPending}
-          className={`app-primary-button overflow-hidden whitespace-nowrap duration-300 ${submitLoading ? 'app-primary-button-loading justify-self-center sm:justify-self-auto' : editing ? 'w-full sm:w-24' : 'w-full sm:w-44'}`}
-        >
-          {submitLoading ? <div className="app-spinner" /> : editing ? 'Save' : 'Add Transaction'}
-        </button>
+        {!readOnly && (
+          <button
+            type="submit"
+            disabled={isPending}
+            className={`app-primary-button overflow-hidden whitespace-nowrap duration-300 ${submitLoading ? 'app-primary-button-loading justify-self-center sm:justify-self-auto' : editing ? 'w-full sm:w-24' : 'w-full sm:w-44'}`}
+          >
+            {submitLoading ? <div className="app-spinner" /> : editing ? 'Save' : 'Add Transaction'}
+          </button>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
@@ -8,6 +8,7 @@ interface TransactionModalShellProps {
   open: boolean
   editing: boolean
   transactionKindLabel: string
+  headerStatus?: string
   children: ReactNode
   footer: ReactNode
   onClose: () => void
@@ -21,6 +22,7 @@ export default function TransactionModalShell({
   open,
   editing,
   transactionKindLabel,
+  headerStatus,
   children,
   footer,
   onClose,
@@ -85,10 +87,20 @@ export default function TransactionModalShell({
                   <div className="flex items-start justify-between gap-6">
                     <div className="min-w-0">
                       <p
-                        className="mb-2 text-xs font-semibold uppercase"
+                        className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-semibold uppercase"
                         style={{ color: 'var(--app-accent)' }}
                       >
-                        {editing ? 'Existing transaction' : `${transactionKindLabel} transaction`}
+                        <span>{editing ? 'Existing transaction' : `${transactionKindLabel} transaction`}</span>
+                        {headerStatus && (
+                          <>
+                            <span aria-hidden style={{ color: 'var(--app-text-subtle)' }}>
+                              &middot;
+                            </span>
+                            <span style={{ color: 'var(--app-warning-text)' }}>
+                              {headerStatus}
+                            </span>
+                          </>
+                        )}
                       </p>
                       <h2
                         id="create-txn-title"

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -15,6 +15,7 @@ interface TransactionDetailsSectionProps {
   amount: string
   amountError?: string | false
   notes: string
+  readOnly: boolean
   onDateChange: (value: string) => void
   onDateBlur: () => void
   onAmountChange: (value: string) => void
@@ -35,6 +36,7 @@ export default function TransactionDetailsSection({
   amount,
   amountError,
   notes,
+  readOnly,
   onDateChange,
   onDateBlur,
   onAmountChange,
@@ -51,7 +53,7 @@ export default function TransactionDetailsSection({
               dateError
                 ? 'app-input-error'
                 : 'focus-within:border-[var(--app-accent-border)] focus-within:shadow-[0_0_0_2px_var(--app-accent-soft)]'
-            }`}
+            } ${readOnly ? 'cursor-not-allowed opacity-60' : ''}`}
           >
             <span className="min-w-0 truncate font-medium tabular-nums" aria-hidden>
               {date}
@@ -61,8 +63,9 @@ export default function TransactionDetailsSection({
               id="txn-date-mobile"
               type="date"
               aria-label="Date"
-              className="absolute inset-0 h-full w-full cursor-pointer opacity-0 text-base"
+              className="absolute inset-0 h-full w-full cursor-pointer opacity-0 text-base disabled:cursor-not-allowed"
               value={date}
+              disabled={readOnly}
               onChange={(event) => onDateChange(event.target.value)}
               onBlur={onDateBlur}
             />
@@ -70,8 +73,9 @@ export default function TransactionDetailsSection({
           <input
             id="txn-date"
             type="date"
-            className={`app-input app-date-input-balanced hidden min-[1050px]:block ${dateError ? 'app-input-error' : ''}`}
+            className={`app-input app-date-input-balanced hidden min-[1050px]:block disabled:cursor-not-allowed disabled:opacity-60 ${dateError ? 'app-input-error' : ''}`}
             value={date}
+            disabled={readOnly}
             onChange={(event) => onDateChange(event.target.value)}
             onBlur={onDateBlur}
           />
@@ -113,9 +117,10 @@ export default function TransactionDetailsSection({
               id="txn-amount"
               type="text"
               inputMode="decimal"
-              className={`app-input w-full ${selectedCurrencySymbol ? 'pl-8' : ''} ${amountError ? 'app-input-error' : ''}`}
+              className={`app-input w-full disabled:cursor-not-allowed disabled:opacity-60 ${selectedCurrencySymbol ? 'pl-8' : ''} ${amountError ? 'app-input-error' : ''}`}
               placeholder="0.00"
               value={formatMoneyInputLive(amount)}
+              disabled={readOnly}
               onChange={(event) => onAmountChange(event.target.value)}
               onBlur={onAmountBlur}
             />
@@ -128,9 +133,10 @@ export default function TransactionDetailsSection({
         <input
           id="txn-notes"
           type="text"
-          className="app-input"
+          className="app-input disabled:cursor-not-allowed disabled:opacity-60"
           placeholder="Optional"
           value={notes}
+          disabled={readOnly}
           onChange={(event) => onNotesChange(event.target.value)}
           maxLength={500}
         />

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -41,6 +41,7 @@ interface TransactionReferencesSectionProps {
   tagHideOptionsWhileLoading: boolean
   tagHasMore: boolean
   selectedTags: SelectedTransactionTag[]
+  readOnly: boolean
   onAccountChange: (value: string) => void
   onMerchantChange: (value: string) => void
   onMerchantSearchChange: (value: string) => void
@@ -91,6 +92,7 @@ export default function TransactionReferencesSection({
   tagHideOptionsWhileLoading,
   tagHasMore,
   selectedTags,
+  readOnly,
   onAccountChange,
   onMerchantChange,
   onMerchantSearchChange,
@@ -120,6 +122,7 @@ export default function TransactionReferencesSection({
           placeholder={accountPlaceholder}
           searchable
           searchPlaceholder="Search accounts..."
+          disabled={readOnly}
         />
         <AnimatePresence initial={false}>
           {runningBalance && (
@@ -171,8 +174,9 @@ export default function TransactionReferencesSection({
           selectHighlightedOnSearchEnter
           hasMore={merchantHasMore}
           onLoadMore={onMerchantLoadMore}
-          onCreateNew={onCreateMerchant}
-          createNewLabel={(query) => query ? `Create merchant "${query}"` : 'Create merchant'}
+          onCreateNew={readOnly ? undefined : onCreateMerchant}
+          createNewLabel={readOnly ? undefined : (query) => query ? `Create merchant "${query}"` : 'Create merchant'}
+          disabled={readOnly}
         />
       </div>
 
@@ -186,7 +190,7 @@ export default function TransactionReferencesSection({
               className="block h-5 min-w-0 max-w-full truncate text-left text-xs font-medium leading-5 disabled:cursor-not-allowed disabled:opacity-60 sm:text-right"
               style={{ color: 'var(--app-accent)' }}
               title={merchantDefaultCategoryActionLabel}
-              disabled={merchantDefaultCategoryPending}
+              disabled={merchantDefaultCategoryPending || readOnly}
               onClick={onMakeMerchantDefaultCategory}
             >
               {merchantDefaultCategoryActionLabel}
@@ -201,8 +205,9 @@ export default function TransactionReferencesSection({
           placeholder="Select category..."
           searchable
           searchPlaceholder="Search categories..."
-          onCreateNew={onCreateCategory}
-          createNewLabel={(query) => query ? `Create category "${query}"` : 'Create category'}
+          onCreateNew={readOnly ? undefined : onCreateCategory}
+          createNewLabel={readOnly ? undefined : (query) => query ? `Create category "${query}"` : 'Create category'}
+          disabled={readOnly}
         />
       </div>
 
@@ -226,9 +231,9 @@ export default function TransactionReferencesSection({
           hideOptionsWhileLoading={tagHideOptionsWhileLoading}
           hasMore={tagHasMore}
           onLoadMore={onTagLoadMore}
-          onCreateNew={onCreateTag}
-          createNewLabel={(query) => query ? `Create tag "${query}"` : 'Create tag'}
-          disabled={tagsDisabled}
+          onCreateNew={readOnly ? undefined : onCreateTag}
+          createNewLabel={readOnly ? undefined : (query) => query ? `Create tag "${query}"` : 'Create tag'}
+          disabled={tagsDisabled || readOnly}
         />
         <AnimatePresence initial={false}>
           {selectedTags.length > 0 && (
@@ -251,12 +256,16 @@ export default function TransactionReferencesSection({
                       layout
                       key={tag.id}
                       type="button"
-                      onClick={() => onRemoveTag(tag.id)}
-                      className="inline-flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors duration-100 hover:bg-[var(--app-accent-soft)]"
+                      onClick={() => {
+                        if (!readOnly) onRemoveTag(tag.id)
+                      }}
+                      disabled={readOnly}
+                      className="inline-flex max-w-full items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors duration-100 enabled:hover:bg-[var(--app-accent-soft)] disabled:cursor-not-allowed"
                       style={{
                         background: 'var(--app-surface-soft)',
                         color: 'var(--app-text-muted)',
                         border: '1px solid var(--app-border)',
+                        opacity: readOnly ? 0.65 : 1,
                       }}
                       initial={{ opacity: 0, scale: 0.96, y: -4 }}
                       animate={{ opacity: 1, scale: 1, y: 0 }}
@@ -266,7 +275,7 @@ export default function TransactionReferencesSection({
                     >
                       <TagIcon size={13} aria-hidden className="shrink-0" />
                       <span className="min-w-0 truncate">{tag.name}</span>
-                      <X size={13} aria-hidden className="shrink-0" />
+                      {!readOnly && <X size={13} aria-hidden className="shrink-0" />}
                     </motion.button>
                   ))}
                 </AnimatePresence>

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/TypeDirectionSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/TypeDirectionSection.tsx
@@ -15,6 +15,7 @@ interface TransactionTypeDirectionSectionProps {
   kind: TransactionModalKind
   direction: TransactionDirection
   editing: boolean
+  readOnly: boolean
   directionHighlightKey: number
   onKindChange: (kind: TransactionModalKind) => void
   onDirectionChange: (direction: TransactionDirection) => void
@@ -27,6 +28,7 @@ export default function TransactionTypeDirectionSection({
   kind,
   direction,
   editing,
+  readOnly,
   directionHighlightKey,
   onKindChange,
   onDirectionChange,
@@ -39,7 +41,7 @@ export default function TransactionTypeDirectionSection({
           options={KIND_OPTIONS}
           ariaLabel="Transaction type"
           onChange={onKindChange}
-          disabled={editing}
+          disabled={editing || readOnly}
         />
         <div className="relative rounded-lg">
           <AnimatePresence initial={false}>
@@ -60,6 +62,7 @@ export default function TransactionTypeDirectionSection({
             options={DIRECTION_OPTIONS}
             ariaLabel="Transaction direction"
             onChange={onDirectionChange}
+            disabled={readOnly}
           />
         </div>
       </div>

--- a/frontend/src/pages/transactions/components/transaction-modal/types.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/types.ts
@@ -38,4 +38,7 @@ export interface CreateTransactionModalProps {
 
   /** Pre-selects this currency in create mode, usually from the default account */
   defaultCurrency?: string
+
+  /** Opens an existing transaction for viewing without allowing changes */
+  readOnly?: boolean
 }

--- a/frontend/src/pages/transactions/hooks/useInfiniteScrollTrigger.ts
+++ b/frontend/src/pages/transactions/hooks/useInfiniteScrollTrigger.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 /**
  * Observes the bottom sentinel and delays infinite-scroll fetches so loading feedback is visible
@@ -14,14 +14,23 @@ export function useInfiniteScrollTrigger({
   disabled: boolean
   fetchNextPage: () => void
 }) {
-  const sentinelRef = useRef<HTMLDivElement>(null)
+  const fetchNextPageRef = useRef(fetchNextPage)
+  const [sentinelElement, setSentinelElement] = useState<HTMLDivElement | null>(null)
   const [pendingFetch, setPendingFetch] = useState(false)
+
+  useEffect(() => {
+    fetchNextPageRef.current = fetchNextPage
+  }, [fetchNextPage])
+
+  const sentinelRef = useCallback((element: HTMLDivElement | null) => {
+    setSentinelElement(element)
+  }, [])
 
   // Watch the sentinel and delay the fetch slightly so the user sees a stable
   // loading state instead of rapid bottom-of-list flicker
   useEffect(() => {
     if (!hasNextPage || isFetchingNextPage || disabled) return
-    const el = sentinelRef.current
+    const el = sentinelElement
     if (!el) return
     let timeoutId: ReturnType<typeof setTimeout> | null = null
     const observer = new IntersectionObserver((entries) => {
@@ -30,7 +39,7 @@ export function useInfiniteScrollTrigger({
           setPendingFetch(true)
           timeoutId = setTimeout(() => {
             setPendingFetch(false)
-            fetchNextPage()
+            fetchNextPageRef.current()
           }, 1000)
         }
       } else if (timeoutId !== null) {
@@ -41,10 +50,13 @@ export function useInfiniteScrollTrigger({
     }, { rootMargin: '200px' })
     observer.observe(el)
     return () => {
-      if (timeoutId !== null) clearTimeout(timeoutId)
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId)
+        setPendingFetch(false)
+      }
       observer.disconnect()
     }
-  }, [disabled, fetchNextPage, hasNextPage, isFetchingNextPage])
+  }, [disabled, hasNextPage, isFetchingNextPage, sentinelElement])
 
   return {
     sentinelRef,

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -105,6 +105,11 @@
     font-family: "DM Sans", system-ui, sans-serif;
   }
 
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]) {
+    cursor: pointer;
+  }
+
   @supports (-webkit-touch-callout: none) {
     input,
     select,

--- a/frontend/tests/accounts/accountsLogic.test.ts
+++ b/frontend/tests/accounts/accountsLogic.test.ts
@@ -30,6 +30,7 @@ import {
 import {
   formatTaxAdvantagedMeterMoney,
   getLifetimeAvailableBoundary,
+  getTaxAdvantagedLimitSummaries,
   getTaxAdvantagedUsageColor,
   getTaxAdvantagedUsagePercent,
   hasTaxAdvantagedLimitTracking,
@@ -419,5 +420,37 @@ describe('tax-advantaged limit helpers', () => {
     expect(hasTaxAdvantagedLimitTracking(createTaxAdvantagedCategory({
       ytd_contributions: 100,
     }))).toBe(true)
+  })
+
+  it('keeps limit summaries independent from account filters', () => {
+    const bank = createInstitution('bank', 'Bank')
+    const rows = [
+      createAccount({
+        id: 'fhsa',
+        account_type: 'investment',
+        institution: bank,
+        tax_advantaged_category_id: 'fhsa',
+      }),
+      createAccount({
+        id: 'rrsp',
+        account_type: 'savings',
+        institution: null,
+        tax_advantaged_category_id: 'rrsp',
+      }),
+    ]
+    const filteredRows = getFilteredRows(rows, { institution_id: 'bank' })
+    const summaries = getTaxAdvantagedLimitSummaries(rows, [
+      createTaxAdvantagedCategory({
+        id: 'fhsa',
+        current_year_contribution_limit: 800_000,
+      }),
+      createTaxAdvantagedCategory({
+        id: 'rrsp',
+        current_year_contribution_limit: 3_000_000,
+      }),
+    ])
+
+    expect(filteredRows.map((account) => account.id)).toEqual(['fhsa'])
+    expect(summaries.map((summary) => summary.plan.id)).toEqual(['fhsa', 'rrsp'])
   })
 })

--- a/frontend/tests/api/fxCache.test.ts
+++ b/frontend/tests/api/fxCache.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import type { Query } from '@tanstack/react-query';
+import {
+  getFxAwareStaleTime,
+  hasUncacheableFxStatus,
+  shouldPersistFxData,
+} from '@/api/shared/fxCache';
+
+const completeFxStatus = {
+  state: 'complete',
+  missing_pairs: [],
+};
+
+const unavailableFxStatus = {
+  state: 'unavailable',
+  missing_pairs: [{ base: 'USD', quote: 'CAD' }],
+};
+
+describe('FX cache status detection', () => {
+  it('detects nested non-success FX statuses', () => {
+    expect(hasUncacheableFxStatus({
+      accounts: [
+        {
+          id: 'acc_123',
+          current_balance_fx_status: unavailableFxStatus,
+        },
+      ],
+    })).toBe(true);
+  });
+
+  it('treats none and complete FX statuses as cacheable', () => {
+    expect(hasUncacheableFxStatus({
+      fx_status: {
+        state: 'none',
+        missing_pairs: [],
+      },
+      details: {
+        fx_status: completeFxStatus,
+      },
+    })).toBe(false);
+  });
+
+  it('keeps unknown future FX states out of cache', () => {
+    expect(hasUncacheableFxStatus({
+      fx_status: {
+        state: 'errored',
+        missing_pairs: [],
+      },
+    })).toBe(true);
+  });
+});
+
+describe('FX cache policy', () => {
+  it('marks failed FX responses stale and keeps them out of persistent storage', () => {
+    const staleTime = getFxAwareStaleTime(600_000);
+    const failedQuery = {
+      state: {
+        data: {
+          fx_status: unavailableFxStatus,
+        },
+      },
+    } as unknown as Query;
+    const successfulQuery = {
+      state: {
+        data: {
+          fx_status: completeFxStatus,
+        },
+      },
+    } as unknown as Query;
+
+    expect(staleTime(failedQuery)).toBe(0);
+    expect(staleTime(successfulQuery)).toBe(600_000);
+    expect(shouldPersistFxData(failedQuery.state.data)).toBe(false);
+    expect(shouldPersistFxData(successfulQuery.state.data)).toBe(true);
+  });
+});

--- a/frontend/tests/budgets/budgetStatus.test.ts
+++ b/frontend/tests/budgets/budgetStatus.test.ts
@@ -55,6 +55,10 @@ describe('budget attention status', () => {
     expect(attentionState(undefined, undefined).label).toBe('Needs attention')
   })
 
+  it('treats missing utilization for an existing period as zero spend', () => {
+    expect(attentionState(createBudget(), undefined).label).toBe('On track')
+  })
+
   it('classifies utilization below the warning threshold as on track', () => {
     expect(attentionState(createBudget(), createUtilization(50000)).label).toBe('On track')
   })

--- a/frontend/tests/dashboard/dashboardLogic.test.ts
+++ b/frontend/tests/dashboard/dashboardLogic.test.ts
@@ -19,6 +19,7 @@ import type { Transaction } from '@/api/transactions'
 import type { RunwayResult } from '@/api/user'
 import { formatDashboardMoney } from '@/pages/dashboard/utils/formatDashboardMoney'
 import { formatDashboardShortDate } from '@/pages/dashboard/utils/formatDashboardShortDate'
+import { getDashboardGreetingForHour } from '@/pages/dashboard/hooks/useDashboardGreeting'
 import { getCreditUsageSummary } from '@/pages/dashboard/utils/getCreditUsageSummary'
 import { getNetWorthSeries } from '@/pages/dashboard/utils/getNetWorthSeries'
 import { getRecentActivityRows } from '@/pages/dashboard/utils/getRecentActivityRows'
@@ -119,6 +120,28 @@ function createBudget(overrides: Partial<LatestBudgetUtilization>): LatestBudget
 }
 
 describe('dashboard logic helpers', () => {
+  it('chooses the dashboard greeting from local hour boundaries', () => {
+    expect(getDashboardGreetingForHour(0)).toEqual({
+      greeting: 'Still up?',
+      subtitle: 'Your finances can wait, your sleep can\u2019t.',
+    })
+    expect(getDashboardGreetingForHour(3)).toMatchObject({ greeting: 'Still up?' })
+    expect(getDashboardGreetingForHour(4)).toMatchObject({ greeting: 'Good morning' })
+    expect(getDashboardGreetingForHour(11)).toMatchObject({ greeting: 'Good morning' })
+    expect(getDashboardGreetingForHour(12)).toMatchObject({ greeting: 'Good afternoon' })
+    expect(getDashboardGreetingForHour(15)).toMatchObject({ greeting: 'Good afternoon' })
+    expect(getDashboardGreetingForHour(16)).toMatchObject({ greeting: 'Good evening' })
+    expect(getDashboardGreetingForHour(20)).toMatchObject({ greeting: 'Good evening' })
+    expect(getDashboardGreetingForHour(21)).toEqual({
+      greeting: 'It\u2019s getting late...',
+      subtitle: 'Your finances can wait, your sleep can\u2019t.',
+    })
+    expect(getDashboardGreetingForHour(23)).toEqual({
+      greeting: 'It\u2019s getting late...',
+      subtitle: 'Your finances can wait, your sleep can\u2019t.',
+    })
+  })
+
   it('summarizes credit usage for used and remaining modes', () => {
     const credit = {
       credit_limit_total: 100000,


### PR DESCRIPTION
- Keep filtered transaction pagination loading additional pages correctly
- Retry backend FX rate fetches before returning unavailable conversion states
- Keep TAC limit summaries independent from account overview filters
- Restore pointer cursors on buttons after the TypeScript upgrade
- Smooth archived account expansion and collapse behaviour
- Clean up auth mode spacing and dashboard greeting timing
- Allow archived account transactions to open in a read-only modal
- Treat missing budget utilization for an existing period as zero spend