### PR TITLE
Support creating symmetric transfer transactions

### DIFF
--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -11,6 +11,7 @@ import {
   useCreateTransaction,
   useDeleteTransaction,
   useUpdateTransaction,
+  type Transaction,
 } from '@/api/transactions'
 import { ApiError } from '@/api/auth'
 import { sanitizeMoneyInput } from '@/utils/moneyInput'
@@ -38,15 +39,21 @@ import { buildInitialTransactionForm } from '@/pages/transactions/components/tra
 import { getDirectionFromAmountInputSign } from '@/pages/transactions/components/transaction-modal/utils/money'
 import {
   buildCreateTransactionPayload,
+  buildSymmetricTransferPayloads,
   buildUpdateTransactionPatch,
 } from '@/pages/transactions/components/transaction-modal/utils/payloads'
 import type {
   CreateTransactionModalProps,
+  TransactionDirection,
   TransactionFormFieldErrors,
   TransactionFormValues,
   TransactionModalKind,
 } from '@/pages/transactions/components/transaction-modal/types'
-import { validateTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
+import {
+  getSymmetricTransferAccountError,
+  isSymmetricTransferForm,
+  validateTransactionForm,
+} from '@/pages/transactions/components/transaction-modal/utils/validation'
 import TransactionDetailsSection from '@/pages/transactions/components/transaction-modal/sections/DetailsSection'
 import TransactionModalFooter from '@/pages/transactions/components/transaction-modal/layout/Footer'
 import TransactionModalShell from '@/pages/transactions/components/transaction-modal/layout/Shell'
@@ -113,6 +120,9 @@ export default function CreateTransactionModal({
   const [sessionAccountDeltas, setSessionAccountDeltas] = useState<Record<string, number>>({})
   const [createDelayPending, setCreateDelayPending] = useState(false)
   const [directionHighlightKey, setDirectionHighlightKey] = useState(0)
+
+  // A heading shown above the submit error when only one leg of a symmetric transfer fails
+  const [submitErrorTitle, setSubmitErrorTitle] = useState('')
   const merchantReferenceSearch = useDebouncedReferenceSearch(MERCHANT_SEARCH_DEBOUNCE_MS)
   const tagReferenceSearch = useDebouncedReferenceSearch(TAG_SEARCH_DEBOUNCE_MS)
   const createdAccountIdsRef = useRef<Set<string>>(new Set())
@@ -140,6 +150,10 @@ export default function CreateTransactionModal({
   const selectedAccount = useMemo(
     () => accounts.find((account) => account.id === form.account_id),
     [accounts, form.account_id],
+  )
+  const selectedToAccount = useMemo(
+    () => accounts.find((account) => account.id === form.to_account_id),
+    [accounts, form.to_account_id],
   )
   const readOnly = editing && (readOnlyProp || Boolean(selectedAccount?.is_archived))
   const merchantQuery = useInfiniteMerchants(
@@ -280,6 +294,7 @@ export default function CreateTransactionModal({
   const clearError = (field: keyof TransactionFormFieldErrors) => {
     if (fieldErrors[field]) setFieldErrors((prev) => ({ ...prev, [field]: undefined }))
     setSubmitError('')
+    setSubmitErrorTitle('')
   }
 
   const handleKindChange = (kind: TransactionModalKind) => {
@@ -332,6 +347,7 @@ export default function CreateTransactionModal({
     if (readOnly || !selectedMerchant || !selectedCategory || updateMerchantMutation.isPending) return
 
     setSubmitError('')
+    setSubmitErrorTitle('')
     updateMerchantMutation.mutate(
       {
         merchantId: selectedMerchant.id,
@@ -433,6 +449,8 @@ export default function CreateTransactionModal({
       ...f,
       account_id: accountId,
       currency: account?.currency || '',
+      // The originating account wins, so empty the receiving field when it held the same account
+      to_account_id: accountId === f.to_account_id ? '' : f.to_account_id,
       tag_ids: f.tag_ids.filter((tagId) => {
         const tag = selectedTagMap.get(tagId)
         return !tag || tag.group_id === null || tag.group_id === accountGroupId
@@ -440,7 +458,23 @@ export default function CreateTransactionModal({
     }))
     clearError('account_id')
     clearError('currency')
+    clearError('to_account_id')
     requestNextModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.account)
+  }
+
+  const handleToAccountChange = (accountId: string) => {
+    setForm((f) => ({
+      ...f,
+      to_account_id: accountId,
+      // The receiving account wins, so empty the originating field when it held the same account
+      account_id: accountId === f.account_id ? '' : f.account_id,
+    }))
+    clearError('to_account_id')
+  }
+
+  const handleSymmetricTransferChange = (value: boolean) => {
+    setForm((f) => ({ ...f, symmetric_transfer: value }))
+    if (!value) clearError('to_account_id')
   }
 
   const handleField = <K extends keyof TransactionFormValues>(field: K, value: TransactionFormValues[K]) => {
@@ -469,8 +503,13 @@ export default function CreateTransactionModal({
     e.preventDefault()
     if (isPending || readOnly) return
     const errors = validateTransactionForm(form)
+    // The receiving account needs both accounts loaded to compare currency and group
+    if (!editing && isSymmetricTransferForm(form) && !errors.to_account_id) {
+      const accountError = getSymmetricTransferAccountError(selectedAccount, selectedToAccount)
+      if (accountError) errors.to_account_id = accountError
+    }
     setFieldErrors(errors)
-    setTouched({ account_id: true, category_id: true, merchant_id: true, amount: true, currency: true, date: true })
+    setTouched({ account_id: true, category_id: true, merchant_id: true, amount: true, currency: true, date: true, to_account_id: true })
     if (Object.keys(errors).length > 0) return
 
     if (editing && transaction) {
@@ -493,9 +532,89 @@ export default function CreateTransactionModal({
       return
     }
 
+    if (isSymmetricTransferForm(form)) {
+      const [fromPayload, toPayload] = buildSymmetricTransferPayloads(form, selectedCurrencyExponent)
+      const legs = [
+        { failedKind: 'debit', accountId: form.account_id, payload: fromPayload },
+        { failedKind: 'credit', accountId: form.to_account_id, payload: toPayload },
+      ]
+
+      setSubmitError('')
+      setSubmitErrorTitle('')
+      setCreateDelayPending(true)
+      const minimumLoading = waitForMilliseconds(
+        keepOpenAfterCreate ? MIN_BATCH_ADD_TRANSACTION_LOADING_MS : MIN_ADD_TRANSACTION_LOADING_MS,
+      )
+
+      // Each leg is independent, so a failed leg leaves the other in place rather than rolling back
+      const results = await Promise.allSettled(legs.map((leg) => createMutation.mutateAsync(leg.payload)))
+      const created: Transaction[] = []
+      const failedLegs: typeof legs = []
+      results.forEach((result, index) => {
+        if (result.status === 'fulfilled') created.push(result.value)
+        else failedLegs.push(legs[index])
+      })
+
+      created.forEach((txn) => createdAccountIdsRef.current.add(txn.account_id))
+      if (created.length > 0) {
+        setSessionAccountDeltas((deltas) => {
+          const next = { ...deltas }
+          created.forEach((txn) => {
+            next[txn.account_id] = (next[txn.account_id] ?? 0) + txn.amount
+          })
+          return next
+        })
+      }
+
+      await minimumLoading
+      setCreateDelayPending(false)
+
+      if (!openRef.current) {
+        flushDeferredAccountInvalidation()
+        return
+      }
+
+      if (failedLegs.length === legs.length) {
+        setSubmitError('Something went wrong. Please try again.')
+        return
+      }
+
+      if (failedLegs.length === 1) {
+        const failedLeg = failedLegs[0]
+        const accountName = accounts.find((account) => account.id === failedLeg.accountId)?.name ?? 'the other account'
+        setSubmitErrorTitle('One of the pair of transactions failed.')
+        setSubmitError(`There was a problem creating a ${failedLeg.failedKind} transfer in ${accountName}. Please add that leg manually.`)
+        return
+      }
+
+      if (!keepOpenAfterCreate) {
+        handleClose()
+        return
+      }
+
+      setForm({
+        ...INITIAL_TRANSACTION_FORM,
+        kind: form.kind,
+        direction: form.direction,
+        account_id: form.account_id,
+        category_id: form.category_id,
+        merchant_id: form.merchant_id,
+        currency: form.currency,
+        date: form.date,
+        symmetric_transfer: form.symmetric_transfer,
+        to_account_id: form.to_account_id,
+      })
+      setFieldErrors({})
+      setTouched({})
+      setSubmitError('')
+      setSubmitErrorTitle('')
+      return
+    }
+
     const payload = buildCreateTransactionPayload(form, selectedCurrencyExponent)
 
     setSubmitError('')
+    setSubmitErrorTitle('')
     setCreateDelayPending(true)
     const minimumLoading = waitForMilliseconds(
       keepOpenAfterCreate ? MIN_BATCH_ADD_TRANSACTION_LOADING_MS : MIN_ADD_TRANSACTION_LOADING_MS,
@@ -544,6 +663,7 @@ export default function CreateTransactionModal({
     if (!transaction || readOnly) return false
 
     setSubmitError('')
+    setSubmitErrorTitle('')
 
     try {
       await deleteMutation.mutateAsync(transaction.id)
@@ -556,6 +676,20 @@ export default function CreateTransactionModal({
   }
 
   const showError = (field: keyof TransactionFormFieldErrors) => touched[field] && fieldErrors[field]
+
+  const isSymmetricTransfer = isSymmetricTransferForm(form)
+
+  // A symmetric transfer shows its direction relative to the account being viewed, so the toggle
+  // reflects whether that account is the source or destination instead of a user choice. It falls
+  // back to the unselected state when the viewed account is on neither leg or no account is in view.
+  const symmetricDisplayDirection: TransactionDirection | '' = !defaultAccountId
+    ? ''
+    : form.account_id === defaultAccountId
+      ? 'debit'
+      : form.to_account_id === defaultAccountId
+        ? 'credit'
+        : ''
+  const directionValue = isSymmetricTransfer ? symmetricDisplayDirection : form.direction
 
   return (
     <>
@@ -583,9 +717,10 @@ export default function CreateTransactionModal({
         <div className="space-y-5">
           <TransactionTypeDirectionSection
             kind={form.kind}
-            direction={form.direction}
+            direction={directionValue}
             editing={editing}
             readOnly={readOnly}
+            directionDisabled={isSymmetricTransfer}
             directionHighlightKey={directionHighlightKey}
             onKindChange={handleKindChange}
             onDirectionChange={(value) => handleField('direction', value)}
@@ -600,6 +735,10 @@ export default function CreateTransactionModal({
             runningBalance={showRunningBalance && selectedAccount
               ? { amount: runningBalance, currency: selectedAccount.currency }
               : undefined}
+            kind={form.kind}
+            isSymmetricTransfer={form.symmetric_transfer}
+            toAccountValue={form.to_account_id}
+            toAccountError={showError('to_account_id')}
             merchantOptions={merchantOptions}
             selectedMerchantOption={selectedMerchantOption}
             merchantValue={form.merchant_id}
@@ -625,6 +764,8 @@ export default function CreateTransactionModal({
             selectedTags={selectedTags}
             readOnly={readOnly}
             onAccountChange={handleAccountChange}
+            onSymmetricTransferChange={handleSymmetricTransferChange}
+            onToAccountChange={handleToAccountChange}
             onMerchantChange={handleMerchantChange}
             onMerchantSearchChange={merchantReferenceSearch.setSearch}
             onMerchantSearchCommit={merchantReferenceSearch.setActiveSearch}
@@ -659,7 +800,7 @@ export default function CreateTransactionModal({
             onNotesChange={(value) => handleField('notes', value)}
           />
 
-          <TransactionModalSubmitError error={submitError} />
+          <TransactionModalSubmitError error={submitError} title={submitErrorTitle} />
         </div>
       </TransactionModalShell>
       <TransactionReferenceCreationModals

--- a/frontend/src/pages/transactions/components/transaction-modal/constants.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/constants.ts
@@ -60,4 +60,6 @@ export const INITIAL_TRANSACTION_FORM: TransactionFormValues = {
   notes: '',
   date: '',
   tag_ids: [],
+  symmetric_transfer: false,
+  to_account_id: '',
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/controls/PillSelector.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/controls/PillSelector.tsx
@@ -6,7 +6,8 @@ import {
 import { joinClassNames } from '@/utils/classNames'
 
 interface TransactionModalPillSelectorProps<T extends string> {
-  value: T
+  // An empty value renders the unselected state with no highlighted option
+  value: T | ''
   options: readonly { value: T; label: string }[]
   ariaLabel: string
   onChange: (value: T) => void
@@ -24,10 +25,12 @@ export default function TransactionModalPillSelector<T extends string>({
   disabled = false,
 }: TransactionModalPillSelectorProps<T>) {
   const shouldReduceMotion = useReducedMotion()
-  const activeIndex = Math.max(options.findIndex((option) => option.value === value), 0)
+  const selectedIndex = options.findIndex((option) => option.value === value)
+  const hasSelection = selectedIndex >= 0
+  const indicatorIndex = hasSelection ? selectedIndex : 0
   const optionGap = options.length > 1 ? SEGMENTED_OPTION_GAP_REM : 0
   const indicatorWidth = `calc((100% - 0.5rem - ${(options.length - 1) * optionGap}rem) / ${options.length})`
-  const indicatorX = `calc(${activeIndex * 100}% + ${activeIndex * optionGap}rem)`
+  const indicatorX = `calc(${indicatorIndex * 100}% + ${indicatorIndex * optionGap}rem)`
 
   return (
     <div
@@ -40,7 +43,7 @@ export default function TransactionModalPillSelector<T extends string>({
         className="app-create-transaction-pill-selector-indicator"
         aria-hidden
         style={{ width: indicatorWidth }}
-        animate={{ x: indicatorX }}
+        animate={{ x: indicatorX, opacity: hasSelection ? 1 : 0 }}
         transition={shouldReduceMotion ? { duration: 0 } : SELECTOR_SPRING}
       />
       {options.map((option) => {

--- a/frontend/src/pages/transactions/components/transaction-modal/controls/SubmitError.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/controls/SubmitError.tsx
@@ -2,16 +2,19 @@ import { AnimatePresence, motion } from 'motion/react'
 
 interface TransactionModalSubmitErrorProps {
   error: string
+
+  // An optional heading shown above the message, used when one leg of a transfer pair fails
+  title?: string
 }
 
 /**
- * Renders the animated form-level submit error message
+ * Renders the animated form-level submit error, with an optional bold heading
  */
-export default function TransactionModalSubmitError({ error }: TransactionModalSubmitErrorProps) {
+export default function TransactionModalSubmitError({ error, title }: TransactionModalSubmitErrorProps) {
   return (
     <AnimatePresence>
       {error && (
-        <motion.p
+        <motion.div
           className="text-sm font-medium"
           style={{ color: 'var(--app-negative)' }}
           initial={{ opacity: 0, y: -4 }}
@@ -19,8 +22,9 @@ export default function TransactionModalSubmitError({ error }: TransactionModalS
           exit={{ opacity: 0, y: -4 }}
           transition={{ duration: 0.15 }}
         >
-          {error}
-        </motion.p>
+          {title && <p className="font-semibold">{title}</p>}
+          <p>{error}</p>
+        </motion.div>
       )}
     </AnimatePresence>
   )

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/pages/transactions/components/transaction-modal/constants'
 import TransactionModalFieldLabelRow from '@/pages/transactions/components/transaction-modal/controls/FieldLabelRow'
 import TransactionModalSectionFrame from '@/pages/transactions/components/transaction-modal/controls/SectionFrame'
+import type { TransactionModalKind } from '@/pages/transactions/components/transaction-modal/types'
 import { formatCurrency } from '@/utils/formatCurrency'
 
 type SelectedTransactionTag = {
@@ -21,6 +22,11 @@ interface TransactionReferencesSectionProps {
   accountError?: string | false
   accountPlaceholder: string
   runningBalance?: { amount: number; currency: string }
+  kind: TransactionModalKind
+
+  isSymmetricTransfer: boolean
+  toAccountValue: string
+  toAccountError?: string | false
   merchantOptions: DropdownOption[]
   selectedMerchantOption?: DropdownOption
   merchantValue: string
@@ -46,6 +52,8 @@ interface TransactionReferencesSectionProps {
   selectedTags: SelectedTransactionTag[]
   readOnly: boolean
   onAccountChange: (value: string) => void
+  onSymmetricTransferChange: (value: boolean) => void
+  onToAccountChange: (value: string) => void
   onMerchantChange: (value: string) => void
   onMerchantSearchChange: (value: string) => void
   onMerchantSearchCommit: (value: string) => void
@@ -72,6 +80,10 @@ export default function TransactionReferencesSection({
   accountError,
   accountPlaceholder,
   runningBalance,
+  kind,
+  isSymmetricTransfer,
+  toAccountValue,
+  toAccountError,
   merchantOptions,
   selectedMerchantOption,
   merchantValue,
@@ -97,6 +109,8 @@ export default function TransactionReferencesSection({
   selectedTags,
   readOnly,
   onAccountChange,
+  onSymmetricTransferChange,
+  onToAccountChange,
   onMerchantChange,
   onMerchantSearchChange,
   onMerchantSearchCommit,
@@ -115,7 +129,10 @@ export default function TransactionReferencesSection({
   return (
     <TransactionModalSectionFrame number="02" title="Source/Destination">
       <div>
-        <TransactionModalFieldLabelRow label="Account" error={accountError} />
+        <TransactionModalFieldLabelRow
+          label={kind === 'transfer' && isSymmetricTransfer ? 'From account' : 'Account'}
+          error={accountError}
+        />
         <Dropdown
           id={TRANSACTION_MODAL_FIELD_IDS.account}
           options={accountOptions}
@@ -149,6 +166,71 @@ export default function TransactionReferencesSection({
                 >
                   {formatCurrency(runningBalance.amount, runningBalance.currency)}
                 </span>
+              </div>
+            </motion.div>
+          )}
+        </AnimatePresence>
+
+        <AnimatePresence initial={false}>
+          {kind === 'transfer' && (
+            <motion.div
+              key="symmetric-transfer"
+              className="overflow-hidden"
+              initial={{ height: 0, opacity: 0 }}
+              animate={{ height: 'auto', opacity: 1 }}
+              exit={{ height: 0, opacity: 0 }}
+              transition={{ height: { duration: 0.2, ease: EASE }, opacity: { duration: 0.14, ease: 'linear' } }}
+            >
+              <div className="pt-3">
+                <label
+                  htmlFor="txn-symmetric-transfer"
+                  className="flex cursor-pointer items-start gap-3 rounded-xl px-1 py-1"
+                >
+                  <input
+                    id="txn-symmetric-transfer"
+                    type="checkbox"
+                    checked={isSymmetricTransfer}
+                    onChange={(event) => onSymmetricTransferChange(event.target.checked)}
+                    disabled={readOnly}
+                    className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer disabled:cursor-not-allowed"
+                    style={{ accentColor: 'var(--app-accent)' }}
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-sm font-medium" style={{ color: 'var(--app-text)' }}>
+                      Record in both accounts
+                    </span>
+                    <span className="block text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                      Also create the matching entry in the receiving account
+                    </span>
+                  </span>
+                </label>
+
+                <AnimatePresence initial={false}>
+                  {isSymmetricTransfer && (
+                    <motion.div
+                      key="to-account"
+                      className="overflow-hidden"
+                      initial={{ height: 0, opacity: 0, y: -3 }}
+                      animate={{ height: 'auto', opacity: 1, y: 0 }}
+                      exit={{ height: 0, opacity: 0, y: -3 }}
+                      transition={{ duration: 0.2, ease: EASE }}
+                    >
+                      <div className="pt-3">
+                        <TransactionModalFieldLabelRow label="To account" error={toAccountError} />
+                        <Dropdown
+                          options={accountOptions}
+                          value={toAccountValue}
+                          onChange={onToAccountChange}
+                          className={`app-input ${toAccountError ? 'app-input-error' : ''}`}
+                          placeholder={accountPlaceholder}
+                          searchable
+                          searchPlaceholder="Search accounts..."
+                          disabled={readOnly}
+                        />
+                      </div>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
               </div>
             </motion.div>
           )}

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/TypeDirectionSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/TypeDirectionSection.tsx
@@ -13,9 +13,14 @@ import TransactionModalSectionFrame from '@/pages/transactions/components/transa
 
 interface TransactionTypeDirectionSectionProps {
   kind: TransactionModalKind
-  direction: TransactionDirection
+
+  // An empty direction renders the unselected state, used when a symmetric transfer does not involve the viewed account
+  direction: TransactionDirection | ''
   editing: boolean
   readOnly: boolean
+
+  // A symmetric transfer derives its direction from the accounts, so the control is shown but not editable
+  directionDisabled: boolean
   directionHighlightKey: number
   onKindChange: (kind: TransactionModalKind) => void
   onDirectionChange: (direction: TransactionDirection) => void
@@ -29,6 +34,7 @@ export default function TransactionTypeDirectionSection({
   direction,
   editing,
   readOnly,
+  directionDisabled,
   directionHighlightKey,
   onKindChange,
   onDirectionChange,
@@ -62,7 +68,7 @@ export default function TransactionTypeDirectionSection({
             options={DIRECTION_OPTIONS}
             ariaLabel="Transaction direction"
             onChange={onDirectionChange}
-            disabled={readOnly}
+            disabled={readOnly || directionDisabled}
           />
         </div>
       </div>

--- a/frontend/src/pages/transactions/components/transaction-modal/types.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/types.ts
@@ -15,6 +15,12 @@ export interface TransactionFormValues {
   notes: string
   date: string
   tag_ids: string[]
+
+  // When set on a transfer, the same amount is recorded in both accounts as two independent rows
+  symmetric_transfer: boolean
+
+  // The receiving account for a symmetric transfer, debited from account_id and credited here
+  to_account_id: string
 }
 
 export interface TransactionFormFieldErrors {
@@ -24,6 +30,7 @@ export interface TransactionFormFieldErrors {
   amount?: string
   currency?: string
   date?: string
+  to_account_id?: string
 }
 
 export interface CreateTransactionModalProps {

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
@@ -55,5 +55,7 @@ export function buildInitialTransactionForm({
     notes: transaction.notes ?? '',
     date: transaction.dt,
     tag_ids: transaction.tags?.map((tag) => tag.id) ?? transaction.tag_ids,
+    symmetric_transfer: false,
+    to_account_id: '',
   }
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
@@ -31,6 +31,34 @@ export function buildCreateTransactionPayload(
 }
 
 /**
+ * Builds the originating and receiving payloads for a symmetric transfer
+ *
+ * The originating account is debited and the receiving account is credited the same magnitude.
+ * Both legs share every other field so they read as the same movement in two accounts. The two
+ * rows stay independent on the backend, matching how the app already records transfers.
+ */
+export function buildSymmetricTransferPayloads(
+  form: TransactionFormValues,
+  selectedCurrencyExponent: number,
+): [CreateTransactionPayload, CreateTransactionPayload] {
+  const magnitude = amountInputToMinorUnits(form.amount, selectedCurrencyExponent) ?? 0
+  const shared = {
+    dt: form.date,
+    category_id: form.category_id,
+    merchant_id: form.merchant_id,
+    currency: form.currency,
+    notes: form.notes.trim() || null,
+  }
+  const fromPayload: CreateTransactionPayload = { account_id: form.account_id, amount: -magnitude, ...shared }
+  const toPayload: CreateTransactionPayload = { account_id: form.to_account_id, amount: magnitude, ...shared }
+  if (form.tag_ids.length > 0) {
+    fromPayload.tag_ids = form.tag_ids
+    toPayload.tag_ids = form.tag_ids
+  }
+  return [fromPayload, toPayload]
+}
+
+/**
  * Builds a minimal update patch so unchanged transaction fields are not sent back to the API
  */
 export function buildUpdateTransactionPatch(

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
@@ -1,7 +1,15 @@
+import type { AccountsOverview } from '@/api/accounts'
 import type {
   TransactionFormFieldErrors,
   TransactionFormValues,
 } from '@/pages/transactions/components/transaction-modal/types'
+
+/**
+ * Reports whether the form is recording a transfer into both accounts at once
+ */
+export function isSymmetricTransferForm(form: TransactionFormValues): boolean {
+  return form.kind === 'transfer' && form.symmetric_transfer
+}
 
 /**
  * Validates fields required before a transaction can be sent to the API
@@ -18,5 +26,27 @@ export function validateTransactionForm(form: TransactionFormValues): Transactio
   }
   if (!form.currency) errors.currency = 'Select a currency'
   if (!form.date) errors.date = 'Select a date'
+
+  // A symmetric transfer needs a second account that differs from the originating one
+  if (isSymmetricTransferForm(form)) {
+    if (!form.to_account_id) errors.to_account_id = 'Select a receiving account'
+    else if (form.to_account_id === form.account_id) errors.to_account_id = 'Choose a different receiving account'
+  }
   return errors
+}
+
+/**
+ * Validates the receiving account against the originating account for a symmetric transfer
+ *
+ * The two legs share a currency and a group so a single amount, category, and tag set apply to
+ * both. It returns the receiving-account error message, or undefined when the pair is valid.
+ */
+export function getSymmetricTransferAccountError(
+  fromAccount: AccountsOverview | undefined,
+  toAccount: AccountsOverview | undefined,
+): string | undefined {
+  if (!fromAccount || !toAccount) return undefined
+  if (toAccount.currency !== fromAccount.currency) return 'Both accounts must use the same currency'
+  if (toAccount.group_id !== fromAccount.group_id) return 'Both accounts must be in the same group'
+  return undefined
 }


### PR DESCRIPTION
- Adds an option in the create transaction modal to record a transfer in both accounts at once, off by default so the existing flow is unchanged
- For transfers, shows a receiving account field and a read-only debit/credit that follows the account you are viewing
- Blocks picking the same account for both sides, and requires both accounts to share a currency and group
- Saves the two sides as independent transactions like existing transfers, and if one side fails, keeps the other and names the leg to add manually

CU-86babp5ew