### PR TITLE
test: advance refresh rotation retry window in client test

### DIFF
--- a/frontend/tests/api/client.test.ts
+++ b/frontend/tests/api/client.test.ts
@@ -49,12 +49,10 @@ describe('authenticatedFetch', () => {
         status: 401,
         json: async () => ({ detail: 'Token is not active' }),
       })
-      .mockResolvedValueOnce({
-        ok: false,
-        status: 409,
-        json: async () => ({ detail: 'Refresh token was already rotated' }),
-      })
-      .mockResolvedValueOnce({
+
+      // Every refresh attempt keeps reporting the rotation conflict so the retry
+      // budget is exhausted and the conflict is surfaced rather than a lost session
+      .mockResolvedValue({
         ok: false,
         status: 409,
         json: async () => ({ detail: 'Refresh token was already rotated' }),
@@ -62,7 +60,8 @@ describe('authenticatedFetch', () => {
 
     const request = authenticatedFetch('/accounts').catch((error: unknown) => error);
 
-    await vi.advanceTimersByTimeAsync(100);
+    // Advance past the full rotation retry budget so the loop gives up
+    await vi.advanceTimersByTimeAsync(5_000);
 
     const error = await request;
 


### PR DESCRIPTION
- Under fake timers the refresh retry waits only fire when the test advances the clock, but the test advanced it by just 100ms while the retry window runs 5s, so the loop parked on a timer that never fired and the test hung until it timed out
- The hung refresh also poisoned the shared refresh promise, timing out the next test too
- The test now advances through the full retry window so the loop reaches its give-up path and settles cleanly, no change to refresh behaviour