### PR TITLE
refactor: simplify modal dropdown focus to keep users on the selected field

### DIFF
--- a/frontend/src/components/create-modal/ReferenceModalShell.tsx
+++ b/frontend/src/components/create-modal/ReferenceModalShell.tsx
@@ -134,7 +134,6 @@ export default function CreateReferenceModalShell({
               role="dialog"
               aria-modal="true"
               aria-labelledby={modalTitleId}
-              data-modal-field-focus-panel="true"
               className={layout.modalClassName}
               style={{
                 background: 'var(--app-bg)',

--- a/frontend/src/components/dropdown/Dropdown.tsx
+++ b/frontend/src/components/dropdown/Dropdown.tsx
@@ -164,6 +164,10 @@ const Dropdown = ({
   const handleSelect = (optionValue: string) => {
     onChange(optionValue);
     close();
+
+    // Closing unmounts the focused option or search input, so return focus to the trigger
+    // to keep the user on this field rather than dropping focus back to the modal top
+    triggerRef.current?.focus({ preventScroll: true });
   };
 
   const createQuery = searchText.trim();
@@ -217,6 +221,7 @@ const Dropdown = ({
         break;
       case 'Escape':
         close();
+        triggerRef.current?.focus({ preventScroll: true });
         break;
     }
   };

--- a/frontend/src/components/modal/focus.ts
+++ b/frontend/src/components/modal/focus.ts
@@ -6,8 +6,6 @@ const MODAL_FIELD_TAB_STOP_SELECTOR = [
   'button[role="combobox"]:not([disabled])',
 ].join(',')
 
-const MODAL_FIELD_FOCUS_PANEL_SELECTOR = '[data-modal-field-focus-panel="true"]'
-
 /**
  * Returns enabled modal fields that should receive sequential Tab focus
  */
@@ -33,25 +31,6 @@ export function getNextModalFieldTabStop<T>(
   }
 
   return fieldTabStops[activeIndex < 0 || activeIndex === fieldTabStops.length - 1 ? 0 : activeIndex + 1]
-}
-
-/**
- * Moves focus to the next modal field after a dropdown value is selected
- */
-export function requestNextModalFieldFocus(currentFieldId: string) {
-  window.requestAnimationFrame(() => {
-    const currentField = document.getElementById(currentFieldId)
-    const panel = currentField?.closest(MODAL_FIELD_FOCUS_PANEL_SELECTOR) as HTMLElement | null
-    if (!currentField || !panel) return
-
-    const nextField = getNextModalFieldTabStop(
-      getModalFieldTabStops(panel),
-      currentField,
-      false,
-    )
-
-    if (nextField && nextField !== currentField) nextField.focus({ preventScroll: true })
-  })
 }
 
 /**

--- a/frontend/src/components/reference-modals/CreateCategoryModal.tsx
+++ b/frontend/src/components/reference-modals/CreateCategoryModal.tsx
@@ -8,7 +8,6 @@ import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import CreateReferenceModalShell, {
   type CreateReferenceModalVariant,
 } from '@/components/create-modal/ReferenceModalShell'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import { CREATE_CATEGORY_FIELD_IDS } from '@/components/reference-modals/createCategoryConstants'
 import { waitForMilliseconds } from '@/utils/timing'
 
@@ -155,10 +154,7 @@ export default function CreateCategoryModal({
                   id={CREATE_CATEGORY_FIELD_IDS.icon}
                   categoryName={form.name || 'New category'}
                   value={form.icon}
-                  onChange={(icon) => {
-                    setField('icon', icon)
-                    requestNextModalFieldFocus(CREATE_CATEGORY_FIELD_IDS.icon)
-                  }}
+                  onChange={(icon) => setField('icon', icon)}
                   buttonClassName={`app-input flex h-10 w-10 items-center justify-center p-0 text-xl leading-none ${showError('icon') ? 'app-input-error' : ''}`}
                   hasError={!!showError('icon')}
                   modalFieldTabStop
@@ -208,10 +204,7 @@ export default function CreateCategoryModal({
                 id={CREATE_CATEGORY_FIELD_IDS.kind}
                 options={KIND_OPTIONS}
                 value={form.kind}
-                onChange={(value) => {
-                  setField('kind', value as CategoryKind)
-                  requestNextModalFieldFocus(CREATE_CATEGORY_FIELD_IDS.kind)
-                }}
+                onChange={(value) => setField('kind', value as CategoryKind)}
               />
             </div>
           </div>

--- a/frontend/src/components/reference-modals/CreateInstitutionModal.tsx
+++ b/frontend/src/components/reference-modals/CreateInstitutionModal.tsx
@@ -6,7 +6,6 @@ import Dropdown from '@/components/dropdown/Dropdown'
 import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow'
 import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import CreateReferenceModalShell from '@/components/create-modal/ReferenceModalShell'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import { CREATE_INSTITUTION_FIELD_IDS } from '@/components/reference-modals/createInstitutionConstants'
 import { COUNTRY_OPTIONS } from '@/constants/countries'
 import { waitForMilliseconds } from '@/utils/timing'
@@ -149,10 +148,7 @@ export default function CreateInstitutionModal({
                 id={CREATE_INSTITUTION_FIELD_IDS.country}
                 options={COUNTRY_OPTIONS}
                 value={form.country_code}
-                onChange={(value) => {
-                  handleChange('country_code', value)
-                  requestNextModalFieldFocus(CREATE_INSTITUTION_FIELD_IDS.country)
-                }}
+                onChange={(value) => handleChange('country_code', value)}
                 className={`app-input ${showError('country_code') ? 'app-input-error' : ''}`}
                 placeholder="Select country..."
                 searchable

--- a/frontend/src/components/reference-modals/CreateMerchantModal.tsx
+++ b/frontend/src/components/reference-modals/CreateMerchantModal.tsx
@@ -8,7 +8,6 @@ import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import CreateReferenceModalShell, {
   type CreateReferenceModalVariant,
 } from '@/components/create-modal/ReferenceModalShell'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import { CREATE_MERCHANT_FIELD_IDS, NO_DEFAULT_CATEGORY_VALUE } from '@/components/reference-modals/createMerchantConstants'
 import { waitForMilliseconds } from '@/utils/timing'
 
@@ -163,10 +162,7 @@ export default function CreateMerchantModal({
                 id={CREATE_MERCHANT_FIELD_IDS.defaultCategory}
                 options={categoryOptions}
                 value={form.default_category_id}
-                onChange={(value) => {
-                  setField('default_category_id', value)
-                  requestNextModalFieldFocus(CREATE_MERCHANT_FIELD_IDS.defaultCategory)
-                }}
+                onChange={(value) => setField('default_category_id', value)}
                 searchable
                 searchPlaceholder="Search categories..."
               />

--- a/frontend/src/pages/accounts/components/create-account-modal/Modal.tsx
+++ b/frontend/src/pages/accounts/components/create-account-modal/Modal.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo, type FormEvent } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import Dropdown from '@/components/dropdown/Dropdown';
-import { requestNextModalFieldFocus } from '@/components/modal/focus';
 import IconTooltip from '@/components/tooltips/IconTooltip';
 import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow';
 import CreateModalSectionFrame from '@/components/create-modal/SectionFrame';
@@ -108,7 +107,6 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
   const handleInstitutionCreated = (institution: { id: string }) => {
     handleChange('institution_id', institution.id);
     setShowInstitutionModal(false);
-    requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.institution);
   };
 
   const handleBlur = (field: CreateAccountValidatedField) => {
@@ -157,10 +155,7 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                   id={CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType}
                   options={CREATE_ACCOUNT_TYPE_OPTIONS}
                   value={form.account_type}
-                  onChange={(v) => {
-                    handleChange('account_type', v);
-                    requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.accountType);
-                  }}
+                  onChange={(v) => handleChange('account_type', v)}
                   className={`app-input ${showError('account_type') ? 'app-input-error' : ''}`}
                   placeholder="Select type..."
                   searchable
@@ -191,10 +186,7 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                   id={CREATE_ACCOUNT_MODAL_FIELD_IDS.currency}
                   options={currencyOptions}
                   value={form.currency}
-                  onChange={(v) => {
-                    handleChange('currency', v);
-                    requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.currency);
-                  }}
+                  onChange={(v) => handleChange('currency', v)}
                   className={`app-input ${showError('currency') ? 'app-input-error' : ''}`}
                   placeholder={currencies.length === 0 ? 'Loading currencies...' : 'Select currency...'}
                   searchable
@@ -217,10 +209,7 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                   id={CREATE_ACCOUNT_MODAL_FIELD_IDS.institution}
                   options={institutionOptions}
                   value={form.institution_id}
-                  onChange={(v) => {
-                    handleChange('institution_id', v);
-                    requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.institution);
-                  }}
+                  onChange={(v) => handleChange('institution_id', v)}
                   placeholder="Select institution..."
                   searchable
                   searchPlaceholder="Search institutions..."
@@ -284,10 +273,7 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                           id={CREATE_ACCOUNT_MODAL_FIELD_IDS.taxAdvantagedCategory}
                           options={taxPlanOptions}
                           value={form.tax_advantaged_category_id}
-                          onChange={(v) => {
-                            handleChange('tax_advantaged_category_id', v);
-                            requestNextModalFieldFocus(CREATE_ACCOUNT_MODAL_FIELD_IDS.taxAdvantagedCategory);
-                          }}
+                          onChange={(v) => handleChange('tax_advantaged_category_id', v)}
                           placeholder="Select category..."
                           searchable
                           searchPlaceholder="Search categories..."

--- a/frontend/src/pages/accounts/components/create-account-modal/Shell.tsx
+++ b/frontend/src/pages/accounts/components/create-account-modal/Shell.tsx
@@ -68,7 +68,6 @@ export default function CreateAccountModalShell({
               role="dialog"
               aria-modal="true"
               aria-labelledby="create-account-title"
-              data-modal-field-focus-panel="true"
               className="app-modal-panel flex max-h-[86vh] w-full max-w-2xl overflow-hidden rounded-2xl"
               style={{
                 background: 'var(--app-bg)',

--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -11,13 +11,9 @@ import { useInstitutions } from '@/api/institutions'
 import { useTaxAdvantagedCategories } from '@/api/taxAdvantagedCategories'
 import CreateInstitutionModal from '@/components/reference-modals/CreateInstitutionModal'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
 import { waitForMilliseconds } from '@/utils/timing'
-import {
-  EDIT_ACCOUNT_IDENTITY_FIELD_IDS,
-  EASE,
-} from '@/pages/accounts/detail/constants/accountDetail'
+import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
 import {
   createIdentityFormValues,
   getIdentityFieldErrors,
@@ -120,7 +116,6 @@ export default function EditAccountIdentityModal({
   const handleInstitutionCreated = (institution: { id: string }) => {
     setField('institution_id', institution.id)
     setShowInstitutionModal(false)
-    requestNextModalFieldFocus(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution)
   }
 
   /**
@@ -263,7 +258,6 @@ export default function EditAccountIdentityModal({
               role="dialog"
               aria-modal="true"
               aria-labelledby="edit-account-identity-title"
-              data-modal-field-focus-panel="true"
               className="app-modal-panel flex max-h-[84vh] w-full max-w-2xl overflow-hidden rounded-2xl"
               style={{
                 background: 'var(--app-bg)',

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
@@ -1,6 +1,5 @@
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import Dropdown from '@/components/dropdown/Dropdown'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import { EDIT_ACCOUNT_IDENTITY_FIELD_IDS } from '@/pages/accounts/detail/constants/accountDetail'
 import {
   formatMoneyInputLive,
@@ -45,10 +44,7 @@ export function AccountDetailsSection({
             id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.taxAdvantagedCategory}
             options={taxAdvantagedCategoryOptions}
             value={form.tax_advantaged_category_id}
-            onChange={(value) => {
-              setField('tax_advantaged_category_id', value)
-              requestNextModalFieldFocus(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.taxAdvantagedCategory)
-            }}
+            onChange={(value) => setField('tax_advantaged_category_id', value)}
             placeholder="Select category..."
             searchable
             searchPlaceholder="Search categories..."

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/IdentitySection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/IdentitySection.tsx
@@ -1,6 +1,5 @@
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import Dropdown from '@/components/dropdown/Dropdown'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import { EDIT_ACCOUNT_IDENTITY_FIELD_IDS } from '@/pages/accounts/detail/constants/accountDetail'
 import type {
   IdentityFieldErrors,
@@ -47,10 +46,7 @@ export function AccountIdentitySection({
           id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution}
           options={institutionOptions}
           value={form.institution_id}
-          onChange={(value) => {
-            setField('institution_id', value)
-            requestNextModalFieldFocus(EDIT_ACCOUNT_IDENTITY_FIELD_IDS.institution)
-          }}
+          onChange={(value) => setField('institution_id', value)}
           placeholder="Select institution..."
           searchable
           searchPlaceholder="Search institutions..."

--- a/frontend/src/pages/budgets/components/budget-editor-modal/layout/Shell.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/layout/Shell.tsx
@@ -103,7 +103,6 @@ export default function BudgetEditorModalShell({
               role="dialog"
               aria-modal="true"
               aria-labelledby={titleId}
-              data-modal-field-focus-panel="true"
               className={appearance.panelClassName}
               style={{
                 background: 'var(--app-bg)',

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -1,5 +1,4 @@
 import Dropdown from '@/components/dropdown/Dropdown'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import type { BudgetEditorModalErrorGetter, BudgetEditorModalFieldIds, BudgetEditorModalHandlers, BudgetEditorModalOptions, BudgetEditorModalViewState } from '@/pages/budgets/components/budget-editor-modal/types'
 import BudgetEditorFieldLabelRow from '@/pages/budgets/components/shared/EditorFieldLabelRow'
@@ -97,10 +96,7 @@ export default function BudgetEditorModalScopeSection({
                   label: `${currency.id} · ${currency.name}`,
                 }))}
                 value={form.currency}
-                onChange={(value) => {
-                  setField('currency', value)
-                  requestNextModalFieldFocus(ids.currency)
-                }}
+                onChange={(value) => setField('currency', value)}
                 className={`app-input ${showError('currency') ? 'app-input-error' : ''}`}
                 placeholder={currencies.length === 0 ? 'Loading currencies...' : 'Select currency...'}
                 searchable

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal.tsx
@@ -5,7 +5,6 @@ import { Landmark, X } from 'lucide-react'
 import type { Currency } from '@/api/currency'
 import type { TaxTreatment } from '@/api/taxAdvantagedCategories'
 import Dropdown from '@/components/dropdown/Dropdown'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
 import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
 import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 import { useCreateTaxAdvantagedCategoryForm } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCreateCategoryForm'
@@ -80,7 +79,6 @@ export default function CreateTaxAdvantagedCategoryModal({
           role="dialog"
           aria-modal="true"
           aria-labelledby="create-tax-advantaged-category-title"
-          data-modal-field-focus-panel="true"
           className="app-modal-panel flex max-h-[86vh] w-full max-w-3xl overflow-hidden rounded-2xl"
           style={{
             background: 'var(--app-bg)',
@@ -164,10 +162,7 @@ export default function CreateTaxAdvantagedCategoryModal({
                           id={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.taxTreatment}
                           options={TAX_TREATMENT_OPTIONS}
                           value={form.tax_treatment}
-                          onChange={(value) => {
-                            setField('tax_treatment', value as TaxTreatment)
-                            requestNextModalFieldFocus(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.taxTreatment)
-                          }}
+                          onChange={(value) => setField('tax_treatment', value as TaxTreatment)}
                         />
                       </div>
                     </div>
@@ -198,10 +193,7 @@ export default function CreateTaxAdvantagedCategoryModal({
                           id={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.currency}
                           options={options}
                           value={selectedCurrency}
-                          onChange={(value) => {
-                            setField('currency', value)
-                            requestNextModalFieldFocus(CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.currency)
-                          }}
+                          onChange={(value) => setField('currency', value)}
                           placeholder="Select currency"
                           searchable
                           searchPlaceholder="Search currencies..."

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -65,8 +65,6 @@ import TransactionTypeDirectionSection from '@/pages/transactions/components/tra
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 import { usePagedReferenceDropdown } from '@/pages/transactions/components/transaction-modal/hooks/usePagedReferenceDropdown'
 import { useTransactionModalEnvironment } from '@/pages/transactions/components/transaction-modal/hooks/useEnvironment'
-import { requestNextModalFieldFocus } from '@/components/modal/focus'
-import { TRANSACTION_MODAL_FIELD_IDS } from '@/pages/transactions/components/transaction-modal/constants'
 
 export default function CreateTransactionModal({
   open,
@@ -327,7 +325,6 @@ export default function CreateTransactionModal({
     }))
     if (kindChanged) setDirectionHighlightKey((key) => key + 1)
     clearError('category_id')
-    requestNextModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.category)
   }
 
   const handleCreateCategory = (name: string) => {
@@ -391,7 +388,6 @@ export default function CreateTransactionModal({
     if (kindChanged) setDirectionHighlightKey((key) => key + 1)
     clearError('merchant_id')
     if (defaultCategoryId) clearError('category_id')
-    requestNextModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.merchant)
   }
 
   const handleCreateMerchant = (name: string) => {
@@ -466,7 +462,6 @@ export default function CreateTransactionModal({
     clearError('account_id')
     clearError('currency')
     clearError('to_account_id')
-    requestNextModalFieldFocus(TRANSACTION_MODAL_FIELD_IDS.account)
   }
 
   const handleToAccountChange = (accountId: string) => {

--- a/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/layout/Shell.tsx
@@ -60,7 +60,6 @@ export default function TransactionModalShell({
               role="dialog"
               aria-modal="true"
               aria-labelledby="create-txn-title"
-              data-modal-field-focus-panel="true"
               className="app-modal-panel flex max-h-[86vh] w-full max-w-2xl overflow-hidden rounded-2xl"
               transition={{ layout: { duration: 0.22, ease: EASE } }}
               style={{


### PR DESCRIPTION
- Remove the auto-advance-to-next-field behaviour from modal dropdowns, which caused keyboard pop-ups and scroll jumps on mobile and tablet and was not worth the upkeep
- After picking a dropdown value or pressing Escape, focus now returns to that dropdown's trigger so the next Tab continues from the same field instead of restarting at the top of the modal
- Drop the now-unused panel marker attribute and focus helper that only the auto-advance path relied on
- Keep the existing modal Tab confinement and the focus-the-first-field-on-open behaviour unchanged