### PR TITLE
Rank the merchant dropdown by recent usage

### DIFF
--- a/backend/alembic/versions/d3f7b1a2c4e9_index_transactions_by_merchant.py
+++ b/backend/alembic/versions/d3f7b1a2c4e9_index_transactions_by_merchant.py
@@ -1,0 +1,26 @@
+"""Index transactions by merchant.
+
+Revision ID: d3f7b1a2c4e9
+Revises: a6eede94e4f4
+Create Date: 2026-06-18 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "d3f7b1a2c4e9"
+down_revision: str | Sequence[str] | None = "a6eede94e4f4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index(op.f("ix_transactions_merchant_id"), "transactions", ["merchant_id"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f("ix_transactions_merchant_id"), table_name="transactions")

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -18,7 +18,7 @@ class Transaction(Base):
     created_by_user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)  # Audit trail
     account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False)
     dt: Mapped[date] = mapped_column(Date, nullable=False)
-    merchant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("merchants.id"))  # Null for transfers
+    merchant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("merchants.id"), index=True)  # Null for transfers
     category_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("categories.id"), nullable=False)
     amount: Mapped[int] = mapped_column(BigInteger, nullable=False)  # In currency base units
     currency: Mapped[str] = mapped_column(VARCHAR(3), ForeignKey("currencies.id"), nullable=False)

--- a/backend/app/routes/merchants/listing_helpers.py
+++ b/backend/app/routes/merchants/listing_helpers.py
@@ -2,14 +2,21 @@
 
 import uuid
 from collections.abc import Sequence
+from datetime import date, timedelta
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.merchant import Merchant
+from app.models.transaction import Transaction
 from app.routes.merchants.access_helpers import require_group_member
 from app.routes.merchants.scope_filter_helpers import get_merchant_list_scope_filter
 from app.utils.sql_search_helpers import escape_like_search_text
+
+# Recent-usage window that ranks the merchant dropdown so the merchants a user
+# transacts with most often surface first, a window shorter than the user's
+# history simply ranks by every transaction they have
+MERCHANT_FREQUENCY_WINDOW_DAYS = 90
 
 
 async def get_merchants_for_user(
@@ -20,7 +27,7 @@ async def get_merchants_for_user(
     limit: int | None,
     offset: int,
 ) -> Sequence[Merchant]:
-    """Return merchants visible in the requested scope
+    """Return merchants visible in the requested scope ranked by recent usage
 
     Args:
         db: Active database session
@@ -31,12 +38,25 @@ async def get_merchants_for_user(
         offset: Number of merchants to skip before returning rows
 
     Returns:
-        Merchants ordered by name
+        Merchants ordered by recent transaction count then name
 
     Raises:
         HTTPException: User is not a member of the requested group
     """
-    merchant_query = select(Merchant).where(get_merchant_list_scope_filter(user_id, group_id))
+    recent_usage_cutoff = date.today() - timedelta(days=MERCHANT_FREQUENCY_WINDOW_DAYS)
+    recent_usage_count = func.count(Transaction.id)
+
+    # Count each merchant's transactions inside the recency window, the date lives
+    # in the join condition so merchants with no recent activity are kept and ranked last
+    merchant_query = (
+        select(Merchant)
+        .outerjoin(
+            Transaction,
+            (Transaction.merchant_id == Merchant.id) & (Transaction.dt >= recent_usage_cutoff),
+        )
+        .where(get_merchant_list_scope_filter(user_id, group_id))
+        .group_by(Merchant.id)
+    )
 
     if group_id is not None:
         await require_group_member(db, group_id, user_id)
@@ -46,7 +66,8 @@ async def get_merchants_for_user(
         escaped_search_text = escape_like_search_text(normalized_search_text)
         merchant_query = merchant_query.where(Merchant.name.ilike(f"%{escaped_search_text}%", escape="\\"))
 
-    merchant_query = merchant_query.order_by(Merchant.name)
+    # Rank by recent usage and fall back to name so untouched merchants stay alphabetical
+    merchant_query = merchant_query.order_by(recent_usage_count.desc(), Merchant.name)
     if limit is not None:
         merchant_query = merchant_query.limit(limit).offset(offset)
 

--- a/backend/app/routes/merchants/router.py
+++ b/backend/app/routes/merchants/router.py
@@ -39,7 +39,7 @@ async def list_merchants(
         offset: Number of merchants to skip before returning rows
 
     Returns:
-        Merchants ordered by name
+        Merchants ordered by recent transaction count then name
     """
     merchants = await get_merchants_for_user(db, user.id, group_id, q, limit, offset)
     return merchants

--- a/backend/tests/routes/merchants/test_merchant_ranking.py
+++ b/backend/tests/routes/merchants/test_merchant_ranking.py
@@ -1,0 +1,132 @@
+from datetime import date, timedelta
+
+from app.routes.merchants.listing_helpers import MERCHANT_FREQUENCY_WINDOW_DAYS
+from tests.routes.merchants._helpers import (
+    _create_merchant,
+    _get_system_category_id,
+)
+from tests.routes.support import _create_user, _get_auth_header
+
+# --- GET /merchants frequency ranking ---
+
+
+async def _create_checking_account(client, headers):
+    """Create a CAD chequing account and return its ID for transaction setup.
+
+    Args:
+        client: The async test client.
+        headers: Auth headers for the requesting user.
+
+    Returns:
+        The created account's ID
+    """
+    resp = await client.post("/accounts", json={
+        "account_kind": "asset",
+        "account_type": "checking",
+        "name": "Chequing",
+        "currency": "CAD",
+    }, headers=headers)
+    return resp.json()["id"]
+
+
+async def _record_merchant_transactions(client, headers, account_id, category_id, merchant_id, count, dt):
+    """Record a number of identical transactions against one merchant on a given date.
+
+    Args:
+        client: The async test client.
+        headers: Auth headers for the requesting user.
+        account_id: Account the transactions belong to.
+        category_id: Category assigned to each transaction.
+        merchant_id: Merchant the transactions reference.
+        count: Number of transactions to record.
+        dt: Transaction date applied to every recorded row.
+    """
+    for _ in range(count):
+        await client.post("/transactions", json={
+            "account_id": account_id,
+            "category_id": category_id,
+            "merchant_id": merchant_id,
+            "dt": dt.isoformat(),
+            "amount": -5000,
+            "currency": "CAD",
+        }, headers=headers)
+
+
+async def test_list_merchants_ranks_more_used_merchant_first(client):
+    """Merchants with more recent transactions rank above less used ones regardless of name."""
+    headers = _get_auth_header(await _create_user(client))
+    category_id = await _get_system_category_id(client, headers)
+    account_id = await _create_checking_account(client, headers)
+    recent_date = date.today() - timedelta(days=5)
+
+    # Names run reverse-alphabetical against usage so only frequency can produce this order
+    least_used_id = (await _create_merchant(client, headers, name="Alpha Store")).json()["id"]
+    mid_used_id = (await _create_merchant(client, headers, name="Mike Store")).json()["id"]
+    most_used_id = (await _create_merchant(client, headers, name="Zulu Store")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, least_used_id, 1, recent_date)
+    await _record_merchant_transactions(client, headers, account_id, category_id, mid_used_id, 2, recent_date)
+    await _record_merchant_transactions(client, headers, account_id, category_id, most_used_id, 3, recent_date)
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == 200
+    assert [merchant["name"] for merchant in resp.json()] == ["Zulu Store", "Mike Store", "Alpha Store"]
+
+
+async def test_list_merchants_breaks_frequency_ties_by_name(client):
+    """Merchants with equal recent usage fall back to alphabetical order."""
+    headers = _get_auth_header(await _create_user(client))
+    category_id = await _get_system_category_id(client, headers)
+    account_id = await _create_checking_account(client, headers)
+    recent_date = date.today() - timedelta(days=5)
+
+    charlie_id = (await _create_merchant(client, headers, name="Charlie Market")).json()["id"]
+    bravo_id = (await _create_merchant(client, headers, name="Bravo Market")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, charlie_id, 1, recent_date)
+    await _record_merchant_transactions(client, headers, account_id, category_id, bravo_id, 1, recent_date)
+
+    # An untouched merchant ties every other at zero usage and sorts by name behind them
+    await _create_merchant(client, headers, name="Alpha Market")
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == 200
+    assert [merchant["name"] for merchant in resp.json()] == ["Bravo Market", "Charlie Market", "Alpha Market"]
+
+
+async def test_list_merchants_ignores_usage_outside_window(client):
+    """Transactions older than the recency window do not count toward ranking."""
+    headers = _get_auth_header(await _create_user(client))
+    category_id = await _get_system_category_id(client, headers)
+    account_id = await _create_checking_account(client, headers)
+    recent_date = date.today() - timedelta(days=5)
+    stale_date = date.today() - timedelta(days=MERCHANT_FREQUENCY_WINDOW_DAYS + 30)
+
+    stale_id = (await _create_merchant(client, headers, name="Stale Store")).json()["id"]
+    fresh_id = (await _create_merchant(client, headers, name="Fresh Store")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, stale_id, 5, stale_date)
+    await _record_merchant_transactions(client, headers, account_id, category_id, fresh_id, 1, recent_date)
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == 200
+    assert [merchant["name"] for merchant in resp.json()] == ["Fresh Store", "Stale Store"]
+
+
+async def test_list_merchants_ranks_by_all_history_when_shorter_than_window(client):
+    """A user whose entire history fits inside the window ranks by every transaction."""
+    headers = _get_auth_header(await _create_user(client))
+    category_id = await _get_system_category_id(client, headers)
+    account_id = await _create_checking_account(client, headers)
+    earliest_date = date.today() - timedelta(days=10)
+    latest_date = date.today() - timedelta(days=1)
+
+    busy_id = (await _create_merchant(client, headers, name="Busy Store")).json()["id"]
+    quiet_id = (await _create_merchant(client, headers, name="Quiet Store")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, busy_id, 2, earliest_date)
+    await _record_merchant_transactions(client, headers, account_id, category_id, quiet_id, 1, latest_date)
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == 200
+    assert [merchant["name"] for merchant in resp.json()] == ["Busy Store", "Quiet Store"]

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -208,11 +208,10 @@ export default function CreateTransactionModal({
     if (createdMerchant) map.set(createdMerchant.id, createdMerchant)
     return [...map.values()]
   }, [createdMerchant, merchantReference.visibleItems])
+  // The backend already ranks merchants by recent usage then name, so preserve that order
+  // here instead of re-sorting and place any just-created merchant at the end
   const merchantOptions = useMemo(
-    () => merchantCandidates
-      .slice()
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map((m) => ({ value: m.id, label: m.name })),
+    () => merchantCandidates.map((m) => ({ value: m.id, label: m.name })),
     [merchantCandidates],
   )
   const selectedTagMap = useMemo(() => {


### PR DESCRIPTION
- Order the merchant list so the merchants used most often in the last 90 days appear at the top, with alphabetical order as the fallback when recent usage is equal
- Keep this ranking while searching, so the most used matches stay at the top of the filtered list
- Count only the transactions a user is allowed to see, so personal activity and permitted group activity both shape the order
- Keep merchants with no recent activity in the list, ranked last in alphabetical order
- Rank by a user's full history when they have less than 90 days of it, so newer accounts still get a useful order
- Add a database index on the transaction merchant reference to keep the usage count fast
- Stop the transaction modal from re-sorting merchants alphabetically so it shows the order the backend returns

CU-86ba7rezg