### PR TITLE
fix: restrict modal tab focus to form fields

### DIFF
--- a/frontend/src/components/category-icon-selector/Selector.tsx
+++ b/frontend/src/components/category-icon-selector/Selector.tsx
@@ -13,6 +13,8 @@ interface CategoryIconSelectorProps {
   buttonClassName?: string
   categoryName: string
   hasError?: boolean
+  id?: string
+  modalFieldTabStop?: boolean
   onChange: (icon: string) => void
   pickerAnchor?: 'button' | 'row'
   pickerAnchorRef?: RefObject<HTMLElement | null>
@@ -93,6 +95,8 @@ export default function CategoryIconSelector({
   buttonClassName = 'group flex h-9 w-9 items-center justify-center rounded-md border p-1 text-xl leading-none transition-colors duration-150 hover:border-[var(--app-border-strong)] focus-visible:border-[var(--app-accent-border)] focus-visible:outline-none',
   categoryName,
   hasError = false,
+  id,
+  modalFieldTabStop = false,
   onChange,
   pickerAnchor = 'button',
   pickerAnchorRef,
@@ -166,6 +170,8 @@ export default function CategoryIconSelector({
   return (
     <div ref={selectorRef} className="relative shrink-0">
       <button
+        id={id}
+        data-modal-field-tab-stop={modalFieldTabStop ? 'true' : undefined}
         type="button"
         className={buttonClassName}
         style={{

--- a/frontend/src/components/create-modal/ReferenceModalShell.tsx
+++ b/frontend/src/components/create-modal/ReferenceModalShell.tsx
@@ -1,13 +1,9 @@
-import { useEffect, useRef, type FormEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
+import { useEffect, type FormEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { X, type LucideIcon } from 'lucide-react'
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
-import {
-  getModalFieldTabStops,
-  getNextModalFieldTabStop,
-  requestFirstModalFieldFocus,
-} from '@/components/modal/focus'
+import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
 
 export type CreateReferenceModalVariant = 'primary' | 'secondary'
 
@@ -96,7 +92,7 @@ export default function CreateReferenceModalShell({
   const layout = layoutByVariant[variant]
   const closeIfAllowed = closeDisabled ? undefined : onClose
   const hasRail = RailIcon && railLabel
-  const panelRef = useRef<HTMLDivElement>(null)
+  const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus(open)
 
   useBodyScrollLock(open && variant !== 'secondary')
 
@@ -109,39 +105,6 @@ export default function CreateReferenceModalShell({
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [closeDisabled, onClose, open])
-
-  useEffect(() => {
-    if (!open) return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const frameId = requestFirstModalFieldFocus(panel)
-
-    return () => window.cancelAnimationFrame(frameId)
-  }, [open])
-
-  /**
-   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
-   */
-  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Tab') return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const fieldTabStops = getModalFieldTabStops(panel)
-    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
-
-    if (!nextField) {
-      event.preventDefault()
-      return
-    }
-
-    event.preventDefault()
-    nextField.focus()
-  }
 
   return createPortal(
     <AnimatePresence>
@@ -179,7 +142,7 @@ export default function CreateReferenceModalShell({
                 boxShadow: 'var(--app-shadow-soft)',
               }}
               onClick={(event) => event.stopPropagation()}
-              onKeyDown={handleTabKeyDown}
+              onKeyDown={handleModalFieldKeyDown}
             >
               {hasRail && (
                 <div className={layout.railClassName} style={layout.railStyle} aria-hidden>

--- a/frontend/src/components/create-modal/ReferenceModalShell.tsx
+++ b/frontend/src/components/create-modal/ReferenceModalShell.tsx
@@ -1,8 +1,13 @@
-import { useEffect, type FormEvent, type ReactNode } from 'react'
+import { useEffect, useRef, type FormEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { X, type LucideIcon } from 'lucide-react'
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
+import {
+  getModalFieldTabStops,
+  getNextModalFieldTabStop,
+  requestFirstModalFieldFocus,
+} from '@/components/modal/focus'
 
 export type CreateReferenceModalVariant = 'primary' | 'secondary'
 
@@ -91,6 +96,7 @@ export default function CreateReferenceModalShell({
   const layout = layoutByVariant[variant]
   const closeIfAllowed = closeDisabled ? undefined : onClose
   const hasRail = RailIcon && railLabel
+  const panelRef = useRef<HTMLDivElement>(null)
 
   useBodyScrollLock(open && variant !== 'secondary')
 
@@ -103,6 +109,39 @@ export default function CreateReferenceModalShell({
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [closeDisabled, onClose, open])
+
+  useEffect(() => {
+    if (!open) return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const frameId = requestFirstModalFieldFocus(panel)
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [open])
+
+  /**
+   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
+   */
+  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const fieldTabStops = getModalFieldTabStops(panel)
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
+
+    if (!nextField) {
+      event.preventDefault()
+      return
+    }
+
+    event.preventDefault()
+    nextField.focus()
+  }
 
   return createPortal(
     <AnimatePresence>
@@ -128,9 +167,11 @@ export default function CreateReferenceModalShell({
             onClick={closeIfAllowed}
           >
             <div
+              ref={panelRef}
               role="dialog"
               aria-modal="true"
               aria-labelledby={modalTitleId}
+              data-modal-field-focus-panel="true"
               className={layout.modalClassName}
               style={{
                 background: 'var(--app-bg)',
@@ -138,6 +179,7 @@ export default function CreateReferenceModalShell({
                 boxShadow: 'var(--app-shadow-soft)',
               }}
               onClick={(event) => event.stopPropagation()}
+              onKeyDown={handleTabKeyDown}
             >
               {hasRail && (
                 <div className={layout.railClassName} style={layout.railStyle} aria-hidden>

--- a/frontend/src/components/dropdown/Dropdown.tsx
+++ b/frontend/src/components/dropdown/Dropdown.tsx
@@ -179,7 +179,18 @@ const Dropdown = ({
    * Handles shared keyboard navigation from the trigger and search field
    */
   const handleKeyDown = (e: KeyboardEvent<HTMLElement>) => {
+    const eventStartedOnTrigger = e.currentTarget === triggerRef.current;
+
     switch (e.key) {
+      case ' ':
+        if (!eventStartedOnTrigger) break;
+        e.preventDefault();
+        if (!open) {
+          updateListPosition();
+          setOpen(true);
+          setHighlightedIndex(visibleFiltered.findIndex((o) => o.value === value));
+        }
+        break;
       case 'ArrowDown':
         e.preventDefault();
         if (!open) {

--- a/frontend/src/components/dropdown/SearchControls.tsx
+++ b/frontend/src/components/dropdown/SearchControls.tsx
@@ -34,6 +34,7 @@ export function DropdownSearchControls({
       <input
         ref={searchRef}
         type="text"
+        data-dropdown-search="true"
         className="app-input min-w-0 flex-1"
         style={{ fontSize: '0.8125rem' }}
         placeholder={searchPlaceholder}
@@ -57,4 +58,3 @@ export function DropdownSearchControls({
     </div>
   )
 }
-

--- a/frontend/src/components/modal/focus.ts
+++ b/frontend/src/components/modal/focus.ts
@@ -1,28 +1,24 @@
-const FIELD_TAB_STOP_SELECTOR = [
+const MODAL_FIELD_TAB_STOP_SELECTOR = [
   'input:not([disabled]):not([type="hidden"]):not([data-dropdown-search="true"])',
   'textarea:not([disabled])',
   'select:not([disabled])',
   'button[role="combobox"]:not([disabled])',
 ].join(',')
 
-export const TRANSACTION_MODAL_FIELD_IDS = {
-  account: 'txn-account',
-  merchant: 'txn-merchant',
-  category: 'txn-category',
-} as const
+const MODAL_FIELD_FOCUS_PANEL_SELECTOR = '[data-modal-field-focus-panel="true"]'
 
 /**
- * Returns enabled transaction modal fields that should receive sequential Tab focus
+ * Returns enabled modal fields that should receive sequential Tab focus
  */
-export function getTransactionModalFieldTabStops(container: HTMLElement) {
-  return Array.from(container.querySelectorAll<HTMLElement>(FIELD_TAB_STOP_SELECTOR))
-    .filter(isVisibleTransactionModalField)
+export function getModalFieldTabStops(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>(MODAL_FIELD_TAB_STOP_SELECTOR))
+    .filter(isVisibleModalField)
 }
 
 /**
- * Gets the next transaction modal field for Tab or Shift+Tab focus wrapping
+ * Gets the next modal field for Tab or Shift+Tab focus wrapping
  */
-export function getNextTransactionModalFieldTabStop<T>(
+export function getNextModalFieldTabStop<T>(
   fieldTabStops: readonly T[],
   activeElement: T | null,
   shiftKey: boolean,
@@ -41,14 +37,14 @@ export function getNextTransactionModalFieldTabStop<T>(
 /**
  * Moves focus to the next modal field after a dropdown value is selected
  */
-export function requestNextTransactionModalFieldFocus(currentFieldId: string) {
+export function requestNextModalFieldFocus(currentFieldId: string) {
   window.requestAnimationFrame(() => {
     const currentField = document.getElementById(currentFieldId)
-    const panel = currentField?.closest('[data-transaction-modal-panel="true"]') as HTMLElement | null
+    const panel = currentField?.closest(MODAL_FIELD_FOCUS_PANEL_SELECTOR) as HTMLElement | null
     if (!currentField || !panel) return
 
-    const nextField = getNextTransactionModalFieldTabStop(
-      getTransactionModalFieldTabStops(panel),
+    const nextField = getNextModalFieldTabStop(
+      getModalFieldTabStops(panel),
       currentField,
       false,
     )
@@ -58,9 +54,18 @@ export function requestNextTransactionModalFieldFocus(currentFieldId: string) {
 }
 
 /**
+ * Requests focus for the first enabled modal field after the modal panel mounts
+ */
+export function requestFirstModalFieldFocus(panel: HTMLElement) {
+  return window.requestAnimationFrame(() => {
+    getModalFieldTabStops(panel)[0]?.focus({ preventScroll: true })
+  })
+}
+
+/**
  * Filters out responsive-hidden fields while preserving visually layered inputs like mobile date
  */
-function isVisibleTransactionModalField(element: HTMLElement) {
+function isVisibleModalField(element: HTMLElement) {
   const style = window.getComputedStyle(element)
   if (style.display === 'none' || style.visibility === 'hidden') return false
 

--- a/frontend/src/components/modal/focus.ts
+++ b/frontend/src/components/modal/focus.ts
@@ -1,4 +1,5 @@
 const MODAL_FIELD_TAB_STOP_SELECTOR = [
+  '[data-modal-field-tab-stop="true"]:not([disabled])',
   'input:not([disabled]):not([type="hidden"]):not([data-dropdown-search="true"])',
   'textarea:not([disabled])',
   'select:not([disabled])',

--- a/frontend/src/components/modal/useModalFieldFocus.ts
+++ b/frontend/src/components/modal/useModalFieldFocus.ts
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import {
+  getModalFieldTabStops,
+  getNextModalFieldTabStop,
+  requestFirstModalFieldFocus,
+} from '@/components/modal/focus'
+
+/**
+ * Provides the modal panel ref and Tab handler that keep keyboard focus on field controls
+ */
+export function useModalFieldFocus<T extends HTMLElement = HTMLDivElement>(open = true) {
+  const panelRef = useRef<T>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const frameId = requestFirstModalFieldFocus(panel)
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [open])
+
+  /**
+   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
+   */
+  const handleModalFieldKeyDown = useCallback((event: ReactKeyboardEvent<T>) => {
+    if (event.key !== 'Tab') return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const fieldTabStops = getModalFieldTabStops(panel)
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
+
+    if (!nextField) {
+      event.preventDefault()
+      return
+    }
+
+    event.preventDefault()
+    nextField.focus()
+  }, [])
+
+  return { panelRef, handleModalFieldKeyDown }
+}

--- a/frontend/src/components/reference-modals/CreateCategoryModal.tsx
+++ b/frontend/src/components/reference-modals/CreateCategoryModal.tsx
@@ -8,6 +8,8 @@ import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import CreateReferenceModalShell, {
   type CreateReferenceModalVariant,
 } from '@/components/create-modal/ReferenceModalShell'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
+import { CREATE_CATEGORY_FIELD_IDS } from '@/components/reference-modals/createCategoryConstants'
 import { waitForMilliseconds } from '@/utils/timing'
 
 type CategoryKind = Category['kind']
@@ -150,11 +152,16 @@ export default function CreateCategoryModal({
                   </AnimatePresence>
                 </div>
                 <CategoryIconSelector
+                  id={CREATE_CATEGORY_FIELD_IDS.icon}
                   categoryName={form.name || 'New category'}
                   value={form.icon}
-                  onChange={(icon) => setField('icon', icon)}
+                  onChange={(icon) => {
+                    setField('icon', icon)
+                    requestNextModalFieldFocus(CREATE_CATEGORY_FIELD_IDS.icon)
+                  }}
                   buttonClassName={`app-input flex h-10 w-10 items-center justify-center p-0 text-xl leading-none ${showError('icon') ? 'app-input-error' : ''}`}
                   hasError={!!showError('icon')}
+                  modalFieldTabStop
                 />
               </div>
 
@@ -178,6 +185,7 @@ export default function CreateCategoryModal({
                   </AnimatePresence>
                 </div>
                 <input
+                  id={CREATE_CATEGORY_FIELD_IDS.name}
                   className={`app-input ${showError('name') ? 'app-input-error' : ''}`}
                   value={form.name}
                   onChange={(event) => setField('name', event.target.value)}
@@ -197,9 +205,13 @@ export default function CreateCategoryModal({
             <div>
               <span className="app-label mb-1.5 block text-[0.9375rem] leading-5">Category type</span>
               <Dropdown
+                id={CREATE_CATEGORY_FIELD_IDS.kind}
                 options={KIND_OPTIONS}
                 value={form.kind}
-                onChange={(value) => setField('kind', value as CategoryKind)}
+                onChange={(value) => {
+                  setField('kind', value as CategoryKind)
+                  requestNextModalFieldFocus(CREATE_CATEGORY_FIELD_IDS.kind)
+                }}
               />
             </div>
           </div>

--- a/frontend/src/components/reference-modals/CreateInstitutionModal.tsx
+++ b/frontend/src/components/reference-modals/CreateInstitutionModal.tsx
@@ -6,6 +6,8 @@ import Dropdown from '@/components/dropdown/Dropdown'
 import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow'
 import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import CreateReferenceModalShell from '@/components/create-modal/ReferenceModalShell'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
+import { CREATE_INSTITUTION_FIELD_IDS } from '@/components/reference-modals/createInstitutionConstants'
 import { COUNTRY_OPTIONS } from '@/constants/countries'
 import { waitForMilliseconds } from '@/utils/timing'
 
@@ -129,9 +131,9 @@ export default function CreateInstitutionModal({
             <p className="flex h-4 items-center text-base font-bold leading-none" style={{ color: 'var(--app-accent)' }}>Identity</p>
 
             <div>
-              <CreateModalFieldLabelRow htmlFor="inst-name" label="Name" error={showError('name') || undefined} />
+              <CreateModalFieldLabelRow htmlFor={CREATE_INSTITUTION_FIELD_IDS.name} label="Name" error={showError('name') || undefined} />
               <input
-                id="inst-name"
+                id={CREATE_INSTITUTION_FIELD_IDS.name}
                 type="text"
                 className={`app-input ${showError('name') ? 'app-input-error' : ''}`}
                 value={form.name}
@@ -142,11 +144,15 @@ export default function CreateInstitutionModal({
             </div>
 
             <div>
-              <CreateModalFieldLabelRow label="Country" error={showError('country_code') || undefined} />
+              <CreateModalFieldLabelRow htmlFor={CREATE_INSTITUTION_FIELD_IDS.country} label="Country" error={showError('country_code') || undefined} />
               <Dropdown
+                id={CREATE_INSTITUTION_FIELD_IDS.country}
                 options={COUNTRY_OPTIONS}
                 value={form.country_code}
-                onChange={(value) => handleChange('country_code', value)}
+                onChange={(value) => {
+                  handleChange('country_code', value)
+                  requestNextModalFieldFocus(CREATE_INSTITUTION_FIELD_IDS.country)
+                }}
                 className={`app-input ${showError('country_code') ? 'app-input-error' : ''}`}
                 placeholder="Select country..."
                 searchable
@@ -161,9 +167,9 @@ export default function CreateInstitutionModal({
             <p className="flex h-4 items-center text-base font-bold leading-none" style={{ color: 'var(--app-accent)' }}>Reference</p>
 
             <div>
-              <CreateModalFieldLabelRow htmlFor="inst-website" label="Website" error={showError('website') || undefined} />
+              <CreateModalFieldLabelRow htmlFor={CREATE_INSTITUTION_FIELD_IDS.website} label="Website" error={showError('website') || undefined} />
               <input
-                id="inst-website"
+                id={CREATE_INSTITUTION_FIELD_IDS.website}
                 type="url"
                 className={`app-input ${showError('website') ? 'app-input-error' : ''}`}
                 placeholder="https://example.com"

--- a/frontend/src/components/reference-modals/CreateMerchantModal.tsx
+++ b/frontend/src/components/reference-modals/CreateMerchantModal.tsx
@@ -8,11 +8,11 @@ import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import CreateReferenceModalShell, {
   type CreateReferenceModalVariant,
 } from '@/components/create-modal/ReferenceModalShell'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
+import { CREATE_MERCHANT_FIELD_IDS, NO_DEFAULT_CATEGORY_VALUE } from '@/components/reference-modals/createMerchantConstants'
 import { waitForMilliseconds } from '@/utils/timing'
 
 const CREATE_MERCHANT_MIN_LOADING_MS = 800
-
-export const NO_DEFAULT_CATEGORY_VALUE = '__none__'
 
 type CreateMerchantField = 'name'
 type CreateMerchantFieldErrors = Partial<Record<CreateMerchantField, string>>
@@ -134,9 +134,9 @@ export default function CreateMerchantModal({
               </AnimatePresence>
             </div>
             <div>
-              <label htmlFor="merchant-name" className="sr-only">Merchant name</label>
+              <label htmlFor={CREATE_MERCHANT_FIELD_IDS.name} className="sr-only">Merchant name</label>
               <input
-                id="merchant-name"
+                id={CREATE_MERCHANT_FIELD_IDS.name}
                 className={`app-input ${showError('name') ? 'app-input-error' : ''}`}
                 value={form.name}
                 onChange={(event) => setField('name', event.target.value)}
@@ -158,12 +158,15 @@ export default function CreateMerchantModal({
               </p>
             </div>
             <div>
-              <label htmlFor="merchant-default-category" className="sr-only">Default category</label>
+              <label htmlFor={CREATE_MERCHANT_FIELD_IDS.defaultCategory} className="sr-only">Default category</label>
               <Dropdown
-                id="merchant-default-category"
+                id={CREATE_MERCHANT_FIELD_IDS.defaultCategory}
                 options={categoryOptions}
                 value={form.default_category_id}
-                onChange={(value) => setField('default_category_id', value)}
+                onChange={(value) => {
+                  setField('default_category_id', value)
+                  requestNextModalFieldFocus(CREATE_MERCHANT_FIELD_IDS.defaultCategory)
+                }}
                 searchable
                 searchPlaceholder="Search categories..."
               />

--- a/frontend/src/components/reference-modals/CreateTagModal.tsx
+++ b/frontend/src/components/reference-modals/CreateTagModal.tsx
@@ -6,6 +6,7 @@ import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import CreateReferenceModalShell, {
   type CreateReferenceModalVariant,
 } from '@/components/create-modal/ReferenceModalShell'
+import { CREATE_TAG_FIELD_IDS } from '@/components/reference-modals/createTagConstants'
 import { waitForMilliseconds } from '@/utils/timing'
 
 const CREATE_TAG_MIN_LOADING_MS = 800
@@ -90,9 +91,9 @@ export default function CreateTagModal({
             Tag Name
           </p>
           <div>
-            <label htmlFor="create-tag-name" className="sr-only">Tag name</label>
+            <label htmlFor={CREATE_TAG_FIELD_IDS.name} className="sr-only">Tag name</label>
             <input
-              id="create-tag-name"
+              id={CREATE_TAG_FIELD_IDS.name}
               className="app-input"
               value={name}
               onChange={(event) => {

--- a/frontend/src/components/reference-modals/createCategoryConstants.ts
+++ b/frontend/src/components/reference-modals/createCategoryConstants.ts
@@ -1,0 +1,5 @@
+export const CREATE_CATEGORY_FIELD_IDS = {
+  icon: 'category-icon',
+  name: 'category-name',
+  kind: 'category-kind',
+} as const

--- a/frontend/src/components/reference-modals/createInstitutionConstants.ts
+++ b/frontend/src/components/reference-modals/createInstitutionConstants.ts
@@ -1,0 +1,5 @@
+export const CREATE_INSTITUTION_FIELD_IDS = {
+  name: 'inst-name',
+  country: 'inst-country',
+  website: 'inst-website',
+} as const

--- a/frontend/src/components/reference-modals/createMerchantConstants.ts
+++ b/frontend/src/components/reference-modals/createMerchantConstants.ts
@@ -1,0 +1,6 @@
+export const NO_DEFAULT_CATEGORY_VALUE = '__none__'
+
+export const CREATE_MERCHANT_FIELD_IDS = {
+  name: 'merchant-name',
+  defaultCategory: 'merchant-default-category',
+} as const

--- a/frontend/src/components/reference-modals/createTagConstants.ts
+++ b/frontend/src/components/reference-modals/createTagConstants.ts
@@ -1,0 +1,3 @@
+export const CREATE_TAG_FIELD_IDS = {
+  name: 'create-tag-name',
+} as const

--- a/frontend/src/pages/accounts/components/create-account-modal/Modal.tsx
+++ b/frontend/src/pages/accounts/components/create-account-modal/Modal.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, type FormEvent } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import Dropdown from '@/components/dropdown/Dropdown';
+import { requestNextModalFieldFocus } from '@/components/modal/focus';
 import IconTooltip from '@/components/tooltips/IconTooltip';
 import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow';
 import CreateModalSectionFrame from '@/components/create-modal/SectionFrame';
@@ -19,6 +20,7 @@ import {
 import {
   ALL_CREATE_ACCOUNT_FIELDS_TOUCHED,
   CREATE_ACCOUNT_EASE,
+  CREATE_ACCOUNT_MODAL_FIELD_IDS,
   CREATE_ACCOUNT_TYPE_OPTIONS,
 } from '@/pages/accounts/components/create-account-modal/constants';
 import {
@@ -106,6 +108,7 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
   const handleInstitutionCreated = (institution: { id: string }) => {
     handleChange('institution_id', institution.id);
     setShowInstitutionModal(false);
+    requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.institution);
   };
 
   const handleBlur = (field: CreateAccountValidatedField) => {
@@ -151,9 +154,13 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
               <div>
                 <CreateModalFieldLabelRow label="Account Type" error={showError('account_type') || undefined} />
                 <Dropdown
+                  id={CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType}
                   options={CREATE_ACCOUNT_TYPE_OPTIONS}
                   value={form.account_type}
-                  onChange={(v) => handleChange('account_type', v)}
+                  onChange={(v) => {
+                    handleChange('account_type', v);
+                    requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType);
+                  }}
                   className={`app-input ${showError('account_type') ? 'app-input-error' : ''}`}
                   placeholder="Select type..."
                   searchable
@@ -181,9 +188,13 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
               <div>
                 <CreateModalFieldLabelRow label="Currency" error={showError('currency') || undefined} />
                 <Dropdown
+                  id={CREATE_ACCOUNT_MODAL_FIELD_IDS.currency}
                   options={currencyOptions}
                   value={form.currency}
-                  onChange={(v) => handleChange('currency', v)}
+                  onChange={(v) => {
+                    handleChange('currency', v);
+                    requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.currency);
+                  }}
                   className={`app-input ${showError('currency') ? 'app-input-error' : ''}`}
                   placeholder={currencies.length === 0 ? 'Loading currencies...' : 'Select currency...'}
                   searchable
@@ -203,9 +214,13 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
               <div>
                 <label className="app-label mb-1.5 block text-[0.9375rem] leading-5">Institution</label>
                 <Dropdown
+                  id={CREATE_ACCOUNT_MODAL_FIELD_IDS.institution}
                   options={institutionOptions}
                   value={form.institution_id}
-                  onChange={(v) => handleChange('institution_id', v)}
+                  onChange={(v) => {
+                    handleChange('institution_id', v);
+                    requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.institution);
+                  }}
                   placeholder="Select institution..."
                   searchable
                   searchPlaceholder="Search institutions..."
@@ -266,9 +281,13 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                       <div>
                         <label className="app-label mb-1.5 block text-[0.9375rem] leading-5">Tax-Advantaged Category</label>
                         <Dropdown
+                          id={CREATE_ACCOUNT_MODAL_FIELD_IDS.taxAdvantagedCategory}
                           options={taxPlanOptions}
                           value={form.tax_advantaged_category_id}
-                          onChange={(v) => handleChange('tax_advantaged_category_id', v)}
+                          onChange={(v) => {
+                            handleChange('tax_advantaged_category_id', v);
+                            requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.taxAdvantagedCategory);
+                          }}
                           placeholder="Select category..."
                           searchable
                           searchPlaceholder="Search categories..."

--- a/frontend/src/pages/accounts/components/create-account-modal/Shell.tsx
+++ b/frontend/src/pages/accounts/components/create-account-modal/Shell.tsx
@@ -1,9 +1,14 @@
-import { useEffect, type FormEvent, type ReactNode } from 'react'
+import { useEffect, useRef, type FormEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { Landmark, X } from 'lucide-react'
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import { CREATE_ACCOUNT_EASE } from '@/pages/accounts/components/create-account-modal/constants'
+import {
+  getModalFieldTabStops,
+  getNextModalFieldTabStop,
+  requestFirstModalFieldFocus,
+} from '@/components/modal/focus'
 
 interface CreateAccountModalShellProps {
   children: ReactNode
@@ -25,6 +30,8 @@ export default function CreateAccountModalShell({
   onClose,
   onSubmit,
 }: CreateAccountModalShellProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
   useBodyScrollLock(open)
 
   useEffect(() => {
@@ -36,6 +43,39 @@ export default function CreateAccountModalShell({
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onClose, open])
+
+  useEffect(() => {
+    if (!open) return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const frameId = requestFirstModalFieldFocus(panel)
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [open])
+
+  /**
+   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
+   */
+  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const fieldTabStops = getModalFieldTabStops(panel)
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
+
+    if (!nextField) {
+      event.preventDefault()
+      return
+    }
+
+    event.preventDefault()
+    nextField.focus()
+  }
 
   return createPortal(
     <AnimatePresence>
@@ -61,9 +101,11 @@ export default function CreateAccountModalShell({
             onClick={onClose}
           >
             <div
+              ref={panelRef}
               role="dialog"
               aria-modal="true"
               aria-labelledby="create-account-title"
+              data-modal-field-focus-panel="true"
               className="app-modal-panel flex max-h-[86vh] w-full max-w-2xl overflow-hidden rounded-2xl"
               style={{
                 background: 'var(--app-bg)',
@@ -71,6 +113,7 @@ export default function CreateAccountModalShell({
                 boxShadow: 'var(--app-shadow-soft)',
               }}
               onClick={(event) => event.stopPropagation()}
+              onKeyDown={handleTabKeyDown}
             >
               <div
                 className="hidden w-16 shrink-0 flex-col items-center justify-between py-6 sm:flex"

--- a/frontend/src/pages/accounts/components/create-account-modal/Shell.tsx
+++ b/frontend/src/pages/accounts/components/create-account-modal/Shell.tsx
@@ -1,14 +1,10 @@
-import { useEffect, useRef, type FormEvent, type KeyboardEvent as ReactKeyboardEvent, type ReactNode } from 'react'
+import { useEffect, type FormEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { Landmark, X } from 'lucide-react'
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import { CREATE_ACCOUNT_EASE } from '@/pages/accounts/components/create-account-modal/constants'
-import {
-  getModalFieldTabStops,
-  getNextModalFieldTabStop,
-  requestFirstModalFieldFocus,
-} from '@/components/modal/focus'
+import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
 
 interface CreateAccountModalShellProps {
   children: ReactNode
@@ -30,7 +26,7 @@ export default function CreateAccountModalShell({
   onClose,
   onSubmit,
 }: CreateAccountModalShellProps) {
-  const panelRef = useRef<HTMLDivElement>(null)
+  const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus(open)
 
   useBodyScrollLock(open)
 
@@ -43,39 +39,6 @@ export default function CreateAccountModalShell({
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [onClose, open])
-
-  useEffect(() => {
-    if (!open) return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const frameId = requestFirstModalFieldFocus(panel)
-
-    return () => window.cancelAnimationFrame(frameId)
-  }, [open])
-
-  /**
-   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
-   */
-  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Tab') return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const fieldTabStops = getModalFieldTabStops(panel)
-    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
-
-    if (!nextField) {
-      event.preventDefault()
-      return
-    }
-
-    event.preventDefault()
-    nextField.focus()
-  }
 
   return createPortal(
     <AnimatePresence>
@@ -113,7 +76,7 @@ export default function CreateAccountModalShell({
                 boxShadow: 'var(--app-shadow-soft)',
               }}
               onClick={(event) => event.stopPropagation()}
-              onKeyDown={handleTabKeyDown}
+              onKeyDown={handleModalFieldKeyDown}
             >
               <div
                 className="hidden w-16 shrink-0 flex-col items-center justify-between py-6 sm:flex"

--- a/frontend/src/pages/accounts/components/create-account-modal/constants.ts
+++ b/frontend/src/pages/accounts/components/create-account-modal/constants.ts
@@ -3,6 +3,13 @@ import type { CreateAccountFieldErrors, CreateAccountForm } from '@/pages/accoun
 
 export const CREATE_ACCOUNT_EASE = [0.25, 0.1, 0.25, 1] as const
 
+export const CREATE_ACCOUNT_MODAL_FIELD_IDS = {
+  accountType: 'account-type',
+  currency: 'account-currency',
+  institution: 'account-institution',
+  taxAdvantagedCategory: 'account-tax-advantaged-category',
+} as const
+
 export const CREATE_ACCOUNT_TYPE_OPTIONS: DropdownOption[] = [
   { value: 'checking', label: 'Checking', group: 'Assets' },
   { value: 'savings', label: 'Savings', group: 'Assets' },

--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import {
@@ -11,8 +11,17 @@ import { useInstitutions } from '@/api/institutions'
 import { useTaxAdvantagedCategories } from '@/api/taxAdvantagedCategories'
 import CreateInstitutionModal from '@/components/reference-modals/CreateInstitutionModal'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
+import {
+  getModalFieldTabStops,
+  getNextModalFieldTabStop,
+  requestFirstModalFieldFocus,
+  requestNextModalFieldFocus,
+} from '@/components/modal/focus'
 import { waitForMilliseconds } from '@/utils/timing'
-import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
+import {
+  EDIT_ACCOUNT_IDENTITY_FIELD_IDS,
+  EASE,
+} from '@/pages/accounts/detail/constants/accountDetail'
 import {
   createIdentityFormValues,
   getIdentityFieldErrors,
@@ -50,6 +59,7 @@ export default function EditAccountIdentityModal({
   onDeleted,
   onDeleteFailed,
 }: EditAccountIdentityModalProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
   const updateAccount = useUpdateAccount()
   const deleteAccount = useDeleteAccount({ minimumPendingMs: MIN_DELETE_SPINNER_MS })
   const { data: currencies = [] } = useCurrencies()
@@ -114,6 +124,7 @@ export default function EditAccountIdentityModal({
   const handleInstitutionCreated = (institution: { id: string }) => {
     setField('institution_id', institution.id)
     setShowInstitutionModal(false)
+    requestNextModalFieldFocus(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution)
   }
 
   /**
@@ -227,6 +238,37 @@ export default function EditAccountIdentityModal({
     }
   }, [isBusy, onClose])
 
+  useEffect(() => {
+    const panel = panelRef.current
+    if (!panel) return
+
+    const frameId = requestFirstModalFieldFocus(panel)
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [])
+
+  /**
+   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
+   */
+  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const fieldTabStops = getModalFieldTabStops(panel)
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
+
+    if (!nextField) {
+      event.preventDefault()
+      return
+    }
+
+    event.preventDefault()
+    nextField.focus()
+  }
+
   return (
     <>
       {createPortal(
@@ -251,10 +293,12 @@ export default function EditAccountIdentityModal({
             onClick={requestClose}
           >
             <motion.div
+              ref={panelRef}
               layout
               role="dialog"
               aria-modal="true"
               aria-labelledby="edit-account-identity-title"
+              data-modal-field-focus-panel="true"
               className="app-modal-panel flex max-h-[84vh] w-full max-w-2xl overflow-hidden rounded-2xl"
               style={{
                 background: 'var(--app-bg)',
@@ -263,6 +307,7 @@ export default function EditAccountIdentityModal({
               }}
               transition={{ layout: { duration: 0.28, ease: EASE } }}
               onClick={(event) => event.stopPropagation()}
+              onKeyDown={handleTabKeyDown}
             >
               <EditModalSideRail />
 

--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type FormEvent, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useEffect, useMemo, useState, type FormEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import {
@@ -11,12 +11,8 @@ import { useInstitutions } from '@/api/institutions'
 import { useTaxAdvantagedCategories } from '@/api/taxAdvantagedCategories'
 import CreateInstitutionModal from '@/components/reference-modals/CreateInstitutionModal'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
-import {
-  getModalFieldTabStops,
-  getNextModalFieldTabStop,
-  requestFirstModalFieldFocus,
-  requestNextModalFieldFocus,
-} from '@/components/modal/focus'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
+import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
 import { waitForMilliseconds } from '@/utils/timing'
 import {
   EDIT_ACCOUNT_IDENTITY_FIELD_IDS,
@@ -59,7 +55,7 @@ export default function EditAccountIdentityModal({
   onDeleted,
   onDeleteFailed,
 }: EditAccountIdentityModalProps) {
-  const panelRef = useRef<HTMLDivElement>(null)
+  const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus()
   const updateAccount = useUpdateAccount()
   const deleteAccount = useDeleteAccount({ minimumPendingMs: MIN_DELETE_SPINNER_MS })
   const { data: currencies = [] } = useCurrencies()
@@ -238,37 +234,6 @@ export default function EditAccountIdentityModal({
     }
   }, [isBusy, onClose])
 
-  useEffect(() => {
-    const panel = panelRef.current
-    if (!panel) return
-
-    const frameId = requestFirstModalFieldFocus(panel)
-
-    return () => window.cancelAnimationFrame(frameId)
-  }, [])
-
-  /**
-   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
-   */
-  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Tab') return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const fieldTabStops = getModalFieldTabStops(panel)
-    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
-
-    if (!nextField) {
-      event.preventDefault()
-      return
-    }
-
-    event.preventDefault()
-    nextField.focus()
-  }
-
   return (
     <>
       {createPortal(
@@ -307,7 +272,7 @@ export default function EditAccountIdentityModal({
               }}
               transition={{ layout: { duration: 0.28, ease: EASE } }}
               onClick={(event) => event.stopPropagation()}
-              onKeyDown={handleTabKeyDown}
+              onKeyDown={handleModalFieldKeyDown}
             >
               <EditModalSideRail />
 

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/ArchiveSection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/ArchiveSection.tsx
@@ -1,6 +1,9 @@
 import { AnimatePresence, motion } from 'motion/react'
 import { EyeOff } from 'lucide-react'
-import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
+import {
+  EDIT_ACCOUNT_IDENTITY_FIELD_IDS,
+  EASE,
+} from '@/pages/accounts/detail/constants/accountDetail'
 import { ArchiveBalanceWarning } from '../controls/ArchiveBalanceWarning'
 import { EditModalSection } from '../layout/Section'
 
@@ -27,7 +30,7 @@ export function AccountArchiveSection({
   return (
     <EditModalSection number={sectionNumber} title="Archive">
       <label
-        htmlFor="edit-account-archived"
+        htmlFor={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.archive}
         className="flex cursor-pointer items-center justify-between gap-4 rounded-xl p-4"
         style={{
           background: 'var(--app-input-bg)',
@@ -45,7 +48,7 @@ export function AccountArchiveSection({
         </span>
         <span className="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors">
           <input
-            id="edit-account-archived"
+            id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.archive}
             type="checkbox"
             role="switch"
             checked={isArchived}

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/DeletePanel.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/DeletePanel.tsx
@@ -1,7 +1,10 @@
 import { AnimatePresence, motion } from 'motion/react'
 import { AlertTriangle, EyeOff } from 'lucide-react'
 import type { Account } from '@/api/accounts'
-import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
+import {
+  EDIT_ACCOUNT_IDENTITY_FIELD_IDS,
+  EASE,
+} from '@/pages/accounts/detail/constants/accountDetail'
 import type { DeleteStage } from '../types'
 
 type DeleteAccountPanelProps = {
@@ -116,14 +119,14 @@ export function DeleteAccountPanel({
                       >
                         <div>
                           <label
-                            htmlFor="delete-account-name"
+                            htmlFor={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.deleteName}
                             className="mb-1.5 block break-words text-sm leading-5"
                             style={{ color: 'var(--app-text-muted)' }}
                           >
                             Type <strong className="font-semibold">"{account.name}"</strong> to delete.
                           </label>
                           <input
-                            id="delete-account-name"
+                            id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.deleteName}
                             className="app-input"
                             value={deleteNameInput}
                             onChange={(event) => {

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
@@ -1,5 +1,7 @@
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import Dropdown from '@/components/dropdown/Dropdown'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
+import { EDIT_ACCOUNT_IDENTITY_FIELD_IDS } from '@/pages/accounts/detail/constants/accountDetail'
 import {
   formatMoneyInputLive,
   sanitizeMoneyInput,
@@ -40,9 +42,13 @@ export function AccountDetailsSection({
         <div>
           <AccountIdentityFieldLabelRow label="Tax-Advantaged Category" />
           <Dropdown
+            id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.taxAdvantagedCategory}
             options={taxAdvantagedCategoryOptions}
             value={form.tax_advantaged_category_id}
-            onChange={(value) => setField('tax_advantaged_category_id', value)}
+            onChange={(value) => {
+              setField('tax_advantaged_category_id', value)
+              requestNextModalFieldFocus(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.taxAdvantagedCategory)
+            }}
             placeholder="Select category..."
             searchable
             searchPlaceholder="Search categories..."
@@ -52,7 +58,7 @@ export function AccountDetailsSection({
 
       {isRevolving && (
         <div>
-          <AccountIdentityFieldLabelRow htmlFor="edit-credit-limit" label="Credit Limit" error={fieldErrors.credit_limit} />
+          <AccountIdentityFieldLabelRow htmlFor={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.creditLimit} label="Credit Limit" error={fieldErrors.credit_limit} />
           <div className="relative">
             {selectedCurrencySymbol && (
               <span
@@ -64,7 +70,7 @@ export function AccountDetailsSection({
               </span>
             )}
             <input
-              id="edit-credit-limit"
+              id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.creditLimit}
               className={`app-input ${selectedCurrencySymbol ? 'pl-8' : ''} ${fieldErrors.credit_limit ? 'app-input-error' : ''}`}
               inputMode="decimal"
               value={form.credit_limit}

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/IdentitySection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/IdentitySection.tsx
@@ -1,5 +1,7 @@
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import Dropdown from '@/components/dropdown/Dropdown'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
+import { EDIT_ACCOUNT_IDENTITY_FIELD_IDS } from '@/pages/accounts/detail/constants/accountDetail'
 import type {
   IdentityFieldErrors,
   IdentityFormValues,
@@ -29,9 +31,9 @@ export function AccountIdentitySection({
   return (
     <EditModalSection number="01" title="Identity">
       <div>
-        <AccountIdentityFieldLabelRow htmlFor="edit-account-name" label="Account Name" error={fieldErrors.name} />
+        <AccountIdentityFieldLabelRow htmlFor={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.name} label="Account Name" error={fieldErrors.name} />
         <input
-          id="edit-account-name"
+          id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.name}
           className={`app-input ${fieldErrors.name ? 'app-input-error' : ''}`}
           value={form.name}
           onChange={(event) => setField('name', event.target.value)}
@@ -42,9 +44,13 @@ export function AccountIdentitySection({
       <div>
         <AccountIdentityFieldLabelRow label="Institution" />
         <Dropdown
+          id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution}
           options={institutionOptions}
           value={form.institution_id}
-          onChange={(value) => setField('institution_id', value)}
+          onChange={(value) => {
+            setField('institution_id', value)
+            requestNextModalFieldFocus(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution)
+          }}
           placeholder="Select institution..."
           searchable
           searchPlaceholder="Search institutions..."

--- a/frontend/src/pages/accounts/detail/constants/accountDetail.ts
+++ b/frontend/src/pages/accounts/detail/constants/accountDetail.ts
@@ -8,6 +8,15 @@ export const ACCOUNT_KIND_LABEL: Record<string, string> = {
 
 export const EASE = [0.25, 0.1, 0.25, 1] as const
 
+export const EDIT_ACCOUNT_IDENTITY_FIELD_IDS = {
+  name: 'edit-account-name',
+  institution: 'edit-account-institution',
+  taxAdvantagedCategory: 'edit-account-tax-advantaged-category',
+  creditLimit: 'edit-credit-limit',
+  archive: 'edit-account-archived',
+  deleteName: 'delete-account-name',
+} as const
+
 export type BalanceRange = '7D' | '30D' | '90D' | '1Y'
 export type BalanceChartMode = 'balance' | 'change'
 export const BALANCE_RANGES: BalanceRange[] = ['7D', '30D', '90D', '1Y']

--- a/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
@@ -24,6 +24,7 @@ const CREATE_FIELD_IDS: BudgetEditorModalFieldIds = {
   limit: 'budget-limit',
   interval: 'budget-interval',
   periodStart: 'budget-period-start',
+  categorySearch: 'budget-category-search',
   categoryError: 'categoryIds-error',
 }
 

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -21,6 +21,7 @@ const EDIT_FIELD_IDS: BudgetEditorModalFieldIds = {
   limit: 'budget-edit-limit',
   interval: 'budget-edit-interval',
   periodStart: 'budget-edit-period-start',
+  categorySearch: 'budget-edit-category-search',
   categoryError: 'budget-edit-category-error',
 }
 

--- a/frontend/src/pages/budgets/components/budget-editor-modal/layout/Shell.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/layout/Shell.tsx
@@ -1,19 +1,12 @@
 import {
-  useEffect,
-  useRef,
   type CSSProperties,
   type FormEvent,
-  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
 } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { CircleAlert, PiggyBank, X } from 'lucide-react'
-import {
-  getModalFieldTabStops,
-  getNextModalFieldTabStop,
-  requestFirstModalFieldFocus,
-} from '@/components/modal/focus'
+import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
 import { EASE } from '@/pages/budgets/constants'
 
 type SurfaceMotion = {
@@ -71,40 +64,7 @@ export default function BudgetEditorModalShell({
   onClose,
   onSubmit,
 }: BudgetEditorModalShellProps) {
-  const panelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const frameId = requestFirstModalFieldFocus(panel)
-
-    return () => window.cancelAnimationFrame(frameId)
-  }, [open])
-
-  /**
-   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
-   */
-  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Tab') return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const fieldTabStops = getModalFieldTabStops(panel)
-    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
-
-    if (!nextField) {
-      event.preventDefault()
-      return
-    }
-
-    event.preventDefault()
-    nextField.focus()
-  }
+  const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus(open)
 
   return createPortal(
     <AnimatePresence>
@@ -151,7 +111,7 @@ export default function BudgetEditorModalShell({
                 boxShadow: 'var(--app-shadow-soft)',
               }}
               onClick={(event) => event.stopPropagation()}
-              onKeyDown={handleTabKeyDown}
+              onKeyDown={handleModalFieldKeyDown}
             >
               <div
                 className={appearance.sideRailClassName}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/layout/Shell.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/layout/Shell.tsx
@@ -1,7 +1,19 @@
-import type React from 'react'
+import {
+  useEffect,
+  useRef,
+  type CSSProperties,
+  type FormEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type ReactNode,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { CircleAlert, PiggyBank, X } from 'lucide-react'
+import {
+  getModalFieldTabStops,
+  getNextModalFieldTabStop,
+  requestFirstModalFieldFocus,
+} from '@/components/modal/focus'
 import { EASE } from '@/pages/budgets/constants'
 
 type SurfaceMotion = {
@@ -12,7 +24,7 @@ type SurfaceMotion = {
 
 export interface BudgetEditorModalShellAppearance {
   backdropClassName: string
-  backdropStyle: React.CSSProperties
+  backdropStyle: CSSProperties
   backdropDuration: number
   stageClassName: string
   panelClassName: string
@@ -20,7 +32,7 @@ export interface BudgetEditorModalShellAppearance {
   surfaceExit: SurfaceMotion
   surfaceDuration: number
   sideRailClassName: string
-  sideRailStyle: React.CSSProperties
+  sideRailStyle: CSSProperties
   sideRailIconSize: number
   sideLabelClassName: string
   headerClassName: string
@@ -36,10 +48,10 @@ interface BudgetEditorModalShellProps {
   warning?: string
   formError: string | null
   appearance: BudgetEditorModalShellAppearance
-  footer: React.ReactNode
-  children: React.ReactNode
+  footer: ReactNode
+  children: ReactNode
   onClose: () => void
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void
 }
 
 /**
@@ -59,6 +71,41 @@ export default function BudgetEditorModalShell({
   onClose,
   onSubmit,
 }: BudgetEditorModalShellProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const frameId = requestFirstModalFieldFocus(panel)
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [open])
+
+  /**
+   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
+   */
+  const handleTabKeyDown = (event: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const fieldTabStops = getModalFieldTabStops(panel)
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
+
+    if (!nextField) {
+      event.preventDefault()
+      return
+    }
+
+    event.preventDefault()
+    nextField.focus()
+  }
+
   return createPortal(
     <AnimatePresence>
       {open && (
@@ -92,9 +139,11 @@ export default function BudgetEditorModalShell({
             }}
           >
             <div
+              ref={panelRef}
               role="dialog"
               aria-modal="true"
               aria-labelledby={titleId}
+              data-modal-field-focus-panel="true"
               className={appearance.panelClassName}
               style={{
                 background: 'var(--app-bg)',
@@ -102,6 +151,7 @@ export default function BudgetEditorModalShell({
                 boxShadow: 'var(--app-shadow-soft)',
               }}
               onClick={(event) => event.stopPropagation()}
+              onKeyDown={handleTabKeyDown}
             >
               <div
                 className={appearance.sideRailClassName}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/CategorySection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/CategorySection.tsx
@@ -95,6 +95,7 @@ export default function BudgetEditorModalCategorySection({
                 aria-hidden
               />
               <input
+                id={ids.categorySearch}
                 className="app-input pl-9"
                 value={categorySearch}
                 onChange={(event) => handlers.onCategorySearchChange(event.target.value)}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -1,4 +1,5 @@
 import Dropdown from '@/components/dropdown/Dropdown'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import type { BudgetEditorModalErrorGetter, BudgetEditorModalFieldIds, BudgetEditorModalHandlers, BudgetEditorModalOptions, BudgetEditorModalViewState } from '@/pages/budgets/components/budget-editor-modal/types'
 import BudgetEditorFieldLabelRow from '@/pages/budgets/components/shared/EditorFieldLabelRow'
@@ -96,7 +97,10 @@ export default function BudgetEditorModalScopeSection({
                   label: `${currency.id} · ${currency.name}`,
                 }))}
                 value={form.currency}
-                onChange={(value) => setField('currency', value)}
+                onChange={(value) => {
+                  setField('currency', value)
+                  requestNextModalFieldFocus(ids.currency)
+                }}
                 className={`app-input ${showError('currency') ? 'app-input-error' : ''}`}
                 placeholder={currencies.length === 0 ? 'Loading currencies...' : 'Select currency...'}
                 searchable

--- a/frontend/src/pages/budgets/components/budget-editor-modal/types.ts
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/types.ts
@@ -33,6 +33,7 @@ export interface BudgetEditorModalFieldIds {
   limit: string
   interval: string
   periodStart: string
+  categorySearch: string
   categoryError: string
 }
 

--- a/frontend/src/pages/settings/components/merchant-settings-section/constants.ts
+++ b/frontend/src/pages/settings/components/merchant-settings-section/constants.ts
@@ -1,5 +1,5 @@
 import type { Category } from '@/api/categories'
-import { NO_DEFAULT_CATEGORY_VALUE } from '@/components/reference-modals/CreateMerchantModal'
+import { NO_DEFAULT_CATEGORY_VALUE } from '@/components/reference-modals/createMerchantConstants'
 
 export const DELETE_SPINNER_MS = 800
 export const NO_CATEGORY_VALUE = NO_DEFAULT_CATEGORY_VALUE

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/controls/FormControls.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/controls/FormControls.tsx
@@ -30,6 +30,7 @@ export function CurrencyInput({
   ariaLabel,
   currencies,
   currency,
+  id,
   onBlur,
   onChange,
   placeholder,
@@ -39,6 +40,7 @@ export function CurrencyInput({
   ariaLabel?: string
   currencies: Currency[]
   currency: string
+  id?: string
   onBlur?: () => void
   onChange: (value: string) => void
   placeholder?: string
@@ -66,6 +68,7 @@ export function CurrencyInput({
       )}
       <input
         aria-label={ariaLabel}
+        id={id}
         className={`app-input w-full ${symbol ? 'pl-8' : ''}`}
         inputMode="decimal"
         onBlur={() => {

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modalFieldIds.ts
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modalFieldIds.ts
@@ -1,0 +1,7 @@
+export const CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS = {
+  name: 'create-tac-name',
+  taxTreatment: 'create-tac-tax-treatment',
+  currency: 'create-tac-currency',
+  lifetimeContributionLimit: 'create-tac-lifetime-contribution-limit',
+  accruedContributions: 'create-tac-accrued-contributions',
+} as const

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal.tsx
@@ -5,12 +5,15 @@ import { Landmark, X } from 'lucide-react'
 import type { Currency } from '@/api/currency'
 import type { TaxTreatment } from '@/api/taxAdvantagedCategories'
 import Dropdown from '@/components/dropdown/Dropdown'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
+import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import { useCreateTaxAdvantagedCategoryForm } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCreateCategoryForm'
 import {
   EASE,
   TAX_TREATMENT_OPTIONS,
 } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/constants'
+import { CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modalFieldIds'
 import {
   CurrencyInput,
   TaxAdvantagedCurrencyWarning,
@@ -37,6 +40,7 @@ export default function CreateTaxAdvantagedCategoryModal({
     selectedCurrency,
     setField,
   } = useCreateTaxAdvantagedCategoryForm({ currencies, onClose, userBaseCurrency })
+  const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus()
 
   useBodyScrollLock(true)
 
@@ -72,9 +76,11 @@ export default function CreateTaxAdvantagedCategoryModal({
         onClick={onClose}
       >
         <div
+          ref={panelRef}
           role="dialog"
           aria-modal="true"
           aria-labelledby="create-tax-advantaged-category-title"
+          data-modal-field-focus-panel="true"
           className="app-modal-panel flex max-h-[86vh] w-full max-w-3xl overflow-hidden rounded-2xl"
           style={{
             background: 'var(--app-bg)',
@@ -82,6 +88,7 @@ export default function CreateTaxAdvantagedCategoryModal({
             boxShadow: 'var(--app-shadow-soft)',
           }}
           onClick={(event) => event.stopPropagation()}
+          onKeyDown={handleModalFieldKeyDown}
         >
           <div
             className="hidden w-16 shrink-0 flex-col items-center justify-between py-6 sm:flex"
@@ -142,6 +149,7 @@ export default function CreateTaxAdvantagedCategoryModal({
                       <div>
                         <span className="app-label mb-1.5 block text-[0.9375rem] leading-5">Category name</span>
                         <input
+                          id={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.name}
                           className="app-input"
                           value={form.name}
                           onChange={(event) => setField('name', event.target.value)}
@@ -153,9 +161,13 @@ export default function CreateTaxAdvantagedCategoryModal({
                       <div>
                         <span className="app-label mb-1.5 block text-[0.9375rem] leading-5">Category type</span>
                         <Dropdown
+                          id={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.taxTreatment}
                           options={TAX_TREATMENT_OPTIONS}
                           value={form.tax_treatment}
-                          onChange={(value) => setField('tax_treatment', value as TaxTreatment)}
+                          onChange={(value) => {
+                            setField('tax_treatment', value as TaxTreatment)
+                            requestNextModalFieldFocus(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.taxTreatment)
+                          }}
                         />
                       </div>
                     </div>
@@ -183,9 +195,13 @@ export default function CreateTaxAdvantagedCategoryModal({
                           <TaxAdvantagedCurrencyWarning />
                         </div>
                         <Dropdown
+                          id={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.currency}
                           options={options}
                           value={selectedCurrency}
-                          onChange={(value) => setField('currency', value)}
+                          onChange={(value) => {
+                            setField('currency', value)
+                            requestNextModalFieldFocus(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.currency)
+                          }}
                           placeholder="Select currency"
                           searchable
                           searchPlaceholder="Search currencies..."
@@ -194,6 +210,7 @@ export default function CreateTaxAdvantagedCategoryModal({
                       <div>
                         <span className="app-label mb-1.5 block text-[0.9375rem] leading-5">Lifetime Contribution Limit</span>
                         <CurrencyInput
+                          id={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.lifetimeContributionLimit}
                           currencies={currencies}
                           currency={selectedCurrency}
                           value={form.lifetime_contribution_limit}
@@ -204,6 +221,7 @@ export default function CreateTaxAdvantagedCategoryModal({
                       <div>
                         <span className="app-label mb-1.5 block text-[0.9375rem] leading-5">Accrued Contributions</span>
                         <CurrencyInput
+                          id={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.accruedContributions}
                           currencies={currencies}
                           currency={selectedCurrency}
                           value={form.accrued_contributions}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
-import { NO_DEFAULT_CATEGORY_VALUE } from '@/components/reference-modals/CreateMerchantModal'
+import { NO_DEFAULT_CATEGORY_VALUE } from '@/components/reference-modals/createMerchantConstants'
 import { useAccounts } from '@/api/accounts'
 import { useCategories, type Category } from '@/api/categories'
 import { useInfiniteMerchants, useMerchant, useUpdateMerchant, type Merchant } from '@/api/merchants'

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -57,6 +57,10 @@ import TransactionTypeDirectionSection from '@/pages/transactions/components/tra
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 import { usePagedReferenceDropdown } from '@/pages/transactions/components/transaction-modal/hooks/usePagedReferenceDropdown'
 import { useTransactionModalEnvironment } from '@/pages/transactions/components/transaction-modal/hooks/useEnvironment'
+import {
+  requestNextTransactionModalFieldFocus,
+  TRANSACTION_MODAL_FIELD_IDS,
+} from '@/pages/transactions/components/transaction-modal/utils/focus'
 
 export default function CreateTransactionModal({
   open,
@@ -304,6 +308,7 @@ export default function CreateTransactionModal({
     }))
     if (kindChanged) setDirectionHighlightKey((key) => key + 1)
     clearError('category_id')
+    requestNextTransactionModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.category)
   }
 
   const handleCreateCategory = (name: string) => {
@@ -366,6 +371,7 @@ export default function CreateTransactionModal({
     if (kindChanged) setDirectionHighlightKey((key) => key + 1)
     clearError('merchant_id')
     if (defaultCategoryId) clearError('category_id')
+    requestNextTransactionModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.merchant)
   }
 
   const handleCreateMerchant = (name: string) => {
@@ -437,6 +443,7 @@ export default function CreateTransactionModal({
     }))
     clearError('account_id')
     clearError('currency')
+    requestNextTransactionModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.account)
   }
 
   const handleField = <K extends keyof TransactionFormValues>(field: K, value: TransactionFormValues[K]) => {

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -57,10 +57,8 @@ import TransactionTypeDirectionSection from '@/pages/transactions/components/tra
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 import { usePagedReferenceDropdown } from '@/pages/transactions/components/transaction-modal/hooks/usePagedReferenceDropdown'
 import { useTransactionModalEnvironment } from '@/pages/transactions/components/transaction-modal/hooks/useEnvironment'
-import {
-  requestNextTransactionModalFieldFocus,
-  TRANSACTION_MODAL_FIELD_IDS,
-} from '@/pages/transactions/components/transaction-modal/utils/focus'
+import { requestNextModalFieldFocus } from '@/components/modal/focus'
+import { TRANSACTION_MODAL_FIELD_IDS } from '@/pages/transactions/components/transaction-modal/constants'
 
 export default function CreateTransactionModal({
   open,
@@ -308,7 +306,7 @@ export default function CreateTransactionModal({
     }))
     if (kindChanged) setDirectionHighlightKey((key) => key + 1)
     clearError('category_id')
-    requestNextTransactionModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.category)
+    requestNextModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.category)
   }
 
   const handleCreateCategory = (name: string) => {
@@ -371,7 +369,7 @@ export default function CreateTransactionModal({
     if (kindChanged) setDirectionHighlightKey((key) => key + 1)
     clearError('merchant_id')
     if (defaultCategoryId) clearError('category_id')
-    requestNextTransactionModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.merchant)
+    requestNextModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.merchant)
   }
 
   const handleCreateMerchant = (name: string) => {
@@ -443,7 +441,7 @@ export default function CreateTransactionModal({
     }))
     clearError('account_id')
     clearError('currency')
-    requestNextTransactionModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.account)
+    requestNextModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.account)
   }
 
   const handleField = <K extends keyof TransactionFormValues>(field: K, value: TransactionFormValues[K]) => {

--- a/frontend/src/pages/transactions/components/transaction-modal/constants.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/constants.ts
@@ -20,6 +20,12 @@ export const TAG_SEARCH_DEBOUNCE_MS = 300
 export const TAG_FETCHING_MORE_TEXT_MIN_MS = 800
 export const SEGMENTED_OPTION_GAP_REM = 0.35
 
+export const TRANSACTION_MODAL_FIELD_IDS = {
+  account: 'txn-account',
+  merchant: 'txn-merchant',
+  category: 'txn-category',
+} as const
+
 export const KIND_OPTIONS: { value: TransactionModalKind; label: string }[] = [
   { value: 'expense', label: 'Expense' },
   { value: 'income', label: 'Income' },

--- a/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
@@ -1,13 +1,9 @@
-import { useEffect, useRef, type FormEvent, type KeyboardEvent, type ReactNode } from 'react'
+import type { FormEvent, ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { ReceiptText, X } from 'lucide-react'
 import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
-import {
-  getModalFieldTabStops,
-  getNextModalFieldTabStop,
-  requestFirstModalFieldFocus,
-} from '@/components/modal/focus'
+import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
 
 interface TransactionModalShellProps {
   open: boolean
@@ -33,40 +29,7 @@ export default function TransactionModalShell({
   onClose,
   onSubmit,
 }: TransactionModalShellProps) {
-  const panelRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const frameId = requestFirstModalFieldFocus(panel)
-
-    return () => window.cancelAnimationFrame(frameId)
-  }, [open])
-
-  /**
-   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
-   */
-  const handleTabKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
-    if (event.key !== 'Tab') return
-
-    const panel = panelRef.current
-    if (!panel) return
-
-    const fieldTabStops = getModalFieldTabStops(panel)
-    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
-
-    if (!nextField) {
-      event.preventDefault()
-      return
-    }
-
-    event.preventDefault()
-    nextField.focus()
-  }
+  const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus(open)
 
   return createPortal(
     <AnimatePresence>
@@ -106,7 +69,7 @@ export default function TransactionModalShell({
                 boxShadow: 'var(--app-shadow-soft)',
               }}
               onClick={(event) => event.stopPropagation()}
-              onKeyDown={handleTabKeyDown}
+              onKeyDown={handleModalFieldKeyDown}
             >
               <div
                 className="hidden w-16 shrink-0 flex-col items-center justify-between py-6 sm:flex"

--- a/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
@@ -4,9 +4,10 @@ import { AnimatePresence, motion } from 'motion/react'
 import { ReceiptText, X } from 'lucide-react'
 import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
 import {
-  getNextTransactionModalFieldTabStop,
-  getTransactionModalFieldTabStops,
-} from '@/pages/transactions/components/transaction-modal/utils/focus'
+  getModalFieldTabStops,
+  getNextModalFieldTabStop,
+  requestFirstModalFieldFocus,
+} from '@/components/modal/focus'
 
 interface TransactionModalShellProps {
   open: boolean
@@ -37,26 +38,26 @@ export default function TransactionModalShell({
   useEffect(() => {
     if (!open) return
 
-    const frameId = window.requestAnimationFrame(() => {
-      const firstField = panelRef.current
-        ? getTransactionModalFieldTabStops(panelRef.current)[0]
-        : undefined
+    const panel = panelRef.current
+    if (!panel) return
 
-      firstField?.focus({ preventScroll: true })
-    })
+    const frameId = requestFirstModalFieldFocus(panel)
 
     return () => window.cancelAnimationFrame(frameId)
   }, [open])
 
+  /**
+   * Keeps sequential Tab focus on modal fields while leaving action buttons pointer-accessible
+   */
   const handleTabKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
     if (event.key !== 'Tab') return
 
     const panel = panelRef.current
     if (!panel) return
 
-    const fieldTabStops = getTransactionModalFieldTabStops(panel)
+    const fieldTabStops = getModalFieldTabStops(panel)
     const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
-    const nextField = getNextTransactionModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
+    const nextField = getNextModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
 
     if (!nextField) {
       event.preventDefault()
@@ -96,7 +97,7 @@ export default function TransactionModalShell({
               role="dialog"
               aria-modal="true"
               aria-labelledby="create-txn-title"
-              data-transaction-modal-panel="true"
+              data-modal-field-focus-panel="true"
               className="app-modal-panel flex max-h-[86vh] w-full max-w-2xl overflow-hidden rounded-2xl"
               transition={{ layout: { duration: 0.22, ease: EASE } }}
               style={{

--- a/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
@@ -1,8 +1,12 @@
-import type { FormEvent, ReactNode } from 'react'
+import { useEffect, useRef, type FormEvent, type KeyboardEvent, type ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { ReceiptText, X } from 'lucide-react'
 import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
+import {
+  getNextTransactionModalFieldTabStop,
+  getTransactionModalFieldTabStops,
+} from '@/pages/transactions/components/transaction-modal/utils/focus'
 
 interface TransactionModalShellProps {
   open: boolean
@@ -28,6 +32,41 @@ export default function TransactionModalShell({
   onClose,
   onSubmit,
 }: TransactionModalShellProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+
+    const frameId = window.requestAnimationFrame(() => {
+      const firstField = panelRef.current
+        ? getTransactionModalFieldTabStops(panelRef.current)[0]
+        : undefined
+
+      firstField?.focus({ preventScroll: true })
+    })
+
+    return () => window.cancelAnimationFrame(frameId)
+  }, [open])
+
+  const handleTabKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key !== 'Tab') return
+
+    const panel = panelRef.current
+    if (!panel) return
+
+    const fieldTabStops = getTransactionModalFieldTabStops(panel)
+    const activeElement = document.activeElement instanceof HTMLElement ? document.activeElement : null
+    const nextField = getNextTransactionModalFieldTabStop(fieldTabStops, activeElement, event.shiftKey)
+
+    if (!nextField) {
+      event.preventDefault()
+      return
+    }
+
+    event.preventDefault()
+    nextField.focus()
+  }
+
   return createPortal(
     <AnimatePresence>
       {open && (
@@ -52,6 +91,7 @@ export default function TransactionModalShell({
             onClick={onClose}
           >
             <motion.div
+              ref={panelRef}
               layout
               role="dialog"
               aria-modal="true"
@@ -64,6 +104,7 @@ export default function TransactionModalShell({
                 boxShadow: 'var(--app-shadow-soft)',
               }}
               onClick={(event) => event.stopPropagation()}
+              onKeyDown={handleTabKeyDown}
             >
               <div
                 className="hidden w-16 shrink-0 flex-col items-center justify-between py-6 sm:flex"

--- a/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
@@ -96,6 +96,7 @@ export default function TransactionModalShell({
               role="dialog"
               aria-modal="true"
               aria-labelledby="create-txn-title"
+              data-transaction-modal-panel="true"
               className="app-modal-panel flex max-h-[86vh] w-full max-w-2xl overflow-hidden rounded-2xl"
               transition={{ layout: { duration: 0.22, ease: EASE } }}
               style={{

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -1,10 +1,12 @@
 import { AnimatePresence, motion } from 'motion/react'
 import { Tag as TagIcon, X } from 'lucide-react'
 import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
-import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
+import {
+  EASE,
+  TRANSACTION_MODAL_FIELD_IDS,
+} from '@/pages/transactions/components/transaction-modal/constants'
 import TransactionModalFieldLabelRow from '@/pages/transactions/components/transaction-modal/controls/FieldLabelRow'
 import TransactionModalSectionFrame from '@/pages/transactions/components/transaction-modal/controls/SectionFrame'
-import { TRANSACTION_MODAL_FIELD_IDS } from '@/pages/transactions/components/transaction-modal/utils/focus'
 import { formatCurrency } from '@/utils/formatCurrency'
 
 type SelectedTransactionTag = {

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -4,6 +4,7 @@ import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
 import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
 import TransactionModalFieldLabelRow from '@/pages/transactions/components/transaction-modal/controls/FieldLabelRow'
 import TransactionModalSectionFrame from '@/pages/transactions/components/transaction-modal/controls/SectionFrame'
+import { TRANSACTION_MODAL_FIELD_IDS } from '@/pages/transactions/components/transaction-modal/utils/focus'
 import { formatCurrency } from '@/utils/formatCurrency'
 
 type SelectedTransactionTag = {
@@ -114,6 +115,7 @@ export default function TransactionReferencesSection({
       <div>
         <TransactionModalFieldLabelRow label="Account" error={accountError} />
         <Dropdown
+          id={TRANSACTION_MODAL_FIELD_IDS.account}
           options={accountOptions}
           selectedOption={selectedArchivedAccountOption}
           value={accountValue}
@@ -154,6 +156,7 @@ export default function TransactionReferencesSection({
       <div>
         <TransactionModalFieldLabelRow label="Merchant" error={merchantError} />
         <Dropdown
+          id={TRANSACTION_MODAL_FIELD_IDS.merchant}
           options={merchantOptions}
           selectedOption={selectedMerchantOption}
           value={merchantValue}
@@ -198,6 +201,7 @@ export default function TransactionReferencesSection({
           )}
         />
         <Dropdown
+          id={TRANSACTION_MODAL_FIELD_IDS.category}
           options={categoryOptions}
           value={categoryValue}
           onChange={onCategoryChange}

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/focus.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/focus.ts
@@ -1,0 +1,43 @@
+const FIELD_TAB_STOP_SELECTOR = [
+  'input:not([disabled]):not([type="hidden"])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  'button[role="combobox"]:not([disabled])',
+].join(',')
+
+/**
+ * Returns enabled transaction modal fields that should receive sequential Tab focus
+ */
+export function getTransactionModalFieldTabStops(container: HTMLElement) {
+  return Array.from(container.querySelectorAll<HTMLElement>(FIELD_TAB_STOP_SELECTOR))
+    .filter(isVisibleTransactionModalField)
+}
+
+/**
+ * Gets the next transaction modal field for Tab or Shift+Tab focus wrapping
+ */
+export function getNextTransactionModalFieldTabStop<T>(
+  fieldTabStops: readonly T[],
+  activeElement: T | null,
+  shiftKey: boolean,
+) {
+  if (fieldTabStops.length === 0) return null
+
+  const activeIndex = activeElement ? fieldTabStops.indexOf(activeElement) : -1
+
+  if (shiftKey) {
+    return fieldTabStops[activeIndex <= 0 ? fieldTabStops.length - 1 : activeIndex - 1]
+  }
+
+  return fieldTabStops[activeIndex < 0 || activeIndex === fieldTabStops.length - 1 ? 0 : activeIndex + 1]
+}
+
+/**
+ * Filters out responsive-hidden fields while preserving visually layered inputs like mobile date
+ */
+function isVisibleTransactionModalField(element: HTMLElement) {
+  const style = window.getComputedStyle(element)
+  if (style.display === 'none' || style.visibility === 'hidden') return false
+
+  return element.getClientRects().length > 0
+}

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/focus.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/focus.ts
@@ -1,9 +1,15 @@
 const FIELD_TAB_STOP_SELECTOR = [
-  'input:not([disabled]):not([type="hidden"])',
+  'input:not([disabled]):not([type="hidden"]):not([data-dropdown-search="true"])',
   'textarea:not([disabled])',
   'select:not([disabled])',
   'button[role="combobox"]:not([disabled])',
 ].join(',')
+
+export const TRANSACTION_MODAL_FIELD_IDS = {
+  account: 'txn-account',
+  merchant: 'txn-merchant',
+  category: 'txn-category',
+} as const
 
 /**
  * Returns enabled transaction modal fields that should receive sequential Tab focus
@@ -30,6 +36,25 @@ export function getNextTransactionModalFieldTabStop<T>(
   }
 
   return fieldTabStops[activeIndex < 0 || activeIndex === fieldTabStops.length - 1 ? 0 : activeIndex + 1]
+}
+
+/**
+ * Moves focus to the next modal field after a dropdown value is selected
+ */
+export function requestNextTransactionModalFieldFocus(currentFieldId: string) {
+  window.requestAnimationFrame(() => {
+    const currentField = document.getElementById(currentFieldId)
+    const panel = currentField?.closest('[data-transaction-modal-panel="true"]') as HTMLElement | null
+    if (!currentField || !panel) return
+
+    const nextField = getNextTransactionModalFieldTabStop(
+      getTransactionModalFieldTabStops(panel),
+      currentField,
+      false,
+    )
+
+    if (nextField && nextField !== currentField) nextField.focus({ preventScroll: true })
+  })
 }
 
 /**

--- a/frontend/tests/accounts/accountDetailLogic.test.ts
+++ b/frontend/tests/accounts/accountDetailLogic.test.ts
@@ -9,6 +9,8 @@ import type {
   AccountSpendingBreakdown,
 } from '@/api/accounts'
 import type { Currency } from '@/api/currency'
+import { getNextModalFieldTabStop } from '@/components/modal/focus'
+import { EDIT_ACCOUNT_IDENTITY_FIELD_IDS } from '@/pages/accounts/detail/constants/accountDetail'
 import { calendarDateMs } from '@/pages/accounts/detail/utils/balanceChartAxis'
 import {
   getBalanceChartSnapshot,
@@ -127,6 +129,23 @@ describe('identity form helpers', () => {
       is_archived: true,
       tax_advantaged_category_id: 'plan',
     })
+  })
+
+  it('wraps edit account modal Tab focus through field controls only', () => {
+    const fieldTabStops = [
+      EDIT_ACCOUNT_IDENTITY_FIELD_IDS.name,
+      EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution,
+      EDIT_ACCOUNT_IDENTITY_FIELD_IDS.taxAdvantagedCategory,
+      EDIT_ACCOUNT_IDENTITY_FIELD_IDS.creditLimit,
+      EDIT_ACCOUNT_IDENTITY_FIELD_IDS.archive,
+      EDIT_ACCOUNT_IDENTITY_FIELD_IDS.deleteName,
+    ]
+
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, EDIT_ACCOUNT_IDENTITY_FIELD_IDS.name, false)).toBe(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution)
+    expect(getNextModalFieldTabStop(fieldTabStops, EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution, false)).toBe(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.taxAdvantagedCategory)
+    expect(getNextModalFieldTabStop(fieldTabStops, EDIT_ACCOUNT_IDENTITY_FIELD_IDS.deleteName, false)).toBe(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, EDIT_ACCOUNT_IDENTITY_FIELD_IDS.name, true)).toBe(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.deleteName)
   })
 })
 

--- a/frontend/tests/accounts/createAccountModal.test.ts
+++ b/frontend/tests/accounts/createAccountModal.test.ts
@@ -17,6 +17,8 @@ import {
   buildCreateAccountInstitutionOptions,
   buildCreateAccountTaxPlanOptions,
 } from '@/pages/accounts/components/create-account-modal/utils/options'
+import { getNextModalFieldTabStop } from '@/components/modal/focus'
+import { CREATE_ACCOUNT_MODAL_FIELD_IDS } from '@/pages/accounts/components/create-account-modal/constants'
 
 const currencies: Currency[] = [
   { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
@@ -152,5 +154,23 @@ describe('create account modal helpers', () => {
       starting_balance: -12345,
       is_archived: false,
     })
+  })
+
+  it('wraps create account modal Tab focus through field controls only', () => {
+    const fieldTabStops = [
+      CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType,
+      'account-name',
+      CREATE_ACCOUNT_MODAL_FIELD_IDS.currency,
+      CREATE_ACCOUNT_MODAL_FIELD_IDS.institution,
+      'starting-balance',
+      CREATE_ACCOUNT_MODAL_FIELD_IDS.taxAdvantagedCategory,
+    ]
+
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe(CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType, false)).toBe('account-name')
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_ACCOUNT_MODAL_FIELD_IDS.currency, false)).toBe(CREATE_ACCOUNT_MODAL_FIELD_IDS.institution)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_ACCOUNT_MODAL_FIELD_IDS.institution, false)).toBe('starting-balance')
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_ACCOUNT_MODAL_FIELD_IDS.taxAdvantagedCategory, false)).toBe(CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType, true)).toBe(CREATE_ACCOUNT_MODAL_FIELD_IDS.taxAdvantagedCategory)
   })
 })

--- a/frontend/tests/budgets/budgetForm.test.ts
+++ b/frontend/tests/budgets/budgetForm.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Category } from '@/api/categories'
 import type { Currency } from '@/api/currency'
+import { getNextModalFieldTabStop } from '@/components/modal/focus'
 import type { BudgetFormState } from '@/pages/budgets/types'
 import { validateBudgetCreateForm } from '@/pages/budgets/utils/budgetCreateValidation'
 import { sameStringSet } from '@/pages/budgets/utils/form'
@@ -77,5 +78,22 @@ describe('budget form helpers', () => {
   it('compares selected category IDs without depending on order', () => {
     expect(sameStringSet(['travel', 'groceries'], ['groceries', 'travel'])).toBe(true)
     expect(sameStringSet(['travel'], ['travel', 'groceries'])).toBe(false)
+  })
+
+  it('wraps create budget modal Tab focus through field controls only', () => {
+    const fieldTabStops = [
+      'budget-name',
+      'budget-currency',
+      'budget-limit',
+      'budget-interval',
+      'budget-period-start',
+      'budget-category-search',
+    ]
+
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe('budget-name')
+    expect(getNextModalFieldTabStop(fieldTabStops, 'budget-name', false)).toBe('budget-currency')
+    expect(getNextModalFieldTabStop(fieldTabStops, 'budget-currency', false)).toBe('budget-limit')
+    expect(getNextModalFieldTabStop(fieldTabStops, 'budget-category-search', false)).toBe('budget-name')
+    expect(getNextModalFieldTabStop(fieldTabStops, 'budget-name', true)).toBe('budget-category-search')
   })
 })

--- a/frontend/tests/components/createCategoryModal.test.ts
+++ b/frontend/tests/components/createCategoryModal.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Tests create-category modal helper behaviour so focus changes preserve keyboard-only field navigation
+ */
+import { describe, expect, it } from 'vitest'
+import { getNextModalFieldTabStop } from '@/components/modal/focus'
+import { CREATE_CATEGORY_FIELD_IDS } from '@/components/reference-modals/createCategoryConstants'
+
+describe('create category modal helpers', () => {
+  it('wraps create category modal Tab focus through field controls only', () => {
+    const fieldTabStops = [
+      CREATE_CATEGORY_FIELD_IDS.icon,
+      CREATE_CATEGORY_FIELD_IDS.name,
+      CREATE_CATEGORY_FIELD_IDS.kind,
+    ]
+
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe(CREATE_CATEGORY_FIELD_IDS.icon)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_CATEGORY_FIELD_IDS.icon, false)).toBe(CREATE_CATEGORY_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_CATEGORY_FIELD_IDS.name, false)).toBe(CREATE_CATEGORY_FIELD_IDS.kind)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_CATEGORY_FIELD_IDS.kind, false)).toBe(CREATE_CATEGORY_FIELD_IDS.icon)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_CATEGORY_FIELD_IDS.icon, true)).toBe(CREATE_CATEGORY_FIELD_IDS.kind)
+  })
+})

--- a/frontend/tests/components/createInstitutionModal.test.ts
+++ b/frontend/tests/components/createInstitutionModal.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Tests create-institution modal helper behaviour so focus changes preserve keyboard-only field navigation
+ */
+import { describe, expect, it } from 'vitest'
+import { getNextModalFieldTabStop } from '@/components/modal/focus'
+import { CREATE_INSTITUTION_FIELD_IDS } from '@/components/reference-modals/createInstitutionConstants'
+
+describe('create institution modal helpers', () => {
+  it('wraps create institution modal Tab focus through field controls only', () => {
+    const fieldTabStops = [
+      CREATE_INSTITUTION_FIELD_IDS.name,
+      CREATE_INSTITUTION_FIELD_IDS.country,
+      CREATE_INSTITUTION_FIELD_IDS.website,
+    ]
+
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe(CREATE_INSTITUTION_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_INSTITUTION_FIELD_IDS.name, false)).toBe(CREATE_INSTITUTION_FIELD_IDS.country)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_INSTITUTION_FIELD_IDS.country, false)).toBe(CREATE_INSTITUTION_FIELD_IDS.website)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_INSTITUTION_FIELD_IDS.website, false)).toBe(CREATE_INSTITUTION_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_INSTITUTION_FIELD_IDS.name, true)).toBe(CREATE_INSTITUTION_FIELD_IDS.website)
+  })
+})

--- a/frontend/tests/components/createMerchantModal.test.ts
+++ b/frontend/tests/components/createMerchantModal.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Tests create-merchant modal helper behaviour so focus changes preserve keyboard-only field navigation
+ */
+import { describe, expect, it } from 'vitest'
+import { getNextModalFieldTabStop } from '@/components/modal/focus'
+import { CREATE_MERCHANT_FIELD_IDS } from '@/components/reference-modals/createMerchantConstants'
+
+describe('create merchant modal helpers', () => {
+  it('wraps create merchant modal Tab focus through field controls only', () => {
+    const fieldTabStops = [
+      CREATE_MERCHANT_FIELD_IDS.name,
+      CREATE_MERCHANT_FIELD_IDS.defaultCategory,
+    ]
+
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe(CREATE_MERCHANT_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_MERCHANT_FIELD_IDS.name, false)).toBe(CREATE_MERCHANT_FIELD_IDS.defaultCategory)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_MERCHANT_FIELD_IDS.defaultCategory, false)).toBe(CREATE_MERCHANT_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_MERCHANT_FIELD_IDS.name, true)).toBe(CREATE_MERCHANT_FIELD_IDS.defaultCategory)
+  })
+})

--- a/frontend/tests/components/createTagModal.test.ts
+++ b/frontend/tests/components/createTagModal.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Tests create-tag modal helper behaviour so focus changes preserve keyboard-only field navigation
+ */
+import { describe, expect, it } from 'vitest'
+import { getNextModalFieldTabStop } from '@/components/modal/focus'
+import { CREATE_TAG_FIELD_IDS } from '@/components/reference-modals/createTagConstants'
+
+describe('create tag modal helpers', () => {
+  it('wraps create tag modal Tab focus through field controls only', () => {
+    const fieldTabStops = [CREATE_TAG_FIELD_IDS.name]
+
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe(CREATE_TAG_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_TAG_FIELD_IDS.name, false)).toBe(CREATE_TAG_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_TAG_FIELD_IDS.name, true)).toBe(CREATE_TAG_FIELD_IDS.name)
+  })
+})

--- a/frontend/tests/settings/taxAdvantagedModalFocus.test.ts
+++ b/frontend/tests/settings/taxAdvantagedModalFocus.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Tests TAC modal helper behaviour so field-only keyboard focus stays aligned across create, details, and annual-limit dialogs
+ */
+import { describe, expect, it } from 'vitest'
+import { getNextModalFieldTabStop } from '@/components/modal/focus'
+import { CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modalFieldIds'
+
+describe('tax-advantaged category modal field focus', () => {
+  it('wraps create TAC modal Tab focus through field controls only', () => {
+    const fieldTabStops = [
+      CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.name,
+      CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.taxTreatment,
+      CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.currency,
+      CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.lifetimeContributionLimit,
+      CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.accruedContributions,
+    ]
+
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.name, false)).toBe(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.taxTreatment)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.taxTreatment, false)).toBe(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.currency)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.accruedContributions, false)).toBe(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.name)
+    expect(getNextModalFieldTabStop(fieldTabStops, CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.name, true)).toBe(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.accruedContributions)
+  })
+})

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -20,9 +20,9 @@ import {
 } from '@/pages/transactions/components/transaction-modal/utils/payloads'
 import { validateTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
 import {
-  getNextTransactionModalFieldTabStop,
-  TRANSACTION_MODAL_FIELD_IDS,
-} from '@/pages/transactions/components/transaction-modal/utils/focus'
+  getNextModalFieldTabStop,
+} from '@/components/modal/focus'
+import { TRANSACTION_MODAL_FIELD_IDS } from '@/pages/transactions/components/transaction-modal/constants'
 
 const currencies: Currency[] = [
   { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
@@ -238,11 +238,11 @@ describe('transaction modal helpers', () => {
       'notes',
     ]
 
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, null, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.account)
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.account, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.merchant)
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.merchant, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.category)
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, 'notes', false)).toBe(TRANSACTION_MODAL_FIELD_IDS.account)
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.account, true)).toBe('notes')
-    expect(getNextTransactionModalFieldTabStop([], null, false)).toBeNull()
+    expect(getNextModalFieldTabStop(fieldTabStops, null, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.account)
+    expect(getNextModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.account, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.merchant)
+    expect(getNextModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.merchant, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.category)
+    expect(getNextModalFieldTabStop(fieldTabStops, 'notes', false)).toBe(TRANSACTION_MODAL_FIELD_IDS.account)
+    expect(getNextModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.account, true)).toBe('notes')
+    expect(getNextModalFieldTabStop([], null, false)).toBeNull()
   })
 })

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -19,7 +19,10 @@ import {
   buildUpdateTransactionPatch,
 } from '@/pages/transactions/components/transaction-modal/utils/payloads'
 import { validateTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
-import { getNextTransactionModalFieldTabStop } from '@/pages/transactions/components/transaction-modal/utils/focus'
+import {
+  getNextTransactionModalFieldTabStop,
+  TRANSACTION_MODAL_FIELD_IDS,
+} from '@/pages/transactions/components/transaction-modal/utils/focus'
 
 const currencies: Currency[] = [
   { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
@@ -226,12 +229,20 @@ describe('transaction modal helpers', () => {
   })
 
   it('wraps transaction modal Tab focus through field controls only', () => {
-    const fieldTabStops = ['account', 'merchant', 'category', 'date', 'amount', 'notes']
+    const fieldTabStops = [
+      TRANSACTION_MODAL_FIELD_IDS.account,
+      TRANSACTION_MODAL_FIELD_IDS.merchant,
+      TRANSACTION_MODAL_FIELD_IDS.category,
+      'date',
+      'amount',
+      'notes',
+    ]
 
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, null, false)).toBe('account')
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, 'account', false)).toBe('merchant')
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, 'notes', false)).toBe('account')
-    expect(getNextTransactionModalFieldTabStop(fieldTabStops, 'account', true)).toBe('notes')
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, null, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.account)
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.account, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.merchant)
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.merchant, false)).toBe(TRANSACTION_MODAL_FIELD_IDS.category)
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, 'notes', false)).toBe(TRANSACTION_MODAL_FIELD_IDS.account)
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, TRANSACTION_MODAL_FIELD_IDS.account, true)).toBe('notes')
     expect(getNextTransactionModalFieldTabStop([], null, false)).toBeNull()
   })
 })

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -19,6 +19,7 @@ import {
   buildUpdateTransactionPatch,
 } from '@/pages/transactions/components/transaction-modal/utils/payloads'
 import { validateTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
+import { getNextTransactionModalFieldTabStop } from '@/pages/transactions/components/transaction-modal/utils/focus'
 
 const currencies: Currency[] = [
   { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
@@ -222,5 +223,15 @@ describe('transaction modal helpers', () => {
       amount: 20000,
       tag_ids: ['business'],
     })
+  })
+
+  it('wraps transaction modal Tab focus through field controls only', () => {
+    const fieldTabStops = ['account', 'merchant', 'category', 'date', 'amount', 'notes']
+
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, null, false)).toBe('account')
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, 'account', false)).toBe('merchant')
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, 'notes', false)).toBe('account')
+    expect(getNextTransactionModalFieldTabStop(fieldTabStops, 'account', true)).toBe('notes')
+    expect(getNextTransactionModalFieldTabStop([], null, false)).toBeNull()
   })
 })


### PR DESCRIPTION
- Keep Tab navigation on form fields in creation modals
- Advance the focus to the next input field after selecting an option in the dropdown