### PR TITLE
Save custom date ranges on the Insights page

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -22,6 +22,7 @@ from app.models import (  # noqa: F401
     group,
     institution,
     merchant,
+    saved_insights_range,
     tag,
     transaction,
     user,

--- a/backend/alembic/versions/e7a1c3b9d2f4_add_saved_insights_ranges.py
+++ b/backend/alembic/versions/e7a1c3b9d2f4_add_saved_insights_ranges.py
@@ -1,0 +1,45 @@
+"""add saved insights ranges
+
+Revision ID: e7a1c3b9d2f4
+Revises: d3f7b1a2c4e9
+Create Date: 2026-06-18 11:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from app.db.rls import secure_registered_table
+
+revision: str = "e7a1c3b9d2f4"
+down_revision: str | Sequence[str] | None = "d3f7b1a2c4e9"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the saved insights ranges table and enable its row-level security"""
+    op.create_table(
+        "saved_insights_ranges",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("user_id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.VARCHAR(length=64), nullable=False),
+        sa.Column("amount", sa.SmallInteger(), nullable=False),
+        sa.Column("unit", sa.VARCHAR(length=16), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("user_id", "name", name="uq_saved_insights_range_user_name"),
+        sa.CheckConstraint("amount > 0", name="ck_saved_insights_range_amount_positive"),
+        sa.CheckConstraint(
+            "unit IN ('day', 'week', 'month', 'quarter', 'year')",
+            name="ck_saved_insights_range_unit",
+        ),
+    )
+    secure_registered_table(op.get_bind(), "saved_insights_ranges")
+
+
+def downgrade() -> None:
+    """Drop the saved insights ranges table, which removes its policy and grants"""
+    op.drop_table("saved_insights_ranges")

--- a/backend/alembic/versions/f2b9c6d4a1e8_add_saved_insights_range_qualifier.py
+++ b/backend/alembic/versions/f2b9c6d4a1e8_add_saved_insights_range_qualifier.py
@@ -1,0 +1,38 @@
+"""add saved insights range qualifier
+
+Revision ID: f2b9c6d4a1e8
+Revises: e7a1c3b9d2f4
+Create Date: 2026-06-19 12:00:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "f2b9c6d4a1e8"
+down_revision: str | Sequence[str] | None = "e7a1c3b9d2f4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the qualifier column distinguishing this, last, and past range anchoring"""
+
+    # Existing rows predate the builder and were all rolling windows, so default them to past
+    op.add_column(
+        "saved_insights_ranges",
+        sa.Column("qualifier", sa.VARCHAR(length=16), nullable=False, server_default="past"),
+    )
+    op.create_check_constraint(
+        "ck_saved_insights_range_qualifier",
+        "saved_insights_ranges",
+        "qualifier IN ('this', 'last', 'past')",
+    )
+
+
+def downgrade() -> None:
+    """Drop the qualifier column and its check constraint"""
+    op.drop_constraint("ck_saved_insights_range_qualifier", "saved_insights_ranges", type_="check")
+    op.drop_column("saved_insights_ranges", "qualifier")

--- a/backend/app/db/rls/__init__.py
+++ b/backend/app/db/rls/__init__.py
@@ -7,9 +7,15 @@ single pair the migration and the test harness call
 from sqlalchemy import Connection
 
 from app.db.rls.functions import create_helper_functions, drop_helper_functions
-from app.db.rls.policies import AUTH_TABLES, GLOBAL_READ_TABLES, apply_policies, drop_policies
+from app.db.rls.policies import (
+    AUTH_TABLES,
+    GLOBAL_READ_TABLES,
+    apply_policies,
+    drop_policies,
+    secure_registered_table,
+)
 
-__all__ = ["AUTH_TABLES", "GLOBAL_READ_TABLES", "apply_rls", "revoke_rls"]
+__all__ = ["AUTH_TABLES", "GLOBAL_READ_TABLES", "apply_rls", "revoke_rls", "secure_registered_table"]
 
 
 def apply_rls(connection: Connection) -> None:

--- a/backend/app/db/rls/policies.py
+++ b/backend/app/db/rls/policies.py
@@ -48,6 +48,7 @@ SECURED_TABLES = (
     ("user_cache_states", f"user_id = {CURRENT_USER_ID}()", f"user_id = {CURRENT_USER_ID}()"),
     ("user_runway_accounts", f"user_id = {CURRENT_USER_ID}()",
      f"user_id = {CURRENT_USER_ID}() AND {CAN_ACCESS_ACCOUNT}(account_id)"),
+    ("saved_insights_ranges", f"user_id = {CURRENT_USER_ID}()", f"user_id = {CURRENT_USER_ID}()"),
     ("users", f"id = {CURRENT_USER_ID}()", f"id = {CURRENT_USER_ID}()"),
     ("merchants", f"owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)",
      f"owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)"),
@@ -76,6 +77,13 @@ AUTH_TABLES = ("auth_identities", "password_credentials", "auth_sessions", "auth
 def apply_policies(connection: Connection) -> None:
     """Enable the policies and grant the app role the access it serves"""
     for table, using_expr, check_expr in SECURED_TABLES:
+
+        # A table added after the bootstrap RLS migration is created and secured by its own
+        # later migration, so a from-scratch upgrade reaches this loop before that table
+        # exists, while the test harness builds the full schema first and secures it here.
+        # The coverage guard test is what proves every registered table ends up secured
+        if not _table_exists(connection, table):
+            continue
         _secure_table(connection, table, using_expr, check_expr)
     _secure_categories(connection)
     _secure_groups(connection)
@@ -89,6 +97,26 @@ def apply_policies(connection: Connection) -> None:
     # The app role evaluates the policies and the auth flows, so it must execute the
     # helpers, while their SECURITY DEFINER owner is what reaches the underlying rows
     connection.execute(text(f'GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA public TO "{APP_DB_USER}"'))
+
+
+def _table_exists(connection: Connection, table: str) -> bool:
+    """Whether a public table is already present in the database"""
+    return connection.execute(
+        text("SELECT to_regclass(:qualified)"), {"qualified": f"public.{table}"}
+    ).scalar() is not None
+
+
+def secure_registered_table(connection: Connection, table: str) -> None:
+    """Enable row-level security on one already-created table using its registered policy
+
+    Incremental migrations that add a secured table call this so the single SECURED_TABLES
+    definition stays the only source of the table's access rule
+    """
+    for name, using_expr, check_expr in SECURED_TABLES:
+        if name == table:
+            _secure_table(connection, name, using_expr, check_expr)
+            return
+    raise KeyError(f"No registered row-level security policy for table {table!r}")
 
 
 def drop_policies(connection: Connection) -> None:

--- a/backend/app/models/saved_insights_range.py
+++ b/backend/app/models/saved_insights_range.py
@@ -19,7 +19,12 @@ from app.models.base import Base
 # Relative window units a saved range can step back by, ordered shortest to longest
 SAVED_INSIGHTS_RANGE_UNITS = ("day", "week", "month", "quarter", "year")
 
+# How a saved range is anchored: the current period to date, the previous complete period(s),
+# or a rolling window of the last N periods ending today
+SAVED_INSIGHTS_RANGE_QUALIFIERS = ("this", "last", "past")
+
 _UNIT_CHECK_VALUES = ", ".join(f"'{unit}'" for unit in SAVED_INSIGHTS_RANGE_UNITS)
+_QUALIFIER_CHECK_VALUES = ", ".join(f"'{qualifier}'" for qualifier in SAVED_INSIGHTS_RANGE_QUALIFIERS)
 
 
 class SavedInsightsRange(Base):
@@ -34,6 +39,9 @@ class SavedInsightsRange(Base):
         UniqueConstraint("user_id", "name", name="uq_saved_insights_range_user_name"),
         CheckConstraint("amount > 0", name="ck_saved_insights_range_amount_positive"),
         CheckConstraint(f"unit IN ({_UNIT_CHECK_VALUES})", name="ck_saved_insights_range_unit"),
+        CheckConstraint(
+            f"qualifier IN ({_QUALIFIER_CHECK_VALUES})", name="ck_saved_insights_range_qualifier"
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
@@ -43,4 +51,7 @@ class SavedInsightsRange(Base):
     name: Mapped[str] = mapped_column(VARCHAR(64), nullable=False)
     amount: Mapped[int] = mapped_column(SmallInteger, nullable=False)
     unit: Mapped[str] = mapped_column(VARCHAR(16), nullable=False)
+
+    # this = current period to date, last = previous complete periods, past = rolling window
+    qualifier: Mapped[str] = mapped_column(VARCHAR(16), nullable=False, server_default="past")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/saved_insights_range.py
+++ b/backend/app/models/saved_insights_range.py
@@ -1,0 +1,46 @@
+"""Saved insights range model"""
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import (
+    VARCHAR,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    SmallInteger,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+# Relative window units a saved range can step back by, ordered shortest to longest
+SAVED_INSIGHTS_RANGE_UNITS = ("day", "week", "month", "quarter", "year")
+
+_UNIT_CHECK_VALUES = ", ".join(f"'{unit}'" for unit in SAVED_INSIGHTS_RANGE_UNITS)
+
+
+class SavedInsightsRange(Base):
+    """A user's named relative date window for the insights page
+
+    Stores the window as an amount and unit, for example three months, rather than fixed
+    dates, so applying a saved range always recomputes against the current day.
+    """
+
+    __tablename__ = "saved_insights_ranges"
+    __table_args__ = (
+        UniqueConstraint("user_id", "name", name="uq_saved_insights_range_user_name"),
+        CheckConstraint("amount > 0", name="ck_saved_insights_range_amount_positive"),
+        CheckConstraint(f"unit IN ({_UNIT_CHECK_VALUES})", name="ck_saved_insights_range_unit"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        ForeignKey("users.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str] = mapped_column(VARCHAR(64), nullable=False)
+    amount: Mapped[int] = mapped_column(SmallInteger, nullable=False)
+    unit: Mapped[str] = mapped_column(VARCHAR(16), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/routes/insights/router.py
+++ b/backend/app/routes/insights/router.py
@@ -353,6 +353,7 @@ async def create_saved_range_route(
         name=data.name,
         amount=data.amount,
         unit=data.unit,
+        qualifier=data.qualifier,
     )
     db.add(saved_range)
 

--- a/backend/app/routes/insights/router.py
+++ b/backend/app/routes/insights/router.py
@@ -1,15 +1,19 @@
 """Insights aggregation endpoints"""
 
+import uuid
 from datetime import date
 from datetime import datetime as DateTime
 from typing import Annotated
 from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.database import get_db
 from app.dependencies import get_current_user
+from app.models.saved_insights_range import SavedInsightsRange
 from app.models.user import User
 from app.schemas.insights import (
     InsightsCashFlowResponse,
@@ -22,6 +26,8 @@ from app.schemas.insights import (
     InsightsNetWorthResponse,
     InsightsPeriodAtAGlanceResponse,
     InsightsSavingsRateTrendResponse,
+    SavedInsightsRangeCreate,
+    SavedInsightsRangeResponse,
 )
 from app.services.insights import (
     get_cash_flow,
@@ -298,3 +304,96 @@ async def get_merchants_route(
     """
     _validate_date_range(from_date, to_date)
     return await get_merchants(db, user, from_date, to_date, comparison_period)
+
+
+@router.get("/saved-ranges", response_model=list[SavedInsightsRangeResponse])
+async def list_saved_ranges_route(
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    """Return the authenticated user's saved relative insights ranges
+
+    Args:
+        user: Authenticated user requesting their saved ranges
+        db: Active database session
+
+    Returns:
+        Saved ranges ordered with the most recently created first
+    """
+    # Read the caller's saved ranges, newest first so the latest save surfaces at the top
+    result = await db.execute(
+        select(SavedInsightsRange)
+        .where(SavedInsightsRange.user_id == user.id)
+        .order_by(SavedInsightsRange.created_at.desc())
+    )
+    return result.scalars().all()
+
+
+@router.post("/saved-ranges", response_model=SavedInsightsRangeResponse, status_code=status.HTTP_201_CREATED)
+async def create_saved_range_route(
+    data: SavedInsightsRangeCreate,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    """Save a named relative insights range for the authenticated user
+
+    Args:
+        data: Saved range payload with a name, amount, and unit
+        user: Authenticated user saving the range
+        db: Active database session
+
+    Returns:
+        Newly saved range
+
+    Raises:
+        HTTPException: Raised with 409 when the user already has a saved range with the same name
+    """
+    saved_range = SavedInsightsRange(
+        user_id=user.id,
+        name=data.name,
+        amount=data.amount,
+        unit=data.unit,
+    )
+    db.add(saved_range)
+
+    # Surface a duplicate name as a domain conflict instead of a raw integrity error
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A saved range with this name already exists",
+        ) from e
+
+    await db.refresh(saved_range)
+    return saved_range
+
+
+@router.delete("/saved-ranges/{range_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_saved_range_route(
+    range_id: uuid.UUID,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    """Delete one of the authenticated user's saved relative insights ranges
+
+    Args:
+        range_id: Saved range identifier from the route path
+        user: Authenticated user deleting the range
+        db: Active database session
+
+    Raises:
+        HTTPException: Raised with 404 when the range does not belong to the user
+    """
+    result = await db.execute(
+        delete(SavedInsightsRange).where(
+            SavedInsightsRange.id == range_id,
+            SavedInsightsRange.user_id == user.id,
+        )
+    )
+    await db.commit()
+
+    # A zero row count means the range is missing or owned by another user
+    if result.rowcount == 0:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Saved range not found")

--- a/backend/app/schemas/insights.py
+++ b/backend/app/schemas/insights.py
@@ -12,6 +12,9 @@ NetWorthGroupKind = Literal["asset", "debt"]
 InsightsComparisonPeriod = Literal["same_length", "previous_month", "previous_year"]
 SavedInsightsRangeUnit = Literal["day", "week", "month", "quarter", "year"]
 
+# this = current period to date, last = previous complete periods, past = rolling window
+SavedInsightsRangeQualifier = Literal["this", "last", "past"]
+
 # Guards a saved range against absurd look-backs while leaving room for any sensible window
 SAVED_INSIGHTS_RANGE_MAX_AMOUNT = 999
 
@@ -113,6 +116,7 @@ class SavedInsightsRangeCreate(BaseModel):
     name: str = Field(min_length=1, max_length=64)
     amount: int = Field(ge=1, le=SAVED_INSIGHTS_RANGE_MAX_AMOUNT)
     unit: SavedInsightsRangeUnit
+    qualifier: SavedInsightsRangeQualifier = "past"
 
 
 class SavedInsightsRangeResponse(BaseModel):
@@ -122,6 +126,7 @@ class SavedInsightsRangeResponse(BaseModel):
     name: str
     amount: int
     unit: SavedInsightsRangeUnit
+    qualifier: SavedInsightsRangeQualifier
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/backend/app/schemas/insights.py
+++ b/backend/app/schemas/insights.py
@@ -1,6 +1,7 @@
 """Schemas for insights endpoint responses"""
 
-from datetime import date
+import uuid
+from datetime import date, datetime
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -9,6 +10,10 @@ from app.schemas.fx import FxStatus
 
 NetWorthGroupKind = Literal["asset", "debt"]
 InsightsComparisonPeriod = Literal["same_length", "previous_month", "previous_year"]
+SavedInsightsRangeUnit = Literal["day", "week", "month", "quarter", "year"]
+
+# Guards a saved range against absurd look-backs while leaving room for any sensible window
+SAVED_INSIGHTS_RANGE_MAX_AMOUNT = 999
 
 
 class InsightsPeriodAtAGlanceResponse(BaseModel):
@@ -100,3 +105,23 @@ class InsightsMerchantsResponse(BaseModel):
     distribution: list[tuple[str, str, int, int | None, int | None]]
     ranking: list[tuple[str, str, int, int, int | None]]
     fx_status: FxStatus = Field(default_factory=FxStatus)
+
+
+class SavedInsightsRangeCreate(BaseModel):
+    """Payload for saving a named relative insights range"""
+
+    name: str = Field(min_length=1, max_length=64)
+    amount: int = Field(ge=1, le=SAVED_INSIGHTS_RANGE_MAX_AMOUNT)
+    unit: SavedInsightsRangeUnit
+
+
+class SavedInsightsRangeResponse(BaseModel):
+    """A user's saved relative insights range"""
+
+    id: uuid.UUID
+    name: str
+    amount: int
+    unit: SavedInsightsRangeUnit
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -23,6 +23,7 @@ from app.models import (  # noqa: F401
     group,
     institution,
     merchant,
+    saved_insights_range,
     tag,
     transaction,
     user,

--- a/backend/tests/routes/insights/test_saved_ranges.py
+++ b/backend/tests/routes/insights/test_saved_ranges.py
@@ -1,0 +1,140 @@
+"""Route tests for insights saved relative ranges."""
+
+from tests.routes.support import _create_user, _get_auth_header
+
+SAVED_RANGE_PAYLOAD = {"name": "Half-year review", "amount": 6, "unit": "month"}
+
+
+async def _create_second_user(client):
+    """Sign up a second user so saved-range isolation can be exercised
+
+    Args:
+        client: Async test client
+
+    Returns:
+        Authorization header for the second user
+    """
+    resp = await client.post("/auth/signup", json={
+        "email": "second@example.com",
+        "password": "securepassword123",
+        "first_name": "Second",
+        "tz": "America/Toronto",
+        "base_currency": "CAD",
+    })
+    return _get_auth_header(resp)
+
+
+async def test_create_saved_range_returns_payload(client):
+    """Saving a range echoes the stored name, amount, and unit."""
+    headers = _get_auth_header(await _create_user(client))
+
+    resp = await client.post("/insights/saved-ranges", json=SAVED_RANGE_PAYLOAD, headers=headers)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Half-year review"
+    assert data["amount"] == 6
+    assert data["unit"] == "month"
+    assert "id" in data
+    assert "created_at" in data
+
+
+async def test_list_saved_ranges_returns_newest_first(client):
+    """Saved ranges list with the most recently created range first."""
+    headers = _get_auth_header(await _create_user(client))
+    await client.post(
+        "/insights/saved-ranges",
+        json={"name": "Weekly", "amount": 7, "unit": "day"},
+        headers=headers,
+    )
+    await client.post(
+        "/insights/saved-ranges",
+        json={"name": "Yearly", "amount": 1, "unit": "year"},
+        headers=headers,
+    )
+
+    resp = await client.get("/insights/saved-ranges", headers=headers)
+
+    assert resp.status_code == 200
+    names = [item["name"] for item in resp.json()]
+    assert names == ["Yearly", "Weekly"]
+
+
+async def test_create_saved_range_rejects_duplicate_name(client):
+    """A second range reusing a name returns a conflict."""
+    headers = _get_auth_header(await _create_user(client))
+    await client.post("/insights/saved-ranges", json=SAVED_RANGE_PAYLOAD, headers=headers)
+
+    resp = await client.post("/insights/saved-ranges", json=SAVED_RANGE_PAYLOAD, headers=headers)
+
+    assert resp.status_code == 409
+
+
+async def test_create_saved_range_rejects_unknown_unit(client):
+    """An unsupported unit is rejected before reaching the database."""
+    headers = _get_auth_header(await _create_user(client))
+
+    resp = await client.post(
+        "/insights/saved-ranges",
+        json={"name": "Decade", "amount": 1, "unit": "decade"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_create_saved_range_rejects_non_positive_amount(client):
+    """An amount below one is rejected."""
+    headers = _get_auth_header(await _create_user(client))
+
+    resp = await client.post(
+        "/insights/saved-ranges",
+        json={"name": "Zero", "amount": 0, "unit": "month"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_delete_saved_range_removes_it(client):
+    """Deleting a saved range drops it from the list."""
+    headers = _get_auth_header(await _create_user(client))
+    created = (await client.post("/insights/saved-ranges", json=SAVED_RANGE_PAYLOAD, headers=headers)).json()
+
+    delete_resp = await client.delete(f"/insights/saved-ranges/{created['id']}", headers=headers)
+    list_resp = await client.get("/insights/saved-ranges", headers=headers)
+
+    assert delete_resp.status_code == 204
+    assert list_resp.json() == []
+
+
+async def test_delete_missing_saved_range_returns_not_found(client):
+    """Deleting an unknown range returns not found."""
+    headers = _get_auth_header(await _create_user(client))
+
+    resp = await client.delete(
+        "/insights/saved-ranges/00000000-0000-0000-0000-000000000000",
+        headers=headers,
+    )
+
+    assert resp.status_code == 404
+
+
+async def test_saved_ranges_are_isolated_per_user(client):
+    """A user never sees or deletes another user's saved ranges."""
+    owner_headers = _get_auth_header(await _create_user(client))
+    created = (await client.post("/insights/saved-ranges", json=SAVED_RANGE_PAYLOAD, headers=owner_headers)).json()
+    other_headers = await _create_second_user(client)
+
+    other_list = await client.get("/insights/saved-ranges", headers=other_headers)
+    other_delete = await client.delete(f"/insights/saved-ranges/{created['id']}", headers=other_headers)
+
+    assert other_list.json() == []
+    assert other_delete.status_code == 404
+
+
+async def test_saved_ranges_require_auth(client):
+    """Saved range endpoints require an authenticated user."""
+    resp = await client.get("/insights/saved-ranges")
+
+    assert resp.status_code == 401

--- a/backend/tests/routes/insights/test_saved_ranges.py
+++ b/backend/tests/routes/insights/test_saved_ranges.py
@@ -35,8 +35,36 @@ async def test_create_saved_range_returns_payload(client):
     assert data["name"] == "Half-year review"
     assert data["amount"] == 6
     assert data["unit"] == "month"
+    assert data["qualifier"] == "past"
     assert "id" in data
     assert "created_at" in data
+
+
+async def test_create_saved_range_stores_qualifier(client):
+    """Saving a previous-complete range echoes the chosen qualifier back."""
+    headers = _get_auth_header(await _create_user(client))
+
+    resp = await client.post(
+        "/insights/saved-ranges",
+        json={"name": "Last quarter", "amount": 1, "unit": "quarter", "qualifier": "last"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["qualifier"] == "last"
+
+
+async def test_create_saved_range_rejects_unknown_qualifier(client):
+    """An unsupported qualifier is rejected before reaching the database."""
+    headers = _get_auth_header(await _create_user(client))
+
+    resp = await client.post(
+        "/insights/saved-ranges",
+        json={"name": "Rolling", "amount": 1, "unit": "quarter", "qualifier": "rolling"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
 
 
 async def test_list_saved_ranges_returns_newest_first(client):

--- a/frontend/src/api/cache/queryKeys.ts
+++ b/frontend/src/api/cache/queryKeys.ts
@@ -98,6 +98,7 @@ export const insightsKeys = {
   merchantsAll: ['insights-merchants'] as const,
   merchants: (fromDate: string, toDate: string, comparisonPeriod = 'same_length') =>
     ['insights-merchants', fromDate, toDate, comparisonPeriod] as const,
+  savedRanges: () => ['insights-saved-ranges'] as const,
 };
 
 export const budgetKeys = {

--- a/frontend/src/api/insights/hooks.ts
+++ b/frontend/src/api/insights/hooks.ts
@@ -14,6 +14,7 @@ import {
 import { insightsKeys } from '@/api/cache/queryKeys';
 import { getFxAwareStaleTime } from '@/api/shared/fxCache';
 import { useAuth } from '@/hooks/useAuth';
+import type { SavedInsightsRange } from '@/api/insights/types';
 import type { InsightsComparisonPeriod } from '@/pages/insights/types/range';
 
 const INSIGHTS_FX_STALE_TIME_MS = 5 * 60 * 1000;
@@ -138,27 +139,33 @@ export function useSavedInsightsRanges(enabled = true) {
 }
 
 /**
- * Saves a named relative range and refreshes the saved range list
+ * Saves a named relative range and prepends it to the cached saved range list
  */
 export function useSaveInsightsRange() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: createSavedInsightsRange,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: insightsKeys.savedRanges() });
+    onSuccess: (savedRange) => {
+      // Prepend the new range so the list stays newest-first without a refetch round-trip
+      queryClient.setQueryData<SavedInsightsRange[]>(insightsKeys.savedRanges(), (ranges) =>
+        ranges ? [savedRange, ...ranges] : [savedRange],
+      );
     },
   });
 }
 
 /**
- * Deletes a saved relative range and refreshes the saved range list
+ * Deletes a saved relative range and drops it from the cached saved range list
  */
 export function useDeleteSavedInsightsRange() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: deleteSavedInsightsRange,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: insightsKeys.savedRanges() });
+    onSuccess: (_, rangeId) => {
+      // Remove the deleted range in place so the exit animation plays without a refetch round-trip
+      queryClient.setQueryData<SavedInsightsRange[]>(insightsKeys.savedRanges(), (ranges) =>
+        ranges?.filter((range) => range.id !== rangeId) ?? ranges,
+      );
     },
   });
 }

--- a/frontend/src/api/insights/hooks.ts
+++ b/frontend/src/api/insights/hooks.ts
@@ -130,11 +130,12 @@ export function useInsightsMerchants(
  */
 export function useSavedInsightsRanges(enabled = true) {
   const { accessToken } = useAuth();
+  // Left at the default stale time, like the app's other lists, so a range saved in another
+  // session is refetched on the next mount rather than staying cached forever
   return useQuery({
     queryKey: insightsKeys.savedRanges(),
     queryFn: fetchSavedInsightsRanges,
     enabled: !!accessToken && enabled,
-    staleTime: Infinity,
   });
 }
 

--- a/frontend/src/api/insights/hooks.ts
+++ b/frontend/src/api/insights/hooks.ts
@@ -1,5 +1,7 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import {
+  createSavedInsightsRange,
+  deleteSavedInsightsRange,
   fetchInsightsCashFlow,
   fetchInsightsFundFlow,
   fetchInsightsIncomeExpenseBreakdown,
@@ -7,6 +9,7 @@ import {
   fetchInsightsNetWorth,
   fetchInsightsPeriodGlance,
   fetchInsightsSavingsRateTrend,
+  fetchSavedInsightsRanges,
 } from '@/api/insights/requests';
 import { insightsKeys } from '@/api/cache/queryKeys';
 import { getFxAwareStaleTime } from '@/api/shared/fxCache';
@@ -118,5 +121,44 @@ export function useInsightsMerchants(
     queryFn: () => fetchInsightsMerchants(fromDate, toDate, comparisonPeriod),
     enabled: !!accessToken && enabled && fromDate !== '' && toDate !== '',
     staleTime: getFxAwareStaleTime(INSIGHTS_FX_STALE_TIME_MS),
+  });
+}
+
+/**
+ * Reads the user's saved relative insights ranges
+ */
+export function useSavedInsightsRanges(enabled = true) {
+  const { accessToken } = useAuth();
+  return useQuery({
+    queryKey: insightsKeys.savedRanges(),
+    queryFn: fetchSavedInsightsRanges,
+    enabled: !!accessToken && enabled,
+    staleTime: Infinity,
+  });
+}
+
+/**
+ * Saves a named relative range and refreshes the saved range list
+ */
+export function useSaveInsightsRange() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: createSavedInsightsRange,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: insightsKeys.savedRanges() });
+    },
+  });
+}
+
+/**
+ * Deletes a saved relative range and refreshes the saved range list
+ */
+export function useDeleteSavedInsightsRange() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: deleteSavedInsightsRange,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: insightsKeys.savedRanges() });
+    },
   });
 }

--- a/frontend/src/api/insights/index.ts
+++ b/frontend/src/api/insights/index.ts
@@ -16,9 +16,13 @@ export type {
   InsightsPeriodGlanceResponse,
   InsightsSavingsRateTrendPoint,
   InsightsSavingsRateTrendResponse,
+  SaveInsightsRangePayload,
+  SavedInsightsRange,
 } from '@/api/insights/types';
 
 export {
+  createSavedInsightsRange,
+  deleteSavedInsightsRange,
   fetchInsightsCashFlow,
   fetchInsightsFundFlow,
   fetchInsightsIncomeExpenseBreakdown,
@@ -26,9 +30,11 @@ export {
   fetchInsightsNetWorth,
   fetchInsightsPeriodGlance,
   fetchInsightsSavingsRateTrend,
+  fetchSavedInsightsRanges,
 } from '@/api/insights/requests';
 
 export {
+  useDeleteSavedInsightsRange,
   useInsightsCashFlow,
   useInsightsFundFlow,
   useInsightsIncomeExpenseBreakdown,
@@ -36,4 +42,6 @@ export {
   useInsightsNetWorth,
   useInsightsPeriodGlance,
   useInsightsSavingsRateTrend,
+  useSaveInsightsRange,
+  useSavedInsightsRanges,
 } from '@/api/insights/hooks';

--- a/frontend/src/api/insights/requests.ts
+++ b/frontend/src/api/insights/requests.ts
@@ -8,6 +8,8 @@ import type {
   InsightsNetWorthResponse,
   InsightsPeriodGlanceResponse,
   InsightsSavingsRateTrendResponse,
+  SaveInsightsRangePayload,
+  SavedInsightsRange,
 } from '@/api/insights/types';
 import type { InsightsComparisonPeriod } from '@/pages/insights/types/range';
 
@@ -101,4 +103,30 @@ export function fetchInsightsMerchants(
   return authenticatedFetch<InsightsMerchantsResponse>(
     `/insights/merchants${buildInsightsRangeQueryString(fromDate, toDate, comparisonPeriod)}`,
   );
+}
+
+/**
+ * Fetches the user's saved relative insights ranges, newest first
+ */
+export function fetchSavedInsightsRanges() {
+  return authenticatedFetch<SavedInsightsRange[]>('/insights/saved-ranges');
+}
+
+/**
+ * Saves a named relative insights range
+ */
+export function createSavedInsightsRange(payload: SaveInsightsRangePayload) {
+  return authenticatedFetch<SavedInsightsRange>('/insights/saved-ranges', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+}
+
+/**
+ * Deletes a saved relative insights range by ID
+ */
+export function deleteSavedInsightsRange(rangeId: string) {
+  return authenticatedFetch<void>(`/insights/saved-ranges/${rangeId}`, {
+    method: 'DELETE',
+  });
 }

--- a/frontend/src/api/insights/types.ts
+++ b/frontend/src/api/insights/types.ts
@@ -1,5 +1,5 @@
 import type { FxStatus } from '@/api/shared/fx';
-import type { SavedInsightsRangeUnit } from '@/pages/insights/types/range';
+import type { SavedInsightsRangeQualifier, SavedInsightsRangeUnit } from '@/pages/insights/types/range';
 
 export interface InsightsPeriodGlanceResponse {
   income: number;
@@ -84,6 +84,8 @@ export interface SavedInsightsRange {
   // Relative window stored as "last {amount} {unit}", resolved to dates on the client
   amount: number;
   unit: SavedInsightsRangeUnit;
+  // How the window is anchored: this (current to date), last (previous complete), past (rolling)
+  qualifier: SavedInsightsRangeQualifier;
   created_at: string;
 }
 
@@ -91,4 +93,5 @@ export interface SaveInsightsRangePayload {
   name: string;
   amount: number;
   unit: SavedInsightsRangeUnit;
+  qualifier: SavedInsightsRangeQualifier;
 }

--- a/frontend/src/api/insights/types.ts
+++ b/frontend/src/api/insights/types.ts
@@ -1,4 +1,5 @@
 import type { FxStatus } from '@/api/shared/fx';
+import type { SavedInsightsRangeUnit } from '@/pages/insights/types/range';
 
 export interface InsightsPeriodGlanceResponse {
   income: number;
@@ -75,4 +76,19 @@ export interface InsightsMerchantsResponse {
   distribution: InsightsMerchantDistributionEntry[];
   ranking: InsightsMerchantRankingEntry[];
   fx_status: FxStatus;
+}
+
+export interface SavedInsightsRange {
+  id: string;
+  name: string;
+  // Relative window stored as "last {amount} {unit}", resolved to dates on the client
+  amount: number;
+  unit: SavedInsightsRangeUnit;
+  created_at: string;
+}
+
+export interface SaveInsightsRangePayload {
+  name: string;
+  amount: number;
+  unit: SavedInsightsRangeUnit;
 }

--- a/frontend/src/pages/insights/InsightsPage.tsx
+++ b/frontend/src/pages/insights/InsightsPage.tsx
@@ -1,4 +1,10 @@
 import { useState } from 'react'
+import {
+  useDeleteSavedInsightsRange,
+  useSaveInsightsRange,
+  useSavedInsightsRanges,
+  type SavedInsightsRange,
+} from '@/api/insights'
 import { useAuth } from '@/hooks/useAuth'
 import { CashFlowCard } from './components/cash-flow-card/Card'
 import {
@@ -27,6 +33,28 @@ export default function InsightsPage() {
   const [netWorthMode, setNetWorthMode] = useState<NetWorthViewMode>('overview')
   const [capSavingsRateChart, setCapSavingsRateChart] = useState(false)
   const range = useInsightsRange()
+  const savedRangesQuery = useSavedInsightsRanges()
+  const saveRange = useSaveInsightsRange()
+  const deleteRange = useDeleteSavedInsightsRange()
+
+  /**
+   * Saves the active relative window, letting the control surface a conflicting name
+   */
+  async function handleSaveCurrentRange(name: string) {
+    await saveRange.mutateAsync({
+      name,
+      amount: range.relativeAmount,
+      unit: range.relativeUnit,
+    })
+  }
+
+  /**
+   * Re-applies a saved range, recomputing its rolling window against today
+   */
+  function handleApplySavedRange(savedRange: SavedInsightsRange) {
+    range.applyRelativeRange(savedRange.amount, savedRange.unit)
+  }
+
   const {
     periodGlanceRef,
     fundFlowRef,
@@ -65,13 +93,17 @@ export default function InsightsPage() {
 
       <InsightsFloatingRangeControl
         preset={range.rangePreset}
-        fromDateValue={range.customFrom}
-        toDateValue={range.customTo}
-        customInvalid={range.customInvalid}
+        relativeAmount={range.relativeAmount}
+        relativeUnit={range.relativeUnit}
+        resolvedFrom={range.rangeInputDates.from}
+        resolvedTo={range.rangeInputDates.to}
+        savedRanges={savedRangesQuery.data ?? []}
         onPresetChange={range.setRangePreset}
-        onCustomFromChange={range.setCustomFrom}
-        onCustomToChange={range.setCustomTo}
-        onCustomRangeCommit={range.commitCustomRange}
+        onRelativeAmountChange={range.setRelativeAmount}
+        onRelativeUnitChange={range.setRelativeUnit}
+        onSaveCurrentRange={handleSaveCurrentRange}
+        onApplySavedRange={handleApplySavedRange}
+        onDeleteSavedRange={deleteRange.mutate}
       />
 
       <div className="space-y-4 pb-28 min-[1050px]:pb-0">

--- a/frontend/src/pages/insights/InsightsPage.tsx
+++ b/frontend/src/pages/insights/InsightsPage.tsx
@@ -3,7 +3,6 @@ import {
   useDeleteSavedInsightsRange,
   useSaveInsightsRange,
   useSavedInsightsRanges,
-  type SavedInsightsRange,
 } from '@/api/insights'
 import { useAuth } from '@/hooks/useAuth'
 import { CashFlowCard } from './components/cash-flow-card/Card'
@@ -45,14 +44,8 @@ export default function InsightsPage() {
       name,
       amount: range.relativeAmount,
       unit: range.relativeUnit,
+      qualifier: range.relativeQualifier,
     })
-  }
-
-  /**
-   * Re-applies a saved range, recomputing its rolling window against today
-   */
-  function handleApplySavedRange(savedRange: SavedInsightsRange) {
-    range.applyRelativeRange(savedRange.amount, savedRange.unit)
   }
 
   const {
@@ -95,14 +88,17 @@ export default function InsightsPage() {
         preset={range.rangePreset}
         relativeAmount={range.relativeAmount}
         relativeUnit={range.relativeUnit}
+        relativeQualifier={range.relativeQualifier}
         resolvedFrom={range.rangeInputDates.from}
         resolvedTo={range.rangeInputDates.to}
+        appliedSavedRangeName={range.appliedSavedRangeName}
         savedRanges={savedRangesQuery.data ?? []}
         onPresetChange={range.setRangePreset}
         onRelativeAmountChange={range.setRelativeAmount}
         onRelativeUnitChange={range.setRelativeUnit}
+        onRelativeQualifierChange={range.setRelativeQualifier}
         onSaveCurrentRange={handleSaveCurrentRange}
-        onApplySavedRange={handleApplySavedRange}
+        onApplySavedRange={range.applySavedRange}
         onDeleteSavedRange={deleteRange.mutate}
       />
 

--- a/frontend/src/pages/insights/InsightsPage.tsx
+++ b/frontend/src/pages/insights/InsightsPage.tsx
@@ -39,13 +39,18 @@ export default function InsightsPage() {
   /**
    * Saves the active relative window, letting the control surface a conflicting name
    */
+  /**
+   * Saves the builder draft under a name, then commits it as the applied range so the cards and
+   * pill switch to it once the save succeeds
+   */
   async function handleSaveCurrentRange(name: string) {
     await saveRange.mutateAsync({
       name,
-      amount: range.relativeAmount,
-      unit: range.relativeUnit,
-      qualifier: range.relativeQualifier,
+      amount: range.draftAmount,
+      unit: range.draftUnit,
+      qualifier: range.draftQualifier,
     })
+    range.applyDraft(name)
   }
 
   const {
@@ -85,18 +90,26 @@ export default function InsightsPage() {
       </div>
 
       <InsightsFloatingRangeControl
-        preset={range.rangePreset}
-        relativeAmount={range.relativeAmount}
-        relativeUnit={range.relativeUnit}
-        relativeQualifier={range.relativeQualifier}
+        selectedPreset={range.selectedPreset}
+        appliedPreset={range.appliedPreset}
+        appliedAmount={range.appliedAmount}
+        appliedUnit={range.appliedUnit}
+        appliedQualifier={range.appliedQualifier}
+        appliedSavedRangeName={range.appliedSavedRangeName}
         resolvedFrom={range.rangeInputDates.from}
         resolvedTo={range.rangeInputDates.to}
-        appliedSavedRangeName={range.appliedSavedRangeName}
+        draftAmount={range.draftAmount}
+        draftUnit={range.draftUnit}
+        draftQualifier={range.draftQualifier}
+        draftFrom={range.draftInputDates.from}
+        draftTo={range.draftInputDates.to}
         savedRanges={savedRangesQuery.data ?? []}
-        onPresetChange={range.setRangePreset}
-        onRelativeAmountChange={range.setRelativeAmount}
-        onRelativeUnitChange={range.setRelativeUnit}
-        onRelativeQualifierChange={range.setRelativeQualifier}
+        onSelectPreset={range.selectPreset}
+        onRevertSelection={range.revertSelection}
+        onDraftAmountChange={range.setDraftAmount}
+        onDraftUnitChange={range.setDraftUnit}
+        onDraftQualifierChange={range.setDraftQualifier}
+        onApplyDraft={range.applyDraft}
         onSaveCurrentRange={handleSaveCurrentRange}
         onApplySavedRange={range.applySavedRange}
         onDeleteSavedRange={deleteRange.mutate}

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { motion, useReducedMotion } from 'motion/react'
 import { Calendar, ChevronDown } from 'lucide-react'
@@ -33,19 +33,29 @@ const INSIGHTS_RANGE_OPTIONS: { value: InsightsRangePreset; code: string; label:
 ]
 
 type InsightsFloatingRangeControlProps = {
-  preset: InsightsRangePreset
-  relativeAmount: number
-  relativeUnit: SavedInsightsRangeUnit
-  relativeQualifier: SavedInsightsRangeQualifier
+  // Highlighted preset segment, CUSTOM while the builder is being edited
+  selectedPreset: InsightsRangePreset
+  // Applied range that the cards and the collapsed pill reflect
+  appliedPreset: InsightsRangePreset
+  appliedAmount: number
+  appliedUnit: SavedInsightsRangeUnit
+  appliedQualifier: SavedInsightsRangeQualifier
+  appliedSavedRangeName: string | null
   resolvedFrom: string
   resolvedTo: string
-  // Name of the applied saved range, shown as the pill label until the window is changed
-  appliedSavedRangeName: string | null
+  // Draft window the builder edits and previews, applied only on Apply, Save, or a saved range
+  draftAmount: number
+  draftUnit: SavedInsightsRangeUnit
+  draftQualifier: SavedInsightsRangeQualifier
+  draftFrom: string
+  draftTo: string
   savedRanges: SavedInsightsRange[]
-  onPresetChange: (value: InsightsRangePreset) => void
-  onRelativeAmountChange: (value: number) => void
-  onRelativeUnitChange: (value: SavedInsightsRangeUnit) => void
-  onRelativeQualifierChange: (value: SavedInsightsRangeQualifier) => void
+  onSelectPreset: (value: InsightsRangePreset) => void
+  onRevertSelection: () => void
+  onDraftAmountChange: (value: number) => void
+  onDraftUnitChange: (value: SavedInsightsRangeUnit) => void
+  onDraftQualifierChange: (value: SavedInsightsRangeQualifier) => void
+  onApplyDraft: () => void
   onSaveCurrentRange: (name: string) => Promise<void>
   onApplySavedRange: (range: SavedInsightsRange) => void
   onDeleteSavedRange: (rangeId: string) => void
@@ -63,18 +73,26 @@ type GlassRangeSelectorProps = InsightsFloatingRangeControlProps & {
  * relative-window builder, and saved ranges
  */
 function GlassRangeSelector({
-  preset,
-  relativeAmount,
-  relativeUnit,
-  relativeQualifier,
+  selectedPreset,
+  appliedPreset,
+  appliedAmount,
+  appliedUnit,
+  appliedQualifier,
+  appliedSavedRangeName,
   resolvedFrom,
   resolvedTo,
-  appliedSavedRangeName,
+  draftAmount,
+  draftUnit,
+  draftQualifier,
+  draftFrom,
+  draftTo,
   savedRanges,
-  onPresetChange,
-  onRelativeAmountChange,
-  onRelativeUnitChange,
-  onRelativeQualifierChange,
+  onSelectPreset,
+  onRevertSelection,
+  onDraftAmountChange,
+  onDraftUnitChange,
+  onDraftQualifierChange,
+  onApplyDraft,
   onSaveCurrentRange,
   onApplySavedRange,
   onDeleteSavedRange,
@@ -84,13 +102,21 @@ function GlassRangeSelector({
   const [open, setOpen] = useState(false)
   const [collapsedWidth, setCollapsedWidth] = useState(COLLAPSED_WIDTH_FALLBACK)
   const containerRef = useRef<HTMLDivElement>(null)
+  // Scopes the sliding-thumb layout animation to this instance so the mobile and desktop pills
+  // never animate their selection highlight into each other
+  const segId = useId()
   const shouldReduceMotion = useReducedMotion()
-  const isCustom = preset === 'CUSTOM'
+  // CUSTOM while the builder is open for editing, which keeps the builder revealed and the Custom
+  // segment highlighted even though the applied range may still be a fixed preset
+  const isCustom = selectedPreset === 'CUSTOM'
   const currentLabel = appliedSavedRangeName
-    ?? (isCustom
-      ? getRelativeRangeLabel(relativeAmount, relativeUnit, relativeQualifier)
-      : INSIGHTS_RANGE_OPTIONS.find((option) => option.value === preset)?.label ?? '')
-  const rangeLabel = formatResolvedRangeLabel(resolvedFrom, resolvedTo)
+    ?? (appliedPreset === 'CUSTOM'
+      ? getRelativeRangeLabel(appliedAmount, appliedUnit, appliedQualifier)
+      : INSIGHTS_RANGE_OPTIONS.find((option) => option.value === appliedPreset)?.label ?? '')
+  // The collapsed pill and the non-custom panel line show the applied window, the builder shows
+  // the draft window being edited
+  const appliedRangeLabel = formatResolvedRangeLabel(resolvedFrom, resolvedTo)
+  const draftRangeLabel = formatResolvedRangeLabel(draftFrom, draftTo)
   const transition = shouldReduceMotion ? { duration: 0 } : glassSpring
 
   // Pins the collapsed desktop pill to its text width, since fit-content would otherwise include
@@ -104,18 +130,27 @@ function GlassRangeSelector({
     setCollapsedWidth(Math.ceil(widest) + COLLAPSED_HEAD_CHROME)
   }, [])
 
-  // The panel closes on an outside press or Escape so a stale open control never lingers
+  /**
+   * Closes the panel without committing, returning the highlight to the applied range so an
+   * abandoned Custom selection does not stay highlighted
+   */
+  const dismiss = useCallback(() => {
+    setOpen(false)
+    onRevertSelection()
+  }, [onRevertSelection])
+
+  // The panel dismisses on an outside press or Escape so a stale open control never lingers
   useEffect(() => {
     if (!open) return
 
     function handlePointerDown(event: PointerEvent) {
       if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
-        setOpen(false)
+        dismiss()
       }
     }
 
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key === 'Escape') setOpen(false)
+      if (event.key === 'Escape') dismiss()
     }
 
     document.addEventListener('pointerdown', handlePointerDown)
@@ -124,14 +159,31 @@ function GlassRangeSelector({
       document.removeEventListener('pointerdown', handlePointerDown)
       document.removeEventListener('keydown', handleKeyDown)
     }
-  }, [open])
+  }, [open, dismiss])
 
   /**
-   * Switches preset and collapses for fixed presets while keeping Custom open for the builder
+   * Highlights a preset, collapsing for fixed presets while keeping Custom open for the builder
    */
-  function handlePresetChange(value: InsightsRangePreset) {
-    onPresetChange(value)
+  function handleSelectPreset(value: InsightsRangePreset) {
+    onSelectPreset(value)
     if (value !== 'CUSTOM') setOpen(false)
+  }
+
+  /**
+   * Commits the builder draft as the applied range and collapses the panel
+   */
+  function handleApplyDraft() {
+    onApplyDraft()
+    setOpen(false)
+  }
+
+  /**
+   * Saves the draft under a name, collapsing only once the save succeeds so a duplicate-name
+   * error keeps the panel open for correction
+   */
+  async function handleSaveCurrentRange(name: string) {
+    await onSaveCurrentRange(name)
+    setOpen(false)
   }
 
   /**
@@ -160,11 +212,11 @@ function GlassRangeSelector({
         className="app-range-glass-head"
         aria-expanded={open}
         aria-label={`Insights date range: ${currentLabel}`}
-        onClick={() => setOpen((current) => !current)}
+        onClick={() => (open ? dismiss() : setOpen(true))}
       >
         <span className="app-range-glass-cur">
           <Calendar size={15} aria-hidden className="shrink-0" />
-          <span key={`${currentLabel}|${rangeLabel}`} ref={measureLabel} className="app-range-glass-text">
+          <span key={`${currentLabel}|${appliedRangeLabel}`} ref={measureLabel} className="app-range-glass-text">
             <span className="truncate">{currentLabel}</span>
             <motion.span
               className="app-range-glass-sub"
@@ -172,7 +224,7 @@ function GlassRangeSelector({
               animate={{ height: open ? 0 : 'auto', opacity: open ? 0 : 1 }}
               transition={transition}
             >
-              {rangeLabel}
+              {appliedRangeLabel}
             </motion.span>
           </span>
         </span>
@@ -198,34 +250,44 @@ function GlassRangeSelector({
                   key={option.value}
                   type="button"
                   role="tab"
-                  aria-selected={option.value === preset}
+                  aria-selected={option.value === selectedPreset}
                   className={joinClassNames(
                     'app-range-seg-option',
-                    option.value === preset && 'app-range-seg-option-active',
+                    option.value === selectedPreset && 'app-range-seg-option-active',
                   )}
-                  onClick={() => handlePresetChange(option.value)}
+                  onClick={() => handleSelectPreset(option.value)}
                 >
-                  {option.code}
+                  {option.value === selectedPreset && (
+                    <motion.span
+                      layoutId={`${segId}-preset`}
+                      className="app-range-seg-thumb"
+                      transition={transition}
+                    />
+                  )}
+                  <span className="app-range-seg-label">{option.code}</span>
                 </button>
               ))}
             </div>
 
-            {!isCustom && <p className="app-range-dates">{rangeLabel}</p>}
+            {!isCustom && <p className="app-range-dates">{appliedRangeLabel}</p>}
 
             <div className={joinClassNames('app-range-custom', isCustom && 'app-range-custom-open')}>
               <div className="app-range-custom-inner">
                 <RelativeRangeBuilder
-                  amount={relativeAmount}
-                  unit={relativeUnit}
-                  qualifier={relativeQualifier}
-                  onAmountChange={onRelativeAmountChange}
-                  onUnitChange={onRelativeUnitChange}
-                  onQualifierChange={onRelativeQualifierChange}
+                  amount={draftAmount}
+                  unit={draftUnit}
+                  qualifier={draftQualifier}
+                  onAmountChange={onDraftAmountChange}
+                  onUnitChange={onDraftUnitChange}
+                  onQualifierChange={onDraftQualifierChange}
                 />
-                <p className="app-range-dates">{rangeLabel}</p>
+                <p className="app-range-dates">{draftRangeLabel}</p>
+                <button type="button" className="app-range-apply" onClick={handleApplyDraft}>
+                  Apply
+                </button>
                 <SavedRanges
                   savedRanges={savedRanges}
-                  onSaveCurrentRange={onSaveCurrentRange}
+                  onSaveCurrentRange={handleSaveCurrentRange}
                   onApplySavedRange={handleApplySavedRange}
                   onDeleteSavedRange={onDeleteSavedRange}
                 />

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -1,20 +1,36 @@
-import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
-import { TimeRangeSelector, type TimeRangeSelectorOption } from '@/components/time-range/Selector'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { motion, useReducedMotion } from 'motion/react'
+import { Calendar, ChevronDown } from 'lucide-react'
 import type { SavedInsightsRange } from '@/api/insights'
+import { joinClassNames } from '@/utils/classNames'
 import type { InsightsRangePreset, SavedInsightsRangeUnit } from '../types/range'
+import { formatResolvedRangeLabel, getRelativeRangeLabel } from '../utils/range'
 import { RelativeRangeBuilder } from './RelativeRangeBuilder'
 import { SavedRanges } from './SavedRanges'
 
-const INSIGHTS_RANGE_OPTIONS: TimeRangeSelectorOption<InsightsRangePreset>[] = [
-  { value: 'THIS_MONTH', label: 'MTD', description: 'This month' },
-  { value: 'LAST_MONTH', label: 'LM', description: 'Last month' },
-  { value: 'LAST_30_DAYS', label: '30D', description: 'Last 30 days' },
-  { value: 'LAST_90_DAYS', label: '90D', description: 'Last 90 days' },
-  { value: 'THIS_YEAR', label: 'YTD', description: 'This year' },
-  { value: 'CUSTOM', label: 'Custom' },
-]
+// Chrome around the measured text column in the collapsed pill: horizontal padding, the calendar
+// icon and its gap, the trailing chevron and its gap, plus a couple of pixels so sub-pixel
+// rounding never truncates the wider line. Added to the measured text width to size the pill
+const COLLAPSED_HEAD_CHROME = 83
 
-const customPanelTransition = { duration: 0.18, ease: [0.22, 1, 0.36, 1] } as const
+// Open width of the desktop sidebar pill (21rem), the start point is the measured label width
+const OPEN_DESKTOP_WIDTH = 336
+
+// Lightly damped spring for a gentle settle with little overshoot, matching the toned-down feel
+const glassSpring = { type: 'spring', stiffness: 420, damping: 34, mass: 0.9 } as const
+
+// Fallback collapsed width used for the first frame before the label is measured
+const COLLAPSED_WIDTH_FALLBACK = 180
+
+const INSIGHTS_RANGE_OPTIONS: { value: InsightsRangePreset; code: string; label: string }[] = [
+  { value: 'THIS_MONTH', code: 'MTD', label: 'This month' },
+  { value: 'LAST_MONTH', code: 'LM', label: 'Last month' },
+  { value: 'LAST_30_DAYS', code: '30D', label: 'Last 30 days' },
+  { value: 'LAST_90_DAYS', code: '90D', label: 'Last 90 days' },
+  { value: 'THIS_YEAR', code: 'YTD', label: 'This year' },
+  { value: 'CUSTOM', code: 'Custom', label: 'Custom' },
+]
 
 type InsightsFloatingRangeControlProps = {
   preset: InsightsRangePreset
@@ -31,11 +47,18 @@ type InsightsFloatingRangeControlProps = {
   onDeleteSavedRange: (rangeId: string) => void
 }
 
+type GlassRangeSelectorProps = InsightsFloatingRangeControlProps & {
+  // The mobile control spans the full width instead of hugging its content like the sidebar pill
+  fullWidth: boolean
+  // The bottom-floating mobile control grows upward so its panel opens above the pill
+  growUp: boolean
+}
+
 /**
- * Renders the sticky insights range picker, the relative custom-window builder, and the
- * list of saved ranges
+ * Renders the collapsing liquid-glass range pill that blooms open into the preset row, the
+ * relative-window builder, and saved ranges
  */
-export function InsightsFloatingRangeControl({
+function GlassRangeSelector({
   preset,
   relativeAmount,
   relativeUnit,
@@ -48,73 +71,225 @@ export function InsightsFloatingRangeControl({
   onSaveCurrentRange,
   onApplySavedRange,
   onDeleteSavedRange,
-}: InsightsFloatingRangeControlProps) {
-  const isCustom = preset === 'CUSTOM'
+  fullWidth,
+  growUp,
+}: GlassRangeSelectorProps) {
+  const [open, setOpen] = useState(false)
+  const [collapsedWidth, setCollapsedWidth] = useState(COLLAPSED_WIDTH_FALLBACK)
+  const containerRef = useRef<HTMLDivElement>(null)
   const shouldReduceMotion = useReducedMotion()
+  const isCustom = preset === 'CUSTOM'
+  const currentLabel = isCustom
+    ? getRelativeRangeLabel(relativeAmount, relativeUnit)
+    : INSIGHTS_RANGE_OPTIONS.find((option) => option.value === preset)?.label ?? ''
+  const rangeLabel = formatResolvedRangeLabel(resolvedFrom, resolvedTo)
+  const transition = shouldReduceMotion ? { duration: 0 } : glassSpring
+
+  // Pins the collapsed desktop pill to its text width, since fit-content would otherwise include
+  // the hidden panel's width. Remeasured on label or date change via the key on the text column
+  const measureLabel = useCallback((node: HTMLSpanElement | null) => {
+    if (!node) return
+    // A clipped nowrap line still reports its full text width through scrollWidth, so the
+    // collapsed pill is sized to whichever of the label or the resolved dates is wider rather
+    // than letting the shrinking flex column under-measure it
+    const widest = Math.max(...Array.from(node.children, (line) => line.scrollWidth))
+    setCollapsedWidth(Math.ceil(widest) + COLLAPSED_HEAD_CHROME)
+  }, [])
+
+  // The panel closes on an outside press or Escape so a stale open control never lingers
+  useEffect(() => {
+    if (!open) return
+
+    function handlePointerDown(event: PointerEvent) {
+      if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+        setOpen(false)
+      }
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape') setOpen(false)
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleKeyDown)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleKeyDown)
+    }
+  }, [open])
 
   /**
-   * Keeps desktop and mobile floating controls structurally identical
+   * Switches preset and collapses for fixed presets while keeping Custom open for the builder
    */
-  const renderControl = (dropdownPlacement?: 'bottom' | 'top') => (
-    <div
-      className="app-card rounded-xl p-3"
-      style={{
-        background: 'color-mix(in srgb, var(--app-accent) 12%, var(--app-bg))',
-        borderColor: 'transparent',
-      }}
+  function handlePresetChange(value: InsightsRangePreset) {
+    onPresetChange(value)
+    if (value !== 'CUSTOM') setOpen(false)
+  }
+
+  return (
+    <motion.div
+      ref={containerRef}
+      className={joinClassNames(
+        'app-range-glass',
+        open && 'app-range-glass-open',
+        fullWidth && 'app-range-glass-full',
+        growUp && 'app-range-glass-up',
+      )}
+      animate={fullWidth ? undefined : { width: open ? OPEN_DESKTOP_WIDTH : collapsedWidth }}
+      transition={transition}
+      whileTap={open || shouldReduceMotion ? undefined : { scale: 0.94 }}
     >
-      <TimeRangeSelector
-        value={preset}
-        options={INSIGHTS_RANGE_OPTIONS}
-        onChange={onPresetChange}
-        ariaLabel="Insights date range"
-        variant="mobile"
-        className="w-full"
-        sheetTitle="Insights date range"
-        dropdownPlacement={dropdownPlacement}
-        shortcutMode="when-description-differs"
-      />
-      <AnimatePresence initial={false}>
-        {isCustom && (
-          <motion.div
-            initial={shouldReduceMotion ? false : { height: 0, opacity: 0 }}
-            animate={{ height: 'auto', opacity: 1 }}
-            exit={shouldReduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
-            transition={shouldReduceMotion ? { duration: 0 } : customPanelTransition}
-            className="overflow-hidden"
-          >
-            <RelativeRangeBuilder
-              amount={relativeAmount}
-              unit={relativeUnit}
-              resolvedFrom={resolvedFrom}
-              resolvedTo={resolvedTo}
-              onAmountChange={onRelativeAmountChange}
-              onUnitChange={onRelativeUnitChange}
-            />
-            <SavedRanges
-              savedRanges={savedRanges}
-              onSaveCurrentRange={onSaveCurrentRange}
-              onApplySavedRange={onApplySavedRange}
-              onDeleteSavedRange={onDeleteSavedRange}
-            />
-          </motion.div>
-        )}
-      </AnimatePresence>
-    </div>
+      <button
+        type="button"
+        className="app-range-glass-head"
+        aria-expanded={open}
+        aria-label={`Insights date range: ${currentLabel}`}
+        onClick={() => setOpen((current) => !current)}
+      >
+        <span className="app-range-glass-cur">
+          <Calendar size={15} aria-hidden className="shrink-0" />
+          <span key={`${currentLabel}|${rangeLabel}`} ref={measureLabel} className="app-range-glass-text">
+            <span className="truncate">{currentLabel}</span>
+            <motion.span
+              className="app-range-glass-sub"
+              initial={false}
+              animate={{ height: open ? 0 : 'auto', opacity: open ? 0 : 1 }}
+              transition={transition}
+            >
+              {rangeLabel}
+            </motion.span>
+          </span>
+        </span>
+        <motion.span
+          className="app-range-glass-chev"
+          style={{ display: 'inline-flex' }}
+          animate={{ rotate: open ? 180 : 0 }}
+          transition={transition}
+        >
+          <ChevronDown size={16} aria-hidden />
+        </motion.span>
+      </button>
+
+      <div className="app-range-glass-bodywrap">
+        <div className="app-range-glass-body">
+          <div className="app-range-glass-inner">
+            <p className="mb-2 ml-0.5 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+              Date range
+            </p>
+            <div className="app-range-seg" role="tablist" aria-label="Insights date range">
+              {INSIGHTS_RANGE_OPTIONS.map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  role="tab"
+                  aria-selected={option.value === preset}
+                  className={joinClassNames(
+                    'app-range-seg-option',
+                    option.value === preset && 'app-range-seg-option-active',
+                  )}
+                  onClick={() => handlePresetChange(option.value)}
+                >
+                  {option.code}
+                </button>
+              ))}
+            </div>
+
+            {!isCustom && <p className="app-range-dates">{rangeLabel}</p>}
+
+            <div className={joinClassNames('app-range-custom', isCustom && 'app-range-custom-open')}>
+              <div className="app-range-custom-inner">
+                <RelativeRangeBuilder
+                  amount={relativeAmount}
+                  unit={relativeUnit}
+                  onAmountChange={onRelativeAmountChange}
+                  onUnitChange={onRelativeUnitChange}
+                />
+                <p className="app-range-dates">{rangeLabel}</p>
+                <SavedRanges
+                  savedRanges={savedRanges}
+                  onSaveCurrentRange={onSaveCurrentRange}
+                  onApplySavedRange={onApplySavedRange}
+                  onDeleteSavedRange={onDeleteSavedRange}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </motion.div>
   )
+}
+
+/**
+ * Reads how far the on-screen keyboard overlaps the bottom of the layout viewport
+ */
+function readKeyboardInset(): number {
+  const viewport = window.visualViewport
+  if (!viewport) return 0
+  return Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop)
+}
+
+/**
+ * Tracks the on-screen keyboard overlap so the bottom-fixed control can lift above it instead
+ * of hiding behind it, which a plain position:fixed element does on mobile
+ */
+function useKeyboardInset(): number {
+  const [inset, setInset] = useState(readKeyboardInset)
+
+  useEffect(() => {
+    const viewport = window.visualViewport
+    if (!viewport) return
+
+    const update = () => setInset(readKeyboardInset())
+    viewport.addEventListener('resize', update)
+    viewport.addEventListener('scroll', update)
+    return () => {
+      viewport.removeEventListener('resize', update)
+      viewport.removeEventListener('scroll', update)
+    }
+  }, [])
+
+  return inset
+}
+
+/**
+ * Positions the insights range pill as a bottom-floating control on mobile and a sticky
+ * sidebar control on wider screens
+ */
+export function InsightsFloatingRangeControl(props: InsightsFloatingRangeControlProps) {
+  const keyboardInset = useKeyboardInset()
+  const [isEditingField, setIsEditingField] = useState(false)
+
+  // Lift the control above the keyboard only while one of its own text fields is focused. Without
+  // that guard the layout-versus-visual-viewport gap from the mobile browser chrome reads as a
+  // keyboard and pushes the control off the bottom, leaving empty space beneath it
+  const keyboardLift = isEditingField ? keyboardInset : 0
 
   return (
     <>
-      <div className="pointer-events-none fixed inset-x-4 bottom-4 z-20 min-[1050px]:hidden">
-        <div className="pointer-events-auto">
-          {renderControl('top')}
-        </div>
-      </div>
+      {/* The route-transition wrapper animates transform, which would otherwise act as the
+          containing block for a position:fixed child and make it scroll with the page, so the
+          bottom-floating mobile control is portaled to the body to stay pinned to the viewport */}
+      {createPortal(
+        <div
+          className="pointer-events-none fixed inset-x-4 bottom-1.5 z-30 min-[1050px]:hidden"
+          style={keyboardLift > 0 ? { transform: `translateY(-${keyboardLift}px)` } : undefined}
+          onFocusCapture={(event) => setIsEditingField(event.target instanceof HTMLInputElement)}
+          onBlurCapture={(event) => {
+            if (!event.currentTarget.contains(event.relatedTarget as Node | null)) setIsEditingField(false)
+          }}
+        >
+          <div className="pointer-events-auto">
+            <GlassRangeSelector {...props} fullWidth growUp />
+          </div>
+        </div>,
+        document.body,
+      )}
 
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 top-0 z-40 hidden min-[1050px]:block">
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 top-0 z-40 hidden pt-[3.8rem] min-[1050px]:block">
         <div className="sticky top-6 flex justify-end">
           <div className="pointer-events-auto w-[24rem]">
-            {renderControl()}
+            <GlassRangeSelector {...props} fullWidth={false} growUp={false} />
           </div>
         </div>
       </div>

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -4,7 +4,7 @@ import { motion, useReducedMotion } from 'motion/react'
 import { Calendar, ChevronDown } from 'lucide-react'
 import type { SavedInsightsRange } from '@/api/insights'
 import { joinClassNames } from '@/utils/classNames'
-import type { InsightsRangePreset, SavedInsightsRangeUnit } from '../types/range'
+import type { InsightsRangePreset, SavedInsightsRangeQualifier, SavedInsightsRangeUnit } from '../types/range'
 import { formatResolvedRangeLabel, getRelativeRangeLabel } from '../utils/range'
 import { RelativeRangeBuilder } from './RelativeRangeBuilder'
 import { SavedRanges } from './SavedRanges'
@@ -36,12 +36,16 @@ type InsightsFloatingRangeControlProps = {
   preset: InsightsRangePreset
   relativeAmount: number
   relativeUnit: SavedInsightsRangeUnit
+  relativeQualifier: SavedInsightsRangeQualifier
   resolvedFrom: string
   resolvedTo: string
+  // Name of the applied saved range, shown as the pill label until the window is changed
+  appliedSavedRangeName: string | null
   savedRanges: SavedInsightsRange[]
   onPresetChange: (value: InsightsRangePreset) => void
   onRelativeAmountChange: (value: number) => void
   onRelativeUnitChange: (value: SavedInsightsRangeUnit) => void
+  onRelativeQualifierChange: (value: SavedInsightsRangeQualifier) => void
   onSaveCurrentRange: (name: string) => Promise<void>
   onApplySavedRange: (range: SavedInsightsRange) => void
   onDeleteSavedRange: (rangeId: string) => void
@@ -62,12 +66,15 @@ function GlassRangeSelector({
   preset,
   relativeAmount,
   relativeUnit,
+  relativeQualifier,
   resolvedFrom,
   resolvedTo,
+  appliedSavedRangeName,
   savedRanges,
   onPresetChange,
   onRelativeAmountChange,
   onRelativeUnitChange,
+  onRelativeQualifierChange,
   onSaveCurrentRange,
   onApplySavedRange,
   onDeleteSavedRange,
@@ -79,9 +86,10 @@ function GlassRangeSelector({
   const containerRef = useRef<HTMLDivElement>(null)
   const shouldReduceMotion = useReducedMotion()
   const isCustom = preset === 'CUSTOM'
-  const currentLabel = isCustom
-    ? getRelativeRangeLabel(relativeAmount, relativeUnit)
-    : INSIGHTS_RANGE_OPTIONS.find((option) => option.value === preset)?.label ?? ''
+  const currentLabel = appliedSavedRangeName
+    ?? (isCustom
+      ? getRelativeRangeLabel(relativeAmount, relativeUnit, relativeQualifier)
+      : INSIGHTS_RANGE_OPTIONS.find((option) => option.value === preset)?.label ?? '')
   const rangeLabel = formatResolvedRangeLabel(resolvedFrom, resolvedTo)
   const transition = shouldReduceMotion ? { duration: 0 } : glassSpring
 
@@ -124,6 +132,14 @@ function GlassRangeSelector({
   function handlePresetChange(value: InsightsRangePreset) {
     onPresetChange(value)
     if (value !== 'CUSTOM') setOpen(false)
+  }
+
+  /**
+   * Applies a saved range and collapses the panel so the selection reads as final
+   */
+  function handleApplySavedRange(savedRange: SavedInsightsRange) {
+    onApplySavedRange(savedRange)
+    setOpen(false)
   }
 
   return (
@@ -201,14 +217,16 @@ function GlassRangeSelector({
                 <RelativeRangeBuilder
                   amount={relativeAmount}
                   unit={relativeUnit}
+                  qualifier={relativeQualifier}
                   onAmountChange={onRelativeAmountChange}
                   onUnitChange={onRelativeUnitChange}
+                  onQualifierChange={onRelativeQualifierChange}
                 />
                 <p className="app-range-dates">{rangeLabel}</p>
                 <SavedRanges
                   savedRanges={savedRanges}
                   onSaveCurrentRange={onSaveCurrentRange}
-                  onApplySavedRange={onApplySavedRange}
+                  onApplySavedRange={handleApplySavedRange}
                   onDeleteSavedRange={onDeleteSavedRange}
                 />
               </div>

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -1,7 +1,9 @@
-import type { KeyboardEvent } from 'react'
-import { Calendar } from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { TimeRangeSelector, type TimeRangeSelectorOption } from '@/components/time-range/Selector'
-import type { InsightsRangePreset } from '../types/range'
+import type { SavedInsightsRange } from '@/api/insights'
+import type { InsightsRangePreset, SavedInsightsRangeUnit } from '../types/range'
+import { RelativeRangeBuilder } from './RelativeRangeBuilder'
+import { SavedRanges } from './SavedRanges'
 
 const INSIGHTS_RANGE_OPTIONS: TimeRangeSelectorOption<InsightsRangePreset>[] = [
   { value: 'THIS_MONTH', label: 'MTD', description: 'This month' },
@@ -12,134 +14,43 @@ const INSIGHTS_RANGE_OPTIONS: TimeRangeSelectorOption<InsightsRangePreset>[] = [
   { value: 'CUSTOM', label: 'Custom' },
 ]
 
+const customPanelTransition = { duration: 0.18, ease: [0.22, 1, 0.36, 1] } as const
+
 type InsightsFloatingRangeControlProps = {
   preset: InsightsRangePreset
-  fromDateValue: string
-  toDateValue: string
-  customInvalid: boolean
+  relativeAmount: number
+  relativeUnit: SavedInsightsRangeUnit
+  resolvedFrom: string
+  resolvedTo: string
+  savedRanges: SavedInsightsRange[]
   onPresetChange: (value: InsightsRangePreset) => void
-  onCustomFromChange: (value: string) => void
-  onCustomToChange: (value: string) => void
-  onCustomRangeCommit: () => void
-}
-
-type InsightsDateFieldProps = {
-  value: string
-  label: string
-  customInvalid: boolean
-  onChange: (value: string) => void
-  onBlur: () => void
-  onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void
+  onRelativeAmountChange: (value: number) => void
+  onRelativeUnitChange: (value: SavedInsightsRangeUnit) => void
+  onSaveCurrentRange: (name: string) => Promise<void>
+  onApplySavedRange: (range: SavedInsightsRange) => void
+  onDeleteSavedRange: (rangeId: string) => void
 }
 
 /**
- * Adds spacing around mobile date parts so narrow inputs remain readable
- */
-function formatMobileDate(value: string) {
-  const [year, month, day] = value.split('-')
-  if (!year || !month || !day) return value
-  return `${year} - ${month} - ${day}`
-}
-
-/**
- * Renders the responsive date input used by the floating insights range control
- */
-function InsightsDateField({
-  value,
-  label,
-  customInvalid,
-  onChange,
-  onBlur,
-  onKeyDown,
-}: InsightsDateFieldProps) {
-  const inputClassName = `app-input app-date-input-balanced min-w-0 ${customInvalid ? 'app-input-error' : ''}`
-  const mobileFocusClassName = customInvalid
-    ? ''
-    : 'focus-within:border-[var(--app-accent-border)] focus-within:shadow-[0_0_0_2px_var(--app-accent-soft)]'
-
-  return (
-    <>
-      <input
-        type="date"
-        className={`${inputClassName} hidden min-[1050px]:block`}
-        aria-label={label}
-        value={value}
-        onChange={(event) => onChange(event.target.value)}
-        onBlur={onBlur}
-        onKeyDown={onKeyDown}
-      />
-      <div
-        className={`app-input relative flex items-center justify-between gap-2 overflow-hidden px-3 text-sm min-[1050px]:hidden ${mobileFocusClassName} ${customInvalid ? 'app-input-error' : ''}`}
-      >
-        <span className="min-w-0 truncate font-medium tabular-nums">{formatMobileDate(value)}</span>
-        <Calendar size={15} className="shrink-0" aria-hidden style={{ color: 'var(--app-text-muted)' }} />
-        <input
-          type="date"
-          className="absolute inset-0 h-full w-full cursor-pointer opacity-0 text-base"
-          aria-label={label}
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          onBlur={onBlur}
-          onKeyDown={onKeyDown}
-        />
-      </div>
-    </>
-  )
-}
-
-/**
- * Renders the sticky insights date range picker and custom range inputs
+ * Renders the sticky insights range picker, the relative custom-window builder, and the
+ * list of saved ranges
  */
 export function InsightsFloatingRangeControl({
   preset,
-  fromDateValue,
-  toDateValue,
-  customInvalid,
+  relativeAmount,
+  relativeUnit,
+  resolvedFrom,
+  resolvedTo,
+  savedRanges,
   onPresetChange,
-  onCustomFromChange,
-  onCustomToChange,
-  onCustomRangeCommit,
+  onRelativeAmountChange,
+  onRelativeUnitChange,
+  onSaveCurrentRange,
+  onApplySavedRange,
+  onDeleteSavedRange,
 }: InsightsFloatingRangeControlProps) {
-  /**
-   * Commits keyboard-entered custom dates before focus leaves the active input
-   */
-  function handleDateKeyDown(event: KeyboardEvent<HTMLInputElement>) {
-    if (event.key === 'Enter') {
-      onCustomRangeCommit()
-      event.currentTarget.blur()
-    }
-  }
-
-  const dateFields = (
-    <div>
-      <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-2">
-        <InsightsDateField
-          label="Insights start date"
-          value={fromDateValue}
-          customInvalid={customInvalid}
-          onChange={onCustomFromChange}
-          onBlur={onCustomRangeCommit}
-          onKeyDown={handleDateKeyDown}
-        />
-        <span className="text-xs font-semibold uppercase" style={{ color: 'var(--app-text-subtle)' }}>
-          to
-        </span>
-        <InsightsDateField
-          label="Insights end date"
-          value={toDateValue}
-          customInvalid={customInvalid}
-          onChange={onCustomToChange}
-          onBlur={onCustomRangeCommit}
-          onKeyDown={handleDateKeyDown}
-        />
-      </div>
-      {customInvalid && (
-        <p className="mt-1 text-xs" style={{ color: 'var(--app-negative)' }}>
-          Start date must be on or before end date.
-        </p>
-      )}
-    </div>
-  )
+  const isCustom = preset === 'CUSTOM'
+  const shouldReduceMotion = useReducedMotion()
 
   /**
    * Keeps desktop and mobile floating controls structurally identical
@@ -163,9 +74,32 @@ export function InsightsFloatingRangeControl({
         dropdownPlacement={dropdownPlacement}
         shortcutMode="when-description-differs"
       />
-      <div className="mt-2">
-        {dateFields}
-      </div>
+      <AnimatePresence initial={false}>
+        {isCustom && (
+          <motion.div
+            initial={shouldReduceMotion ? false : { height: 0, opacity: 0 }}
+            animate={{ height: 'auto', opacity: 1 }}
+            exit={shouldReduceMotion ? { opacity: 0 } : { height: 0, opacity: 0 }}
+            transition={shouldReduceMotion ? { duration: 0 } : customPanelTransition}
+            className="overflow-hidden"
+          >
+            <RelativeRangeBuilder
+              amount={relativeAmount}
+              unit={relativeUnit}
+              resolvedFrom={resolvedFrom}
+              resolvedTo={resolvedTo}
+              onAmountChange={onRelativeAmountChange}
+              onUnitChange={onRelativeUnitChange}
+            />
+            <SavedRanges
+              savedRanges={savedRanges}
+              onSaveCurrentRange={onSaveCurrentRange}
+              onApplySavedRange={onApplySavedRange}
+              onDeleteSavedRange={onDeleteSavedRange}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
     </div>
   )
 

--- a/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
+++ b/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
@@ -1,0 +1,75 @@
+import { useId, type ChangeEvent } from 'react'
+import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
+import type { SavedInsightsRangeUnit } from '../types/range'
+
+const RELATIVE_UNIT_OPTIONS: DropdownOption[] = [
+  { value: 'day', label: 'days' },
+  { value: 'week', label: 'weeks' },
+  { value: 'month', label: 'months' },
+  { value: 'quarter', label: 'quarters' },
+  { value: 'year', label: 'years' },
+]
+
+type RelativeRangeBuilderProps = {
+  amount: number
+  unit: SavedInsightsRangeUnit
+  resolvedFrom: string
+  resolvedTo: string
+  onAmountChange: (value: number) => void
+  onUnitChange: (value: SavedInsightsRangeUnit) => void
+}
+
+/**
+ * Renders the "Last N units" builder for the custom insights window, with the dates it
+ * currently resolves to so a relative window never reads as abstract
+ */
+export function RelativeRangeBuilder({
+  amount,
+  unit,
+  resolvedFrom,
+  resolvedTo,
+  onAmountChange,
+  onUnitChange,
+}: RelativeRangeBuilderProps) {
+  const unitFieldId = useId()
+
+  /**
+   * Forwards only whole amounts of at least one so the window never inverts or empties
+   */
+  function handleAmountChange(event: ChangeEvent<HTMLInputElement>) {
+    const parsed = Number.parseInt(event.target.value, 10)
+    if (Number.isFinite(parsed) && parsed >= 1) {
+      onAmountChange(parsed)
+    }
+  }
+
+  return (
+    <div className="mt-2">
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-medium" style={{ color: 'var(--app-text-muted)' }}>Last</span>
+        <input
+          type="number"
+          min={1}
+          step={1}
+          value={amount}
+          onChange={handleAmountChange}
+          className="app-input app-input-no-spinner w-16 text-center tabular-nums"
+          aria-label="Relative range amount"
+        />
+        <div className="min-w-0 flex-1">
+          <label htmlFor={unitFieldId} className="sr-only">Relative range unit</label>
+          <Dropdown
+            id={unitFieldId}
+            options={RELATIVE_UNIT_OPTIONS}
+            value={unit}
+            onChange={(value) => onUnitChange(value as SavedInsightsRangeUnit)}
+            className="app-input w-full"
+          />
+        </div>
+      </div>
+      <p className="mt-1 text-xs tabular-nums" style={{ color: 'var(--app-text-subtle)' }}>
+        {resolvedFrom} to {resolvedTo}
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
+++ b/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
@@ -1,9 +1,13 @@
-import { useState, type ChangeEvent } from 'react'
+import { useId, useState, type ChangeEvent } from 'react'
+import { motion, useReducedMotion } from 'motion/react'
 import { ChevronDown } from 'lucide-react'
 import { joinClassNames } from '@/utils/classNames'
 import type { SavedInsightsRangeQualifier, SavedInsightsRangeUnit } from '../types/range'
 
 const RELATIVE_UNITS: SavedInsightsRangeUnit[] = ['day', 'week', 'month', 'quarter', 'year']
+
+// Matches the pill's settle so the qualifier highlight glides between options in the same feel
+const qualifierSpring = { type: 'spring', stiffness: 420, damping: 34, mass: 0.9 } as const
 
 // This and Last name whole calendar periods, so they hide the day unit, and This takes no count
 const QUALIFIER_OPTIONS: {
@@ -51,6 +55,10 @@ export function RelativeRangeBuilder({
   const [unitMenuOpen, setUnitMenuOpen] = useState(false)
   const [amountText, setAmountText] = useState(String(amount))
   const [trackedAmount, setTrackedAmount] = useState(amount)
+  // Scopes the sliding-thumb layout animation to this builder instance
+  const groupId = useId()
+  const shouldReduceMotion = useReducedMotion()
+  const thumbTransition = shouldReduceMotion ? { duration: 0 } : qualifierSpring
 
   const activeQualifier = QUALIFIER_OPTIONS.find((option) => option.value === qualifier) ?? QUALIFIER_OPTIONS[2]
   const usePlural = activeQualifier.hasCount && amount !== 1
@@ -107,7 +115,14 @@ export function RelativeRangeBuilder({
             )}
             onClick={() => onQualifierChange(option.value)}
           >
-            {option.label}
+            {option.value === qualifier && (
+              <motion.span
+                layoutId={`${groupId}-qualifier`}
+                className="app-range-seg-thumb"
+                transition={thumbTransition}
+              />
+            )}
+            <span className="app-range-seg-label">{option.label}</span>
           </button>
         ))}
       </div>

--- a/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
+++ b/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
@@ -1,39 +1,60 @@
 import { useState, type ChangeEvent } from 'react'
 import { ChevronDown } from 'lucide-react'
 import { joinClassNames } from '@/utils/classNames'
-import type { SavedInsightsRangeUnit } from '../types/range'
+import type { SavedInsightsRangeQualifier, SavedInsightsRangeUnit } from '../types/range'
 
-const RELATIVE_UNIT_OPTIONS: { value: SavedInsightsRangeUnit; label: string }[] = [
-  { value: 'day', label: 'days' },
-  { value: 'week', label: 'weeks' },
-  { value: 'month', label: 'months' },
-  { value: 'quarter', label: 'quarters' },
-  { value: 'year', label: 'years' },
+const RELATIVE_UNITS: SavedInsightsRangeUnit[] = ['day', 'week', 'month', 'quarter', 'year']
+
+// This and Last name whole calendar periods, so they hide the day unit, and This takes no count
+const QUALIFIER_OPTIONS: {
+  value: SavedInsightsRangeQualifier
+  label: string
+  allowsDay: boolean
+  hasCount: boolean
+}[] = [
+  { value: 'this', label: 'This', allowsDay: false, hasCount: false },
+  { value: 'last', label: 'Last', allowsDay: false, hasCount: true },
+  { value: 'past', label: 'Past', allowsDay: true, hasCount: true },
 ]
 
 // Restored when the amount field is left empty or invalid
 const DEFAULT_RELATIVE_AMOUNT = 3
 
+/**
+ * Labels a unit singular or plural, for example "month" or "months"
+ */
+function formatUnitLabel(unit: SavedInsightsRangeUnit, plural: boolean) {
+  return plural ? `${unit}s` : unit
+}
+
 type RelativeRangeBuilderProps = {
   amount: number
   unit: SavedInsightsRangeUnit
+  qualifier: SavedInsightsRangeQualifier
   onAmountChange: (value: number) => void
   onUnitChange: (value: SavedInsightsRangeUnit) => void
+  onQualifierChange: (value: SavedInsightsRangeQualifier) => void
 }
 
 /**
- * Renders the "Last N units" builder for the custom insights window
+ * Renders the custom insights window builder: a This/Last/Past qualifier with a period unit, plus
+ * a count for the Last and Past qualifiers
  */
 export function RelativeRangeBuilder({
   amount,
   unit,
+  qualifier,
   onAmountChange,
   onUnitChange,
+  onQualifierChange,
 }: RelativeRangeBuilderProps) {
   const [unitMenuOpen, setUnitMenuOpen] = useState(false)
   const [amountText, setAmountText] = useState(String(amount))
   const [trackedAmount, setTrackedAmount] = useState(amount)
-  const unitLabel = RELATIVE_UNIT_OPTIONS.find((option) => option.value === unit)?.label ?? unit
+
+  const activeQualifier = QUALIFIER_OPTIONS.find((option) => option.value === qualifier) ?? QUALIFIER_OPTIONS[2]
+  const usePlural = activeQualifier.hasCount && amount !== 1
+  const unitOptions = activeQualifier.allowsDay ? RELATIVE_UNITS : RELATIVE_UNITS.filter((value) => value !== 'day')
 
   // Reflect amounts applied from presets or saved ranges back into the editable field
   if (amount !== trackedAmount) {
@@ -73,18 +94,37 @@ export function RelativeRangeBuilder({
 
   return (
     <div className="mt-2">
-      <div className="flex items-center gap-2">
-        <span className="text-sm font-medium" style={{ color: 'var(--app-text-muted)' }}>Last</span>
-        <input
-          type="number"
-          min={1}
-          step={1}
-          value={amountText}
-          onChange={handleAmountChange}
-          onBlur={handleAmountBlur}
-          className="app-input app-input-no-spinner w-16 text-center tabular-nums"
-          aria-label="Relative range amount"
-        />
+      <div className="app-range-qualifier" role="tablist" aria-label="Relative range type">
+        {QUALIFIER_OPTIONS.map((option) => (
+          <button
+            key={option.value}
+            type="button"
+            role="tab"
+            aria-selected={option.value === qualifier}
+            className={joinClassNames(
+              'app-range-seg-option',
+              option.value === qualifier && 'app-range-seg-option-active',
+            )}
+            onClick={() => onQualifierChange(option.value)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="mt-2 flex items-center gap-2">
+        {activeQualifier.hasCount && (
+          <input
+            type="number"
+            min={1}
+            step={1}
+            value={amountText}
+            onChange={handleAmountChange}
+            onBlur={handleAmountBlur}
+            className="app-input app-input-no-spinner w-16 text-center tabular-nums"
+            aria-label="Relative range amount"
+          />
+        )}
         <button
           type="button"
           className="app-input flex min-w-0 flex-1 items-center justify-between gap-2"
@@ -92,7 +132,7 @@ export function RelativeRangeBuilder({
           aria-label="Relative range unit"
           onClick={() => setUnitMenuOpen((current) => !current)}
         >
-          <span className="truncate">{unitLabel}</span>
+          <span className="truncate">{formatUnitLabel(unit, usePlural)}</span>
           <ChevronDown
             size={15}
             aria-hidden
@@ -105,19 +145,19 @@ export function RelativeRangeBuilder({
       <div className={joinClassNames('app-range-unit-menu', unitMenuOpen && 'app-range-unit-menu-open')}>
         <div className="app-range-unit-menu-body">
           <div className="app-range-unit-list" role="listbox" aria-label="Relative range unit">
-            {RELATIVE_UNIT_OPTIONS.map((option) => (
+            {unitOptions.map((value) => (
               <button
-                key={option.value}
+                key={value}
                 type="button"
                 role="option"
-                aria-selected={option.value === unit}
+                aria-selected={value === unit}
                 className={joinClassNames(
                   'app-range-unit-option',
-                  option.value === unit && 'app-range-unit-option-active',
+                  value === unit && 'app-range-unit-option-active',
                 )}
-                onClick={() => selectUnit(option.value)}
+                onClick={() => selectUnit(value)}
               >
-                {option.label}
+                {formatUnitLabel(value, usePlural)}
               </button>
             ))}
           </div>

--- a/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
+++ b/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
@@ -1,8 +1,9 @@
-import { useId, type ChangeEvent } from 'react'
-import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
+import { useState, type ChangeEvent } from 'react'
+import { ChevronDown } from 'lucide-react'
+import { joinClassNames } from '@/utils/classNames'
 import type { SavedInsightsRangeUnit } from '../types/range'
 
-const RELATIVE_UNIT_OPTIONS: DropdownOption[] = [
+const RELATIVE_UNIT_OPTIONS: { value: SavedInsightsRangeUnit; label: string }[] = [
   { value: 'day', label: 'days' },
   { value: 'week', label: 'weeks' },
   { value: 'month', label: 'months' },
@@ -10,37 +11,64 @@ const RELATIVE_UNIT_OPTIONS: DropdownOption[] = [
   { value: 'year', label: 'years' },
 ]
 
+// Restored when the amount field is left empty or invalid
+const DEFAULT_RELATIVE_AMOUNT = 3
+
 type RelativeRangeBuilderProps = {
   amount: number
   unit: SavedInsightsRangeUnit
-  resolvedFrom: string
-  resolvedTo: string
   onAmountChange: (value: number) => void
   onUnitChange: (value: SavedInsightsRangeUnit) => void
 }
 
 /**
- * Renders the "Last N units" builder for the custom insights window, with the dates it
- * currently resolves to so a relative window never reads as abstract
+ * Renders the "Last N units" builder for the custom insights window
  */
 export function RelativeRangeBuilder({
   amount,
   unit,
-  resolvedFrom,
-  resolvedTo,
   onAmountChange,
   onUnitChange,
 }: RelativeRangeBuilderProps) {
-  const unitFieldId = useId()
+  const [unitMenuOpen, setUnitMenuOpen] = useState(false)
+  const [amountText, setAmountText] = useState(String(amount))
+  const [trackedAmount, setTrackedAmount] = useState(amount)
+  const unitLabel = RELATIVE_UNIT_OPTIONS.find((option) => option.value === unit)?.label ?? unit
+
+  // Reflect amounts applied from presets or saved ranges back into the editable field
+  if (amount !== trackedAmount) {
+    setTrackedAmount(amount)
+    setAmountText(String(amount))
+  }
 
   /**
-   * Forwards only whole amounts of at least one so the window never inverts or empties
+   * Lets the field be cleared while typing and commits only whole amounts of at least one
    */
   function handleAmountChange(event: ChangeEvent<HTMLInputElement>) {
-    const parsed = Number.parseInt(event.target.value, 10)
+    const nextText = event.target.value
+    setAmountText(nextText)
+    const parsed = Number.parseInt(nextText, 10)
     if (Number.isFinite(parsed) && parsed >= 1) {
       onAmountChange(parsed)
     }
+  }
+
+  /**
+   * Falls back to the default amount when the field is left empty or invalid
+   */
+  function handleAmountBlur() {
+    const parsed = Number.parseInt(amountText, 10)
+    if (!Number.isFinite(parsed) || parsed < 1) {
+      setAmountText(String(DEFAULT_RELATIVE_AMOUNT))
+      onAmountChange(DEFAULT_RELATIVE_AMOUNT)
+      return
+    }
+    setAmountText(String(parsed))
+  }
+
+  function selectUnit(value: SavedInsightsRangeUnit) {
+    onUnitChange(value)
+    setUnitMenuOpen(false)
   }
 
   return (
@@ -51,25 +79,50 @@ export function RelativeRangeBuilder({
           type="number"
           min={1}
           step={1}
-          value={amount}
+          value={amountText}
           onChange={handleAmountChange}
+          onBlur={handleAmountBlur}
           className="app-input app-input-no-spinner w-16 text-center tabular-nums"
           aria-label="Relative range amount"
         />
-        <div className="min-w-0 flex-1">
-          <label htmlFor={unitFieldId} className="sr-only">Relative range unit</label>
-          <Dropdown
-            id={unitFieldId}
-            options={RELATIVE_UNIT_OPTIONS}
-            value={unit}
-            onChange={(value) => onUnitChange(value as SavedInsightsRangeUnit)}
-            className="app-input w-full"
+        <button
+          type="button"
+          className="app-input flex min-w-0 flex-1 items-center justify-between gap-2"
+          aria-expanded={unitMenuOpen}
+          aria-label="Relative range unit"
+          onClick={() => setUnitMenuOpen((current) => !current)}
+        >
+          <span className="truncate">{unitLabel}</span>
+          <ChevronDown
+            size={15}
+            aria-hidden
+            className={joinClassNames('shrink-0 transition-transform', unitMenuOpen && 'rotate-180')}
+            style={{ color: 'var(--app-text-subtle)' }}
           />
+        </button>
+      </div>
+
+      <div className={joinClassNames('app-range-unit-menu', unitMenuOpen && 'app-range-unit-menu-open')}>
+        <div className="app-range-unit-menu-body">
+          <div className="app-range-unit-list" role="listbox" aria-label="Relative range unit">
+            {RELATIVE_UNIT_OPTIONS.map((option) => (
+              <button
+                key={option.value}
+                type="button"
+                role="option"
+                aria-selected={option.value === unit}
+                className={joinClassNames(
+                  'app-range-unit-option',
+                  option.value === unit && 'app-range-unit-option-active',
+                )}
+                onClick={() => selectUnit(option.value)}
+              >
+                {option.label}
+              </button>
+            ))}
+          </div>
         </div>
       </div>
-      <p className="mt-1 text-xs tabular-nums" style={{ color: 'var(--app-text-subtle)' }}>
-        {resolvedFrom} to {resolvedTo}
-      </p>
     </div>
   )
 }

--- a/frontend/src/pages/insights/components/SavedRanges.tsx
+++ b/frontend/src/pages/insights/components/SavedRanges.tsx
@@ -1,9 +1,13 @@
 import { useState, type FormEvent } from 'react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { BookmarkPlus, X } from 'lucide-react'
 import type { SavedInsightsRange } from '@/api/insights'
 import { getRelativeRangeLabel } from '../utils/range'
 
 const SAVED_RANGE_NAME_MAX_LENGTH = 64
+
+// Matches the range pill's settle so a saved row eases in and collapses out in the same feel
+const savedRangeSpring = { type: 'spring', stiffness: 420, damping: 34, mass: 0.9 } as const
 
 type SavedRangesProps = {
   savedRanges: SavedInsightsRange[]
@@ -24,8 +28,10 @@ export function SavedRanges({
   const [name, setName] = useState('')
   const [saveError, setSaveError] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
+  const shouldReduceMotion = useReducedMotion()
 
   const trimmedName = name.trim()
+  const rowTransition = shouldReduceMotion ? { duration: 0 } : savedRangeSpring
 
   /**
    * Saves the active relative window under the entered name, surfacing duplicate names
@@ -78,34 +84,43 @@ export function SavedRanges({
         </button>
       </form>
 
-      {savedRanges.length > 0 && (
-        <ul className="mt-2 flex flex-col gap-1">
+      <ul className={savedRanges.length > 0 ? 'mt-2' : ''}>
+        <AnimatePresence initial={false}>
           {savedRanges.map((range) => (
-            <li key={range.id} className="flex items-center gap-1">
-              <button
-                type="button"
-                className="app-card flex min-w-0 flex-1 items-center justify-between gap-2 rounded-lg px-3 py-1.5 text-left text-sm"
-                onClick={() => onApplySavedRange(range)}
-                title={`Apply ${range.name}`}
+              <motion.li
+                key={range.id}
+                initial={shouldReduceMotion ? false : { opacity: 0, height: 0 }}
+                animate={{ opacity: 1, height: 'auto' }}
+                exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, height: 0 }}
+                transition={rowTransition}
+                style={{ overflow: 'hidden' }}
               >
-                <span className="min-w-0 truncate font-medium">{range.name}</span>
-                <span className="shrink-0 text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                  {getRelativeRangeLabel(range.amount, range.unit)}
-                </span>
-              </button>
-              <button
-                type="button"
-                className="app-icon-button h-8 w-8 shrink-0"
-                onClick={() => onDeleteSavedRange(range.id)}
-                title={`Delete ${range.name}`}
-                aria-label={`Delete ${range.name}`}
-              >
-                <X size={15} aria-hidden />
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
+                <div className="flex items-center gap-1 pb-1">
+                  <button
+                    type="button"
+                    className="app-card flex min-w-0 flex-1 items-center justify-between gap-2 rounded-lg px-3 py-1.5 text-left text-sm"
+                    onClick={() => onApplySavedRange(range)}
+                    title={`Apply ${range.name}`}
+                  >
+                    <span className="min-w-0 truncate font-medium">{range.name}</span>
+                    <span className="shrink-0 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                      {getRelativeRangeLabel(range.amount, range.unit)}
+                    </span>
+                  </button>
+                  <button
+                    type="button"
+                    className="app-icon-button h-8 w-8 shrink-0"
+                    onClick={() => onDeleteSavedRange(range.id)}
+                    title={`Delete ${range.name}`}
+                    aria-label={`Delete ${range.name}`}
+                  >
+                    <X size={15} aria-hidden />
+                  </button>
+                </div>
+              </motion.li>
+            ))}
+        </AnimatePresence>
+      </ul>
     </div>
   )
 }

--- a/frontend/src/pages/insights/components/SavedRanges.tsx
+++ b/frontend/src/pages/insights/components/SavedRanges.tsx
@@ -1,0 +1,111 @@
+import { useState, type FormEvent } from 'react'
+import { BookmarkPlus, X } from 'lucide-react'
+import type { SavedInsightsRange } from '@/api/insights'
+import { getRelativeRangeLabel } from '../utils/range'
+
+const SAVED_RANGE_NAME_MAX_LENGTH = 64
+
+type SavedRangesProps = {
+  savedRanges: SavedInsightsRange[]
+  onSaveCurrentRange: (name: string) => Promise<void>
+  onApplySavedRange: (range: SavedInsightsRange) => void
+  onDeleteSavedRange: (rangeId: string) => void
+}
+
+/**
+ * Lets a user name and save the active relative window, then reapply or delete saved ranges
+ */
+export function SavedRanges({
+  savedRanges,
+  onSaveCurrentRange,
+  onApplySavedRange,
+  onDeleteSavedRange,
+}: SavedRangesProps) {
+  const [name, setName] = useState('')
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [isSaving, setIsSaving] = useState(false)
+
+  const trimmedName = name.trim()
+
+  /**
+   * Saves the active relative window under the entered name, surfacing duplicate names
+   */
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    if (trimmedName === '' || isSaving) return
+
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      await onSaveCurrentRange(trimmedName)
+      setName('')
+    } catch (error) {
+      setSaveError(error instanceof Error ? error.message : 'Could not save this range')
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return (
+    <div className="mt-2 border-t pt-2" style={{ borderColor: 'var(--app-border)' }}>
+      <form onSubmit={handleSubmit} className="flex items-start gap-2">
+        <div className="min-w-0 flex-1">
+          <input
+            type="text"
+            className={`app-input w-full text-sm ${saveError ? 'app-input-error' : ''}`}
+            placeholder="Name this range"
+            aria-label="Saved range name"
+            maxLength={SAVED_RANGE_NAME_MAX_LENGTH}
+            value={name}
+            onChange={(event) => {
+              setName(event.target.value)
+              setSaveError(null)
+            }}
+          />
+          {saveError && (
+            <p className="mt-1 text-xs" style={{ color: 'var(--app-negative)' }}>
+              {saveError}
+            </p>
+          )}
+        </div>
+        <button
+          type="submit"
+          className="app-secondary-button flex shrink-0 items-center gap-1.5 text-sm"
+          disabled={trimmedName === '' || isSaving}
+        >
+          <BookmarkPlus size={15} aria-hidden />
+          Save
+        </button>
+      </form>
+
+      {savedRanges.length > 0 && (
+        <ul className="mt-2 flex flex-col gap-1">
+          {savedRanges.map((range) => (
+            <li key={range.id} className="flex items-center gap-1">
+              <button
+                type="button"
+                className="app-card flex min-w-0 flex-1 items-center justify-between gap-2 rounded-lg px-3 py-1.5 text-left text-sm"
+                onClick={() => onApplySavedRange(range)}
+                title={`Apply ${range.name}`}
+              >
+                <span className="min-w-0 truncate font-medium">{range.name}</span>
+                <span className="shrink-0 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                  {getRelativeRangeLabel(range.amount, range.unit)}
+                </span>
+              </button>
+              <button
+                type="button"
+                className="app-icon-button h-8 w-8 shrink-0"
+                onClick={() => onDeleteSavedRange(range.id)}
+                title={`Delete ${range.name}`}
+                aria-label={`Delete ${range.name}`}
+              >
+                <X size={15} aria-hidden />
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/insights/components/SavedRanges.tsx
+++ b/frontend/src/pages/insights/components/SavedRanges.tsx
@@ -104,7 +104,7 @@ export function SavedRanges({
                   >
                     <span className="min-w-0 truncate font-medium">{range.name}</span>
                     <span className="shrink-0 text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                      {getRelativeRangeLabel(range.amount, range.unit)}
+                      {getRelativeRangeLabel(range.amount, range.unit, range.qualifier)}
                     </span>
                   </button>
                   <button

--- a/frontend/src/pages/insights/hooks/useInsightsRange.ts
+++ b/frontend/src/pages/insights/hooks/useInsightsRange.ts
@@ -1,24 +1,31 @@
 import { useMemo, useState } from 'react'
+import type { SavedInsightsRange } from '@/api/insights'
 import type {
   InsightsComparisonPeriod,
   InsightsRangeInputDates,
   InsightsRangePreset,
+  SavedInsightsRangeQualifier,
   SavedInsightsRangeUnit,
 } from '../types/range'
 import { getRangeComparisonPeriod, getRangeInputDates, getRelativeRangeInputDates } from '../utils/range'
 
-// The relative builder opens on a familiar three-month look-back when Custom is first picked
+// The relative builder opens on a familiar three-month rolling window when Custom is first picked
 const DEFAULT_RELATIVE_AMOUNT = 3
 const DEFAULT_RELATIVE_UNIT: SavedInsightsRangeUnit = 'month'
+const DEFAULT_RELATIVE_QUALIFIER: SavedInsightsRangeQualifier = 'past'
 
 export type InsightsRangeState = {
   rangePreset: InsightsRangePreset
   setRangePreset: (value: InsightsRangePreset) => void
   relativeAmount: number
   relativeUnit: SavedInsightsRangeUnit
+  relativeQualifier: SavedInsightsRangeQualifier
   setRelativeAmount: (value: number) => void
   setRelativeUnit: (value: SavedInsightsRangeUnit) => void
-  applyRelativeRange: (amount: number, unit: SavedInsightsRangeUnit) => void
+  setRelativeQualifier: (value: SavedInsightsRangeQualifier) => void
+  applySavedRange: (savedRange: SavedInsightsRange) => void
+  // Name of the saved range currently applied, shown as the pill label until the window changes
+  appliedSavedRangeName: string | null
   rangeInputDates: InsightsRangeInputDates
   comparisonPeriod: InsightsComparisonPeriod
   cardTransitionKey: string
@@ -34,40 +41,64 @@ export function useInsightsRange(): InsightsRangeState {
   const [rangePreset, setRangePresetState] = useState<InsightsRangePreset>('THIS_MONTH')
   const [relativeAmount, setRelativeAmountState] = useState(DEFAULT_RELATIVE_AMOUNT)
   const [relativeUnit, setRelativeUnitState] = useState<SavedInsightsRangeUnit>(DEFAULT_RELATIVE_UNIT)
+  const [relativeQualifier, setRelativeQualifierState] = useState<SavedInsightsRangeQualifier>(DEFAULT_RELATIVE_QUALIFIER)
   const [rangeInputDates, setRangeInputDates] = useState<InsightsRangeInputDates>(initialRangeInputDates)
   const [comparisonPeriod, setComparisonPeriod] = useState<InsightsComparisonPeriod>(getRangeComparisonPeriod('THIS_MONTH'))
+  const [appliedSavedRangeName, setAppliedSavedRangeName] = useState<string | null>(null)
 
   const cardTransitionKey = `${rangeInputDates.from}:${rangeInputDates.to}:${comparisonPeriod}`
   const cardQueriesEnabled = rangeInputDates.from !== '' && rangeInputDates.to !== ''
 
   /**
-   * Switches to a fixed preset, or re-resolves the rolling window when Custom is chosen
+   * Switches to a fixed preset, or re-resolves the relative window when Custom is chosen
    */
   function setRangePreset(value: InsightsRangePreset) {
     setRangePresetState(value)
     setRangeInputDates(
-      value === 'CUSTOM' ? getRelativeRangeInputDates(relativeAmount, relativeUnit) : getRangeInputDates(value),
+      value === 'CUSTOM'
+        ? getRelativeRangeInputDates(relativeAmount, relativeUnit, relativeQualifier)
+        : getRangeInputDates(value),
     )
     setComparisonPeriod(getRangeComparisonPeriod(value))
+    setAppliedSavedRangeName(null)
   }
 
   /**
-   * Makes a relative window the active range and remembers its amount and unit for saving
+   * Makes a relative window the active range, normalizing inputs a qualifier cannot hold, and
+   * clearing any saved range name since a manually built window no longer matches a saved one
    */
-  function applyRelativeRange(amount: number, unit: SavedInsightsRangeUnit) {
+  function applyRelativeRange(amount: number, unit: SavedInsightsRangeUnit, qualifier: SavedInsightsRangeQualifier) {
+    // Only a rolling window counts days, so This and Last fall back to whole weeks. The count is
+    // kept across qualifier switches even for This, whose resolver and label ignore it anyway
+    const normalizedUnit = qualifier !== 'past' && unit === 'day' ? 'week' : unit
+
     setRangePresetState('CUSTOM')
     setRelativeAmountState(amount)
-    setRelativeUnitState(unit)
-    setRangeInputDates(getRelativeRangeInputDates(amount, unit))
+    setRelativeUnitState(normalizedUnit)
+    setRelativeQualifierState(qualifier)
+    setRangeInputDates(getRelativeRangeInputDates(amount, normalizedUnit, qualifier))
     setComparisonPeriod(getRangeComparisonPeriod('CUSTOM'))
+    setAppliedSavedRangeName(null)
+  }
+
+  /**
+   * Applies a saved range's window and keeps its name so the pill reads as that saved range
+   */
+  function applySavedRange(savedRange: SavedInsightsRange) {
+    applyRelativeRange(savedRange.amount, savedRange.unit, savedRange.qualifier)
+    setAppliedSavedRangeName(savedRange.name)
   }
 
   function setRelativeAmount(value: number) {
-    applyRelativeRange(value, relativeUnit)
+    applyRelativeRange(value, relativeUnit, relativeQualifier)
   }
 
   function setRelativeUnit(value: SavedInsightsRangeUnit) {
-    applyRelativeRange(relativeAmount, value)
+    applyRelativeRange(relativeAmount, value, relativeQualifier)
+  }
+
+  function setRelativeQualifier(value: SavedInsightsRangeQualifier) {
+    applyRelativeRange(relativeAmount, relativeUnit, value)
   }
 
   return {
@@ -75,9 +106,12 @@ export function useInsightsRange(): InsightsRangeState {
     setRangePreset,
     relativeAmount,
     relativeUnit,
+    relativeQualifier,
     setRelativeAmount,
     setRelativeUnit,
-    applyRelativeRange,
+    setRelativeQualifier,
+    applySavedRange,
+    appliedSavedRangeName,
     rangeInputDates,
     comparisonPeriod,
     cardTransitionKey,

--- a/frontend/src/pages/insights/hooks/useInsightsRange.ts
+++ b/frontend/src/pages/insights/hooks/useInsightsRange.ts
@@ -1,22 +1,24 @@
 import { useMemo, useState } from 'react'
-import type { InsightsComparisonPeriod, InsightsRangeInputDates, InsightsRangePreset } from '../types/range'
-import {
-  getCustomRangeDays,
-  getDefaultCustomRange,
-  getRangeComparisonPeriod,
-  getRangeDisplayDates,
-  getRangeInputDates,
-} from '../utils/range'
+import type {
+  InsightsComparisonPeriod,
+  InsightsRangeInputDates,
+  InsightsRangePreset,
+  SavedInsightsRangeUnit,
+} from '../types/range'
+import { getRangeComparisonPeriod, getRangeInputDates, getRelativeRangeInputDates } from '../utils/range'
+
+// The relative builder opens on a familiar three-month look-back when Custom is first picked
+const DEFAULT_RELATIVE_AMOUNT = 3
+const DEFAULT_RELATIVE_UNIT: SavedInsightsRangeUnit = 'month'
 
 export type InsightsRangeState = {
   rangePreset: InsightsRangePreset
   setRangePreset: (value: InsightsRangePreset) => void
-  customFrom: string
-  setCustomFrom: (value: string) => void
-  customTo: string
-  setCustomTo: (value: string) => void
-  commitCustomRange: () => void
-  customInvalid: boolean
+  relativeAmount: number
+  relativeUnit: SavedInsightsRangeUnit
+  setRelativeAmount: (value: number) => void
+  setRelativeUnit: (value: SavedInsightsRangeUnit) => void
+  applyRelativeRange: (amount: number, unit: SavedInsightsRangeUnit) => void
   rangeInputDates: InsightsRangeInputDates
   comparisonPeriod: InsightsComparisonPeriod
   cardTransitionKey: string
@@ -24,89 +26,58 @@ export type InsightsRangeState = {
 }
 
 /**
- * Owns insight range presets, custom date drafts, query enablement, and card transition keys
+ * Owns insight range presets, the relative custom-window builder, query enablement, and
+ * card transition keys
  */
 export function useInsightsRange(): InsightsRangeState {
-  const defaultCustomRange = useMemo(() => getDefaultCustomRange(), [])
-  const initialRangeInputDates = useMemo(
-    () => getRangeInputDates('THIS_MONTH', defaultCustomRange.from, defaultCustomRange.to),
-    [defaultCustomRange],
-  )
-  const initialRangeDisplayDates = useMemo(
-    () => getRangeDisplayDates('THIS_MONTH', defaultCustomRange.from, defaultCustomRange.to),
-    [defaultCustomRange],
-  )
+  const initialRangeInputDates = useMemo(() => getRangeInputDates('THIS_MONTH'), [])
   const [rangePreset, setRangePresetState] = useState<InsightsRangePreset>('THIS_MONTH')
-  const [committedCustomFrom, setCommittedCustomFrom] = useState(defaultCustomRange.from)
-  const [committedCustomTo, setCommittedCustomTo] = useState(defaultCustomRange.to)
-  const [customFrom, setCustomFromState] = useState(initialRangeDisplayDates.from)
-  const [customTo, setCustomToState] = useState(initialRangeDisplayDates.to)
+  const [relativeAmount, setRelativeAmountState] = useState(DEFAULT_RELATIVE_AMOUNT)
+  const [relativeUnit, setRelativeUnitState] = useState<SavedInsightsRangeUnit>(DEFAULT_RELATIVE_UNIT)
   const [rangeInputDates, setRangeInputDates] = useState<InsightsRangeInputDates>(initialRangeInputDates)
   const [comparisonPeriod, setComparisonPeriod] = useState<InsightsComparisonPeriod>(getRangeComparisonPeriod('THIS_MONTH'))
 
-  const customInvalid = rangePreset === 'CUSTOM'
-    && customFrom !== ''
-    && customTo !== ''
-    && getCustomRangeDays(customFrom, customTo) === null
   const cardTransitionKey = `${rangeInputDates.from}:${rangeInputDates.to}:${comparisonPeriod}`
   const cardQueriesEnabled = rangeInputDates.from !== '' && rangeInputDates.to !== ''
 
   /**
-   * Updates preset dates while preserving the committed custom range for later reuse
+   * Switches to a fixed preset, or re-resolves the rolling window when Custom is chosen
    */
   function setRangePreset(value: InsightsRangePreset) {
     setRangePresetState(value)
-
-    if (value === 'CUSTOM') {
-      const nextRange = { from: committedCustomFrom, to: committedCustomTo }
-      setCustomFromState(nextRange.from)
-      setCustomToState(nextRange.to)
-      setRangeInputDates(nextRange)
-      setComparisonPeriod(getRangeComparisonPeriod(value))
-      return
-    }
-
-    const nextInputRange = getRangeInputDates(value, committedCustomFrom, committedCustomTo)
-    const nextDisplayRange = getRangeDisplayDates(value, committedCustomFrom, committedCustomTo)
-    setCustomFromState(nextDisplayRange.from)
-    setCustomToState(nextDisplayRange.to)
-    setRangeInputDates(nextInputRange)
+    setRangeInputDates(
+      value === 'CUSTOM' ? getRelativeRangeInputDates(relativeAmount, relativeUnit) : getRangeInputDates(value),
+    )
     setComparisonPeriod(getRangeComparisonPeriod(value))
   }
 
-  function setCustomFrom(value: string) {
-    setRangePresetState('CUSTOM')
-    setCustomFromState(value)
-  }
-
-  function setCustomTo(value: string) {
-    setRangePresetState('CUSTOM')
-    setCustomToState(value)
-  }
-
   /**
-   * Commits custom dates only after both inputs form a valid range
+   * Makes a relative window the active range and remembers its amount and unit for saving
    */
-  function commitCustomRange() {
-    if (rangePreset !== 'CUSTOM' || customFrom === '' || customTo === '' || getCustomRangeDays(customFrom, customTo) === null) {
-      return
-    }
-
-    setCommittedCustomFrom(customFrom)
-    setCommittedCustomTo(customTo)
-    setRangeInputDates({ from: customFrom, to: customTo })
+  function applyRelativeRange(amount: number, unit: SavedInsightsRangeUnit) {
+    setRangePresetState('CUSTOM')
+    setRelativeAmountState(amount)
+    setRelativeUnitState(unit)
+    setRangeInputDates(getRelativeRangeInputDates(amount, unit))
     setComparisonPeriod(getRangeComparisonPeriod('CUSTOM'))
+  }
+
+  function setRelativeAmount(value: number) {
+    applyRelativeRange(value, relativeUnit)
+  }
+
+  function setRelativeUnit(value: SavedInsightsRangeUnit) {
+    applyRelativeRange(relativeAmount, value)
   }
 
   return {
     rangePreset,
     setRangePreset,
-    customFrom,
-    setCustomFrom,
-    customTo,
-    setCustomTo,
-    commitCustomRange,
-    customInvalid,
+    relativeAmount,
+    relativeUnit,
+    setRelativeAmount,
+    setRelativeUnit,
+    applyRelativeRange,
     rangeInputDates,
     comparisonPeriod,
     cardTransitionKey,

--- a/frontend/src/pages/insights/hooks/useInsightsRange.ts
+++ b/frontend/src/pages/insights/hooks/useInsightsRange.ts
@@ -14,17 +14,41 @@ const DEFAULT_RELATIVE_AMOUNT = 3
 const DEFAULT_RELATIVE_UNIT: SavedInsightsRangeUnit = 'month'
 const DEFAULT_RELATIVE_QUALIFIER: SavedInsightsRangeQualifier = 'past'
 
+/**
+ * The applied range that drives the cards and the collapsed pill. It is committed only on a fixed
+ * preset click, Apply, Save, or applying a saved range, never while the builder draft is edited
+ */
+type CommittedRange = {
+  preset: InsightsRangePreset
+  amount: number
+  unit: SavedInsightsRangeUnit
+  qualifier: SavedInsightsRangeQualifier
+  savedRangeName: string | null
+  inputDates: InsightsRangeInputDates
+  comparisonPeriod: InsightsComparisonPeriod
+}
+
 export type InsightsRangeState = {
-  rangePreset: InsightsRangePreset
-  setRangePreset: (value: InsightsRangePreset) => void
-  relativeAmount: number
-  relativeUnit: SavedInsightsRangeUnit
-  relativeQualifier: SavedInsightsRangeQualifier
-  setRelativeAmount: (value: number) => void
-  setRelativeUnit: (value: SavedInsightsRangeUnit) => void
-  setRelativeQualifier: (value: SavedInsightsRangeQualifier) => void
+  // Preset highlighted in the control, which reads CUSTOM while the builder is being edited
+  selectedPreset: InsightsRangePreset
+  selectPreset: (value: InsightsRangePreset) => void
+  revertSelection: () => void
+  // Draft window shown in the builder, applied to the cards only on commit
+  draftAmount: number
+  draftUnit: SavedInsightsRangeUnit
+  draftQualifier: SavedInsightsRangeQualifier
+  draftInputDates: InsightsRangeInputDates
+  setDraftAmount: (value: number) => void
+  setDraftUnit: (value: SavedInsightsRangeUnit) => void
+  setDraftQualifier: (value: SavedInsightsRangeQualifier) => void
+  // Commits the draft window, optionally tagging it with the name it was just saved under
+  applyDraft: (savedRangeName?: string | null) => void
   applySavedRange: (savedRange: SavedInsightsRange) => void
-  // Name of the saved range currently applied, shown as the pill label until the window changes
+  // Applied range, for the collapsed pill label and the card queries
+  appliedPreset: InsightsRangePreset
+  appliedAmount: number
+  appliedUnit: SavedInsightsRangeUnit
+  appliedQualifier: SavedInsightsRangeQualifier
   appliedSavedRangeName: string | null
   rangeInputDates: InsightsRangeInputDates
   comparisonPeriod: InsightsComparisonPeriod
@@ -33,87 +57,137 @@ export type InsightsRangeState = {
 }
 
 /**
- * Owns insight range presets, the relative custom-window builder, query enablement, and
- * card transition keys
+ * Owns insight range presets, the relative custom-window builder draft, the committed range the
+ * cards query, query enablement, and card transition keys
  */
 export function useInsightsRange(): InsightsRangeState {
-  const initialRangeInputDates = useMemo(() => getRangeInputDates('THIS_MONTH'), [])
-  const [rangePreset, setRangePresetState] = useState<InsightsRangePreset>('THIS_MONTH')
-  const [relativeAmount, setRelativeAmountState] = useState(DEFAULT_RELATIVE_AMOUNT)
-  const [relativeUnit, setRelativeUnitState] = useState<SavedInsightsRangeUnit>(DEFAULT_RELATIVE_UNIT)
-  const [relativeQualifier, setRelativeQualifierState] = useState<SavedInsightsRangeQualifier>(DEFAULT_RELATIVE_QUALIFIER)
-  const [rangeInputDates, setRangeInputDates] = useState<InsightsRangeInputDates>(initialRangeInputDates)
-  const [comparisonPeriod, setComparisonPeriod] = useState<InsightsComparisonPeriod>(getRangeComparisonPeriod('THIS_MONTH'))
-  const [appliedSavedRangeName, setAppliedSavedRangeName] = useState<string | null>(null)
+  const initialDates = useMemo(() => getRangeInputDates('THIS_MONTH'), [])
+  const [selectedPreset, setSelectedPreset] = useState<InsightsRangePreset>('THIS_MONTH')
+  const [draftAmount, setDraftAmountState] = useState(DEFAULT_RELATIVE_AMOUNT)
+  const [draftUnit, setDraftUnitState] = useState<SavedInsightsRangeUnit>(DEFAULT_RELATIVE_UNIT)
+  const [draftQualifier, setDraftQualifierState] = useState<SavedInsightsRangeQualifier>(DEFAULT_RELATIVE_QUALIFIER)
+  const [committed, setCommitted] = useState<CommittedRange>({
+    preset: 'THIS_MONTH',
+    amount: DEFAULT_RELATIVE_AMOUNT,
+    unit: DEFAULT_RELATIVE_UNIT,
+    qualifier: DEFAULT_RELATIVE_QUALIFIER,
+    savedRangeName: null,
+    inputDates: initialDates,
+    comparisonPeriod: getRangeComparisonPeriod('THIS_MONTH'),
+  })
 
-  const cardTransitionKey = `${rangeInputDates.from}:${rangeInputDates.to}:${comparisonPeriod}`
-  const cardQueriesEnabled = rangeInputDates.from !== '' && rangeInputDates.to !== ''
+  const draftInputDates = getRelativeRangeInputDates(draftAmount, draftUnit, draftQualifier)
+  const cardTransitionKey = `${committed.inputDates.from}:${committed.inputDates.to}:${committed.comparisonPeriod}`
+  const cardQueriesEnabled = committed.inputDates.from !== '' && committed.inputDates.to !== ''
 
   /**
-   * Switches to a fixed preset, or re-resolves the relative window when Custom is chosen
+   * Highlights a preset segment. Fixed presets apply and query immediately, while Custom only
+   * opens the builder and seeds the draft from the applied range when that range is already custom
    */
-  function setRangePreset(value: InsightsRangePreset) {
-    setRangePresetState(value)
-    setRangeInputDates(
-      value === 'CUSTOM'
-        ? getRelativeRangeInputDates(relativeAmount, relativeUnit, relativeQualifier)
-        : getRangeInputDates(value),
-    )
-    setComparisonPeriod(getRangeComparisonPeriod(value))
-    setAppliedSavedRangeName(null)
+  function selectPreset(value: InsightsRangePreset) {
+    setSelectedPreset(value)
+    if (value === 'CUSTOM') {
+      if (committed.preset === 'CUSTOM') {
+        setDraftAmountState(committed.amount)
+        setDraftUnitState(committed.unit)
+        setDraftQualifierState(committed.qualifier)
+      }
+      return
+    }
+    setCommitted({
+      preset: value,
+      amount: committed.amount,
+      unit: committed.unit,
+      qualifier: committed.qualifier,
+      savedRangeName: null,
+      inputDates: getRangeInputDates(value),
+      comparisonPeriod: getRangeComparisonPeriod(value),
+    })
   }
 
   /**
-   * Makes a relative window the active range, normalizing inputs a qualifier cannot hold, and
-   * clearing any saved range name since a manually built window no longer matches a saved one
+   * Returns the highlight to the applied range, used when the panel is dismissed without
+   * committing so an abandoned Custom selection does not stay highlighted
    */
-  function applyRelativeRange(amount: number, unit: SavedInsightsRangeUnit, qualifier: SavedInsightsRangeQualifier) {
-    // Only a rolling window counts days, so This and Last fall back to whole weeks. The count is
-    // kept across qualifier switches even for This, whose resolver and label ignore it anyway
-    const normalizedUnit = qualifier !== 'past' && unit === 'day' ? 'week' : unit
+  function revertSelection() {
+    setSelectedPreset(committed.preset)
+  }
 
-    setRangePresetState('CUSTOM')
-    setRelativeAmountState(amount)
-    setRelativeUnitState(normalizedUnit)
-    setRelativeQualifierState(qualifier)
-    setRangeInputDates(getRelativeRangeInputDates(amount, normalizedUnit, qualifier))
-    setComparisonPeriod(getRangeComparisonPeriod('CUSTOM'))
-    setAppliedSavedRangeName(null)
+  function setDraftAmount(value: number) {
+    setSelectedPreset('CUSTOM')
+    setDraftAmountState(value)
+  }
+
+  function setDraftUnit(value: SavedInsightsRangeUnit) {
+    setSelectedPreset('CUSTOM')
+    setDraftUnitState(value)
+  }
+
+  function setDraftQualifier(value: SavedInsightsRangeQualifier) {
+    setSelectedPreset('CUSTOM')
+    setDraftQualifierState(value)
+    // Only a rolling window counts days, so This and Last fall back to whole weeks
+    if (value !== 'past' && draftUnit === 'day') {
+      setDraftUnitState('week')
+    }
   }
 
   /**
-   * Applies a saved range's window and keeps its name so the pill reads as that saved range
+   * Commits the current draft as the applied range, tagging it with a saved range name when the
+   * commit came from saving so the pill reads as that saved range
+   */
+  function applyDraft(savedRangeName: string | null = null) {
+    setSelectedPreset('CUSTOM')
+    setCommitted({
+      preset: 'CUSTOM',
+      amount: draftAmount,
+      unit: draftUnit,
+      qualifier: draftQualifier,
+      savedRangeName,
+      inputDates: getRelativeRangeInputDates(draftAmount, draftUnit, draftQualifier),
+      comparisonPeriod: getRangeComparisonPeriod('CUSTOM'),
+    })
+  }
+
+  /**
+   * Applies a saved range, committing it and seeding the draft so reopening the builder shows it
    */
   function applySavedRange(savedRange: SavedInsightsRange) {
-    applyRelativeRange(savedRange.amount, savedRange.unit, savedRange.qualifier)
-    setAppliedSavedRangeName(savedRange.name)
-  }
-
-  function setRelativeAmount(value: number) {
-    applyRelativeRange(value, relativeUnit, relativeQualifier)
-  }
-
-  function setRelativeUnit(value: SavedInsightsRangeUnit) {
-    applyRelativeRange(relativeAmount, value, relativeQualifier)
-  }
-
-  function setRelativeQualifier(value: SavedInsightsRangeQualifier) {
-    applyRelativeRange(relativeAmount, relativeUnit, value)
+    setSelectedPreset('CUSTOM')
+    setDraftAmountState(savedRange.amount)
+    setDraftUnitState(savedRange.unit)
+    setDraftQualifierState(savedRange.qualifier)
+    setCommitted({
+      preset: 'CUSTOM',
+      amount: savedRange.amount,
+      unit: savedRange.unit,
+      qualifier: savedRange.qualifier,
+      savedRangeName: savedRange.name,
+      inputDates: getRelativeRangeInputDates(savedRange.amount, savedRange.unit, savedRange.qualifier),
+      comparisonPeriod: getRangeComparisonPeriod('CUSTOM'),
+    })
   }
 
   return {
-    rangePreset,
-    setRangePreset,
-    relativeAmount,
-    relativeUnit,
-    relativeQualifier,
-    setRelativeAmount,
-    setRelativeUnit,
-    setRelativeQualifier,
+    selectedPreset,
+    selectPreset,
+    revertSelection,
+    draftAmount,
+    draftUnit,
+    draftQualifier,
+    draftInputDates,
+    setDraftAmount,
+    setDraftUnit,
+    setDraftQualifier,
+    applyDraft,
     applySavedRange,
-    appliedSavedRangeName,
-    rangeInputDates,
-    comparisonPeriod,
+    appliedPreset: committed.preset,
+    appliedAmount: committed.amount,
+    appliedUnit: committed.unit,
+    appliedQualifier: committed.qualifier,
+    appliedSavedRangeName: committed.savedRangeName,
+    rangeInputDates: committed.inputDates,
+    comparisonPeriod: committed.comparisonPeriod,
     cardTransitionKey,
     cardQueriesEnabled,
   }

--- a/frontend/src/pages/insights/types/range.ts
+++ b/frontend/src/pages/insights/types/range.ts
@@ -5,6 +5,10 @@ export type InsightsComparisonPeriod = 'same_length' | 'previous_month' | 'previ
 // Relative window units a saved range can step back by, mirrored from the backend schema
 export type SavedInsightsRangeUnit = 'day' | 'week' | 'month' | 'quarter' | 'year'
 
+// How a window is anchored, mirrored from the backend: the current period to date (this), the
+// previous complete period(s) (last), or a rolling window of the last N periods ending today (past)
+export type SavedInsightsRangeQualifier = 'this' | 'last' | 'past'
+
 export type InsightsRangeInputDates = {
   from: string
   to: string

--- a/frontend/src/pages/insights/types/range.ts
+++ b/frontend/src/pages/insights/types/range.ts
@@ -2,6 +2,9 @@ export type InsightsRangePreset = 'THIS_MONTH' | 'LAST_MONTH' | 'LAST_30_DAYS' |
 
 export type InsightsComparisonPeriod = 'same_length' | 'previous_month' | 'previous_year'
 
+// Relative window units a saved range can step back by, mirrored from the backend schema
+export type SavedInsightsRangeUnit = 'day' | 'week' | 'month' | 'quarter' | 'year'
+
 export type InsightsRangeInputDates = {
   from: string
   to: string

--- a/frontend/src/pages/insights/utils/date.ts
+++ b/frontend/src/pages/insights/utils/date.ts
@@ -17,6 +17,29 @@ export function addDays(date: Date, days: number) {
   return next
 }
 
+/**
+ * Returns the Monday that starts the ISO week containing the given date
+ */
+export function getStartOfWeek(date: Date) {
+  // getDay reports 0 for Sunday, so shift it to the end of the week to make Monday day zero
+  const daysFromMonday = (date.getDay() + 6) % 7
+  return addDays(date, -daysFromMonday)
+}
+
+/**
+ * Adds (or subtracts) whole months, clamping the day so stepping back from a month end
+ * never overflows into the following month, for example Mar 31 minus one month is Feb 28
+ */
+export function addMonths(date: Date, months: number) {
+  const next = new Date(date)
+  const targetDay = next.getDate()
+  next.setDate(1)
+  next.setMonth(next.getMonth() + months)
+  const lastDayOfResultMonth = new Date(next.getFullYear(), next.getMonth() + 1, 0).getDate()
+  next.setDate(Math.min(targetDay, lastDayOfResultMonth))
+  return next
+}
+
 export function getShortDateLabel(date: Date) {
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
 }

--- a/frontend/src/pages/insights/utils/range.ts
+++ b/frontend/src/pages/insights/utils/range.ts
@@ -1,15 +1,20 @@
-import type { InsightsComparisonPeriod, InsightsRangeInputDates, InsightsRangePreset } from '../types/range'
-import {
-  addDays,
-  formatYmd,
-  parseYmd,
-} from './date'
+import type {
+  InsightsComparisonPeriod,
+  InsightsRangeInputDates,
+  InsightsRangePreset,
+  SavedInsightsRangeUnit,
+} from '../types/range'
+import { addDays, formatYmd, getStartOfWeek, parseYmd } from './date'
 
-function getEffectiveRangeBounds(
-  preset: InsightsRangePreset,
-  customFrom: string,
-  customTo: string,
-): { start: Date; end: Date } {
+// How many months each calendar unit spans, which doubles as the alignment granularity used to
+// roll a window start back to the first day of a whole month, quarter, or year
+const MONTHS_PER_UNIT: Record<'month' | 'quarter' | 'year', number> = {
+  month: 1,
+  quarter: 3,
+  year: 12,
+}
+
+function getFixedPresetBounds(preset: InsightsRangePreset): { start: Date; end: Date } {
   const today = new Date()
 
   switch (preset) {
@@ -21,55 +26,10 @@ function getEffectiveRangeBounds(
       const start = new Date(today.getFullYear(), today.getMonth() - 1, 1)
       return { start, end: new Date(today.getFullYear(), today.getMonth(), 0) }
     }
-    case 'LAST_30_DAYS':
-      return { start: addDays(today, -29), end: today }
     case 'LAST_90_DAYS':
       return { start: addDays(today, -89), end: today }
-    case 'CUSTOM': {
-      const fromDate = parseYmd(customFrom)
-      const toDate = parseYmd(customTo)
-      if (fromDate && toDate && fromDate <= toDate) {
-        return { start: fromDate, end: toDate }
-      }
-      return { start: addDays(today, -29), end: today }
-    }
     default:
       return { start: addDays(today, -29), end: today }
-  }
-}
-
-function getDisplayRangeBounds(
-  preset: InsightsRangePreset,
-  customFrom: string,
-  customTo: string,
-): { start: Date; end: Date } {
-  const today = new Date()
-
-  switch (preset) {
-    case 'THIS_MONTH':
-      return {
-        start: new Date(today.getFullYear(), today.getMonth(), 1),
-        end: new Date(today.getFullYear(), today.getMonth() + 1, 0),
-      }
-    case 'THIS_YEAR':
-      return {
-        start: new Date(today.getFullYear(), 0, 1),
-        end: new Date(today.getFullYear(), 11, 31),
-      }
-    default:
-      return getEffectiveRangeBounds(preset, customFrom, customTo)
-  }
-}
-
-function formatRangeBounds({ start, end }: { start: Date; end: Date }): InsightsRangeInputDates {
-  return { from: formatYmd(start), to: formatYmd(end) }
-}
-
-export function getDefaultCustomRange(): InsightsRangeInputDates {
-  const today = new Date()
-  return {
-    from: formatYmd(addDays(today, -29)),
-    to: formatYmd(today),
   }
 }
 
@@ -80,20 +40,49 @@ export function getCustomRangeDays(from: string, to: string) {
   return Math.max(1, Math.round((toDate.getTime() - fromDate.getTime()) / 86400000) + 1)
 }
 
-export function getRangeInputDates(
-  preset: InsightsRangePreset,
-  customFrom: string,
-  customTo: string,
-): InsightsRangeInputDates {
-  return formatRangeBounds(getEffectiveRangeBounds(preset, customFrom, customTo))
+/**
+ * Resolves a fixed preset to the inclusive from/to dates its cards query
+ */
+export function getRangeInputDates(preset: InsightsRangePreset): InsightsRangeInputDates {
+  const { start, end } = getFixedPresetBounds(preset)
+  return { from: formatYmd(start), to: formatYmd(end) }
 }
 
-export function getRangeDisplayDates(
-  preset: InsightsRangePreset,
-  customFrom: string,
-  customTo: string,
+/**
+ * Resolves a relative "last N units" window to inclusive from/to dates ending today
+ *
+ * Day windows count the exact number of trailing days ending today. Week, month, quarter, and
+ * year windows align the start to the beginning of the earliest whole period they cover, so the
+ * window always reaches back to a week, month, quarter, or year boundary
+ */
+export function getRelativeRangeInputDates(
+  amount: number,
+  unit: SavedInsightsRangeUnit,
 ): InsightsRangeInputDates {
-  return formatRangeBounds(getDisplayRangeBounds(preset, customFrom, customTo))
+  const today = new Date()
+
+  if (unit === 'day') {
+    return { from: formatYmd(addDays(today, -(amount - 1))), to: formatYmd(today) }
+  }
+  if (unit === 'week') {
+    const start = addDays(getStartOfWeek(today), -(amount - 1) * 7)
+    return { from: formatYmd(start), to: formatYmd(today) }
+  }
+
+  // Roll back to the first day of the month, quarter, or year that opens the window so the span
+  // covers whole calendar periods up to today regardless of which day of the period it is
+  const periodMonths = MONTHS_PER_UNIT[unit]
+  const alignedStartMonth = Math.floor(today.getMonth() / periodMonths) * periodMonths - (amount - 1) * periodMonths
+  const start = new Date(today.getFullYear(), alignedStartMonth, 1)
+  return { from: formatYmd(start), to: formatYmd(today) }
+}
+
+/**
+ * Builds the human label for a relative window, for example "Last 6 months"
+ */
+export function getRelativeRangeLabel(amount: number, unit: SavedInsightsRangeUnit) {
+  const unitLabel = amount === 1 ? unit : `${unit}s`
+  return `Last ${amount} ${unitLabel}`
 }
 
 export function getRangeComparisonPeriod(preset: InsightsRangePreset): InsightsComparisonPeriod {

--- a/frontend/src/pages/insights/utils/range.ts
+++ b/frontend/src/pages/insights/utils/range.ts
@@ -2,6 +2,7 @@ import type {
   InsightsComparisonPeriod,
   InsightsRangeInputDates,
   InsightsRangePreset,
+  SavedInsightsRangeQualifier,
   SavedInsightsRangeUnit,
 } from '../types/range'
 import { addDays, formatYmd, getShortDateLabel, getStartOfWeek, parseYmd } from './date'
@@ -49,18 +50,17 @@ export function getRangeInputDates(preset: InsightsRangePreset): InsightsRangeIn
 }
 
 /**
- * Resolves a relative "last N units" window to inclusive from/to dates ending today
+ * Resolves a trailing "last N units" window ending today
  *
- * Day windows count the exact number of trailing days ending today. Week, month, quarter, and
- * year windows align the start to the beginning of the earliest whole period they cover, so the
- * window always reaches back to a week, month, quarter, or year boundary
+ * Day windows count the exact number of trailing days. Week, month, quarter, and year windows
+ * align the start to the beginning of the earliest whole period they cover, so the window always
+ * reaches back to a week, month, quarter, or year boundary
  */
-export function getRelativeRangeInputDates(
+function getTrailingRangeInputDates(
   amount: number,
   unit: SavedInsightsRangeUnit,
+  today: Date,
 ): InsightsRangeInputDates {
-  const today = new Date()
-
   if (unit === 'day') {
     return { from: formatYmd(addDays(today, -(amount - 1))), to: formatYmd(today) }
   }
@@ -69,20 +69,73 @@ export function getRelativeRangeInputDates(
     return { from: formatYmd(start), to: formatYmd(today) }
   }
 
-  // Roll back to the first day of the month, quarter, or year that opens the window so the span
-  // covers whole calendar periods up to today regardless of which day of the period it is
   const periodMonths = MONTHS_PER_UNIT[unit]
   const alignedStartMonth = Math.floor(today.getMonth() / periodMonths) * periodMonths - (amount - 1) * periodMonths
-  const start = new Date(today.getFullYear(), alignedStartMonth, 1)
-  return { from: formatYmd(start), to: formatYmd(today) }
+  return { from: formatYmd(new Date(today.getFullYear(), alignedStartMonth, 1)), to: formatYmd(today) }
 }
 
 /**
- * Builds the human label for a relative window, for example "Last 6 months"
+ * Resolves a window of the last N whole completed periods, ending the day before the current
+ * period begins so the in-progress period is excluded
  */
-export function getRelativeRangeLabel(amount: number, unit: SavedInsightsRangeUnit) {
+function getCompleteRangeInputDates(
+  amount: number,
+  unit: SavedInsightsRangeUnit,
+  today: Date,
+): InsightsRangeInputDates {
+  if (unit === 'day') {
+    return { from: formatYmd(addDays(today, -amount)), to: formatYmd(addDays(today, -1)) }
+  }
+  if (unit === 'week') {
+    const currentWeekStart = getStartOfWeek(today)
+    return { from: formatYmd(addDays(currentWeekStart, -amount * 7)), to: formatYmd(addDays(currentWeekStart, -1)) }
+  }
+
+  const periodMonths = MONTHS_PER_UNIT[unit]
+  const currentPeriodStartMonth = Math.floor(today.getMonth() / periodMonths) * periodMonths
+  const currentPeriodStart = new Date(today.getFullYear(), currentPeriodStartMonth, 1)
+  const start = new Date(today.getFullYear(), currentPeriodStartMonth - amount * periodMonths, 1)
+  return { from: formatYmd(start), to: formatYmd(addDays(currentPeriodStart, -1)) }
+}
+
+/**
+ * Resolves a relative window to inclusive from/to dates based on its qualifier: the current
+ * period to date (this), the last N whole completed periods (last), or a rolling window of the
+ * last N periods ending today (past)
+ */
+export function getRelativeRangeInputDates(
+  amount: number,
+  unit: SavedInsightsRangeUnit,
+  qualifier: SavedInsightsRangeQualifier = 'past',
+): InsightsRangeInputDates {
+  const today = new Date()
+  if (qualifier === 'this') {
+    return getTrailingRangeInputDates(1, unit, today)
+  }
+  if (qualifier === 'last') {
+    return getCompleteRangeInputDates(amount, unit, today)
+  }
+  return getTrailingRangeInputDates(amount, unit, today)
+}
+
+/**
+ * Builds the human label for a relative window, for example "This quarter", "Last quarter", or
+ * "Past 6 months"
+ */
+export function getRelativeRangeLabel(
+  amount: number,
+  unit: SavedInsightsRangeUnit,
+  qualifier: SavedInsightsRangeQualifier = 'past',
+) {
+  if (qualifier === 'this') {
+    return `This ${unit}`
+  }
+  if (qualifier === 'last' && amount === 1) {
+    return `Last ${unit}`
+  }
   const unitLabel = amount === 1 ? unit : `${unit}s`
-  return `Last ${amount} ${unitLabel}`
+  const verb = qualifier === 'last' ? 'Last' : 'Past'
+  return `${verb} ${amount} ${unitLabel}`
 }
 
 /**

--- a/frontend/src/pages/insights/utils/range.ts
+++ b/frontend/src/pages/insights/utils/range.ts
@@ -4,7 +4,7 @@ import type {
   InsightsRangePreset,
   SavedInsightsRangeUnit,
 } from '../types/range'
-import { addDays, formatYmd, getStartOfWeek, parseYmd } from './date'
+import { addDays, formatYmd, getShortDateLabel, getStartOfWeek, parseYmd } from './date'
 
 // How many months each calendar unit spans, which doubles as the alignment granularity used to
 // roll a window start back to the first day of a whole month, quarter, or year
@@ -83,6 +83,21 @@ export function getRelativeRangeInputDates(
 export function getRelativeRangeLabel(amount: number, unit: SavedInsightsRangeUnit) {
   const unitLabel = amount === 1 ? unit : `${unit}s`
   return `Last ${amount} ${unitLabel}`
+}
+
+/**
+ * Formats a resolved from/to range for display, for example "Jan 1 – Jun 19", adding the year on
+ * each end only when the range spans more than one calendar year
+ */
+export function formatResolvedRangeLabel(from: string, to: string) {
+  const fromDate = parseYmd(from)
+  const toDate = parseYmd(to)
+  if (!fromDate || !toDate) return ''
+
+  if (fromDate.getFullYear() === toDate.getFullYear()) {
+    return `${getShortDateLabel(fromDate)} – ${getShortDateLabel(toDate)}`
+  }
+  return `${getShortDateLabel(fromDate)}, ${fromDate.getFullYear()} – ${getShortDateLabel(toDate)}, ${toDate.getFullYear()}`
 }
 
 export function getRangeComparisonPeriod(preset: InsightsRangePreset): InsightsComparisonPeriod {

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -469,6 +469,16 @@
     background: color-mix(in srgb, var(--app-text) 7%, transparent);
   }
 
+  /* This/Last/Past qualifier selector leading the custom builder, reusing the segmented styling */
+  .app-range-qualifier {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 2px;
+    padding: 3px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--app-text) 7%, transparent);
+  }
+
   .app-range-seg-option {
     appearance: none;
     min-width: 0;

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -413,6 +413,25 @@
     font-variant-numeric: tabular-nums;
   }
 
+  /* Primary action that commits the builder draft to the cards without saving it as a named range */
+  .app-range-apply {
+    margin-top: 10px;
+    width: 100%;
+    padding: 8px 0;
+    border: 1px solid var(--app-button-primary-bg);
+    border-radius: 10px;
+    background: var(--app-button-primary-bg);
+    color: var(--app-button-primary-text);
+    cursor: pointer;
+    font-size: 0.8125rem;
+    font-weight: 500;
+  }
+
+  .app-range-apply:hover {
+    background: var(--app-button-primary-bg-hover);
+    border-color: var(--app-button-primary-bg-hover);
+  }
+
   .app-range-glass-chev {
     flex-shrink: 0;
     color: var(--app-text-subtle);
@@ -480,6 +499,7 @@
   }
 
   .app-range-seg-option {
+    position: relative;
     appearance: none;
     min-width: 0;
     padding: 6px 0;
@@ -494,10 +514,22 @@
   }
 
   .app-range-seg-option-active {
-    background: var(--app-input-bg);
     color: var(--app-text);
     font-weight: 500;
+  }
+
+  /* Sliding highlight behind the active segment, carried between options by a shared layout
+     animation so the selection glides rather than jumping */
+  .app-range-seg-thumb {
+    position: absolute;
+    inset: 0;
+    border-radius: 8px;
+    background: var(--app-input-bg);
     box-shadow: 0 1px 2px #00000014, inset 0 1px 0 color-mix(in srgb, white 28%, transparent);
+  }
+
+  .app-range-seg-label {
+    position: relative;
   }
 
   .app-range-custom {

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -307,6 +307,16 @@
     appearance: none;
   }
 
+  .app-input-no-spinner {
+    appearance: textfield;
+  }
+
+  .app-input-no-spinner::-webkit-outer-spin-button,
+  .app-input-no-spinner::-webkit-inner-spin-button {
+    margin: 0;
+    appearance: none;
+  }
+
   .import-auto-fill-row {
     animation: import-auto-fill-row 900ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
   }

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -317,6 +317,253 @@
     appearance: none;
   }
 
+  /* Translucent collapsing date-range control on the insights page. The pill widens with a
+     soft overshoot and the panel height settles smoothly, so it blooms open with a bounce */
+  .app-range-glass {
+    --app-range-glass-bounce: cubic-bezier(0.34, 1.6, 0.5, 1);
+    --app-range-glass-ease: cubic-bezier(0.22, 1, 0.36, 1);
+    display: flex;
+    flex-direction: column;
+    margin-left: auto;
+    width: fit-content;
+    max-width: 100%;
+    overflow: hidden;
+    border-radius: 20px;
+    border: 1px solid var(--app-border-strong);
+    background: color-mix(in srgb, var(--app-input-bg) 62%, transparent);
+    -webkit-backdrop-filter: blur(20px) saturate(160%);
+    backdrop-filter: blur(20px) saturate(160%);
+    box-shadow: var(--app-shadow-soft), inset 0 1px 0 color-mix(in srgb, white 32%, transparent);
+  }
+
+  /* The mobile control spans the full width instead of hugging its content like the sidebar pill */
+  .app-range-glass-full {
+    width: 100%;
+    margin-left: 0;
+  }
+
+  /* The mobile control floats at the bottom, so it stacks the panel above the pill and grows
+     upward while the panel content keeps its normal top-to-bottom order */
+  .app-range-glass-up {
+    flex-direction: column-reverse;
+  }
+
+  .app-range-glass-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 7px 14px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    white-space: nowrap;
+    color: var(--app-text);
+    transition: padding-top 0.4s var(--app-range-glass-ease);
+  }
+
+  /* The bottom-floating mobile control is a primary tap target, so it sits taller and uses the
+     standard control text size instead of the compact size the desktop sidebar pill can afford */
+  .app-range-glass-full .app-range-glass-head {
+    padding: 9px 16px;
+    font-size: 0.9375rem;
+  }
+
+  /* Expanding the desktop panel opens up its top edge to match the panel's side and bottom
+     spacing while the collapsed pill stays compact */
+  .app-range-glass-open:not(.app-range-glass-up) .app-range-glass-head {
+    padding-top: 12px;
+  }
+
+  .app-range-glass-cur {
+    display: flex;
+    min-width: 0;
+    align-items: center;
+    gap: 8px;
+  }
+
+  /* Stacks the label over its resolved dates so both left-align to each other while the calendar
+     icon stays a separate column centred against the two-line block */
+  .app-range-glass-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    align-items: flex-start;
+    gap: 1px;
+    line-height: 1.2;
+  }
+
+  /* The resolved date range shown under the label while collapsed, animated to height zero on
+     open so the same range can fade in below the preset row instead */
+  .app-range-glass-sub {
+    display: block;
+    overflow: hidden;
+    font-size: 0.6875rem;
+    font-weight: 400;
+    line-height: 1.2;
+    white-space: nowrap;
+    color: var(--app-text-subtle);
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* The resolved date range shown inside the open panel, directly under the preset row */
+  .app-range-dates {
+    margin-top: 10px;
+    font-size: 0.75rem;
+    color: var(--app-text-subtle);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .app-range-glass-chev {
+    flex-shrink: 0;
+    color: var(--app-text-subtle);
+  }
+
+  .app-range-glass-bodywrap {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.45s var(--app-range-glass-ease);
+  }
+
+  .app-range-glass-open .app-range-glass-bodywrap {
+    grid-template-rows: 1fr;
+  }
+
+  .app-range-glass-body {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .app-range-glass-inner {
+    padding: 0 12px 12px;
+    opacity: 0;
+    transition: opacity 0.26s ease 0.05s;
+  }
+
+  .app-range-glass-open .app-range-glass-inner {
+    opacity: 1;
+  }
+
+  /* The grow-up control has no pill header above the panel, so the label needs its own top room */
+  .app-range-glass-up .app-range-glass-inner {
+    padding-top: 12px;
+  }
+
+  /* The full-width control cannot bounce its width like the sidebar pill, so its panel
+     content rises into place with the same overshoot for a matching fluid feel */
+  .app-range-glass-full .app-range-glass-inner {
+    transform: translateY(14px);
+    transition: opacity 0.28s ease, transform 0.55s var(--app-range-glass-bounce);
+  }
+
+  .app-range-glass-full.app-range-glass-open .app-range-glass-inner {
+    transform: translateY(0);
+  }
+
+  /* Flat segmented preset row, appearance reset so native button chrome never boxes a pill */
+  .app-range-seg {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 2px;
+    padding: 3px;
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--app-text) 7%, transparent);
+  }
+
+  .app-range-seg-option {
+    appearance: none;
+    min-width: 0;
+    padding: 6px 0;
+    border: 0;
+    border-radius: 8px;
+    background: none;
+    cursor: pointer;
+    font-size: 0.75rem;
+    text-align: center;
+    white-space: nowrap;
+    color: var(--app-text-muted);
+  }
+
+  .app-range-seg-option-active {
+    background: var(--app-input-bg);
+    color: var(--app-text);
+    font-weight: 500;
+    box-shadow: 0 1px 2px #00000014, inset 0 1px 0 color-mix(in srgb, white 28%, transparent);
+  }
+
+  .app-range-custom {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.4s var(--app-range-glass-ease);
+  }
+
+  .app-range-custom-open {
+    grid-template-rows: 1fr;
+  }
+
+  .app-range-custom-inner {
+    min-height: 0;
+    overflow: hidden;
+    padding-top: 2px;
+  }
+
+  /* Inline unit picker that expands in place, since the glass backdrop-filter traps and
+     clips an absolutely positioned dropdown menu */
+  .app-range-unit-menu {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 0.22s cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .app-range-unit-menu-open {
+    grid-template-rows: 1fr;
+  }
+
+  .app-range-unit-menu-body {
+    min-height: 0;
+    overflow: hidden;
+  }
+
+  .app-range-unit-list {
+    margin-top: 6px;
+    padding: 4px;
+    border: 1px solid var(--app-border-strong);
+    border-radius: 10px;
+    background: var(--app-input-bg);
+  }
+
+  .app-range-unit-option {
+    appearance: none;
+    width: 100%;
+    padding: 7px 10px;
+    border: 0;
+    border-radius: 7px;
+    background: none;
+    cursor: pointer;
+    text-align: left;
+    font-size: 0.8125rem;
+    color: var(--app-text);
+  }
+
+  .app-range-unit-option:hover {
+    background: color-mix(in srgb, var(--app-text) 6%, transparent);
+  }
+
+  .app-range-unit-option-active {
+    color: var(--app-accent);
+    font-weight: 500;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .app-range-glass-head,
+    .app-range-glass-bodywrap,
+    .app-range-glass-inner,
+    .app-range-glass-full .app-range-glass-inner,
+    .app-range-custom,
+    .app-range-unit-menu {
+      transition-duration: 0s;
+    }
+  }
+
   .import-auto-fill-row {
     animation: import-auto-fill-row 900ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
   }

--- a/frontend/tests/api/insights.test.ts
+++ b/frontend/tests/api/insights.test.ts
@@ -15,6 +15,8 @@ vi.mock('@/api/client', () => ({
 }));
 
 import {
+  createSavedInsightsRange,
+  deleteSavedInsightsRange,
   fetchInsightsCashFlow,
   fetchInsightsFundFlow,
   fetchInsightsIncomeExpenseBreakdown,
@@ -22,6 +24,7 @@ import {
   fetchInsightsNetWorth,
   fetchInsightsPeriodGlance,
   fetchInsightsSavingsRateTrend,
+  fetchSavedInsightsRanges,
 } from '@/api/insights';
 
 beforeEach(() => {
@@ -72,5 +75,30 @@ describe('insights fetch functions', () => {
     await fetchInsightsSavingsRateTrend();
 
     expect(authenticatedFetchMock).toHaveBeenCalledWith('/insights/savings-rate-trend');
+  });
+});
+
+describe('saved insights range functions', () => {
+  it('lists saved ranges from the saved-ranges endpoint', async () => {
+    await fetchSavedInsightsRanges();
+
+    expect(authenticatedFetchMock).toHaveBeenCalledWith('/insights/saved-ranges');
+  });
+
+  it('creates a saved range with the name, amount, and unit', async () => {
+    await createSavedInsightsRange({ name: 'Half-year', amount: 6, unit: 'month' });
+
+    expect(authenticatedFetchMock).toHaveBeenCalledWith('/insights/saved-ranges', {
+      method: 'POST',
+      body: JSON.stringify({ name: 'Half-year', amount: 6, unit: 'month' }),
+    });
+  });
+
+  it('deletes a saved range by ID', async () => {
+    await deleteSavedInsightsRange('range_123');
+
+    expect(authenticatedFetchMock).toHaveBeenCalledWith('/insights/saved-ranges/range_123', {
+      method: 'DELETE',
+    });
   });
 });

--- a/frontend/tests/pages/insights/relativeRange.test.ts
+++ b/frontend/tests/pages/insights/relativeRange.test.ts
@@ -46,15 +46,39 @@ describe('getRelativeRangeInputDates', () => {
 
     expect(getRelativeRangeInputDates(6, 'month')).toEqual({ from: '2026-01-01', to: '2026-06-30' });
   });
+
+  it('resolves last-qualifier windows as whole finished periods ending before the current one', () => {
+    expect(getRelativeRangeInputDates(1, 'month', 'last')).toEqual({ from: '2026-05-01', to: '2026-05-31' });
+    expect(getRelativeRangeInputDates(1, 'quarter', 'last')).toEqual({ from: '2026-01-01', to: '2026-03-31' });
+    expect(getRelativeRangeInputDates(2, 'quarter', 'last')).toEqual({ from: '2025-10-01', to: '2026-03-31' });
+    expect(getRelativeRangeInputDates(1, 'year', 'last')).toEqual({ from: '2025-01-01', to: '2025-12-31' });
+    expect(getRelativeRangeInputDates(1, 'week', 'last')).toEqual({ from: '2026-06-08', to: '2026-06-14' });
+  });
+
+  it('resolves this-qualifier windows as the current period up to today', () => {
+    expect(getRelativeRangeInputDates(1, 'month', 'this')).toEqual({ from: '2026-06-01', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(1, 'quarter', 'this')).toEqual({ from: '2026-04-01', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(1, 'year', 'this')).toEqual({ from: '2026-01-01', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(1, 'week', 'this')).toEqual({ from: '2026-06-15', to: '2026-06-18' });
+  });
 });
 
 describe('getRelativeRangeLabel', () => {
-  it('singularizes a one-unit window and pluralizes the rest', () => {
-    expect(getRelativeRangeLabel(1, 'month')).toBe('Last 1 month');
-    expect(getRelativeRangeLabel(6, 'month')).toBe('Last 6 months');
-    expect(getRelativeRangeLabel(7, 'day')).toBe('Last 7 days');
-    expect(getRelativeRangeLabel(1, 'quarter')).toBe('Last 1 quarter');
-    expect(getRelativeRangeLabel(2, 'year')).toBe('Last 2 years');
+  it('labels the current period without a count', () => {
+    expect(getRelativeRangeLabel(1, 'month', 'this')).toBe('This month');
+    expect(getRelativeRangeLabel(3, 'quarter', 'this')).toBe('This quarter');
+  });
+
+  it('labels a single completed period without a count and pluralizes the rest', () => {
+    expect(getRelativeRangeLabel(1, 'quarter', 'last')).toBe('Last quarter');
+    expect(getRelativeRangeLabel(1, 'month', 'last')).toBe('Last month');
+    expect(getRelativeRangeLabel(2, 'quarter', 'last')).toBe('Last 2 quarters');
+  });
+
+  it('labels a rolling window with its count', () => {
+    expect(getRelativeRangeLabel(1, 'month', 'past')).toBe('Past 1 month');
+    expect(getRelativeRangeLabel(6, 'month', 'past')).toBe('Past 6 months');
+    expect(getRelativeRangeLabel(7, 'day', 'past')).toBe('Past 7 days');
   });
 });
 

--- a/frontend/tests/pages/insights/relativeRange.test.ts
+++ b/frontend/tests/pages/insights/relativeRange.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Covers the relative range resolver that turns a saved "last N units" window into the
+ * inclusive from/to dates the insights cards query
+ *
+ * The system clock is pinned so trailing-window arithmetic and month-end clamping are
+ * asserted against known dates
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { getRelativeRangeInputDates, getRelativeRangeLabel } from '@/pages/insights/utils/range';
+
+beforeEach(() => {
+  vi.useFakeTimers();
+
+  vi.setSystemTime(new Date(2026, 5, 18));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('getRelativeRangeInputDates', () => {
+  it('resolves trailing day windows ending today', () => {
+    expect(getRelativeRangeInputDates(30, 'day')).toEqual({ from: '2026-05-20', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(1, 'day')).toEqual({ from: '2026-06-18', to: '2026-06-18' });
+  });
+
+  it('aligns week windows to the Monday that starts the earliest week', () => {
+    expect(getRelativeRangeInputDates(1, 'week')).toEqual({ from: '2026-06-15', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(2, 'week')).toEqual({ from: '2026-06-08', to: '2026-06-18' });
+  });
+
+  it('aligns month, quarter, and year windows to the start of the earliest whole period', () => {
+    expect(getRelativeRangeInputDates(1, 'month')).toEqual({ from: '2026-06-01', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(6, 'month')).toEqual({ from: '2026-01-01', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(1, 'quarter')).toEqual({ from: '2026-04-01', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(1, 'year')).toEqual({ from: '2026-01-01', to: '2026-06-18' });
+    expect(getRelativeRangeInputDates(2, 'year')).toEqual({ from: '2025-01-01', to: '2026-06-18' });
+  });
+
+  it('keeps the aligned start fixed for any day within the current period', () => {
+    vi.setSystemTime(new Date(2026, 5, 30));
+
+    expect(getRelativeRangeInputDates(6, 'month')).toEqual({ from: '2026-01-01', to: '2026-06-30' });
+  });
+});
+
+describe('getRelativeRangeLabel', () => {
+  it('singularizes a one-unit window and pluralizes the rest', () => {
+    expect(getRelativeRangeLabel(1, 'month')).toBe('Last 1 month');
+    expect(getRelativeRangeLabel(6, 'month')).toBe('Last 6 months');
+    expect(getRelativeRangeLabel(7, 'day')).toBe('Last 7 days');
+    expect(getRelativeRangeLabel(1, 'quarter')).toBe('Last 1 quarter');
+    expect(getRelativeRangeLabel(2, 'year')).toBe('Last 2 years');
+  });
+});

--- a/frontend/tests/pages/insights/relativeRange.test.ts
+++ b/frontend/tests/pages/insights/relativeRange.test.ts
@@ -6,7 +6,11 @@
  * asserted against known dates
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { getRelativeRangeInputDates, getRelativeRangeLabel } from '@/pages/insights/utils/range';
+import {
+  formatResolvedRangeLabel,
+  getRelativeRangeInputDates,
+  getRelativeRangeLabel,
+} from '@/pages/insights/utils/range';
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -51,5 +55,15 @@ describe('getRelativeRangeLabel', () => {
     expect(getRelativeRangeLabel(7, 'day')).toBe('Last 7 days');
     expect(getRelativeRangeLabel(1, 'quarter')).toBe('Last 1 quarter');
     expect(getRelativeRangeLabel(2, 'year')).toBe('Last 2 years');
+  });
+});
+
+describe('formatResolvedRangeLabel', () => {
+  it('formats a same-year range without the year', () => {
+    expect(formatResolvedRangeLabel('2026-01-01', '2026-06-19')).toBe('Jan 1 – Jun 19');
+  });
+
+  it('adds the year on each end when the range crosses years', () => {
+    expect(formatResolvedRangeLabel('2025-01-01', '2026-06-19')).toBe('Jan 1, 2025 – Jun 19, 2026');
   });
 });


### PR DESCRIPTION
- Lets users save and reuse custom Insights date ranges, which before could only be set as a one-time window that was lost as soon as the range changed
- Stores saved ranges per user in a new table protected by row-level security, with endpoints to list, create, and delete them, and rejects a duplicate name
- Lets users name and save any custom window, re-apply a saved one with a tap, and delete saved ones, with the active range name and its resolved dates shown on the collapsed control
- Reworks the Insights date-range picker into a single control: a quick preset row (this month, last month, last 30/90 days, this year) plus a custom builder, shown as a collapsing pill that floats at the bottom on mobile and a sticky sidebar on desktop
- Lets the custom builder compose a window as This, Last, or Past a chosen period, reading as plain phrases like "This quarter", "Last quarter", or "Past 6 months" (week, month, quarter, and year, plus days for Past)
- Resolves each window against today on the calendar: This is the current period up to today, Last is the previous complete period(s), and Past is a rolling window ending today
- Previews the custom window live while building but only applies it to the cards on Apply, Save, or picking a saved range, so editing the builder never refetches
- Keeps the saved range list consistent across sessions so a range saved in one session is picked up by another
- Animates saved ranges in and out, slides the selection highlight between options, and gives the pill a press response

CU-86bac8m4p
