### PR TITLE
Frontend visual and animation consistency polish

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,7 +77,6 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase }
   // Only show loading screen if there's a session being restored or user just authenticated
   const shouldShowLoading = loading || (!hasShownLoadingScreen && user);
   const [minTimePassed, setMinTimePassed] = useState(hasShownLoadingScreen);
-  const [animateInitialPageMount] = useState(() => !hasShownLoadingScreen);
   const ready = !loading && minTimePassed;
 
   // The loading phase runs after the switch while the new route's chunk mounts
@@ -113,8 +112,10 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase }
 
   // The Routes subtree remounts on each path change, so this wrapper is recreated
   // per navigation and must start hidden through both loading and entering, otherwise
-  // an already-cached route mounts at full opacity and snaps in instead of fading
-  const pageContentEntering = pageTransitionPhase === 'entering' || pageTransitionPhase === 'loading' || animateInitialPageMount;
+  // an already-mounted route shows at full opacity and snaps in instead of fading.
+  // The first mount also starts in the loading phase, so the fade waits for the lazy
+  // chunk to mount rather than animating the empty Suspense wrapper before it resolves
+  const pageContentEntering = pageTransitionPhase === 'entering' || pageTransitionPhase === 'loading';
 
   return (
     <>
@@ -186,7 +187,11 @@ function PublicRoute() {
 function AnimatedRoutes() {
   const location = useLocation();
   const [displayLocation, setDisplayLocation] = useState(location);
-  const [pageTransitionPhase, setPageTransitionPhase] = useState<PageTransitionPhase>('idle');
+
+  // Start in the loading phase so the very first route fades in through the same
+  // chunk-ready gate as later navigations, instead of fading the empty wrapper
+  // before its lazy chunk resolves and letting the real content snap in
+  const [pageTransitionPhase, setPageTransitionPhase] = useState<PageTransitionPhase>('loading');
 
   // Reveal the freshly switched route only once its chunk has mounted, so the enter
   // fade animates real content rather than an empty wrapper. The functional updater

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -142,8 +142,6 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase }
           className="flex min-h-screen"
           style={{ backgroundColor: 'var(--app-bg)', color: 'var(--app-text)' }}
         >
-          <Navigation />
-
           {/* The main variant keeps the navigation visible while AnimatePresence
               lets the loader fade back out once the route chunk has mounted */}
           <AnimatePresence>
@@ -205,6 +203,7 @@ function PublicRoute() {
 
 function AnimatedRoutes() {
   const location = useLocation();
+  const { user } = useAuth();
   const [displayLocation, setDisplayLocation] = useState(location);
 
   // Start in the loading phase so the very first route fades in through the same
@@ -274,10 +273,15 @@ function AnimatedRoutes() {
   }, [pageTransitionPhase]);
 
   return (
-    <Routes
-      location={displayLocation}
-      key={displayLocation.pathname === '/signup' ? '/login' : displayLocation.pathname}
-    >
+    <>
+      {/* The navigation chrome renders outside the keyed Routes so it persists across
+          page changes. A persistent nav lets the active-link highlight crossfade through
+          its CSS transition instead of snapping when the route subtree remounts */}
+      {user && isProtectedPath(displayLocation.pathname) && <Navigation />}
+      <Routes
+        location={displayLocation}
+        key={displayLocation.pathname === '/signup' ? '/login' : displayLocation.pathname}
+      >
         {/* Public routes — login, signup */}
         <Route element={<PublicRoute />}>
           <Route path="/login" element={<AuthPage />} />
@@ -297,7 +301,8 @@ function AnimatedRoutes() {
         </Route>
 
         <Route path="*" element={<Navigate to="/" replace />} />
-    </Routes>
+      </Routes>
+    </>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useLayoutEffect, useCallback, lazy, Suspense } from 'react'
+import { useState, useEffect, useLayoutEffect, useCallback, startTransition, lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation, type Location } from 'react-router-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import { AuthProvider } from '@/contexts/AuthContext'
@@ -83,6 +83,21 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase }
   const routeLoading = pageTransitionPhase === 'loading';
   const [routeLoaderDelayElapsed, setRouteLoaderDelayElapsed] = useState(false);
 
+  // Hold the heavy page body back until the navigation shell has painted, then
+  // mount it as a non-urgent transition. The route subtree remounts per path, so
+  // this resets on every navigation. Without it the lazy page and its charts render
+  // in one blocking commit that freezes taps on the menu and toolbar for the length
+  // of that render, which is roughly a second on a phone
+  const [contentMounted, setContentMounted] = useState(false);
+
+  useEffect(() => {
+    if (!ready) return;
+    const frame = requestAnimationFrame(() => {
+      startTransition(() => setContentMounted(true));
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [ready]);
+
   useCacheValidation(user?.id, Boolean(user && ready));
 
   // Hold the route loader back until the chunk has stayed pending past the delay so
@@ -159,8 +174,12 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase }
               style={{ pointerEvents: pageContentVisible ? 'auto' : 'none' }}
             >
               <Suspense fallback={null}>
-                <RouteReadyNotifier path={displayLocation.pathname} onReady={onContentReady} />
-                <Outlet />
+                {contentMounted && (
+                  <>
+                    <RouteReadyNotifier path={displayLocation.pathname} onReady={onContentReady} />
+                    <Outlet />
+                  </>
+                )}
               </Suspense>
             </motion.div>
           </main>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -127,7 +127,7 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase }
 
   // The Routes subtree remounts on each path change, so this wrapper is recreated
   // per navigation and must start hidden through both loading and entering, otherwise
-  // an already-mounted route shows at full opacity and snaps in instead of fading.
+  // an already-mounted route shows at full opacity and snaps in instead of fading
   // The first mount also starts in the loading phase, so the fade waits for the lazy
   // chunk to mount rather than animating the empty Suspense wrapper before it resolves
   const pageContentEntering = pageTransitionPhase === 'entering' || pageTransitionPhase === 'loading';

--- a/frontend/src/components/charts/CursorTooltipPortal.tsx
+++ b/frontend/src/components/charts/CursorTooltipPortal.tsx
@@ -14,7 +14,6 @@ type CursorTooltipPortalProps = {
 }
 
 const defaultTooltipStyle: CSSProperties = {
-  maxWidth: 'var(--app-cursor-tooltip-max-width, calc(100vw - 16px))',
   transition: 'opacity 150ms ease-out, transform 160ms cubic-bezier(0.22, 1, 0.36, 1)',
   willChange: 'opacity, transform',
 }
@@ -28,14 +27,18 @@ const CursorTooltipPortal = forwardRef<HTMLDivElement, CursorTooltipPortalProps>
   const tooltip = (
     <div
       ref={ref}
-      className={`app-chart-tooltip-default-content pointer-events-none fixed left-0 top-0 z-[60] ${className}`}
+      className="pointer-events-none fixed left-0 top-0 z-[60]"
       onTransitionEnd={onTransitionEnd}
       style={{
         ...defaultTooltipStyle,
         ...style,
       }}
     >
-      {children}
+      {/* The inner card carries the above/below flip so it can animate while the outer wrapper keeps
+          following the cursor instantly */}
+      <div className={`app-cursor-tooltip-flip app-chart-tooltip-default-content ${className}`}>
+        {children}
+      </div>
     </div>
   )
 

--- a/frontend/src/components/charts/DeferredTooltipOverlay.tsx
+++ b/frontend/src/components/charts/DeferredTooltipOverlay.tsx
@@ -77,7 +77,7 @@ function DeferredChartTooltipOverlayInner<T>({
     const tooltip = tooltipRef.current
     if (!chart || !rect || !tooltip) return
 
-    const { x: tooltipX, y: tooltipY, maxWidth } = getCursorTooltipPosition({
+    const { x: tooltipX, y: tooltipY, flipY, maxWidth } = getCursorTooltipPosition({
       origin: chart,
       tooltip,
       clientX: pointer.clientX,
@@ -92,6 +92,7 @@ function DeferredChartTooltipOverlayInner<T>({
 
     tooltip.style.setProperty('--chart-tooltip-x', `${tooltipX}px`)
     tooltip.style.setProperty('--chart-tooltip-y', `${tooltipY}px`)
+    tooltip.style.setProperty('--cursor-tooltip-flip-y', `${flipY}px`)
     tooltip.style.setProperty('--app-cursor-tooltip-max-width', `${maxWidth}px`)
     guideRef.current?.style.setProperty('--chart-tooltip-guide-x', `${guideX}px`)
     guideRef.current?.style.setProperty('--chart-tooltip-guide-width', `${resolvedGuideWidth}px`)

--- a/frontend/src/components/filters/MultiSelectChecklist.tsx
+++ b/frontend/src/components/filters/MultiSelectChecklist.tsx
@@ -115,8 +115,8 @@ function ChecklistRow({
         role="checkbox"
         aria-checked={selected}
         onClick={() => onToggle(option.value)}
-        className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-[var(--app-surface-soft)]"
-        style={{ color: selected ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: selected ? 500 : 400 }}
+        className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
+        style={{ color: selected ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: selected ? 500 : 400, background: selected ? 'var(--app-accent-soft)' : undefined }}
       >
         {option.icon && (
           <span className="shrink-0 text-base leading-none" aria-hidden>

--- a/frontend/src/components/filters/MultiSelectChecklist.tsx
+++ b/frontend/src/components/filters/MultiSelectChecklist.tsx
@@ -55,7 +55,7 @@ export function MultiSelectChecklist({ options, selectedValues, searchPlaceholde
         />
       </div>
 
-      <ul className={fillHeight ? 'min-h-0 flex-1 overflow-auto' : 'max-h-56 overflow-auto'}>
+      <ul className={fillHeight ? 'min-h-0 flex-1 space-y-1 overflow-auto py-2' : 'max-h-56 space-y-1 overflow-auto py-2'}>
         {filtered.length === 0 ? (
           <li className="px-2 py-2 text-xs" style={{ color: 'var(--app-text-subtle)' }}>
             No matches
@@ -69,7 +69,7 @@ export function MultiSelectChecklist({ options, selectedValues, searchPlaceholde
               >
                 {group.label}
               </div>
-              <ul>
+              <ul className="space-y-1">
                 {group.items.map((option) => (
                   <ChecklistRow
                     key={option.value}

--- a/frontend/src/components/filters/MultiSelectChecklist.tsx
+++ b/frontend/src/components/filters/MultiSelectChecklist.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Check, Search } from 'lucide-react'
 import type { OptionItem } from '@/components/filters/OptionList'
+import { getFilterOptionListClass, getFilterOptionStyle } from '@/components/filters/optionAppearance'
 import { joinClassNames } from '@/utils/classNames'
 
 type MultiSelectChecklistProps = {
@@ -55,7 +56,7 @@ export function MultiSelectChecklist({ options, selectedValues, searchPlaceholde
         />
       </div>
 
-      <ul className={fillHeight ? 'min-h-0 flex-1 space-y-1 overflow-auto py-2' : 'max-h-56 space-y-1 overflow-auto py-2'}>
+      <ul className={getFilterOptionListClass(fillHeight)}>
         {filtered.length === 0 ? (
           <li className="px-2 py-2 text-xs" style={{ color: 'var(--app-text-subtle)' }}>
             No matches
@@ -116,7 +117,7 @@ function ChecklistRow({
         aria-checked={selected}
         onClick={() => onToggle(option.value)}
         className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
-        style={{ color: selected ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: selected ? 500 : 400, background: selected ? 'var(--app-accent-soft)' : undefined }}
+        style={getFilterOptionStyle(selected)}
       >
         {option.imageUrl ? (
           <img

--- a/frontend/src/components/filters/MultiSelectChecklist.tsx
+++ b/frontend/src/components/filters/MultiSelectChecklist.tsx
@@ -118,10 +118,20 @@ function ChecklistRow({
         className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
         style={{ color: selected ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: selected ? 500 : 400, background: selected ? 'var(--app-accent-soft)' : undefined }}
       >
-        {option.icon && (
-          <span className="shrink-0 text-base leading-none" aria-hidden>
-            {option.icon}
-          </span>
+        {option.imageUrl ? (
+          <img
+            src={option.imageUrl}
+            alt=""
+            aria-hidden
+            loading="lazy"
+            className="h-5 w-5 shrink-0 rounded-md object-contain"
+          />
+        ) : (
+          option.icon && (
+            <span className="shrink-0 text-base leading-none" aria-hidden>
+              {option.icon}
+            </span>
+          )
         )}
         <span className="min-w-0 flex-1 truncate">{option.label}</span>
         {selected && <Check size={15} aria-hidden className="shrink-0" />}

--- a/frontend/src/components/filters/OptionList.tsx
+++ b/frontend/src/components/filters/OptionList.tsx
@@ -7,4 +7,6 @@ export interface OptionItem {
   label: string
   group?: string
   icon?: string | null
+  // Logo or image source shown in place of the text icon, used by the institution filter options
+  imageUrl?: string | null
 }

--- a/frontend/src/components/filters/hooks/useToolbarStuck.ts
+++ b/frontend/src/components/filters/hooks/useToolbarStuck.ts
@@ -1,0 +1,57 @@
+import { useEffect, useRef, useState, type RefObject } from 'react'
+
+// The toolbar docks 10px below the viewport top so the search field's own 10px of top padding lands
+// its top on the navigation pane's 1.25rem (20px) top line rather than below it. Keep in sync with the
+// top-2.5 sticky offset on the toolbar element
+export const TOOLBAR_DOCK_OFFSET_PX = 10
+export const DESKTOP_MEDIA_QUERY = '(min-width: 1050px)'
+
+export type ToolbarStuckState = {
+  toolbarStuckSentinelRef: RefObject<HTMLDivElement | null>
+  isToolbarStuck: boolean
+}
+
+/**
+ * Tracks when the desktop toolbar has pinned to the navigation pane's top line so its background can
+ * extend upward and mask the list content scrolling through the gap above it
+ */
+export function useToolbarStuck(): ToolbarStuckState {
+  const toolbarStuckSentinelRef = useRef<HTMLDivElement>(null)
+  const [isToolbarStuck, setIsToolbarStuck] = useState(false)
+
+  useEffect(() => {
+    const sentinel = toolbarStuckSentinelRef.current
+    if (!sentinel) return undefined
+
+    const desktopQuery = window.matchMedia(DESKTOP_MEDIA_QUERY)
+    let sentinelIntersecting = true
+
+    /**
+     * Combines viewport width and sentinel visibility so the upward mask only applies on desktop, where
+     * the toolbar docks below the viewport edge
+     */
+    function updateStuck() {
+      setIsToolbarStuck(desktopQuery.matches && !sentinelIntersecting)
+    }
+
+    // Shrinking the root's top edge by the nav offset makes the sentinel read as hidden exactly when
+    // the toolbar reaches the pane's top line instead of when it touches the viewport edge
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        sentinelIntersecting = entry.isIntersecting
+        updateStuck()
+      },
+      { rootMargin: `-${TOOLBAR_DOCK_OFFSET_PX}px 0px 0px 0px`, threshold: 0 },
+    )
+
+    observer.observe(sentinel)
+    desktopQuery.addEventListener('change', updateStuck)
+
+    return () => {
+      observer.disconnect()
+      desktopQuery.removeEventListener('change', updateStuck)
+    }
+  }, [])
+
+  return { toolbarStuckSentinelRef, isToolbarStuck }
+}

--- a/frontend/src/components/filters/optionAppearance.ts
+++ b/frontend/src/components/filters/optionAppearance.ts
@@ -1,0 +1,24 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * Returns the accent fill, text colour, and weight that mark a selected filter option, keeping the
+ * checklist rows and facet dropdowns aligned with the theme switcher and segmented control selection
+ * colours
+ */
+export function getFilterOptionStyle(selected: boolean): CSSProperties {
+  return {
+    color: selected ? 'var(--app-accent)' : 'var(--app-text)',
+    fontWeight: selected ? 500 : 400,
+    background: selected ? 'var(--app-accent-soft)' : undefined,
+  }
+}
+
+/**
+ * Returns the scroll container classes shared by the filter option lists, switching between the
+ * capped desktop height and the fill height the mobile sheet gives the list
+ */
+export function getFilterOptionListClass(fillHeight: boolean): string {
+  return fillHeight
+    ? 'min-h-0 flex-1 space-y-1 overflow-auto py-2'
+    : 'max-h-56 space-y-1 overflow-auto py-2'
+}

--- a/frontend/src/components/list-controls/GlassSearchField.tsx
+++ b/frontend/src/components/list-controls/GlassSearchField.tsx
@@ -1,0 +1,51 @@
+import { Search } from 'lucide-react'
+import { joinClassNames } from '@/utils/classNames'
+
+type GlassSearchFieldProps = {
+  value: string
+  onValueChange: (value: string) => void
+  placeholder: string
+  // Extra wrapper classes carrying the per-surface layout, such as the sticky toolbar margins or a
+  // modal section's flex sizing
+  wrapperClassName?: string
+  inputId?: string
+  disabled?: boolean
+  // Called on Enter for the surfaces that commit the search on submit instead of filtering as the
+  // user types
+  onSubmit?: () => void
+}
+
+/**
+ * Renders the shared glass search field: a leading search glyph over the translucent glass input,
+ * fixed to the 44px control height used across the toolbars, settings, and modals
+ */
+export function GlassSearchField({
+  value,
+  onValueChange,
+  placeholder,
+  wrapperClassName,
+  inputId,
+  disabled,
+  onSubmit,
+}: GlassSearchFieldProps) {
+  return (
+    <div className={joinClassNames('relative min-w-0', wrapperClassName)}>
+      <Search
+        size={16}
+        className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
+        style={{ color: 'var(--app-text-subtle)' }}
+        aria-hidden
+      />
+      <input
+        id={inputId}
+        type="text"
+        className="app-glass-input h-11 w-full pl-9"
+        value={value}
+        placeholder={placeholder}
+        disabled={disabled}
+        onChange={(event) => onValueChange(event.target.value)}
+        onKeyDown={onSubmit ? (event) => { if (event.key === 'Enter') onSubmit() } : undefined}
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/list-controls/toolbarStyles.ts
+++ b/frontend/src/components/list-controls/toolbarStyles.ts
@@ -1,0 +1,41 @@
+import type { CSSProperties } from 'react'
+import type { Transition } from 'motion/react'
+import { joinClassNames } from '@/utils/classNames'
+
+// The collapsed filter pill matches the 44px create and search control height once its 1px glass
+// border is added, so the head fixes its inner height to 42px
+export const FILTER_PILL_HEAD_STYLE: CSSProperties = {
+  height: 42,
+  padding: '0 16px',
+  gap: 8,
+  fontSize: '0.9375rem',
+}
+
+// The panel grows its height on a slower curve than the cross-fade so the content settles after the
+// box has finished expanding
+export const FILTER_PANEL_BODY_TRANSITION: Transition = {
+  height: { duration: 0.45, ease: [0.22, 1, 0.36, 1] },
+  opacity: { duration: 0.26, delay: 0.05 },
+}
+
+/**
+ * Builds the sticky classes that dock the list toolbar to the navigation pane line on desktop, with
+ * the inline layout moving the search and actions onto one row from the medium breakpoint up
+ */
+export function getToolbarStickyRowClass(desktopInlineLayout: boolean): string {
+  return joinClassNames(
+    'sticky top-0 z-30 !mt-1 mb-1 flex flex-col gap-3 pb-1 pt-2 min-[1050px]:top-2.5 min-[1050px]:pt-2.5',
+    desktopInlineLayout && 'min-[750px]:flex-row min-[750px]:items-center',
+  )
+}
+
+/**
+ * Returns the toolbar drop shadow. While docked at the nav line the upward shadow masks list rows
+ * scrolling through the gap above the toolbar, and it drops at rest so it never covers the content
+ * above the row
+ */
+export function getToolbarStuckShadow(isStuck: boolean): string {
+  return isStuck
+    ? '0 0.25rem 0 var(--app-bg), 0 -1.5rem 0 var(--app-bg)'
+    : '0 0.25rem 0 var(--app-bg)'
+}

--- a/frontend/src/components/loading/Screen.tsx
+++ b/frontend/src/components/loading/Screen.tsx
@@ -4,9 +4,12 @@ type LoadingScreenProps = {
   variant?: 'screen' | 'main';
 };
 
+// The overlay carries no interactive content, so it stays click-through the whole
+// time it is mounted, otherwise its exit fade keeps swallowing taps on the menu and
+// in-page buttons for the length of the fade after the content is already interactive
 const loadingScreenClassNames = {
-  screen: 'fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6',
-  main: 'fixed inset-0 z-30 flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6 min-[1050px]:left-[260px]',
+  screen: 'pointer-events-none fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6',
+  main: 'pointer-events-none fixed inset-0 z-30 flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6 min-[1050px]:left-[260px]',
 };
 
 const LoadingScreen = ({ variant = 'screen' }: LoadingScreenProps) => (

--- a/frontend/src/components/navigation/Mobile.tsx
+++ b/frontend/src/components/navigation/Mobile.tsx
@@ -48,12 +48,7 @@ export function MobileNavigation({
         aria-controls="mobile-primary-navigation"
         aria-expanded={isOpen}
         onClick={() => setIsOpen((open) => !open)}
-        className="app-icon-button fixed right-4 top-4 z-50 h-11 w-11 min-[1050px]:hidden"
-        style={{
-          background: 'var(--app-nav-bg)',
-          border: '1px solid var(--app-border)',
-          color: 'var(--app-text)',
-        }}
+        className="app-glass-icon-button fixed right-4 top-2 z-50 h-11 w-11 min-[1050px]:hidden"
       >
         <AnimatedMobileMenuIcon isOpen={isOpen} shouldReduceMotion={shouldReduceMotion} />
       </button>

--- a/frontend/src/components/time-range/Selector.tsx
+++ b/frontend/src/components/time-range/Selector.tsx
@@ -215,7 +215,7 @@ function MobileTimeRangeSelector<T extends string>({
             transition={shouldReduceMotion ? { duration: 0 } : mobileDropdownTransition}
             style={{ transformOrigin: dropdownOrigin, willChange: 'transform, opacity' }}
           >
-            <div className="py-1">
+            <div>
               {options.map((option) => {
                 const active = option.value === value
                 const optionDisplay = option.description ?? option.label

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -143,12 +143,15 @@ export default function TransactionRow({
         opacity: readOnly ? 0.68 : 1,
       }}
     >
-      <span className="hidden min-[1300px]:grid min-[1300px]:grid-cols-[2.5rem_14rem_13rem_minmax(2.75rem,1fr)_max-content_minmax(8rem,1fr)] min-[1300px]:items-center min-[1300px]:gap-3">
-        <span className="text-2xl leading-none" aria-hidden>
+      {/* Desktop row: category and account size to their content while notes is the flexible filler
+          that compresses first, then the tags compress (their high flex-shrink lets them give way
+          before the names), keeping the tags pinned to the right next to the always-visible amount */}
+      <span className="hidden min-[1300px]:flex min-[1300px]:items-center min-[1300px]:gap-3">
+        <span className="w-10 shrink-0 text-2xl leading-none" aria-hidden>
           {categoryIcon}
         </span>
 
-        <span className="min-w-0">
+        <span className="min-w-[11rem]">
           <span className="block truncate font-medium">{categoryName}</span>
           <span
             className="mt-0.5 block truncate text-sm"
@@ -158,75 +161,67 @@ export default function TransactionRow({
           </span>
         </span>
 
-        <span className="flex min-w-0 items-center self-stretch">
-          {hasAccountMeta ? (
-            <span
-              className="flex min-w-0 max-w-full flex-col gap-1 text-sm font-medium leading-none"
-              style={{ color: 'var(--app-text-muted)' }}
-            >
-              <span className="inline-flex min-w-0 max-w-full items-center gap-2">
-                <AccountLogo accountName={accountName} institution={accountInstitution} />
-                {accountName && <span className="min-w-0 truncate">{accountName}</span>}
-              </span>
-              {readOnlyReason && <ReadOnlyReasonPill reason={readOnlyReason} />}
+        {hasAccountMeta && (
+          <span
+            className="flex min-w-[13rem] flex-col gap-1 text-sm font-medium leading-none"
+            style={{ color: 'var(--app-text-muted)' }}
+          >
+            <span className="inline-flex min-w-0 max-w-full items-center gap-2">
+              <AccountLogo accountName={accountName} institution={accountInstitution} />
+              {accountName && <span className="min-w-0 truncate">{accountName}</span>}
             </span>
-          ) : (
-            <span aria-hidden>&nbsp;</span>
-          )}
-        </span>
+            {readOnlyReason && <ReadOnlyReasonPill reason={readOnlyReason} />}
+          </span>
+        )}
 
         <span
-          className="flex min-w-0 items-center self-stretch overflow-hidden text-sm leading-none"
+          className="min-w-0 flex-1 truncate px-5 text-sm leading-none"
           style={{ color: 'var(--app-text-muted)' }}
         >
-          <span className="min-w-0 truncate whitespace-nowrap">
-            {transaction.notes || '\u00A0'}
-          </span>
+          {transaction.notes}
         </span>
 
-        <span className="flex min-w-0 justify-end gap-1.5">
-          {hasVisibleTags && (
-            <>
-              {visibleTags.map((tag) => (
+        {hasVisibleTags && (
+          <span className="flex shrink-0 justify-end gap-1.5">
+            {visibleTags.map((tag) => (
+              <span
+                key={tag.id}
+                className="group relative inline-flex max-w-[8rem] shrink-0"
+              >
                 <span
-                  key={tag.id}
-                  className="group relative inline-flex max-w-[8rem] shrink-0"
+                  className="inline-flex min-w-0 items-center gap-1 rounded-full px-2 py-0.5 text-sm font-medium"
+                  style={{
+                    background: 'var(--app-surface-soft)',
+                    color: 'var(--app-text-muted)',
+                    border: '1px solid var(--app-border)',
+                  }}
                 >
-                  <span
-                    className="inline-flex min-w-0 items-center gap-1 rounded-full px-2 py-0.5 text-sm font-medium"
-                    style={{
-                      background: 'var(--app-surface-soft)',
-                      color: 'var(--app-text-muted)',
-                      border: '1px solid var(--app-border)',
-                    }}
-                  >
-                    <TagIcon size={11} aria-hidden className="shrink-0" />
-                    <span className="truncate">{tag.name}</span>
-                  </span>
-                  <TagTooltip tags={tags} />
+                  <TagIcon size={11} aria-hidden className="shrink-0" />
+                  <span className="truncate">{tag.name}</span>
                 </span>
-              ))}
-              {extraTagCount > 0 && (
-                <span className="group relative inline-flex shrink-0">
-                  <span
-                    className="inline-flex rounded-full px-2 py-0.5 text-sm font-medium"
-                    style={{
-                      background: 'var(--app-surface-soft)',
-                      color: 'var(--app-text-muted)',
-                      border: '1px solid var(--app-border)',
-                    }}
-                  >
-                    +{extraTagCount}
-                  </span>
-                  <TagTooltip tags={tags} />
+                <TagTooltip tags={tags} />
+              </span>
+            ))}
+            {extraTagCount > 0 && (
+              <span className="group relative inline-flex shrink-0">
+                <span
+                  className="inline-flex rounded-full px-2 py-0.5 text-sm font-medium"
+                  style={{
+                    background: 'var(--app-surface-soft)',
+                    color: 'var(--app-text-muted)',
+                    border: '1px solid var(--app-border)',
+                  }}
+                >
+                  +{extraTagCount}
                 </span>
-              )}
-            </>
-          )}
-        </span>
+                <TagTooltip tags={tags} />
+              </span>
+            )}
+          </span>
+        )}
 
         <span
-          className="justify-self-end font-financial text-base font-semibold tabular-nums"
+          className="min-w-[8rem] shrink-0 text-right font-financial text-base font-semibold tabular-nums"
           style={{ color: transactionAmountColor }}
         >
           {formattedAmount}

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -3,6 +3,7 @@ import type { Institution } from '@/api/institutions'
 import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
 import { formatCurrency } from '@/utils/formatCurrency'
+import { resolveInstitutionLogoUrl } from '@/utils/institutionLogo'
 
 const MAX_VISIBLE_TAGS = 1
 const DEFAULT_CATEGORY_ICON = '🏷️'
@@ -23,12 +24,6 @@ function amountColor(category: Category | undefined, amount: number) {
   return 'var(--app-text)'
 }
 
-function accountLogoSrc(institution: Institution | null | undefined) {
-  if (institution?.logo_url) return institution.logo_url
-  if (!institution?.website) return null
-  return `https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${encodeURIComponent(institution.website)}&size=256`
-}
-
 function AccountLogo({
   accountName,
   institution,
@@ -36,7 +31,7 @@ function AccountLogo({
   accountName: string | undefined
   institution: Institution | null | undefined
 }) {
-  const logoSrc = accountLogoSrc(institution)
+  const logoSrc = resolveInstitutionLogoUrl(institution)
   const fallback = accountName?.trim().charAt(0).toUpperCase() || '$'
 
   return (

--- a/frontend/src/hooks/useDeferredMount.ts
+++ b/frontend/src/hooks/useDeferredMount.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState, startTransition } from 'react'
+
+/**
+ * Holds an expensive subtree back until after the first paint so the surrounding interactive
+ * controls commit and respond to input first. Safari cannot yield to a pending tap mid-commit the
+ * way Chromium can through isInputPending, so deferring a heavy chart mount by a frame keeps the
+ * toolbar and menu tappable right after the page loads. Returns false until the deferred frame runs
+ */
+export function useDeferredMount(): boolean {
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    // The second frame guarantees the light first paint lands before the heavy subtree renders
+    let secondFrame = 0
+    const firstFrame = requestAnimationFrame(() => {
+      secondFrame = requestAnimationFrame(() => {
+        startTransition(() => setMounted(true))
+      })
+    })
+    return () => {
+      cancelAnimationFrame(firstFrame)
+      cancelAnimationFrame(secondFrame)
+    }
+  }, [])
+
+  return mounted
+}

--- a/frontend/src/pages/accounts/AccountsPage.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.tsx
@@ -71,22 +71,27 @@ export default function AccountsPage() {
           <MetricsBand metrics={accountMetrics} displayCurrency={displayCurrency} />
           <TaxAdvantagedLimitsSection summaries={taxAdvantagedLimitSummaries} />
         </div>
+      </div>
 
-        <AccountListToolbar
-          search={search}
-          onSearchChange={setSearch}
-          filters={filters}
-          setFilter={setFilter}
-          activeFilterCount={activeFilterCount}
-          institutionOptions={institutionOptions}
-          kindOptions={kindOptions}
-          typeOptions={typeOptions}
-          onAddAccount={() => {
-            setCreateModalKey((key) => key + 1)
-            setShowCreateModal(true)
-          }}
-        />
+      {/* The toolbar sits outside the surrounding space-y groups so its own
+          sticky margins set its top and bottom spacing, matching the transactions
+          toolbar instead of inheriting the page group's larger gaps */}
+      <AccountListToolbar
+        search={search}
+        onSearchChange={setSearch}
+        filters={filters}
+        setFilter={setFilter}
+        activeFilterCount={activeFilterCount}
+        institutionOptions={institutionOptions}
+        kindOptions={kindOptions}
+        typeOptions={typeOptions}
+        onAddAccount={() => {
+          setCreateModalKey((key) => key + 1)
+          setShowCreateModal(true)
+        }}
+      />
 
+      <div className="space-y-4">
         <AccountListSection
           title="Assets"
           accent="positive"

--- a/frontend/src/pages/accounts/components/InstitutionLogo.tsx
+++ b/frontend/src/pages/accounts/components/InstitutionLogo.tsx
@@ -1,4 +1,5 @@
 import type { Institution } from '@/api/institutions'
+import { resolveInstitutionLogoUrl } from '@/utils/institutionLogo'
 
 type InstitutionLogoProps = {
   institution: Institution | null
@@ -23,9 +24,7 @@ export function InstitutionLogo({
   institution,
   variant = 'row',
 }: InstitutionLogoProps) {
-  const faviconUrl = institution?.website
-    ? `https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL&url=${encodeURIComponent(institution.website)}&size=256`
-    : null
+  const faviconUrl = resolveInstitutionLogoUrl(institution)
   const classNames = variantClassName[variant]
 
   return (

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanel.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanel.tsx
@@ -161,8 +161,8 @@ export function AccountFilterPanel({
           ref={headRef}
           type="button"
           className="app-range-glass-head"
-          // Match the Add Account button: 40px outer height once the glass border is added
-          style={{ height: 38, padding: '0 16px', gap: 8, fontSize: '0.9375rem' }}
+          // Match the Add Account button: 44px outer height once the glass border is added
+          style={{ height: 42, padding: '0 16px', gap: 8, fontSize: '0.9375rem' }}
           aria-expanded={open}
           aria-label="Account filters"
           onClick={() => (open ? setOpen(false) : handleOpen())}

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanel.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanel.tsx
@@ -156,6 +156,7 @@ export function AccountFilterPanel({
         initial={false}
         animate={{ width: open ? OPEN_WIDTH : collapsedSize.width }}
         transition={transition}
+        whileTap={open || shouldReduceMotion ? undefined : { scale: 0.94 }}
       >
         <button
           ref={headRef}
@@ -165,7 +166,7 @@ export function AccountFilterPanel({
           style={{ height: 42, padding: '0 16px', gap: 8, fontSize: '0.9375rem' }}
           aria-expanded={open}
           aria-label="Account filters"
-          onClick={() => (open ? setOpen(false) : handleOpen())}
+          onClick={() => (open ? dismiss() : handleOpen())}
         >
           <span ref={headContentRef} className="app-range-glass-cur">
             <SlidersHorizontal size={18} aria-hidden className="shrink-0" />
@@ -210,7 +211,14 @@ export function AccountFilterPanel({
           style={{ overflow: 'hidden' }}
           initial={false}
           animate={{ height: open ? openContentHeight : 0, opacity: open ? 1 : 0 }}
-          transition={transition}
+          transition={
+            shouldReduceMotion
+              ? { duration: 0 }
+              : {
+                  height: { duration: 0.45, ease: [0.22, 1, 0.36, 1] },
+                  opacity: { duration: 0.26, delay: 0.05 },
+                }
+          }
         >
           <div className="flex flex-col" style={{ height: openContentHeight, padding: '0 12px 12px' }}>
             <FilterPanelBody draft={draft} fillHeight />

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanel.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import { motion, useReducedMotion } from 'motion/react'
 import { ChevronDown, SlidersHorizontal, X } from 'lucide-react'
 import type { OptionItem } from '@/components/filters/OptionList'
+import { FILTER_PANEL_BODY_TRANSITION, FILTER_PILL_HEAD_STYLE } from '@/components/list-controls/toolbarStyles'
 import { FilterPanelBody } from '@/pages/accounts/components/toolbar/FilterPanelBody'
 import { FILTER_GLASS_SPRING, useAccountFilterDraft } from '@/pages/accounts/components/toolbar/useAccountFilterDraft'
 import type { FilterValues } from '@/pages/accounts/types/accounts'
@@ -162,8 +163,7 @@ export function AccountFilterPanel({
           ref={headRef}
           type="button"
           className="app-range-glass-head"
-          // Match the Add Account button: 44px outer height once the glass border is added
-          style={{ height: 42, padding: '0 16px', gap: 8, fontSize: '0.9375rem' }}
+          style={FILTER_PILL_HEAD_STYLE}
           aria-expanded={open}
           aria-label="Account filters"
           onClick={() => (open ? dismiss() : handleOpen())}
@@ -211,14 +211,7 @@ export function AccountFilterPanel({
           style={{ overflow: 'hidden' }}
           initial={false}
           animate={{ height: open ? openContentHeight : 0, opacity: open ? 1 : 0 }}
-          transition={
-            shouldReduceMotion
-              ? { duration: 0 }
-              : {
-                  height: { duration: 0.45, ease: [0.22, 1, 0.36, 1] },
-                  opacity: { duration: 0.26, delay: 0.05 },
-                }
-          }
+          transition={shouldReduceMotion ? { duration: 0 } : FILTER_PANEL_BODY_TRANSITION}
         >
           <div className="flex flex-col" style={{ height: openContentHeight, padding: '0 12px 12px' }}>
             <FilterPanelBody draft={draft} fillHeight />

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
@@ -217,7 +217,7 @@ function MobileFacetSelect({ activeFacetId, countFacet, onSelect }: MobileFacetS
         {open && (
           <motion.ul
             role="listbox"
-            className="absolute inset-x-0 top-full z-30 mt-1 max-h-[60vh] overflow-auto rounded-xl py-1"
+            className="absolute inset-x-0 top-full z-30 mt-1 max-h-[60vh] overflow-auto rounded-xl"
             style={{
               background: 'var(--app-input-bg)',
               border: '1px solid var(--app-border-strong)',

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
@@ -60,7 +60,7 @@ export function FilterPanelBody({
         <motion.div
           layout={blockLayout}
           transition={transition}
-          className="app-range-seg app-filter-facet-grid"
+          className="app-range-seg"
           style={{ gridTemplateColumns: FACET_GRID_COLUMNS }}
           role="tablist"
           aria-label="Filter facets"

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
@@ -69,11 +69,12 @@ export function FilterPanelBody({
             const facetCount = draft.countFacet(facet)
             const isActive = facet.id === activeFacetId
             return (
-              <button
+              <motion.button
                 key={facet.id}
                 type="button"
                 role="tab"
                 aria-selected={isActive}
+                whileTap={shouldReduceMotion ? undefined : { scale: 0.94 }}
                 className={joinClassNames('app-range-seg-option', isActive && 'app-range-seg-option-active')}
                 style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2 }}
                 onClick={() => setActiveFacetId(facet.id)}
@@ -93,7 +94,7 @@ export function FilterPanelBody({
                     {facetCount}
                   </span>
                 )}
-              </button>
+              </motion.button>
             )
           })}
         </motion.div>

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
@@ -59,7 +59,7 @@ export function FilterPanelBody({
         <motion.div
           layout={blockLayout}
           transition={transition}
-          className="app-range-seg"
+          className="app-range-seg app-filter-facet-grid"
           style={{ gridTemplateColumns: FACET_GRID_COLUMNS }}
           role="tablist"
           aria-label="Filter facets"
@@ -237,8 +237,8 @@ function MobileFacetSelect({ activeFacetId, countFacet, onSelect }: MobileFacetS
                   key={facet.id}
                   role="option"
                   aria-selected={isActive}
-                  className="flex cursor-pointer items-center gap-2 px-4 py-2.5 text-sm transition-colors hover:bg-[var(--app-surface-soft)]"
-                  style={{ color: isActive ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: isActive ? 500 : 400 }}
+                  className="flex cursor-pointer items-center gap-2 px-4 py-2.5 text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
+                  style={{ color: isActive ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: isActive ? 500 : 400, background: isActive ? 'var(--app-accent-soft)' : undefined }}
                   onClick={() => {
                     onSelect(facet.id)
                     setOpen(false)

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { Check, ChevronDown, X } from 'lucide-react'
 import type { OptionItem } from '@/components/filters/OptionList'
 import { MultiSelectChecklist } from '@/components/filters/MultiSelectChecklist'
+import { getFilterOptionStyle } from '@/components/filters/optionAppearance'
 import { joinClassNames } from '@/utils/classNames'
 import {
   FILTER_FACETS,
@@ -238,7 +239,7 @@ function MobileFacetSelect({ activeFacetId, countFacet, onSelect }: MobileFacetS
                   role="option"
                   aria-selected={isActive}
                   className="flex cursor-pointer items-center gap-2 px-4 py-2.5 text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
-                  style={{ color: isActive ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: isActive ? 500 : 400, background: isActive ? 'var(--app-accent-soft)' : undefined }}
+                  style={getFilterOptionStyle(isActive)}
                   onClick={() => {
                     onSelect(facet.id)
                     setOpen(false)

--- a/frontend/src/pages/accounts/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/ListToolbar.tsx
@@ -2,6 +2,7 @@ import { useCallback, useState } from 'react'
 import { useDesktopToolbarLayout } from '@/components/filters/hooks/useDesktopToolbarLayout'
 import { useMobileSearchStuck } from '@/components/filters/hooks/useMobileSearchStuck'
 import { useToolbarStuck } from '@/components/filters/hooks/useToolbarStuck'
+import { getToolbarStickyRowClass, getToolbarStuckShadow } from '@/components/list-controls/toolbarStyles'
 import { AccountSearchField } from '@/pages/accounts/components/toolbar/SearchField'
 import { MobileToolbarActions } from '@/pages/accounts/components/toolbar/mobile/Actions'
 import { DesktopAccountToolbarControls } from '@/pages/accounts/components/toolbar/desktop/Controls'
@@ -51,14 +52,10 @@ export default function AccountListToolbar({
       <div ref={toolbarStuckSentinelRef} aria-hidden className="h-px max-[1049px]:hidden" />
       <div
         ref={toolbarRef}
-        className={`sticky top-0 z-30 !mt-1 mb-1 flex flex-col gap-3 pb-1 pt-2 min-[1050px]:top-2.5 min-[1050px]:pt-2.5 ${desktopInlineLayout ? 'min-[750px]:flex-row min-[750px]:items-center' : ''}`}
+        className={getToolbarStickyRowClass(desktopInlineLayout)}
         style={{
           background: 'var(--app-bg)',
-          // While docked at the nav line the upward shadow masks list rows scrolling through the gap
-          // above the toolbar, and it is dropped at rest so it never covers the content above the row
-          boxShadow: isToolbarStuck
-            ? '0 0.25rem 0 var(--app-bg), 0 -1.5rem 0 var(--app-bg)'
-            : '0 0.25rem 0 var(--app-bg)',
+          boxShadow: getToolbarStuckShadow(isToolbarStuck),
         }}
       >
         <AccountSearchField

--- a/frontend/src/pages/accounts/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/ListToolbar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import { useDesktopToolbarLayout } from '@/components/filters/hooks/useDesktopToolbarLayout'
 import { useMobileSearchStuck } from '@/components/filters/hooks/useMobileSearchStuck'
+import { useToolbarStuck } from '@/components/filters/hooks/useToolbarStuck'
 import { AccountSearchField } from '@/pages/accounts/components/toolbar/SearchField'
 import { MobileToolbarActions } from '@/pages/accounts/components/toolbar/mobile/Actions'
 import { DesktopAccountToolbarControls } from '@/pages/accounts/components/toolbar/desktop/Controls'
@@ -35,6 +36,7 @@ export default function AccountListToolbar({
     desktopCreateStacked,
   } = useDesktopToolbarLayout()
   const { mobileSearchStickySentinelRef, mobileSearchStuck } = useMobileSearchStuck()
+  const { toolbarStuckSentinelRef, isToolbarStuck } = useToolbarStuck()
 
   const openMobileSheet = useCallback(() => {
     setIsMobileSheetMounted(true)
@@ -46,12 +48,17 @@ export default function AccountListToolbar({
   return (
     <>
       <div ref={mobileSearchStickySentinelRef} aria-hidden className="h-px min-[1050px]:hidden" />
+      <div ref={toolbarStuckSentinelRef} aria-hidden className="h-px max-[1049px]:hidden" />
       <div
         ref={toolbarRef}
-        className={`sticky top-0 z-30 !mt-2 mb-2 flex flex-col gap-3 pb-2 pt-4 min-[1050px]:pt-5 ${desktopInlineLayout ? 'min-[750px]:flex-row min-[750px]:items-center' : ''}`}
+        className={`sticky top-0 z-30 !mt-1 mb-1 flex flex-col gap-3 pb-1 pt-2 min-[1050px]:top-2.5 min-[1050px]:pt-2.5 ${desktopInlineLayout ? 'min-[750px]:flex-row min-[750px]:items-center' : ''}`}
         style={{
           background: 'var(--app-bg)',
-          boxShadow: '0 0.25rem 0 var(--app-bg)',
+          // While docked at the nav line the upward shadow masks list rows scrolling through the gap
+          // above the toolbar, and it is dropped at rest so it never covers the content above the row
+          boxShadow: isToolbarStuck
+            ? '0 0.25rem 0 var(--app-bg), 0 -1.5rem 0 var(--app-bg)'
+            : '0 0.25rem 0 var(--app-bg)',
         }}
       >
         <AccountSearchField

--- a/frontend/src/pages/accounts/components/toolbar/SearchField.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/SearchField.tsx
@@ -1,4 +1,5 @@
-import { Search } from 'lucide-react'
+import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
+import { joinClassNames } from '@/utils/classNames'
 
 type AccountSearchFieldProps = {
   search: string
@@ -18,22 +19,15 @@ export function AccountSearchField({
   desktopInlineLayout,
 }: AccountSearchFieldProps) {
   return (
-    <div
-      className={`relative min-w-0 transition-[margin-right] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none ${mobileSearchStuck ? 'max-[1049px]:mr-14' : 'max-[1049px]:mr-0'} ${desktopInlineLayout ? 'min-[750px]:min-w-80 min-[750px]:flex-1' : ''}`}
-    >
-      <Search
-        size={16}
-        className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
-        style={{ color: 'var(--app-text-subtle)' }}
-        aria-hidden
-      />
-      <input
-        type="text"
-        placeholder="Search accounts..."
-        value={search}
-        onChange={(event) => onSearchChange(event.target.value)}
-        className="app-glass-input h-11 w-full pl-9"
-      />
-    </div>
+    <GlassSearchField
+      value={search}
+      onValueChange={onSearchChange}
+      placeholder="Search accounts..."
+      wrapperClassName={joinClassNames(
+        'transition-[margin-right] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none',
+        mobileSearchStuck ? 'max-[1049px]:mr-14' : 'max-[1049px]:mr-0',
+        desktopInlineLayout && 'min-[750px]:min-w-80 min-[750px]:flex-1',
+      )}
+    />
   )
 }

--- a/frontend/src/pages/accounts/components/toolbar/SearchField.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/SearchField.tsx
@@ -32,7 +32,7 @@ export function AccountSearchField({
         placeholder="Search accounts..."
         value={search}
         onChange={(event) => onSearchChange(event.target.value)}
-        className="app-glass-input h-11 w-full pl-9 min-[1050px]:h-10"
+        className="app-glass-input h-11 w-full pl-9"
       />
     </div>
   )

--- a/frontend/src/pages/accounts/components/toolbar/desktop/Controls.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/desktop/Controls.tsx
@@ -51,7 +51,7 @@ export function DesktopAccountToolbarControls({
 
       <button
         type="button"
-        className={`app-glass-button-primary h-11 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
+        className={`app-glass-button-primary h-10 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
         onClick={onAddAccount}
       >
         <Plus size={18} aria-hidden />
@@ -60,7 +60,7 @@ export function DesktopAccountToolbarControls({
       <button
         ref={createMeasureRef}
         type="button"
-        className="app-glass-button-primary pointer-events-none invisible absolute h-11 w-auto shrink-0"
+        className="app-glass-button-primary pointer-events-none invisible absolute h-10 w-auto shrink-0"
         tabIndex={-1}
         aria-hidden
       >

--- a/frontend/src/pages/accounts/components/toolbar/desktop/Controls.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/desktop/Controls.tsx
@@ -51,7 +51,7 @@ export function DesktopAccountToolbarControls({
 
       <button
         type="button"
-        className={`app-glass-button-primary h-10 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
+        className={`app-glass-button-primary h-11 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
         onClick={onAddAccount}
       >
         <Plus size={18} aria-hidden />
@@ -60,7 +60,7 @@ export function DesktopAccountToolbarControls({
       <button
         ref={createMeasureRef}
         type="button"
-        className="app-glass-button-primary pointer-events-none invisible absolute h-10 w-auto shrink-0"
+        className="app-glass-button-primary pointer-events-none invisible absolute h-11 w-auto shrink-0"
         tabIndex={-1}
         aria-hidden
       >

--- a/frontend/src/pages/accounts/utils/filters.ts
+++ b/frontend/src/pages/accounts/utils/filters.ts
@@ -1,6 +1,8 @@
 import type { AccountKind, AccountType, AccountsOverview } from '@/api/accounts'
+import type { Institution } from '@/api/institutions'
 import type { OptionItem } from '@/components/filters/OptionList'
 import type { FilterValues } from '@/pages/accounts/types/accounts'
+import { resolveInstitutionLogoUrl } from '@/utils/institutionLogo'
 
 const KIND_OPTIONS: OptionItem[] = [
   { value: 'asset', label: 'Assets' },
@@ -38,12 +40,15 @@ export function getActiveFilters(filters: FilterValues) {
  * Builds sorted institution filter options from accounts with linked institutions
  */
 export function getInstitutionOptions(rows: AccountsOverview[]): OptionItem[] {
-  const seen = new Map<string, string>()
+  const seen = new Map<string, Institution>()
   for (const account of rows) {
-    if (account.institution) seen.set(account.institution.id, account.institution.name)
+    if (account.institution) seen.set(account.institution.id, account.institution)
   }
-  return Array.from(seen, ([value, label]) => ({ value, label }))
-    .sort((a, b) => a.label.localeCompare(b.label))
+  return Array.from(seen.values(), (institution) => ({
+    value: institution.id,
+    label: institution.name,
+    imageUrl: resolveInstitutionLogoUrl(institution),
+  })).sort((a, b) => a.label.localeCompare(b.label))
 }
 
 /**

--- a/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
@@ -3,6 +3,7 @@ import {
   Bar,
   BarChart,
   CartesianGrid,
+  Rectangle,
   ResponsiveContainer,
   XAxis,
   YAxis,
@@ -26,6 +27,40 @@ import {
 } from '@/pages/budgets/utils/budgetDetails'
 
 const CHART_INITIAL_DIMENSION = { width: 1, height: 192 }
+
+/**
+ * Rounds the axis maximum up to the next multiple of 25 strictly above the data, so a bar that lands
+ * on a multiple of 25 (such as exactly 100 percent) keeps a little headroom and its rounded top
+ * corner is not flattened against the plot edge
+ */
+function getBudgetChartAxisMax(dataMax: number): number {
+  return Math.max(100, (Math.floor(dataMax / 25) + 1) * 25)
+}
+
+type StackedBarSegmentProps = {
+  category: BudgetChartCategory
+  chartCategories: BudgetChartCategory[]
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  fill?: string
+  payload?: BudgetChartPoint
+}
+
+/**
+ * Rounds the top of a stacked segment only when it is the topmost non-zero category in its bar, so
+ * each column gets one rounded cap no matter which category happens to sit on top. Applying the
+ * radius to a fixed segment instead leaves bars flat-topped whenever that category is empty
+ */
+function StackedBarSegment({ category, chartCategories, x, y, width, height, fill, payload }: StackedBarSegmentProps) {
+  const topSegment = [...chartCategories]
+    .reverse()
+    .find((entry) => Number((payload as Record<string, unknown> | undefined)?.[entry.dataKey] ?? 0) > 0)
+  const isTopSegment = topSegment?.id === category.id
+
+  return <Rectangle x={x} y={y} width={width} height={height} fill={fill} radius={isTopSegment ? [4, 4, 0, 0] : 0} />
+}
 
 type BudgetHistoryChartProps = {
   chartData: BudgetChartPoint[]
@@ -116,18 +151,18 @@ export default function BudgetHistoryChart({
               <YAxis
                 tickLine={false}
                 axisLine={false}
-                domain={[0, (dataMax: number) => Math.max(100, Math.ceil(dataMax / 25) * 25)]}
+                domain={[0, getBudgetChartAxisMax]}
                 tick={{ fill: 'var(--app-text-subtle)', fontSize: 12 }}
                 tickFormatter={(value) => `${Number(value)}%`}
                 width={BUDGET_CHART_LAYOUT.yAxisWidth}
               />
-              {showStackedCategoryChart ? chartCategories.map((category, index) => (
+              {showStackedCategoryChart ? chartCategories.map((category) => (
                 <Bar
                   key={category.id}
                   dataKey={category.dataKey}
                   stackId="category-spending"
                   fill={category.color}
-                  radius={index === chartCategories.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]}
+                  shape={(props) => <StackedBarSegment {...props} category={category} chartCategories={chartCategories} />}
                   barSize={28}
                   animationBegin={MODAL_SURFACE_TRANSITION_MS}
                 />

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/CategorySection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/CategorySection.tsx
@@ -90,13 +90,13 @@ export default function BudgetEditorModalCategorySection({
             <div className="relative mt-3">
               <Search
                 size={16}
-                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
+                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
                 style={{ color: 'var(--app-text-subtle)' }}
                 aria-hidden
               />
               <input
                 id={ids.categorySearch}
-                className="app-input pl-9"
+                className="app-glass-input h-11 w-full pl-9"
                 value={categorySearch}
                 onChange={(event) => handlers.onCategorySearchChange(event.target.value)}
                 placeholder="Search categories..."

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/CategorySection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/CategorySection.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from 'motion/react'
-import { Check, Search } from 'lucide-react'
+import { Check } from 'lucide-react'
+import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import type { Category } from '@/api/categories'
 import type { BudgetEditorModalErrorGetter, BudgetEditorModalFieldIds, BudgetEditorModalHandlers, BudgetEditorModalOptions, BudgetEditorModalViewState } from '@/pages/budgets/components/budget-editor-modal/types'
 import { EASE } from '@/pages/budgets/constants'
@@ -87,21 +88,13 @@ export default function BudgetEditorModalCategorySection({
                 </p>
               </div>
             </div>
-            <div className="relative mt-3">
-              <Search
-                size={16}
-                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
-                style={{ color: 'var(--app-text-subtle)' }}
-                aria-hidden
-              />
-              <input
-                id={ids.categorySearch}
-                className="app-glass-input h-11 w-full pl-9"
-                value={categorySearch}
-                onChange={(event) => handlers.onCategorySearchChange(event.target.value)}
-                placeholder="Search categories..."
-              />
-            </div>
+            <GlassSearchField
+              inputId={ids.categorySearch}
+              value={categorySearch}
+              onValueChange={handlers.onCategorySearchChange}
+              placeholder="Search categories..."
+              wrapperClassName="mt-3"
+            />
             <div className="relative mb-1 mt-3 min-h-0 min-[1050px]:flex-1">
               <motion.div
                 className="app-selection-list m-0 min-[1050px]:absolute min-[1050px]:inset-0 min-[1050px]:max-h-none"

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -246,11 +246,12 @@ function GlassRangeSelector({
             </p>
             <div className="app-range-seg" role="tablist" aria-label="Insights date range">
               {INSIGHTS_RANGE_OPTIONS.map((option) => (
-                <button
+                <motion.button
                   key={option.value}
                   type="button"
                   role="tab"
                   aria-selected={option.value === selectedPreset}
+                  whileTap={shouldReduceMotion ? undefined : { scale: 0.94 }}
                   className={joinClassNames(
                     'app-range-seg-option',
                     option.value === selectedPreset && 'app-range-seg-option-active',
@@ -265,7 +266,7 @@ function GlassRangeSelector({
                     />
                   )}
                   <span className="app-range-seg-label">{option.code}</span>
-                </button>
+                </motion.button>
               ))}
             </div>
 
@@ -282,9 +283,14 @@ function GlassRangeSelector({
                   onQualifierChange={onDraftQualifierChange}
                 />
                 <p className="app-range-dates">{draftRangeLabel}</p>
-                <button type="button" className="app-range-apply" onClick={handleApplyDraft}>
+                <motion.button
+                  type="button"
+                  className="app-range-apply"
+                  whileTap={shouldReduceMotion ? undefined : { scale: 0.94 }}
+                  onClick={handleApplyDraft}
+                >
                   Apply
-                </button>
+                </motion.button>
                 <SavedRanges
                   savedRanges={savedRanges}
                   onSaveCurrentRange={handleSaveCurrentRange}

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -215,7 +215,7 @@ function GlassRangeSelector({
         onClick={() => (open ? dismiss() : setOpen(true))}
       >
         <span className="app-range-glass-cur">
-          <Calendar size={15} aria-hidden className="shrink-0" />
+          <Calendar size={18} aria-hidden className="shrink-0" />
           <span key={`${currentLabel}|${appliedRangeLabel}`} ref={measureLabel} className="app-range-glass-text">
             <span className="truncate">{currentLabel}</span>
             <motion.span

--- a/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
+++ b/frontend/src/pages/insights/components/RelativeRangeBuilder.tsx
@@ -104,11 +104,12 @@ export function RelativeRangeBuilder({
     <div className="mt-2">
       <div className="app-range-qualifier" role="tablist" aria-label="Relative range type">
         {QUALIFIER_OPTIONS.map((option) => (
-          <button
+          <motion.button
             key={option.value}
             type="button"
             role="tab"
             aria-selected={option.value === qualifier}
+            whileTap={shouldReduceMotion ? undefined : { scale: 0.94 }}
             className={joinClassNames(
               'app-range-seg-option',
               option.value === qualifier && 'app-range-seg-option-active',
@@ -123,7 +124,7 @@ export function RelativeRangeBuilder({
               />
             )}
             <span className="app-range-seg-label">{option.label}</span>
-          </button>
+          </motion.button>
         ))}
       </div>
 

--- a/frontend/src/pages/settings/components/SectionNavigation.tsx
+++ b/frontend/src/pages/settings/components/SectionNavigation.tsx
@@ -76,7 +76,7 @@ export function SettingsMobileSectionMenu({
       <div className="settings-mobile-section-menu-lock-spacer hidden min-[1200px]:hidden" aria-hidden />
 
       <div
-        className="settings-mobile-section-menu-shell sticky top-0 z-20 -mx-2 -mt-4 mb-4 min-h-[3.75rem] px-2 pt-4 min-[1050px]:-mt-5 min-[1050px]:min-h-16 min-[1050px]:pt-5 min-[1200px]:hidden"
+        className="settings-mobile-section-menu-shell sticky top-0 z-20 -mx-2 -mt-2 mb-4 min-h-[3.25rem] px-2 pt-2 min-[1050px]:-mt-5 min-[1050px]:min-h-16 min-[1050px]:pt-5 min-[1200px]:hidden"
         style={{
           background: 'color-mix(in srgb, var(--app-bg) 72%, transparent)',
           backdropFilter: 'blur(10px)',

--- a/frontend/src/pages/settings/components/category-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/category-settings-section/Section.tsx
@@ -92,12 +92,12 @@ export default function CategorySettingsSection() {
             <div className="relative min-w-0 flex-1">
               <Search
                 size={16}
-                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
+                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
                 style={{ color: 'var(--app-text-subtle)' }}
                 aria-hidden
               />
               <input
-                className="app-input pl-9"
+                className="app-glass-input h-11 w-full pl-9"
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Search categories..."

--- a/frontend/src/pages/settings/components/category-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/category-settings-section/Section.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence } from 'motion/react'
-import { Plus, Search } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import { ApiError } from '@/api/auth'
+import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import {
   useCategories,
   useDeleteCategory,
@@ -89,21 +90,13 @@ export default function CategorySettingsSection() {
       <SettingsCard>
         <div className="space-y-4">
           <div className="flex flex-col gap-3 sm:flex-row">
-            <div className="relative min-w-0 flex-1">
-              <Search
-                size={16}
-                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
-                style={{ color: 'var(--app-text-subtle)' }}
-                aria-hidden
-              />
-              <input
-                className="app-glass-input h-11 w-full pl-9"
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="Search categories..."
-                disabled={categories.length === 0}
-              />
-            </div>
+            <GlassSearchField
+              value={search}
+              onValueChange={setSearch}
+              placeholder="Search categories..."
+              wrapperClassName="flex-1"
+              disabled={categories.length === 0}
+            />
             <button
               type="button"
               className="app-primary-button shrink-0"

--- a/frontend/src/pages/settings/components/merchant-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/merchant-settings-section/Section.tsx
@@ -1,7 +1,8 @@
 import { useMemo, useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence } from 'motion/react'
-import { Plus, Search } from 'lucide-react'
+import { Plus } from 'lucide-react'
+import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { ApiError } from '@/api/auth'
 import { useCategories } from '@/api/categories'
 import {
@@ -84,26 +85,13 @@ export default function MerchantSettingsSection() {
       <SettingsCard>
         <div className="space-y-4">
           <div className="flex flex-col gap-3 sm:flex-row">
-            <div className="relative min-w-0 flex-1">
-              <Search
-                size={16}
-                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
-                style={{ color: 'var(--app-text-subtle)' }}
-                aria-hidden
-              />
-              <input
-                className="app-glass-input h-11 w-full pl-9"
-                value={merchantList.search}
-                onChange={(event) => {
-                  merchantList.setSearch(event.target.value)
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== 'Enter') return
-                  merchantList.setActiveSearch(merchantList.search)
-                }}
-                placeholder="Search merchants..."
-              />
-            </div>
+            <GlassSearchField
+              value={merchantList.search}
+              onValueChange={merchantList.setSearch}
+              onSubmit={() => merchantList.setActiveSearch(merchantList.search)}
+              placeholder="Search merchants..."
+              wrapperClassName="flex-1"
+            />
             <button
               type="button"
               className="app-primary-button shrink-0"

--- a/frontend/src/pages/settings/components/merchant-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/merchant-settings-section/Section.tsx
@@ -87,12 +87,12 @@ export default function MerchantSettingsSection() {
             <div className="relative min-w-0 flex-1">
               <Search
                 size={16}
-                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
+                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
                 style={{ color: 'var(--app-text-subtle)' }}
                 aria-hidden
               />
               <input
-                className="app-input pl-9"
+                className="app-glass-input h-11 w-full pl-9"
                 value={merchantList.search}
                 onChange={(event) => {
                   merchantList.setSearch(event.target.value)

--- a/frontend/src/pages/settings/components/merchant-settings-section/hooks/useList.ts
+++ b/frontend/src/pages/settings/components/merchant-settings-section/hooks/useList.ts
@@ -30,11 +30,12 @@ export function useMerchantSettingsList(locallyDeletedMerchantIds: string[]) {
     () => new Set(locallyDeletedMerchantIds),
     [locallyDeletedMerchantIds],
   )
+  // Preserve the server's order, recent usage then name, so appended pages keep the rows already on
+  // screen in place. Re-sorting here would interleave each new page among the loaded rows and
+  // reshuffle the list on every load
   const fetchedMerchants = useMemo(
     () => (merchantQuery.data?.pages.flat() ?? [])
-      .filter((merchant) => !locallyDeletedMerchantIdSet.has(merchant.id))
-      .slice()
-      .sort((a, b) => a.name.localeCompare(b.name)),
+      .filter((merchant) => !locallyDeletedMerchantIdSet.has(merchant.id)),
     [locallyDeletedMerchantIdSet, merchantQuery.data],
   )
   const fetchedMerchantKey = useMemo(

--- a/frontend/src/pages/settings/components/merchant-settings-section/list/Row.tsx
+++ b/frontend/src/pages/settings/components/merchant-settings-section/list/Row.tsx
@@ -3,7 +3,6 @@ import { motion } from 'motion/react'
 import type { Category } from '@/api/categories'
 import type { Merchant } from '@/api/merchants'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
-import MarqueeText from '@/components/display/MarqueeText'
 import InlineMerchantEdit from '@/pages/settings/components/merchant-settings-section/editors/InlineEdit'
 import {
   MERCHANT_ROW_EXIT,
@@ -59,11 +58,10 @@ export default function MerchantRow({
       layout={!shouldReduceMotion}
       exit={shouldReduceMotion ? { opacity: 0 } : MERCHANT_ROW_EXIT}
       transition={shouldReduceMotion ? { duration: 0.12 } : MERCHANT_ROW_EXIT_TRANSITION}
-      className="app-marquee-trigger"
       style={{ borderBottom: isLast ? 'none' : '1px solid var(--app-border)' }}
     >
-      <td className="w-px max-w-[14rem] whitespace-nowrap py-3 pl-4 pr-6 align-middle">
-        <MarqueeText className="font-medium">{merchant.name}</MarqueeText>
+      <td className="min-w-[8rem] max-w-[14rem] py-3 pl-4 pr-6 align-middle">
+        <p className="truncate font-medium">{merchant.name}</p>
         <p className="truncate text-xs" style={{ color: 'var(--app-text-muted)' }}>
           {scopeLabel(merchant)}
         </p>

--- a/frontend/src/pages/settings/components/tag-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tag-settings-section/Section.tsx
@@ -81,12 +81,12 @@ export default function TagSettingsSection() {
             <div className="relative min-w-0 flex-1">
               <Search
                 size={16}
-                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
+                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
                 style={{ color: 'var(--app-text-subtle)' }}
                 aria-hidden
               />
               <input
-                className="app-input pl-9"
+                className="app-glass-input h-11 w-full pl-9"
                 value={tagList.search}
                 onChange={(event) => {
                   tagList.setSearch(event.target.value)

--- a/frontend/src/pages/settings/components/tag-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tag-settings-section/Section.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useQueryClient } from '@tanstack/react-query'
 import { AnimatePresence } from 'motion/react'
-import { Plus, Search } from 'lucide-react'
+import { Plus } from 'lucide-react'
+import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { ApiError } from '@/api/auth'
 import { tagKeys } from '@/api/cache/queryKeys'
 import {
@@ -78,26 +79,13 @@ export default function TagSettingsSection() {
       <SettingsCard>
         <div className="space-y-4">
           <div className="flex flex-col gap-3 sm:flex-row">
-            <div className="relative min-w-0 flex-1">
-              <Search
-                size={16}
-                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
-                style={{ color: 'var(--app-text-subtle)' }}
-                aria-hidden
-              />
-              <input
-                className="app-glass-input h-11 w-full pl-9"
-                value={tagList.search}
-                onChange={(event) => {
-                  tagList.setSearch(event.target.value)
-                }}
-                onKeyDown={(event) => {
-                  if (event.key !== 'Enter') return
-                  tagList.setActiveSearch(tagList.search)
-                }}
-                placeholder="Search tags..."
-              />
-            </div>
+            <GlassSearchField
+              value={tagList.search}
+              onValueChange={tagList.setSearch}
+              onSubmit={() => tagList.setActiveSearch(tagList.search)}
+              placeholder="Search tags..."
+              wrapperClassName="flex-1"
+            />
             <button
               type="button"
               className="app-primary-button shrink-0"

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { AnimatePresence } from 'motion/react'
-import { Plus, Search } from 'lucide-react'
+import { Plus } from 'lucide-react'
 import type { AccountsOverview } from '@/api/accounts'
+import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { useCurrencies } from '@/api/currency'
 import { useTaxAdvantagedCategories } from '@/api/taxAdvantagedCategories'
 import SettingsSectionHeader from '@/pages/settings/components/SectionHeader'
@@ -49,21 +50,13 @@ export default function TaxAdvantagedCategoriesSection({
       <SettingsCard>
         <div className="space-y-4">
           <div className="flex flex-col gap-3 sm:flex-row">
-            <div className="relative min-w-0 flex-1">
-              <Search
-                size={16}
-                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
-                style={{ color: 'var(--app-text-subtle)' }}
-                aria-hidden
-              />
-              <input
-                className="app-glass-input h-11 w-full pl-9"
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="Search categories..."
-                disabled={plans.length === 0}
-              />
-            </div>
+            <GlassSearchField
+              value={search}
+              onValueChange={setSearch}
+              placeholder="Search categories..."
+              wrapperClassName="flex-1"
+              disabled={plans.length === 0}
+            />
             <button
               type="button"
               className="app-primary-button shrink-0"

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
@@ -52,12 +52,12 @@ export default function TaxAdvantagedCategoriesSection({
             <div className="relative min-w-0 flex-1">
               <Search
                 size={16}
-                className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2"
+                className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
                 style={{ color: 'var(--app-text-subtle)' }}
                 aria-hidden
               />
               <input
-                className="app-input pl-9"
+                className="app-glass-input h-11 w-full pl-9"
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Search categories..."

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -146,7 +146,7 @@ export default function TransactionListSection({
   })
 
   return (
-    <section className="transaction-list-section">
+    <section>
       <TransactionListToolbar
         search={search}
         onSearchChange={setSearch}

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -194,7 +194,6 @@ export default function TransactionListSection({
           ) : displayedTransactionsLoaded ? (
             <motion.section
               key={`list-${listRevealKey}`}
-              className="space-y-4"
               exit={{ opacity: 0 }}
               transition={{ duration: prefersReducedMotion ? 0 : 0.22, ease: TRANSACTION_LIST_EASE }}
             >

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanel.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanel.tsx
@@ -166,8 +166,8 @@ export function TransactionFilterPanel({
           ref={headRef}
           type="button"
           className="app-range-glass-head"
-          // Match the Add Transaction button: 40px outer height once the glass border is added
-          style={{ height: 38, padding: '0 16px', gap: 8, fontSize: '0.9375rem' }}
+          // Match the Add Transaction button: 44px outer height once the glass border is added
+          style={{ height: 42, padding: '0 16px', gap: 8, fontSize: '0.9375rem' }}
           aria-expanded={open}
           aria-label="Transaction filters"
           onClick={() => (open ? setOpen(false) : handleOpen())}

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanel.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanel.tsx
@@ -161,6 +161,7 @@ export function TransactionFilterPanel({
         initial={false}
         animate={{ width: open ? OPEN_WIDTH : collapsedSize.width }}
         transition={transition}
+        whileTap={open || shouldReduceMotion ? undefined : { scale: 0.94 }}
       >
         <button
           ref={headRef}
@@ -170,7 +171,7 @@ export function TransactionFilterPanel({
           style={{ height: 42, padding: '0 16px', gap: 8, fontSize: '0.9375rem' }}
           aria-expanded={open}
           aria-label="Transaction filters"
-          onClick={() => (open ? setOpen(false) : handleOpen())}
+          onClick={() => (open ? dismiss() : handleOpen())}
         >
           <span ref={headContentRef} className="app-range-glass-cur">
             <SlidersHorizontal size={18} aria-hidden className="shrink-0" />
@@ -215,7 +216,14 @@ export function TransactionFilterPanel({
           style={{ overflow: 'hidden' }}
           initial={false}
           animate={{ height: open ? openContentHeight : 0, opacity: open ? 1 : 0 }}
-          transition={transition}
+          transition={
+            shouldReduceMotion
+              ? { duration: 0 }
+              : {
+                  height: { duration: 0.45, ease: [0.22, 1, 0.36, 1] },
+                  opacity: { duration: 0.26, delay: 0.05 },
+                }
+          }
         >
           <div className="flex flex-col" style={{ height: openContentHeight, padding: '0 12px 12px' }}>
             <FilterPanelBody draft={draft} fillHeight showAccountFilter={showAccountFilter} />

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanel.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanel.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import { motion, useReducedMotion } from 'motion/react'
 import { ChevronDown, SlidersHorizontal, X } from 'lucide-react'
 import type { OptionItem } from '@/components/filters/OptionList'
+import { FILTER_PANEL_BODY_TRANSITION, FILTER_PILL_HEAD_STYLE } from '@/components/list-controls/toolbarStyles'
 import { FilterPanelBody } from '@/pages/transactions/components/toolbar/FilterPanelBody'
 import { FILTER_GLASS_SPRING, useTransactionFilterDraft } from '@/pages/transactions/components/toolbar/useTransactionFilterDraft'
 import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
@@ -167,8 +168,7 @@ export function TransactionFilterPanel({
           ref={headRef}
           type="button"
           className="app-range-glass-head"
-          // Match the Add Transaction button: 44px outer height once the glass border is added
-          style={{ height: 42, padding: '0 16px', gap: 8, fontSize: '0.9375rem' }}
+          style={FILTER_PILL_HEAD_STYLE}
           aria-expanded={open}
           aria-label="Transaction filters"
           onClick={() => (open ? dismiss() : handleOpen())}
@@ -216,14 +216,7 @@ export function TransactionFilterPanel({
           style={{ overflow: 'hidden' }}
           initial={false}
           animate={{ height: open ? openContentHeight : 0, opacity: open ? 1 : 0 }}
-          transition={
-            shouldReduceMotion
-              ? { duration: 0 }
-              : {
-                  height: { duration: 0.45, ease: [0.22, 1, 0.36, 1] },
-                  opacity: { duration: 0.26, delay: 0.05 },
-                }
-          }
+          transition={shouldReduceMotion ? { duration: 0 } : FILTER_PANEL_BODY_TRANSITION}
         >
           <div className="flex flex-col" style={{ height: openContentHeight, padding: '0 12px 12px' }}>
             <FilterPanelBody draft={draft} fillHeight showAccountFilter={showAccountFilter} />

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -272,8 +272,8 @@ function MobileFacetSelect({ activeFacetId, countFacet, disabledFacetIds, onSele
                   role="option"
                   aria-selected={isActive}
                   aria-disabled={isDisabled}
-                  className={joinClassNames('flex items-center gap-2 px-4 py-2.5 text-sm transition-colors', isDisabled ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--app-surface-soft)]')}
-                  style={{ color: isActive ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: isActive ? 500 : 400, opacity: isDisabled ? 0.4 : 1 }}
+                  className={joinClassNames('flex items-center gap-2 px-4 py-2.5 text-sm transition-colors', isDisabled ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--app-accent-soft)]')}
+                  style={{ color: isActive ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: isActive ? 500 : 400, opacity: isDisabled ? 0.4 : 1, background: isActive ? 'var(--app-accent-soft)' : undefined }}
                   onClick={() => {
                     if (isDisabled) return
                     onSelect(facet.id)
@@ -437,7 +437,7 @@ function FacetEditor({
                       key={option.value}
                       type="button"
                       aria-pressed={isSelected}
-                      className="rounded-full border px-3 py-1 text-sm transition-colors"
+                      className="rounded-full border px-3 py-1 text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
                       style={
                         isSelected
                           ? { background: 'var(--app-accent-soft)', borderColor: 'transparent', color: 'var(--app-accent)', fontWeight: 500 }

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { Calendar, Check, ChevronDown, X } from 'lucide-react'
 import type { OptionItem } from '@/components/filters/OptionList'
 import { MultiSelectChecklist } from '@/components/filters/MultiSelectChecklist'
+import { getFilterOptionStyle } from '@/components/filters/optionAppearance'
 import { joinClassNames } from '@/utils/classNames'
 import { formatMoneyInputLive, sanitizeMoneyInput } from '@/utils/moneyInput'
 import { ReferenceFacet } from '@/pages/transactions/components/toolbar/ReferenceFacet'
@@ -273,7 +274,7 @@ function MobileFacetSelect({ activeFacetId, countFacet, disabledFacetIds, onSele
                   aria-selected={isActive}
                   aria-disabled={isDisabled}
                   className={joinClassNames('flex items-center gap-2 px-4 py-2.5 text-sm transition-colors', isDisabled ? 'cursor-not-allowed' : 'cursor-pointer hover:bg-[var(--app-accent-soft)]')}
-                  style={{ color: isActive ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: isActive ? 500 : 400, opacity: isDisabled ? 0.4 : 1, background: isActive ? 'var(--app-accent-soft)' : undefined }}
+                  style={{ ...getFilterOptionStyle(isActive), opacity: isDisabled ? 0.4 : 1 }}
                   onClick={() => {
                     if (isDisabled) return
                     onSelect(facet.id)

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -413,6 +413,9 @@ function FacetEditor({
   onAmountChange,
   onDateRangeChange,
 }: FacetEditorProps) {
+  const shouldReduceMotion = useReducedMotion()
+  const tagMatchThumbId = useId()
+
   if (facet.kind === 'amount') {
     return (
       <div className="flex flex-col gap-3">
@@ -543,16 +546,23 @@ function FacetEditor({
               {(['all', 'any'] as const).map((mode) => {
                 const isActive = tagMatch === mode
                 return (
-                  <button
+                  <motion.button
                     key={mode}
                     type="button"
                     aria-pressed={isActive}
+                    whileTap={shouldReduceMotion ? undefined : { scale: 0.94 }}
                     className={joinClassNames('app-range-seg-option', isActive && 'app-range-seg-option-active')}
-                    style={isActive ? { background: 'var(--app-input-bg)', boxShadow: '0 1px 2px #00000014, inset 0 1px 0 color-mix(in srgb, white 28%, transparent)' } : undefined}
                     onClick={() => onTagMatchChange(mode)}
                   >
+                    {isActive && (
+                      <motion.span
+                        layoutId={`${tagMatchThumbId}-thumb`}
+                        className="app-range-seg-thumb"
+                        transition={shouldReduceMotion ? { duration: 0 } : FILTER_GLASS_SPRING}
+                      />
+                    )}
                     <span className="app-range-seg-label">{mode === 'all' ? 'All' : 'Any'}</span>
-                  </button>
+                  </motion.button>
                 )
               })}
             </div>

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -81,12 +81,13 @@ export function FilterPanelBody({
             const isActive = facet.id === activeFacetId
             const isDisabled = disabledFacetIds.has(facet.id)
             return (
-              <button
+              <motion.button
                 key={facet.id}
                 type="button"
                 role="tab"
                 aria-selected={isActive}
                 disabled={isDisabled}
+                whileTap={shouldReduceMotion || isDisabled ? undefined : { scale: 0.94 }}
                 className={joinClassNames('app-range-seg-option', isActive && 'app-range-seg-option-active')}
                 style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, opacity: isDisabled ? 0.4 : 1, cursor: isDisabled ? 'not-allowed' : undefined }}
                 onClick={() => setActiveFacetId(facet.id)}
@@ -106,7 +107,7 @@ export function FilterPanelBody({
                     {facetCount}
                   </span>
                 )}
-              </button>
+              </motion.button>
             )
           })}
         </motion.div>

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -356,7 +356,7 @@ function DateFacetInput({
         <Calendar
           size={15}
           aria-hidden
-          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2"
+          className="app-date-overlay-icon pointer-events-none absolute right-3 top-1/2 -translate-y-1/2"
           style={{ color: 'var(--app-text-subtle)' }}
         />
       </div>

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -72,7 +72,7 @@ export function FilterPanelBody({
         <motion.div
           layout={blockLayout}
           transition={transition}
-          className="app-range-seg app-filter-facet-grid"
+          className="app-range-seg"
           role="tablist"
           aria-label="Filter facets"
         >

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -250,7 +250,7 @@ function MobileFacetSelect({ activeFacetId, countFacet, disabledFacetIds, onSele
         {open && (
           <motion.ul
             role="listbox"
-            className="absolute inset-x-0 top-full z-30 mt-1 max-h-[60vh] overflow-auto rounded-xl py-1"
+            className="absolute inset-x-0 top-full z-30 mt-1 max-h-[60vh] overflow-auto rounded-xl"
             style={{
               background: 'var(--app-input-bg)',
               border: '1px solid var(--app-border-strong)',

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -6,6 +6,7 @@ import { MobileFilterPanel } from '@/pages/transactions/components/toolbar/Mobil
 import { TransactionSearchField } from '@/pages/transactions/components/toolbar/SearchField'
 import { useDesktopToolbarLayout } from '@/components/filters/hooks/useDesktopToolbarLayout'
 import { useMobileSearchStuck } from '@/components/filters/hooks/useMobileSearchStuck'
+import { useToolbarStuck } from '@/components/filters/hooks/useToolbarStuck'
 import { useToolbarStickyOffset } from '@/pages/transactions/components/toolbar/hooks/useStickyOffset'
 import {
   getAccountOptions,
@@ -55,6 +56,7 @@ export default function TransactionListToolbar({
     desktopCreateStacked,
   } = useDesktopToolbarLayout()
   const { mobileSearchStickySentinelRef, mobileSearchStuck } = useMobileSearchStuck()
+  const { toolbarStuckSentinelRef, isToolbarStuck } = useToolbarStuck()
 
   useToolbarStickyOffset(toolbarRef, onStickyOffsetChange)
 
@@ -68,12 +70,17 @@ export default function TransactionListToolbar({
   return (
     <>
       <div ref={mobileSearchStickySentinelRef} aria-hidden className="h-px min-[1050px]:hidden" />
+      <div ref={toolbarStuckSentinelRef} aria-hidden className="h-px max-[1049px]:hidden" />
       <div
         ref={toolbarRef}
-        className={`sticky top-0 z-30 !mt-2 mb-2 flex flex-col gap-3 pb-2 pt-4 min-[1050px]:pt-5 ${desktopInlineLayout ? 'min-[750px]:flex-row min-[750px]:items-center' : ''}`}
+        className={`sticky top-0 z-30 !mt-1 mb-1 flex flex-col gap-3 pb-1 pt-2 min-[1050px]:top-2.5 min-[1050px]:pt-2.5 ${desktopInlineLayout ? 'min-[750px]:flex-row min-[750px]:items-center' : ''}`}
         style={{
           background: 'var(--app-bg)',
-          boxShadow: '0 0.25rem 0 var(--app-bg)',
+          // While docked at the nav line the upward shadow masks list rows scrolling through the gap
+          // above the toolbar, and it is dropped at rest so it never covers the content above the row
+          boxShadow: isToolbarStuck
+            ? '0 0.25rem 0 var(--app-bg), 0 -1.5rem 0 var(--app-bg)'
+            : '0 0.25rem 0 var(--app-bg)',
         }}
       >
         <TransactionSearchField

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -7,6 +7,7 @@ import { TransactionSearchField } from '@/pages/transactions/components/toolbar/
 import { useDesktopToolbarLayout } from '@/components/filters/hooks/useDesktopToolbarLayout'
 import { useMobileSearchStuck } from '@/components/filters/hooks/useMobileSearchStuck'
 import { useToolbarStuck } from '@/components/filters/hooks/useToolbarStuck'
+import { getToolbarStickyRowClass, getToolbarStuckShadow } from '@/components/list-controls/toolbarStyles'
 import { useToolbarStickyOffset } from '@/pages/transactions/components/toolbar/hooks/useStickyOffset'
 import {
   getAccountOptions,
@@ -73,14 +74,10 @@ export default function TransactionListToolbar({
       <div ref={toolbarStuckSentinelRef} aria-hidden className="h-px max-[1049px]:hidden" />
       <div
         ref={toolbarRef}
-        className={`sticky top-0 z-30 !mt-1 mb-1 flex flex-col gap-3 pb-1 pt-2 min-[1050px]:top-2.5 min-[1050px]:pt-2.5 ${desktopInlineLayout ? 'min-[750px]:flex-row min-[750px]:items-center' : ''}`}
+        className={getToolbarStickyRowClass(desktopInlineLayout)}
         style={{
           background: 'var(--app-bg)',
-          // While docked at the nav line the upward shadow masks list rows scrolling through the gap
-          // above the toolbar, and it is dropped at rest so it never covers the content above the row
-          boxShadow: isToolbarStuck
-            ? '0 0.25rem 0 var(--app-bg), 0 -1.5rem 0 var(--app-bg)'
-            : '0 0.25rem 0 var(--app-bg)',
+          boxShadow: getToolbarStuckShadow(isToolbarStuck),
         }}
       >
         <TransactionSearchField

--- a/frontend/src/pages/transactions/components/toolbar/ReferenceFacet.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ReferenceFacet.tsx
@@ -1,6 +1,7 @@
 import { Check, Search } from 'lucide-react'
 import { useInfiniteMerchants } from '@/api/merchants'
 import { useInfiniteTags } from '@/api/tags'
+import { getFilterOptionListClass, getFilterOptionStyle } from '@/components/filters/optionAppearance'
 import { joinClassNames } from '@/utils/classNames'
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 
@@ -54,7 +55,7 @@ export function ReferenceFacet({ kind, selectedValues, selectedLabels, searchPla
         />
       </div>
 
-      <ul className={fillHeight ? 'min-h-0 flex-1 space-y-1 overflow-auto py-2' : 'max-h-56 space-y-1 overflow-auto py-2'}>
+      <ul className={getFilterOptionListClass(fillHeight)}>
         {query.isPending ? (
           <li className="px-2 py-2 text-xs" style={{ color: 'var(--app-text-subtle)' }}>
             Loading…
@@ -74,7 +75,7 @@ export function ReferenceFacet({ kind, selectedValues, selectedLabels, searchPla
                   aria-checked={selected}
                   onClick={() => onToggle(option.value, option.label)}
                   className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
-                  style={{ color: selected ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: selected ? 500 : 400, background: selected ? 'var(--app-accent-soft)' : undefined }}
+                  style={getFilterOptionStyle(selected)}
                 >
                   <span className="min-w-0 flex-1 truncate">{option.label}</span>
                   {selected && <Check size={15} aria-hidden className="shrink-0" />}

--- a/frontend/src/pages/transactions/components/toolbar/ReferenceFacet.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ReferenceFacet.tsx
@@ -73,8 +73,8 @@ export function ReferenceFacet({ kind, selectedValues, selectedLabels, searchPla
                   role="checkbox"
                   aria-checked={selected}
                   onClick={() => onToggle(option.value, option.label)}
-                  className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-[var(--app-surface-soft)]"
-                  style={{ color: selected ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: selected ? 500 : 400 }}
+                  className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
+                  style={{ color: selected ? 'var(--app-accent)' : 'var(--app-text)', fontWeight: selected ? 500 : 400, background: selected ? 'var(--app-accent-soft)' : undefined }}
                 >
                   <span className="min-w-0 flex-1 truncate">{option.label}</span>
                   {selected && <Check size={15} aria-hidden className="shrink-0" />}

--- a/frontend/src/pages/transactions/components/toolbar/ReferenceFacet.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ReferenceFacet.tsx
@@ -54,7 +54,7 @@ export function ReferenceFacet({ kind, selectedValues, selectedLabels, searchPla
         />
       </div>
 
-      <ul className={fillHeight ? 'min-h-0 flex-1 overflow-auto' : 'max-h-56 overflow-auto'}>
+      <ul className={fillHeight ? 'min-h-0 flex-1 space-y-1 overflow-auto py-2' : 'max-h-56 space-y-1 overflow-auto py-2'}>
         {query.isPending ? (
           <li className="px-2 py-2 text-xs" style={{ color: 'var(--app-text-subtle)' }}>
             Loading…

--- a/frontend/src/pages/transactions/components/toolbar/SearchField.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/SearchField.tsx
@@ -1,4 +1,5 @@
-import { Search } from 'lucide-react'
+import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
+import { joinClassNames } from '@/utils/classNames'
 
 type TransactionSearchFieldProps = {
   search: string
@@ -19,25 +20,16 @@ export function TransactionSearchField({
   desktopInlineLayout,
 }: TransactionSearchFieldProps) {
   return (
-    <div
-      className={`relative min-w-0 transition-[margin-right] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none ${mobileSearchStuck ? 'max-[1049px]:mr-14' : 'max-[1049px]:mr-0'} ${desktopInlineLayout ? 'min-[750px]:min-w-80 min-[750px]:flex-1' : ''}`}
-    >
-      <Search
-        size={16}
-        className="pointer-events-none absolute left-3 top-1/2 z-10 -translate-y-1/2"
-        style={{ color: 'var(--app-text-subtle)' }}
-        aria-hidden
-      />
-      <input
-        type="text"
-        placeholder="Search transactions..."
-        value={search}
-        onChange={(event) => onSearchChange(event.target.value)}
-        onKeyDown={(event) => {
-          if (event.key === 'Enter') onSearchSubmit()
-        }}
-        className="app-glass-input h-11 w-full pl-9"
-      />
-    </div>
+    <GlassSearchField
+      value={search}
+      onValueChange={onSearchChange}
+      onSubmit={onSearchSubmit}
+      placeholder="Search transactions..."
+      wrapperClassName={joinClassNames(
+        'transition-[margin-right] duration-300 ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none',
+        mobileSearchStuck ? 'max-[1049px]:mr-14' : 'max-[1049px]:mr-0',
+        desktopInlineLayout && 'min-[750px]:min-w-80 min-[750px]:flex-1',
+      )}
+    />
   )
 }

--- a/frontend/src/pages/transactions/components/toolbar/SearchField.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/SearchField.tsx
@@ -36,7 +36,7 @@ export function TransactionSearchField({
         onKeyDown={(event) => {
           if (event.key === 'Enter') onSearchSubmit()
         }}
-        className="app-glass-input h-11 w-full pl-9 min-[1050px]:h-10"
+        className="app-glass-input h-11 w-full pl-9"
       />
     </div>
   )

--- a/frontend/src/pages/transactions/components/toolbar/desktop/Controls.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/desktop/Controls.tsx
@@ -62,7 +62,7 @@ export function DesktopTransactionToolbarControls({
 
       <button
         type="button"
-        className={`app-glass-button-primary h-10 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
+        className={`app-glass-button-primary h-11 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
         onClick={onCreateTransaction}
         disabled={createDisabled}
         title={createDisabledReason}
@@ -73,7 +73,7 @@ export function DesktopTransactionToolbarControls({
       <button
         ref={createMeasureRef}
         type="button"
-        className="app-glass-button-primary pointer-events-none invisible absolute h-10 w-auto shrink-0"
+        className="app-glass-button-primary pointer-events-none invisible absolute h-11 w-auto shrink-0"
         tabIndex={-1}
         aria-hidden
       >

--- a/frontend/src/pages/transactions/components/toolbar/desktop/Controls.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/desktop/Controls.tsx
@@ -62,7 +62,7 @@ export function DesktopTransactionToolbarControls({
 
       <button
         type="button"
-        className={`app-glass-button-primary h-11 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
+        className={`app-glass-button-primary h-10 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
         onClick={onCreateTransaction}
         disabled={createDisabled}
         title={createDisabledReason}
@@ -73,7 +73,7 @@ export function DesktopTransactionToolbarControls({
       <button
         ref={createMeasureRef}
         type="button"
-        className="app-glass-button-primary pointer-events-none invisible absolute h-11 w-auto shrink-0"
+        className="app-glass-button-primary pointer-events-none invisible absolute h-10 w-auto shrink-0"
         tabIndex={-1}
         aria-hidden
       >

--- a/frontend/src/pages/transactions/components/toolbar/hooks/useStickyOffset.ts
+++ b/frontend/src/pages/transactions/components/toolbar/hooks/useStickyOffset.ts
@@ -1,5 +1,6 @@
 import { useLayoutEffect } from 'react'
 import type { RefObject } from 'react'
+import { DESKTOP_MEDIA_QUERY, TOOLBAR_DOCK_OFFSET_PX } from '@/components/filters/hooks/useToolbarStuck'
 
 const DATE_HEADER_STICKY_GAP_PX = 4
 
@@ -17,10 +18,12 @@ export function useToolbarStickyOffset(
     const publishStickyOffset = onStickyOffsetChange
 
     /**
-     * Uses the rendered toolbar height because desktop filters can wrap as labels change
+     * Uses the rendered toolbar height because desktop filters can wrap as labels change, and adds the
+     * desktop dock offset so headers stick below the toolbar once it pins to the navigation pane line
      */
     function updateStickyOffset() {
-      publishStickyOffset(Math.ceil(toolbarElement.getBoundingClientRect().height + DATE_HEADER_STICKY_GAP_PX))
+      const dockOffset = window.matchMedia(DESKTOP_MEDIA_QUERY).matches ? TOOLBAR_DOCK_OFFSET_PX : 0
+      publishStickyOffset(Math.ceil(toolbarElement.getBoundingClientRect().height) + DATE_HEADER_STICKY_GAP_PX + dockOffset)
     }
 
     updateStickyOffset()

--- a/frontend/src/pages/transactions/components/top-band/DailyCashFlowChart.tsx
+++ b/frontend/src/pages/transactions/components/top-band/DailyCashFlowChart.tsx
@@ -30,6 +30,7 @@ import {
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { formatCurrency } from '@/utils/formatCurrency'
+import { useDeferredMount } from '@/hooks/useDeferredMount'
 import { PLACEHOLDER_DAILY_FLOW } from '@/pages/transactions/components/top-band/constants'
 import {
   DAILY_CASH_FLOW_CHART_MARGIN,
@@ -183,6 +184,8 @@ export default function DailyCashFlowChart({
 }) {
   const dailyFlowChartRef = useRef<HTMLDivElement>(null)
   const dailyFlowTooltipRef = useRef<DeferredChartTooltipOverlayHandle<DailyCashFlowPoint>>(null)
+  // The fixed-height wrapper reserves the plot space so deferring the recharts mount shifts nothing
+  const chartReady = useDeferredMount()
   const [dailyFlowChartWidth, setDailyFlowChartWidth] = useState<number>()
   const dailyFlowGranularity = useMemo(
     () => getDailyCashFlowGranularity(fromDate, toDate),
@@ -323,6 +326,7 @@ export default function DailyCashFlowChart({
         className="relative h-[11.75rem]"
         onMouseLeave={hideDailyCashFlowTooltip}
       >
+        {chartReady && (
         <motion.div
           key={`daily-flow-reveal-${mode}-${chartAnimationKey}-${dailyFlowSignature}`}
           className="h-full w-full"
@@ -405,6 +409,7 @@ export default function DailyCashFlowChart({
           </AreaChart>
         </ResponsiveContainer>
         </motion.div>
+        )}
         <DeferredChartTooltipOverlay
           ref={dailyFlowTooltipRef}
           chartRef={dailyFlowChartRef}

--- a/frontend/src/pages/transactions/components/top-band/DailyCashFlowChart.tsx
+++ b/frontend/src/pages/transactions/components/top-band/DailyCashFlowChart.tsx
@@ -60,8 +60,10 @@ const titleCharVariants = {
   enter: { y: 0, opacity: 1, filter: 'blur(0px)' },
   exit: { y: '-0.7em', opacity: 0, filter: 'blur(2px)' },
 } as const
-// Recharts runtime accepts cubic-bezier strings, but Area's public type only lists preset names
-const chartAnimationEasing = 'cubic-bezier(0.05,0.025,0.41,0.941)' as 'ease-in-out'
+// A gentle sine ease for the reveal: near-even pace with soft ends. The reveal is driven by a CSS clip
+// on a wrapper rather than Recharts' own area animation, which gets cut to its final frame whenever the
+// points change mid-animation (a data load or a width change as the layout settles)
+const chartRevealEasing = [0.37, 0, 0.63, 1] as const
 
 function getDailyCashFlowTooltipKey(point: DailyCashFlowPoint) {
   return point.key
@@ -198,6 +200,17 @@ export default function DailyCashFlowChart({
     () => new Map(dailyFlow.map((point) => [point.key, point])),
     [dailyFlow],
   )
+  // Re-key the chart on the displayed values so a placeholder-to-real swap or a refetch remounts it
+  // for one clean reveal, instead of letting Recharts cut the in-flight animation to its final frame
+  // when the points change mid-animation
+  const dailyFlowSignature = useMemo(
+    () =>
+      `${dailyFlow.length}:${dailyFlow.reduce(
+        (total, point) => total + point.net + point.inflow + point.outflow,
+        0,
+      )}`,
+    [dailyFlow],
+  )
   const dailyFlowLabelsByKey = useMemo(
     () => new Map(dailyFlow.map((point) => [point.key, point.date])),
     [dailyFlow],
@@ -215,7 +228,7 @@ export default function DailyCashFlowChart({
       { x: dailyFlow[dailyFlow.length - 1].key, y: 0 },
     ] as const
   }, [dailyFlow])
-  const chartAnimationDuration = prefersReducedMotion ? 0 : 1000
+  const chartAnimationDuration = prefersReducedMotion ? 0 : 1400
   const toggleLabel = mode === 'net' ? 'Show inflow and outflow' : 'Show net cash flow'
   const cashFlowCadenceTitle = getDailyCashFlowCadenceTitle(dailyFlowGranularity)
   const calculationTooltipLabel = mode === 'net'
@@ -310,9 +323,19 @@ export default function DailyCashFlowChart({
         className="relative h-[11.75rem]"
         onMouseLeave={hideDailyCashFlowTooltip}
       >
+        <motion.div
+          key={`daily-flow-reveal-${mode}-${chartAnimationKey}-${dailyFlowSignature}`}
+          className="h-full w-full"
+          initial={prefersReducedMotion ? false : { clipPath: 'inset(0 100% 0 0)' }}
+          animate={{ clipPath: 'inset(0 0% 0 0)' }}
+          transition={
+            prefersReducedMotion
+              ? { duration: 0 }
+              : { duration: chartAnimationDuration / 1000, ease: chartRevealEasing }
+          }
+        >
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart
-            key={`daily-flow-${mode}-${chartAnimationKey}`}
             data={dailyFlow}
             margin={DAILY_CASH_FLOW_CHART_MARGIN}
             onMouseMove={(state, event) => showDailyCashFlowTooltip(state, event)}
@@ -357,9 +380,7 @@ export default function DailyCashFlowChart({
                 stroke="var(--app-text-muted)"
                 fill="url(#netFlowGrad)"
                 strokeWidth={1.5}
-                isAnimationActive={!prefersReducedMotion}
-                animationDuration={chartAnimationDuration}
-                animationEasing={chartAnimationEasing}
+                isAnimationActive={false}
               />
             ) : (
               <>
@@ -369,9 +390,7 @@ export default function DailyCashFlowChart({
                   stroke="var(--app-positive)"
                   fill="url(#inflowGrad)"
                   strokeWidth={1.5}
-                  isAnimationActive={!prefersReducedMotion}
-                  animationDuration={chartAnimationDuration}
-                  animationEasing={chartAnimationEasing}
+                  isAnimationActive={false}
                 />
                 <Area
                   type="monotone"
@@ -379,14 +398,13 @@ export default function DailyCashFlowChart({
                   stroke="var(--app-negative)"
                   fill="url(#outflowGrad)"
                   strokeWidth={1.5}
-                  isAnimationActive={!prefersReducedMotion}
-                  animationDuration={chartAnimationDuration}
-                  animationEasing={chartAnimationEasing}
+                  isAnimationActive={false}
                 />
               </>
             )}
           </AreaChart>
         </ResponsiveContainer>
+        </motion.div>
         <DeferredChartTooltipOverlay
           ref={dailyFlowTooltipRef}
           chartRef={dailyFlowChartRef}

--- a/frontend/src/pages/transactions/components/top-band/TopCategoriesChart.tsx
+++ b/frontend/src/pages/transactions/components/top-band/TopCategoriesChart.tsx
@@ -29,6 +29,7 @@ import {
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { formatCurrency } from '@/utils/formatCurrency'
+import { useDeferredMount } from '@/hooks/useDeferredMount'
 import {
   TOP_CATEGORY_AXIS_AVG_CHAR_WIDTH,
   TOP_CATEGORY_AXIS_LABEL_PADDING,
@@ -114,6 +115,8 @@ export default function TopCategoriesChart({
   const topCategoryChartRef = useRef<HTMLDivElement>(null)
   const topCategoryTooltipRef = useRef<DeferredChartTooltipOverlayHandle<OverviewCategorySpend>>(null)
   const topCategoryChartHeight = Math.max(24, categorySpend.length * TOP_CATEGORY_ROW_HEIGHT)
+  // The motion wrapper keeps the reserved height so deferring the recharts mount shifts nothing
+  const chartReady = useDeferredMount()
 
   // Recharts needs an explicit Y-axis width because otherwise long category labels can clip
   const topCategoryAxisWidth = Math.max(
@@ -204,6 +207,7 @@ export default function TopCategoriesChart({
               exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
               transition={contentTransition}
             >
+              {chartReady && (
               <ResponsiveContainer width="100%" height="100%">
                 <BarChart
                   key={`categories-${chartAnimationKey}`}
@@ -240,6 +244,7 @@ export default function TopCategoriesChart({
                   </Bar>
                 </BarChart>
               </ResponsiveContainer>
+              )}
               <DeferredChartTooltipOverlay
                 ref={topCategoryTooltipRef}
                 chartRef={topCategoryChartRef}

--- a/frontend/src/pages/transactions/utils/filterOptions.ts
+++ b/frontend/src/pages/transactions/utils/filterOptions.ts
@@ -2,6 +2,7 @@ import type { Category } from '@/api/categories'
 import type { OptionItem } from '@/components/filters/OptionList'
 import { DEFAULT_TRANSACTION_CATEGORY_ICON } from '@/pages/transactions/constants/transactionList'
 import type { TransactionListAccount, TransactionListFilters } from '@/pages/transactions/types/transactionList'
+import { resolveInstitutionLogoUrl } from '@/utils/institutionLogo'
 
 const CATEGORY_KIND_LABELS = {
   expense: 'Expense',
@@ -16,6 +17,7 @@ export function getAccountOptions(accounts: TransactionListAccount[] | undefined
   return (accounts ?? []).map((account) => ({
     value: account.id,
     label: account.name ?? 'Unnamed account',
+    imageUrl: resolveInstitutionLogoUrl(account.institution),
   }))
 }
 

--- a/frontend/src/utils/institutionLogo.ts
+++ b/frontend/src/utils/institutionLogo.ts
@@ -1,0 +1,17 @@
+import type { Institution } from '@/api/institutions'
+
+// Google favicon service used as the logo source when an institution has no uploaded logo
+const FAVICON_SERVICE_BASE =
+  'https://t2.gstatic.com/faviconV2?client=SOCIAL&type=FAVICON&fallback_opts=TYPE,SIZE,URL'
+
+const FAVICON_SIZE = 256
+
+/**
+ * Resolves the best logo source for an institution, preferring an uploaded logo and otherwise
+ * deriving a favicon from the institution website, returning null when neither is available
+ */
+export function resolveInstitutionLogoUrl(institution: Institution | null | undefined): string | null {
+  if (institution?.logo_url) return institution.logo_url
+  if (!institution?.website) return null
+  return `${FAVICON_SERVICE_BASE}&url=${encodeURIComponent(institution.website)}&size=${FAVICON_SIZE}`
+}

--- a/frontend/src/utils/tooltipPosition.ts
+++ b/frontend/src/utils/tooltipPosition.ts
@@ -54,15 +54,19 @@ export function getCursorTooltipPosition({
   const minX = boundsRect.left - coordinateLeft + margin
   const minY = boundsRect.top - coordinateTop + margin
   const maxX = boundsRect.right - coordinateLeft - tooltip.offsetWidth - margin
-  const maxY = boundsRect.bottom - coordinateTop - tooltip.offsetHeight - margin
   const pointerX = clientX - coordinateLeft
   const pointerY = clientY - coordinateTop
-  const aboveY = pointerY - tooltip.offsetHeight - offset
-  const belowY = pointerY + offset
+
+  // The tooltip sits above the cursor unless it would clip the top bound, where it flips below. The
+  // vertical follow and the flip offset are returned apart so the flip can animate while the tooltip
+  // keeps tracking the cursor instantly
+  const placeAbove = pointerY - tooltip.offsetHeight - offset >= minY
+  const flipY = placeAbove ? -(tooltip.offsetHeight + offset) : offset
 
   return {
     x: clamp(pointerX - tooltip.offsetWidth - offset, minX, maxX),
-    y: clamp(aboveY >= minY ? aboveY : belowY, minY, maxY),
+    y: pointerY,
+    flipY,
     maxWidth: Math.max(boundsRect.width - margin * 2, 1),
   }
 }
@@ -79,4 +83,5 @@ export function applyCursorTooltipPosition({
   tooltip.style.setProperty('--app-cursor-tooltip-max-width', `${position.maxWidth}px`)
   tooltip.style.setProperty(xProperty, `${position.x}px`)
   tooltip.style.setProperty(yProperty, `${position.y}px`)
+  tooltip.style.setProperty('--cursor-tooltip-flip-y', `${position.flipY}px`)
 }

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -623,18 +623,18 @@
   }
 
   .app-primary-button {
-    @apply inline-flex h-10 items-center justify-center gap-2 rounded-lg px-3.5 font-medium transition-all duration-150 motion-reduce:transition-none;
+    @apply inline-flex h-10 items-center justify-center gap-2 px-4 font-medium transition-all duration-150 motion-reduce:transition-none;
     box-sizing: border-box;
+    border-radius: 20px;
     font-size: 0.9375rem;
-    background: var(--app-button-primary-bg);
-    border: 1px solid var(--app-button-primary-bg);
     color: var(--app-button-primary-text);
-    box-shadow: none;
+    border: 1px solid color-mix(in srgb, var(--app-button-primary-bg) 65%, var(--app-border-strong));
+    background: color-mix(in srgb, var(--app-button-primary-bg) 82%, transparent);
   }
 
   .app-primary-button:hover {
-    background: var(--app-button-primary-bg-hover);
-    border-color: var(--app-button-primary-bg-hover);
+    background: color-mix(in srgb, var(--app-button-primary-bg-hover) 88%, transparent);
+    border-color: color-mix(in srgb, var(--app-button-primary-bg-hover) 70%, var(--app-border-strong));
   }
 
   .app-primary-button:active {
@@ -652,18 +652,18 @@
   }
 
   .app-secondary-button {
-    @apply inline-flex h-10 items-center justify-center gap-2 rounded-lg px-3.5 font-medium transition-all duration-150 motion-reduce:transition-none;
+    @apply inline-flex h-10 items-center justify-center gap-2 px-4 font-medium transition-all duration-150 motion-reduce:transition-none;
+    box-sizing: border-box;
+    border-radius: 20px;
     font-size: 0.9375rem;
-    background: var(--app-input-bg);
-    border: 1px solid var(--app-border);
     color: var(--app-text-muted);
-    box-shadow: none;
+    border: 1px solid var(--app-border-strong);
+    background: color-mix(in srgb, var(--app-input-bg) 62%, transparent);
   }
 
   .app-secondary-button:hover {
-    background: var(--app-surface-soft);
-    border-color: var(--app-border-strong);
     color: var(--app-text);
+    background: color-mix(in srgb, var(--app-input-bg) 76%, transparent);
   }
 
   .app-secondary-button:active {
@@ -681,16 +681,18 @@
   }
 
   .app-danger-button {
-    @apply inline-flex h-10 items-center justify-center gap-2 rounded-lg px-3.5 font-medium transition-all duration-150 motion-reduce:transition-none;
+    @apply inline-flex h-10 items-center justify-center gap-2 px-4 font-medium transition-all duration-150 motion-reduce:transition-none;
+    box-sizing: border-box;
+    border-radius: 20px;
     font-size: 0.9375rem;
-    background: var(--app-negative);
-    border: 1px solid var(--app-negative-border);
     color: white;
+    border: 1px solid color-mix(in srgb, var(--app-negative) 65%, var(--app-border-strong));
+    background: color-mix(in srgb, var(--app-negative) 82%, transparent);
   }
 
   .app-danger-button:hover {
-    background: color-mix(in srgb, var(--app-negative) 92%, var(--app-bg));
-    border-color: var(--app-negative);
+    background: color-mix(in srgb, var(--app-negative) 90%, transparent);
+    border-color: color-mix(in srgb, var(--app-negative) 72%, var(--app-border-strong));
   }
 
   .app-danger-button:active {
@@ -734,8 +736,6 @@
     color: var(--app-button-primary-text);
     border: 1px solid color-mix(in srgb, var(--app-button-primary-bg) 65%, var(--app-border-strong));
     background: color-mix(in srgb, var(--app-button-primary-bg) 82%, transparent);
-    -webkit-backdrop-filter: blur(20px) saturate(160%);
-    backdrop-filter: blur(20px) saturate(160%);
   }
 
   .app-glass-button-primary:hover {

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -47,7 +47,7 @@
     --app-border-strong: #d2b4782b;
     --app-text: #ECE6DA;
     --app-text-muted: #8C8074;
-    --app-text-subtle: #534940;
+    --app-text-subtle: #74685C;
     --app-accent: #C9A96A;
     --app-accent-soft: #c9a96a1f;
     --app-accent-border: #c9a96a38;

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -361,8 +361,8 @@
   .app-range-glass-sub {
     display: block;
     overflow: hidden;
-    font-size: 0.6875rem;
-    font-weight: 500;
+    font-size: 0.75rem;
+    font-weight: 600;
     line-height: 1.2;
     white-space: nowrap;
     color: var(--app-text-muted);
@@ -372,8 +372,8 @@
   /* The resolved date range shown inside the open panel, directly under the preset row */
   .app-range-dates {
     margin-top: 10px;
-    font-size: 0.75rem;
-    font-weight: 500;
+    font-size: 0.8125rem;
+    font-weight: 600;
     color: var(--app-text-muted);
     font-variant-numeric: tabular-nums;
   }

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -1218,6 +1218,21 @@
   }
 
   .recharts-default-tooltip.app-chart-tooltip-default,
+  /* Inner card of the cursor tooltip. The above/below flip is a translateY driven by a variable the
+     positioning code sets, so the card eases between sides while the outer wrapper follows the cursor
+     instantly without smearing */
+  .app-cursor-tooltip-flip {
+    transform: translateY(var(--cursor-tooltip-flip-y, 0px));
+    transition: transform 200ms cubic-bezier(0.22, 1, 0.36, 1);
+    will-change: transform;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .app-cursor-tooltip-flip {
+      transition: none;
+    }
+  }
+
   .app-chart-tooltip-default-content {
     background: var(--app-bg) !important;
     border: 1px solid var(--app-border-strong) !important;

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -1422,7 +1422,7 @@
   @media (max-width: 1049.98px) {
     .app-body-scroll-locked .settings-mobile-section-menu-lock-spacer {
       display: block;
-      height: 3.75rem;
+      height: 3.25rem;
     }
 
     .app-body-scroll-locked .settings-mobile-section-menu-shell {

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -819,6 +819,31 @@
     box-shadow: 0 0 0 3px var(--app-accent-soft);
   }
 
+  /* Square icon-button member of the glass family for the floating mobile menu toggle, sharing the
+     translucent blurred surface so it blurs the page content behind it like the toolbar controls */
+  .app-glass-icon-button {
+    @apply inline-flex items-center justify-center transition-colors duration-150 motion-reduce:transition-none;
+    border-radius: 16px;
+    color: var(--app-text);
+    border: 1px solid var(--app-border-strong);
+    background: color-mix(in srgb, var(--app-input-bg) 62%, transparent);
+    -webkit-backdrop-filter: blur(20px) saturate(160%);
+    backdrop-filter: blur(20px) saturate(160%);
+  }
+
+  .app-glass-icon-button:hover {
+    background: color-mix(in srgb, var(--app-input-bg) 76%, transparent);
+  }
+
+  .app-glass-icon-button:active {
+    transform: translateY(1px);
+  }
+
+  .app-glass-icon-button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 3px var(--app-accent-soft);
+  }
+
   .app-primary-button-loading {
     width: 40px;
     height: 40px;

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -462,13 +462,6 @@
     gap: 2px;
     padding: 3px;
     border-radius: 12px;
-    background: color-mix(in srgb, var(--app-text) 7%, transparent);
-  }
-
-  /* The desktop filter panel lays its six facet tabs out in a single row, while the mobile sheet
-     swaps these tabs for a dropdown */
-  .app-filter-facet-grid {
-    grid-template-columns: repeat(6, minmax(0, 1fr));
     background: var(--app-input-bg);
     border: 1px solid var(--app-border);
   }
@@ -480,9 +473,13 @@
     gap: 2px;
     padding: 3px;
     border-radius: 12px;
-    background: color-mix(in srgb, var(--app-text) 7%, transparent);
+    background: var(--app-input-bg);
+    border: 1px solid var(--app-border);
   }
 
+  /* The segmented toggles adopt the accent colours of the theme switcher and the facet dropdown
+     options so the insights range presets, the This/Last/Past qualifier, and the filter facet tabs
+     all read as the same control */
   .app-range-seg-option {
     position: relative;
     appearance: none;
@@ -496,10 +493,16 @@
     text-align: center;
     white-space: nowrap;
     color: var(--app-text-muted);
+    transition: color 180ms ease, background-color 180ms ease;
+  }
+
+  .app-range-seg-option:hover {
+    color: var(--app-text);
+    background: var(--app-accent-soft);
   }
 
   .app-range-seg-option-active {
-    color: var(--app-text);
+    color: var(--app-accent);
     font-weight: 500;
   }
 
@@ -509,33 +512,12 @@
     position: absolute;
     inset: 0;
     border-radius: 8px;
-    background: var(--app-input-bg);
-    box-shadow: 0 1px 2px #00000014, inset 0 1px 0 color-mix(in srgb, white 28%, transparent);
+    background: var(--app-accent-soft);
+    border: 1px solid var(--app-accent-border);
   }
 
   .app-range-seg-label {
     position: relative;
-  }
-
-  /* The filter facet tabs adopt the accent toggle colours of the theme switcher and the facet
-     dropdown options, instead of the neutral sliding thumb the insights presets keep */
-  .app-filter-facet-grid .app-range-seg-option {
-    transition: color 180ms ease, background-color 180ms ease;
-  }
-
-  .app-filter-facet-grid .app-range-seg-option:hover {
-    color: var(--app-text);
-    background: var(--app-accent-soft);
-  }
-
-  .app-filter-facet-grid .app-range-seg-option-active {
-    color: var(--app-accent);
-  }
-
-  .app-filter-facet-grid .app-range-seg-thumb {
-    background: var(--app-accent-soft);
-    border: 1px solid var(--app-accent-border);
-    box-shadow: none;
   }
 
   .app-range-custom {

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -230,10 +230,16 @@
   }
 
   /* Firefox keeps its own native calendar button and ignores the WebKit indicator rules above, so
-     the overlaid glyph would double it. Hide the overlay in Firefox and let the native button stand */
+     the overlaid glyph would double it. Hide the overlay in Firefox and let the native button stand.
+     The right padding only exists to clear the WebKit overlay, so it is dropped here to keep the
+     native button against the right edge instead of leaving a wide gap beside it */
   @supports (-moz-appearance: none) {
     .app-date-overlay-icon {
       display: none;
+    }
+
+    .app-date-input-balanced[type="date"] {
+      padding-right: 0.75rem !important;
     }
   }
 

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -466,6 +466,8 @@
      swaps these tabs for a dropdown */
   .app-filter-facet-grid {
     grid-template-columns: repeat(6, minmax(0, 1fr));
+    background: var(--app-input-bg);
+    border: 1px solid var(--app-border);
   }
 
   /* This/Last/Past qualifier selector leading the custom builder, reusing the segmented styling */
@@ -510,6 +512,27 @@
 
   .app-range-seg-label {
     position: relative;
+  }
+
+  /* The filter facet tabs adopt the accent toggle colours of the theme switcher and the facet
+     dropdown options, instead of the neutral sliding thumb the insights presets keep */
+  .app-filter-facet-grid .app-range-seg-option {
+    transition: color 180ms ease, background-color 180ms ease;
+  }
+
+  .app-filter-facet-grid .app-range-seg-option:hover {
+    color: var(--app-text);
+    background: var(--app-accent-soft);
+  }
+
+  .app-filter-facet-grid .app-range-seg-option-active {
+    color: var(--app-accent);
+  }
+
+  .app-filter-facet-grid .app-range-seg-thumb {
+    background: var(--app-accent-soft);
+    border: 1px solid var(--app-accent-border);
+    box-shadow: none;
   }
 
   .app-range-custom {

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -310,13 +310,15 @@
     flex-direction: column-reverse;
   }
 
+  /* Vertical padding keeps the collapsed two-line pill at the 44px outer height the toolbar filter
+     button uses, so the insights selector reads as the same control family */
   .app-range-glass-head {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    gap: 10px;
-    padding: 7px 14px;
-    font-size: 0.8125rem;
+    gap: 8px;
+    padding: 5px 16px;
+    font-size: 0.9375rem;
     font-weight: 500;
     white-space: nowrap;
     color: var(--app-text);

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -229,6 +229,14 @@
     cursor: pointer;
   }
 
+  /* Firefox keeps its own native calendar button and ignores the WebKit indicator rules above, so
+     the overlaid glyph would double it. Hide the overlay in Firefox and let the native button stand */
+  @supports (-moz-appearance: none) {
+    .app-date-overlay-icon {
+      display: none;
+    }
+  }
+
   .app-input:hover {
     border-color: var(--app-border-strong);
     background: var(--app-input-bg);

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -292,7 +292,6 @@
     background: color-mix(in srgb, var(--app-input-bg) 62%, transparent);
     -webkit-backdrop-filter: blur(20px) saturate(160%);
     backdrop-filter: blur(20px) saturate(160%);
-    box-shadow: var(--app-shadow-soft), inset 0 1px 0 color-mix(in srgb, white 32%, transparent);
   }
 
   /* The mobile control spans the full width instead of hugging its content like the sidebar pill */
@@ -719,7 +718,6 @@
     background: color-mix(in srgb, var(--app-input-bg) 62%, transparent);
     -webkit-backdrop-filter: blur(20px) saturate(160%);
     backdrop-filter: blur(20px) saturate(160%);
-    box-shadow: var(--app-shadow-soft), inset 0 1px 0 color-mix(in srgb, white 32%, transparent);
   }
 
   .app-glass-input::placeholder {
@@ -738,7 +736,6 @@
     background: color-mix(in srgb, var(--app-button-primary-bg) 82%, transparent);
     -webkit-backdrop-filter: blur(20px) saturate(160%);
     backdrop-filter: blur(20px) saturate(160%);
-    box-shadow: var(--app-shadow-soft), inset 0 1px 0 color-mix(in srgb, white 28%, transparent);
   }
 
   .app-glass-button-primary:hover {
@@ -757,7 +754,7 @@
 
   .app-glass-button-primary:focus-visible {
     outline: none;
-    box-shadow: var(--app-shadow-soft), 0 0 0 3px var(--app-accent-soft);
+    box-shadow: 0 0 0 3px var(--app-accent-soft);
   }
 
   /* Neutral glass counterpart of the secondary button, sharing the filter pill surface */
@@ -771,7 +768,6 @@
     background: color-mix(in srgb, var(--app-input-bg) 62%, transparent);
     -webkit-backdrop-filter: blur(20px) saturate(160%);
     backdrop-filter: blur(20px) saturate(160%);
-    box-shadow: var(--app-shadow-soft), inset 0 1px 0 color-mix(in srgb, white 32%, transparent);
   }
 
   .app-glass-button:hover {
@@ -790,7 +786,7 @@
 
   .app-glass-button:focus-visible {
     outline: none;
-    box-shadow: var(--app-shadow-soft), 0 0 0 3px var(--app-accent-soft);
+    box-shadow: 0 0 0 3px var(--app-accent-soft);
   }
 
   .app-primary-button-loading {

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -360,10 +360,10 @@
     display: block;
     overflow: hidden;
     font-size: 0.6875rem;
-    font-weight: 400;
+    font-weight: 500;
     line-height: 1.2;
     white-space: nowrap;
-    color: var(--app-text-subtle);
+    color: var(--app-text-muted);
     font-variant-numeric: tabular-nums;
   }
 
@@ -371,7 +371,8 @@
   .app-range-dates {
     margin-top: 10px;
     font-size: 0.75rem;
-    color: var(--app-text-subtle);
+    font-weight: 500;
+    color: var(--app-text-muted);
     font-variant-numeric: tabular-nums;
   }
 

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -229,10 +229,6 @@
     cursor: pointer;
   }
 
-  .transaction-list-section > :not(:first-child) {
-    margin-top: 1.5rem;
-  }
-
   .app-input:hover {
     border-color: var(--app-border-strong);
     background: var(--app-input-bg);

--- a/frontend/tests/transactions/transactionsLogic.test.ts
+++ b/frontend/tests/transactions/transactionsLogic.test.ts
@@ -41,8 +41,8 @@ describe('filter option helpers', () => {
       createAccount({ id: 'checking', name: 'Checking' }),
       createAccount({ id: 'unnamed', name: undefined }),
     ])).toEqual([
-      { value: 'checking', label: 'Checking' },
-      { value: 'unnamed', label: 'Unnamed account' },
+      { value: 'checking', label: 'Checking', imageUrl: null },
+      { value: 'unnamed', label: 'Unnamed account', imageUrl: null },
     ])
   })
 


### PR DESCRIPTION
A pass across the frontend to make the visual design and animations consistent, fix a number of load-time and rendering bugs, and remove duplication left behind along the way.

### Page load and responsiveness
- The first page load fades in once its content is ready, instead of flashing or skipping the animation
- Navigation and toolbar buttons stay tappable while a page loads, fixing a delay (most noticeable on Safari) where taps did nothing for about a second after load
- The transactions overview charts mount a frame after the toolbar, so the controls respond to taps immediately
- The navigation highlight crossfades between pages instead of snapping

### Toolbars, search, and buttons
- Every search bar (transactions, accounts, settings, budgets) shares one glass search field at a single height
- The search bar, filter, and create buttons line up to the same height at every screen width
- The toolbar docks to the navigation pane line when it sticks while scrolling, with tighter, consistent spacing

### Filters
- The account and transaction filter pills open and animate exactly like the insights time selector, including a press effect on the facet tabs
- Filter options use the theme accent colours, with clearer spacing and hover states
- Institution logos appear beside accounts and institutions in the filters

### Insights and segmented toggles
- All the segmented toggles (insights presets, the This/Last/Past selector, the filter facet tabs, and the transaction All/Any toggle) share one accent style with a tap-down press
- Lightened the dark mode subtle text colour so dimmed labels are easier to read

### Transactions and budgets
- The transaction row sizes the category and account to their content and lets notes' width flex
- The daily cash flow chart reveals with a smooth animation instead of snapping to the end
- Removed the extra white space above the transaction date section headers
- The tallest bar in the budget history chart keeps its rounded top corner

### Settings
- The merchant list no longer reshuffles as more rows load; it follows the server's ranking instead of re-sorting on the client
- Long merchant names truncate instead of playing the marquee animation

### Mobile and tooltips
- The mobile menu button matches the glass design and lines up with the docked search bar
- Chart tooltips animate when they flip between the top and bottom of the cursor at the edge of a graph
- The settings section menu lines up with the mobile menu button when it docks while scrolling

### Code organization
- Extracted shared building blocks for the glass search field, the filter option styling, institution logo resolution, the filter pill and sticky toolbar styles, and the segmented toggle styling, removing duplicated markup and constants across the toolbars, settings, and filters

CU-86bahe64p