### PR TITLE
Optimize frontend bundle size with route-level code splitting

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useLayoutEffect, useCallback, lazy, Suspense } from 'react'
-import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation, type Location } from 'react-router-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { useAuth } from '@/hooks/useAuth'
@@ -64,14 +64,16 @@ function scrollDocumentToTop() {
 let hasShownLoadingScreen = false;
 
 /** Redirect to /login if unauthenticated. Show loading screen on first visit. */
-function ProtectedRoute({ displayPath, onContentReady, pageTransitionPhase }: { displayPath: string; onContentReady: () => void; pageTransitionPhase: PageTransitionPhase }) {
+function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase }: { displayLocation: Location; onContentReady: () => void; pageTransitionPhase: PageTransitionPhase }) {
   const { user, loading } = useAuth();
-  const location = useLocation();
   const pageTransitioning = pageTransitionPhase !== 'idle';
   const pageContentVisible = pageTransitionPhase === 'idle' || pageTransitionPhase === 'entering';
-  const isFocusedPage = location.pathname === '/settings/imports';
-  const desktopBottomPadding = location.pathname === '/transactions' ? 'min-[1050px]:pb-12' : 'min-[1050px]:pb-5';
-  const pageTransitionOffset = isBudgetDetailRoute(location.pathname, location.search) ? 0 : PAGE_TRANSITION_OFFSET_PX;
+  // Derive layout from the displayed location, not the URL, so the focused-page
+  // container and offsets switch in step with the content swap rather than jumping
+  // ahead at navigation time and snapping the page between layouts
+  const isFocusedPage = displayLocation.pathname === '/settings/imports';
+  const desktopBottomPadding = displayLocation.pathname === '/transactions' ? 'min-[1050px]:pb-12' : 'min-[1050px]:pb-5';
+  const pageTransitionOffset = isBudgetDetailRoute(displayLocation.pathname, displayLocation.search) ? 0 : PAGE_TRANSITION_OFFSET_PX;
   // Only show loading screen if there's a session being restored or user just authenticated
   const shouldShowLoading = loading || (!hasShownLoadingScreen && user);
   const [minTimePassed, setMinTimePassed] = useState(hasShownLoadingScreen);
@@ -109,7 +111,10 @@ function ProtectedRoute({ displayPath, onContentReady, pageTransitionPhase }: { 
   // No session and not loading — go straight to login
   if (!loading && !user) return <Navigate to="/login" replace />;
 
-  const pageContentEntering = pageTransitionPhase === 'entering' || animateInitialPageMount;
+  // The Routes subtree remounts on each path change, so this wrapper is recreated
+  // per navigation and must start hidden through both loading and entering, otherwise
+  // an already-cached route mounts at full opacity and snaps in instead of fading
+  const pageContentEntering = pageTransitionPhase === 'entering' || pageTransitionPhase === 'loading' || animateInitialPageMount;
 
   return (
     <>
@@ -153,7 +158,7 @@ function ProtectedRoute({ displayPath, onContentReady, pageTransitionPhase }: { 
               style={{ pointerEvents: pageContentVisible ? 'auto' : 'none' }}
             >
               <Suspense fallback={null}>
-                <RouteReadyNotifier path={displayPath} onReady={onContentReady} />
+                <RouteReadyNotifier path={displayLocation.pathname} onReady={onContentReady} />
                 <Outlet />
               </Suspense>
             </motion.div>
@@ -256,7 +261,7 @@ function AnimatedRoutes() {
         </Route>
 
         {/* Protected app routes */}
-        <Route element={<ProtectedRoute displayPath={displayLocation.pathname} onContentReady={handleContentReady} pageTransitionPhase={pageTransitionPhase} />}>
+        <Route element={<ProtectedRoute displayLocation={displayLocation} onContentReady={handleContentReady} pageTransitionPhase={pageTransitionPhase} />}>
           <Route path="/" element={<DashboardPage />} />
           <Route path="/accounts" element={<AccountsPage />} />
           <Route path="/accounts/:accountId" element={<AccountDetailPage />} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect } from 'react'
+import { useState, useEffect, useLayoutEffect, lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { AuthProvider } from '@/contexts/AuthContext'
@@ -6,16 +6,20 @@ import { useAuth } from '@/hooks/useAuth'
 import { useCacheValidation } from '@/hooks/useCacheValidation'
 import { useTheme } from '@/hooks/useTheme'
 import Navigation from '@/components/navigation/Navigation'
-import DashboardPage from '@/pages/dashboard/DashboardPage'
-import AccountsPage from '@/pages/accounts/AccountsPage'
-import AccountDetailPage from '@/pages/accounts/detail/AccountDetailPage'
-import TransactionsPage from '@/pages/transactions/TransactionsPage'
-import BudgetsPage from '@/pages/budgets/BudgetsPage'
-import InsightsPage from '@/pages/insights/InsightsPage'
-import SettingsPage from '@/pages/settings/SettingsPage'
-import ImportsPage from '@/pages/imports/ImportsPage'
 import LoadingScreen from '@/components/loading/Screen'
-import AuthPage from '@/pages/auth/AuthPage'
+
+// Pages are lazy-loaded so each route ships as its own chunk instead of the
+// initial bundle, keeping first load small and pulling heavy page-only deps
+// like recharts off the landing path
+const DashboardPage = lazy(() => import('@/pages/dashboard/DashboardPage'))
+const AccountsPage = lazy(() => import('@/pages/accounts/AccountsPage'))
+const AccountDetailPage = lazy(() => import('@/pages/accounts/detail/AccountDetailPage'))
+const TransactionsPage = lazy(() => import('@/pages/transactions/TransactionsPage'))
+const BudgetsPage = lazy(() => import('@/pages/budgets/BudgetsPage'))
+const InsightsPage = lazy(() => import('@/pages/insights/InsightsPage'))
+const SettingsPage = lazy(() => import('@/pages/settings/SettingsPage'))
+const ImportsPage = lazy(() => import('@/pages/imports/ImportsPage'))
+const AuthPage = lazy(() => import('@/pages/auth/AuthPage'))
 
 const LOADING_SCREEN_MIN_MS = 1000;
 const PAGE_TRANSITION_MS = 350;
@@ -108,7 +112,11 @@ function ProtectedRoute({ pageTransitionPhase }: { pageTransitionPhase: PageTran
               }}
               style={{ pointerEvents: pageContentVisible ? 'auto' : 'none' }}
             >
-              <Outlet />
+              {/* Null fallback keeps the surrounding shell mounted while a cold
+                  route chunk loads instead of flashing a full-screen loader */}
+              <Suspense fallback={null}>
+                <Outlet />
+              </Suspense>
             </motion.div>
           </main>
         </div>
@@ -124,7 +132,11 @@ function PublicRoute() {
   if (loading) return null;
   if (user) return <Navigate to="/" replace />;
 
-  return <Outlet />;
+  return (
+    <Suspense fallback={null}>
+      <Outlet />
+    </Suspense>
+  );
 }
 
 function AnimatedRoutes() {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, lazy, Suspense } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation } from 'react-router-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { AuthProvider } from '@/contexts/AuthContext'
@@ -24,8 +24,22 @@ const AuthPage = lazy(() => import('@/pages/auth/AuthPage'))
 const LOADING_SCREEN_MIN_MS = 1000;
 const PAGE_TRANSITION_MS = 350;
 const PAGE_TRANSITION_OFFSET_PX = 12;
+const ROUTE_LOADER_DELAY_MS = 300;
 
-type PageTransitionPhase = 'idle' | 'exiting' | 'entering';
+type PageTransitionPhase = 'idle' | 'exiting' | 'loading' | 'entering';
+
+/**
+ * Reports the displayed route once its lazy chunk has resolved and mounted so the
+ * route loader can fade out under AnimatePresence rather than being unmounted
+ * instantly the way a Suspense fallback would be
+ */
+function RouteReadyNotifier({ path, onReady }: { path: string; onReady: () => void }) {
+  useEffect(() => {
+    onReady();
+  }, [path, onReady]);
+
+  return null;
+}
 
 function isProtectedPath(pathname: string) {
   return (
@@ -50,7 +64,7 @@ function scrollDocumentToTop() {
 let hasShownLoadingScreen = false;
 
 /** Redirect to /login if unauthenticated. Show loading screen on first visit. */
-function ProtectedRoute({ pageTransitionPhase }: { pageTransitionPhase: PageTransitionPhase }) {
+function ProtectedRoute({ displayPath, onContentReady, pageTransitionPhase }: { displayPath: string; onContentReady: () => void; pageTransitionPhase: PageTransitionPhase }) {
   const { user, loading } = useAuth();
   const location = useLocation();
   const pageTransitioning = pageTransitionPhase !== 'idle';
@@ -64,7 +78,23 @@ function ProtectedRoute({ pageTransitionPhase }: { pageTransitionPhase: PageTran
   const [animateInitialPageMount] = useState(() => !hasShownLoadingScreen);
   const ready = !loading && minTimePassed;
 
+  // The loading phase runs after the switch while the new route's chunk mounts
+  const routeLoading = pageTransitionPhase === 'loading';
+  const [routeLoaderDelayElapsed, setRouteLoaderDelayElapsed] = useState(false);
+
   useCacheValidation(user?.id, Boolean(user && ready));
+
+  // Hold the route loader back until the chunk has stayed pending past the delay so
+  // cached or fast navigations never flash the spinner, and clear the flag on
+  // teardown so the next navigation starts its own delay from scratch
+  useEffect(() => {
+    if (!ready || !routeLoading) return;
+    const timer = setTimeout(() => setRouteLoaderDelayElapsed(true), ROUTE_LOADER_DELAY_MS);
+    return () => {
+      clearTimeout(timer);
+      setRouteLoaderDelayElapsed(false);
+    };
+  }, [ready, routeLoading]);
 
   // Enforce the first-session loading-screen minimum before revealing the app.
   useEffect(() => {
@@ -92,6 +122,12 @@ function ProtectedRoute({ pageTransitionPhase }: { pageTransitionPhase: PageTran
           style={{ backgroundColor: 'var(--app-bg)', color: 'var(--app-text)' }}
         >
           <Navigation />
+
+          {/* The main variant keeps the navigation visible while AnimatePresence
+              lets the loader fade back out once the route chunk has mounted */}
+          <AnimatePresence>
+            {routeLoading && routeLoaderDelayElapsed && <LoadingScreen key="route-loader" variant="main" />}
+          </AnimatePresence>
           <main
             id="app-page-content"
             className={`min-w-0 flex-1 ${isFocusedPage ? 'fixed inset-0 z-[60] p-0' : `relative px-4 pb-8 pt-6 min-[1050px]:ml-[260px] min-[1050px]:px-6 ${desktopBottomPadding} min-[1050px]:pt-10`}`}
@@ -104,7 +140,11 @@ function ProtectedRoute({ pageTransitionPhase }: { pageTransitionPhase: PageTran
               }}
               animate={{
                 opacity: pageContentVisible ? 1 : 0,
-                y: pageTransitionPhase === 'exiting' ? -pageTransitionOffset : 0,
+                y: pageTransitionPhase === 'exiting'
+                  ? -pageTransitionOffset
+                  : pageTransitionPhase === 'loading'
+                    ? pageTransitionOffset
+                    : 0,
               }}
               transition={{
                 duration: PAGE_TRANSITION_MS / 1000,
@@ -112,9 +152,8 @@ function ProtectedRoute({ pageTransitionPhase }: { pageTransitionPhase: PageTran
               }}
               style={{ pointerEvents: pageContentVisible ? 'auto' : 'none' }}
             >
-              {/* Null fallback keeps the surrounding shell mounted while a cold
-                  route chunk loads instead of flashing a full-screen loader */}
               <Suspense fallback={null}>
+                <RouteReadyNotifier path={displayPath} onReady={onContentReady} />
                 <Outlet />
               </Suspense>
             </motion.div>
@@ -144,6 +183,13 @@ function AnimatedRoutes() {
   const [displayLocation, setDisplayLocation] = useState(location);
   const [pageTransitionPhase, setPageTransitionPhase] = useState<PageTransitionPhase>('idle');
 
+  // Reveal the freshly switched route only once its chunk has mounted, so the enter
+  // fade animates real content rather than an empty wrapper. The functional updater
+  // reads the current phase so a late notifier from an abandoned navigation is ignored
+  const handleContentReady = useCallback(() => {
+    setPageTransitionPhase((current) => (current === 'loading' ? 'entering' : current));
+  }, []);
+
   useLayoutEffect(() => {
     scrollDocumentToTop();
   }, [displayLocation.pathname]);
@@ -169,7 +215,7 @@ function AnimatedRoutes() {
 
       if (!nextPathIsProtected || !displayedPathIsProtected) {
         setDisplayLocation(location);
-        setPageTransitionPhase(nextPathIsProtected ? 'entering' : 'idle');
+        setPageTransitionPhase(nextPathIsProtected ? 'loading' : 'idle');
         return;
       }
 
@@ -177,7 +223,7 @@ function AnimatedRoutes() {
 
       exitTimer = window.setTimeout(() => {
         setDisplayLocation(location);
-        setPageTransitionPhase('entering');
+        setPageTransitionPhase('loading');
       }, PAGE_TRANSITION_MS);
     }, 0);
 
@@ -210,7 +256,7 @@ function AnimatedRoutes() {
         </Route>
 
         {/* Protected app routes */}
-        <Route element={<ProtectedRoute pageTransitionPhase={pageTransitionPhase} />}>
+        <Route element={<ProtectedRoute displayPath={displayLocation.pathname} onContentReady={handleContentReady} pageTransitionPhase={pageTransitionPhase} />}>
           <Route path="/" element={<DashboardPage />} />
           <Route path="/accounts" element={<AccountsPage />} />
           <Route path="/accounts/:accountId" element={<AccountDetailPage />} />

--- a/frontend/src/components/category-icon-selector/Selector.tsx
+++ b/frontend/src/components/category-icon-selector/Selector.tsx
@@ -1,6 +1,5 @@
 import { useEffect, useRef, useState, type RefObject } from 'react'
 import { createPortal } from 'react-dom'
-import { Picker } from 'emoji-mart'
 
 type EmojiPickerPosition = {
   left: number
@@ -251,50 +250,59 @@ function EmojiMartIconPicker({
     const container = containerRef.current
     if (!container || !data) return
 
-    container.innerHTML = ''
-    const picker = new Picker({
-      data,
-      autoFocus: false,
-      emojiButtonColors: ['var(--app-accent-soft)'],
-      emojiButtonRadius: '6px',
-      emojiButtonSize: 32,
-      emojiSize: 20,
-      emojiVersion: 14,
-      icons: 'outline',
-      maxFrequentRows: 0,
-      navPosition: 'none',
-      noCountryFlags: true,
-      onEmojiSelect: (selection: EmojiMartSelection) => {
-        if (!selection.native) return
-        onChange(selection.native)
-        onClose()
-      },
-      perLine: 7,
-      previewPosition: 'none',
-      searchPosition: 'sticky',
-      set: 'native',
-      skinTonePosition: 'none',
-      theme: isDark ? 'dark' : 'light',
+    let cancelled = false
+    let pickerElement: HTMLElement | null = null
+
+    // Load the emoji-mart picker on demand so its bundle stays out of the initial load
+    import('emoji-mart').then(({ Picker }) => {
+      if (cancelled || !containerRef.current) return
+
+      container.innerHTML = ''
+      const picker = new Picker({
+        data,
+        autoFocus: false,
+        emojiButtonColors: ['var(--app-accent-soft)'],
+        emojiButtonRadius: '6px',
+        emojiButtonSize: 32,
+        emojiSize: 20,
+        emojiVersion: 14,
+        icons: 'outline',
+        maxFrequentRows: 0,
+        navPosition: 'none',
+        noCountryFlags: true,
+        onEmojiSelect: (selection: EmojiMartSelection) => {
+          if (!selection.native) return
+          onChange(selection.native)
+          onClose()
+        },
+        perLine: 7,
+        previewPosition: 'none',
+        searchPosition: 'sticky',
+        set: 'native',
+        skinTonePosition: 'none',
+        theme: isDark ? 'dark' : 'light',
+      })
+      pickerElement = picker as unknown as HTMLElement
+      const theme = EMOJI_MART_THEME[isDark ? 'dark' : 'light']
+      pickerElement.style.width = '100%'
+      pickerElement.style.setProperty('--font-family', '"DM Sans", system-ui, sans-serif')
+      pickerElement.style.setProperty('--font-size', '14px')
+      pickerElement.style.setProperty('--border-radius', '0.75rem')
+      pickerElement.style.setProperty('--shadow', 'none')
+      pickerElement.style.setProperty('--sidebar-width', '8px')
+      pickerElement.style.setProperty('--rgb-color', theme.color)
+      pickerElement.style.setProperty('--rgb-accent', theme.accent)
+      pickerElement.style.setProperty('--rgb-background', theme.background)
+      pickerElement.style.setProperty('--rgb-input', theme.input)
+      pickerElement.style.setProperty('--color-border', theme.border)
+      pickerElement.style.setProperty('--color-border-over', theme.borderOver)
+      pickerElement.style.height = `${Math.max(position.maxHeight - 14, 220)}px`
+      container.appendChild(pickerElement)
     })
-    const pickerElement = picker as unknown as HTMLElement
-    const theme = EMOJI_MART_THEME[isDark ? 'dark' : 'light']
-    pickerElement.style.width = '100%'
-    pickerElement.style.setProperty('--font-family', '"DM Sans", system-ui, sans-serif')
-    pickerElement.style.setProperty('--font-size', '14px')
-    pickerElement.style.setProperty('--border-radius', '0.75rem')
-    pickerElement.style.setProperty('--shadow', 'none')
-    pickerElement.style.setProperty('--sidebar-width', '8px')
-    pickerElement.style.setProperty('--rgb-color', theme.color)
-    pickerElement.style.setProperty('--rgb-accent', theme.accent)
-    pickerElement.style.setProperty('--rgb-background', theme.background)
-    pickerElement.style.setProperty('--rgb-input', theme.input)
-    pickerElement.style.setProperty('--color-border', theme.border)
-    pickerElement.style.setProperty('--color-border-over', theme.borderOver)
-    pickerElement.style.height = `${Math.max(position.maxHeight - 14, 220)}px`
-    container.appendChild(pickerElement)
 
     return () => {
-      pickerElement.remove()
+      cancelled = true
+      pickerElement?.remove()
       container.innerHTML = ''
     }
   }, [data, isDark, onChange, onClose, position.maxHeight])

--- a/frontend/src/pages/imports/utils/csv.ts
+++ b/frontend/src/pages/imports/utils/csv.ts
@@ -1,4 +1,3 @@
-import { parse } from 'papaparse'
 import type { CsvRow, ImportFileDraft } from '../types'
 import { isSupportedCurrency, isValidAmountValue, isValidDateValue } from './valueParsers'
 
@@ -84,7 +83,10 @@ function createFileId(file: File) {
   return `${file.name}-${file.lastModified}-${file.size}-${Math.random().toString(36).slice(2)}`
 }
 
-function parseCsvFile(file: File): Promise<{ headers: string[]; hasHeaderRow: boolean; rows: CsvRow[] }> {
+async function parseCsvFile(file: File): Promise<{ headers: string[]; hasHeaderRow: boolean; rows: CsvRow[] }> {
+  // Pull the CSV parser on demand so papaparse only ships with the import flow
+  const { parse } = await import('papaparse')
+
   return new Promise((resolve, reject) => {
     const records: string[][] = []
 


### PR DESCRIPTION
Splits the frontend into per-route bundles so the app no longer ships everything in one file, and keeps page transitions smooth even though each page's code is now fetched only when you first visit it.

- Load each page as its own bundle on demand, cutting the initial JavaScript download from about 1.6 MB to about 270 KB and clearing the build size warning
- Load the CSV parser only when a file is actually imported, instead of bundling it into every page load
- Load the emoji picker only when the category icon picker is opened
- Hold each page hidden until its on-demand bundle has loaded and then fade it in, with a brief loading screen on slow connections, so the deferred loading stays as smooth as the old single-bundle navigation
- Keep the full-screen import page fading in and out on open, close, and re-entry as part of the same deferred-loading transition

CU-86baa4m0h