### PR TITLE
feat: warn when balance adjustments are excluded from cash flow

### DIFF
--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -17,6 +17,7 @@ import { ApiError } from '@/api/auth'
 import { sanitizeMoneyInput } from '@/utils/moneyInput'
 import { waitForMilliseconds } from '@/utils/timing'
 import {
+  BALANCE_ADJUSTMENT_CATEGORY_NAME,
   INITIAL_TRANSACTION_FORM,
   KIND_LABELS,
   MERCHANT_DROPDOWN_PAGE_SIZE,
@@ -261,6 +262,12 @@ export default function CreateTransactionModal({
     ? { value: selectedMerchant.id, label: selectedMerchant.name }
     : undefined
   const selectedCategory = form.category_id ? categoryById.get(form.category_id) : undefined
+
+  // The synthetic balance adjustment category never counts toward cash flow, so warn when it is picked
+  const isBalanceAdjustmentCategory = !!(
+    selectedCategory?.is_system &&
+    selectedCategory.name === BALANCE_ADJUSTMENT_CATEGORY_NAME
+  )
   const showMerchantDefaultCategoryAction = !!(
     selectedMerchant &&
     selectedCategory &&
@@ -751,6 +758,7 @@ export default function CreateTransactionModal({
             categoryOptions={categoryOptions}
             categoryValue={form.category_id}
             categoryError={showError('category_id')}
+            isBalanceAdjustmentCategory={isBalanceAdjustmentCategory}
             showMerchantDefaultCategoryAction={showMerchantDefaultCategoryAction}
             merchantDefaultCategoryActionLabel={merchantDefaultCategoryActionLabel}
             merchantDefaultCategoryPending={updateMerchantMutation.isPending}

--- a/frontend/src/pages/transactions/components/transaction-modal/constants.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/constants.ts
@@ -5,6 +5,9 @@ import type {
 } from '@/pages/transactions/components/transaction-modal/types'
 
 export const EASE = [0.25, 0.1, 0.25, 1] as const
+
+// The backend tags synthetic balance adjustments with this system transfer category name and excludes them from cash flow
+export const BALANCE_ADJUSTMENT_CATEGORY_NAME = 'Balance Adjustment'
 export const SELECTOR_SPRING = { type: 'spring', stiffness: 420, damping: 36, mass: 0.8 } as const
 export const DEFAULT_CATEGORY_ICON = '🏷️'
 export const MIN_ADD_TRANSACTION_LOADING_MS = 800

--- a/frontend/src/pages/transactions/components/transaction-modal/controls/TransferCashFlowNotice.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/controls/TransferCashFlowNotice.tsx
@@ -1,0 +1,60 @@
+import { AlertTriangle } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
+
+type TransferCashFlowNoticeProps = {
+  show: boolean
+}
+
+/**
+ * Reminds the user that balance adjustments never count toward cash flow and that a
+ * transfer is the right way to record money actually moving between their accounts
+ */
+export default function TransferCashFlowNotice({
+  show,
+}: TransferCashFlowNoticeProps) {
+  return (
+    <AnimatePresence initial={false}>
+      {show && (
+        <motion.div
+          key="transfer-cash-flow-notice"
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          transition={{ duration: 0.2, ease: EASE }}
+          className="overflow-hidden"
+        >
+          <div
+            className="mt-3 rounded-lg px-3 py-2.5"
+            style={{
+              background: 'var(--app-warning-soft)',
+              border: '1px solid var(--app-border)',
+            }}
+          >
+            <div className="flex gap-2.5">
+              <div
+                className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
+                style={{ background: 'var(--app-bg)', color: 'var(--app-warning)' }}
+              >
+                <AlertTriangle size={13} aria-hidden />
+              </div>
+              <div className="min-w-0">
+                <p className="text-sm font-semibold leading-5">
+                  Balance adjustments are not cash flow
+                </p>
+                <p
+                  className="mt-0.5 text-sm leading-5"
+                  style={{ color: 'var(--app-text-muted)' }}
+                >
+                  A balance adjustment only corrects an account&apos;s balance, so it is left
+                  out of cash flow. If money actually moved between your accounts, pick a
+                  regular transfer category instead.
+                </p>
+              </div>
+            </div>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/pages/transactions/components/transaction-modal/constants'
 import TransactionModalFieldLabelRow from '@/pages/transactions/components/transaction-modal/controls/FieldLabelRow'
 import TransactionModalSectionFrame from '@/pages/transactions/components/transaction-modal/controls/SectionFrame'
+import TransferCashFlowNotice from '@/pages/transactions/components/transaction-modal/controls/TransferCashFlowNotice'
 import type { TransactionModalKind } from '@/pages/transactions/components/transaction-modal/types'
 import { formatCurrency } from '@/utils/formatCurrency'
 
@@ -39,6 +40,9 @@ interface TransactionReferencesSectionProps {
   categoryOptions: DropdownOption[]
   categoryValue: string
   categoryError?: string | false
+
+  // True when the chosen category is the synthetic balance adjustment, which is excluded from cash flow
+  isBalanceAdjustmentCategory: boolean
   showMerchantDefaultCategoryAction: boolean
   merchantDefaultCategoryActionLabel: string
   merchantDefaultCategoryPending: boolean
@@ -96,6 +100,7 @@ export default function TransactionReferencesSection({
   categoryOptions,
   categoryValue,
   categoryError,
+  isBalanceAdjustmentCategory,
   showMerchantDefaultCategoryAction,
   merchantDefaultCategoryActionLabel,
   merchantDefaultCategoryPending,
@@ -297,6 +302,7 @@ export default function TransactionReferencesSection({
           createNewLabel={readOnly ? undefined : (query) => query ? `Create category "${query}"` : 'Create category'}
           disabled={readOnly}
         />
+        <TransferCashFlowNotice show={isBalanceAdjustmentCategory} />
       </div>
 
       <div>


### PR DESCRIPTION
Show a warning in the create transaction modal when the Balance Adjustment category is chosen for a transfer

CU-86bab5nxg