### PR TITLE
fix: stop the date picker sticking open on chrome and align it across browsers

### DIFF
--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -355,12 +355,16 @@ function DateFacetInput({
           value={value}
           onChange={(event) => onValueChange(event.target.value)}
         />
-        <Calendar
-          size={15}
-          aria-hidden
-          className="app-date-overlay-icon pointer-events-none absolute right-3 top-1/2 -translate-y-1/2"
+        <button
+          type="button"
+          aria-label="Open calendar"
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={() => inputRef.current?.showPicker?.()}
+          className="app-date-overlay-icon absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer border-0 bg-transparent p-0"
           style={{ color: 'var(--app-text-subtle)' }}
-        />
+        >
+          <Calendar size={15} aria-hidden className="block" />
+        </button>
       </div>
     </label>
   )

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { Calendar } from 'lucide-react'
 import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
 import IconTooltip from '@/components/tooltips/IconTooltip'
@@ -43,6 +44,8 @@ export default function TransactionDetailsSection({
   onAmountBlur,
   onNotesChange,
 }: TransactionDetailsSectionProps) {
+  const dateInputRef = useRef<HTMLInputElement>(null)
+
   return (
     <TransactionModalSectionFrame number="03" title="Details">
       <div className="grid gap-3 sm:grid-cols-[11rem_8.5rem_minmax(0,1fr)]">
@@ -72,6 +75,7 @@ export default function TransactionDetailsSection({
           </div>
           <div className="relative hidden min-[1050px]:block">
             <input
+              ref={dateInputRef}
               id="txn-date"
               type="date"
               className={`app-input app-date-input-balanced pr-9 disabled:cursor-not-allowed disabled:opacity-60 ${dateError ? 'app-input-error' : ''}`}
@@ -80,12 +84,17 @@ export default function TransactionDetailsSection({
               onChange={(event) => onDateChange(event.target.value)}
               onBlur={onDateBlur}
             />
-            <Calendar
-              size={15}
-              aria-hidden
-              className="app-date-overlay-icon pointer-events-none absolute right-3 top-1/2 -translate-y-1/2"
+            <button
+              type="button"
+              aria-label="Open calendar"
+              disabled={readOnly}
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={() => dateInputRef.current?.showPicker?.()}
+              className="app-date-overlay-icon absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer border-0 bg-transparent p-0 disabled:cursor-not-allowed"
               style={{ color: 'var(--app-text-subtle)' }}
-            />
+            >
+              <Calendar size={15} aria-hidden className="block" />
+            </button>
           </div>
         </div>
         <div>

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -70,15 +70,23 @@ export default function TransactionDetailsSection({
               onBlur={onDateBlur}
             />
           </div>
-          <input
-            id="txn-date"
-            type="date"
-            className={`app-input app-date-input-balanced hidden min-[1050px]:block disabled:cursor-not-allowed disabled:opacity-60 ${dateError ? 'app-input-error' : ''}`}
-            value={date}
-            disabled={readOnly}
-            onChange={(event) => onDateChange(event.target.value)}
-            onBlur={onDateBlur}
-          />
+          <div className="relative hidden min-[1050px]:block">
+            <input
+              id="txn-date"
+              type="date"
+              className={`app-input app-date-input-balanced pr-9 disabled:cursor-not-allowed disabled:opacity-60 ${dateError ? 'app-input-error' : ''}`}
+              value={date}
+              disabled={readOnly}
+              onChange={(event) => onDateChange(event.target.value)}
+              onBlur={onDateBlur}
+            />
+            <Calendar
+              size={15}
+              aria-hidden
+              className="app-date-overlay-icon pointer-events-none absolute right-3 top-1/2 -translate-y-1/2"
+              style={{ color: 'var(--app-text-subtle)' }}
+            />
+          </div>
         </div>
         <div>
           <div className="mb-1.5 flex items-center gap-2">

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -208,16 +208,19 @@
     text-align: left;
   }
 
+  /* The stretched indicator below is absolutely positioned, so the field itself must be the
+     containing block. Without this, Chrome resolves the indicator against the nearest positioned
+     ancestor (the modal panel) and blankets it with a transparent click target that traps every
+     click and never lets the picker dismiss */
   .app-date-input-balanced {
+    position: relative;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
   }
 
-  /* The native date appearance gives WebKit an intrinsic width that ignores the flex track and
-     overflows the panel, so the appearance stays stripped from the base rule to let the field
-     shrink. Stripping it also removes the native calendar glyph, so the visible icon is an overlaid
-     element and the native indicator is stretched transparently across the field to keep a tap
-     anywhere opening the picker */
+  /* WebKit's native date appearance forces an intrinsic width that overflows the flex track, so the
+     base rule strips it and the visible calendar glyph is an overlaid element instead. The native
+     indicator is kept transparent and stretched across the field so a tap anywhere opens the picker */
   .app-date-input-balanced[type="date"]::-webkit-calendar-picker-indicator {
     position: absolute;
     inset: 0;

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -208,28 +208,33 @@
     text-align: left;
   }
 
-  /* The stretched indicator below is absolutely positioned, so the field itself must be the
-     containing block. Without this, Chrome resolves the indicator against the nearest positioned
-     ancestor (the modal panel) and blankets it with a transparent click target that traps every
-     click and never lets the picker dismiss */
+  /* WebKit top-aligns the date text once the native appearance is stripped, while Firefox already
+     centres it. The datetime-edit selector guard keeps this WebKit only so the Firefox rendering
+     stays untouched. The host flexes so the edit region stretches to the full field height, then the
+     edit region centres its own fields, since aligning on the host alone still leaves Chrome biased
+     toward the top */
+  @supports selector(::-webkit-datetime-edit) {
+    .app-input[type="date"] {
+      display: inline-flex;
+    }
+
+    .app-input[type="date"]::-webkit-datetime-edit {
+      display: flex;
+      align-items: center;
+      padding: 0;
+    }
+  }
+
   .app-date-input-balanced {
-    position: relative;
     padding-left: 0.75rem;
     padding-right: 0.75rem;
   }
 
-  /* WebKit's native date appearance forces an intrinsic width that overflows the flex track, so the
-     base rule strips it and the visible calendar glyph is an overlaid element instead. The native
-     indicator is kept transparent and stretched across the field so a tap anywhere opens the picker */
+  /* The overlaid calendar button opens the picker through showPicker, which is the one trigger that
+     fires reliably in Chrome, so the native WebKit indicator is hidden to avoid a second glyph while
+     the date segments stay directly editable */
   .app-date-input-balanced[type="date"]::-webkit-calendar-picker-indicator {
-    position: absolute;
-    inset: 0;
-    width: auto;
-    height: auto;
-    margin: 0;
-    padding: 0;
-    opacity: 0;
-    cursor: pointer;
+    display: none;
   }
 
   /* Firefox keeps its own native calendar button and ignores the WebKit indicator rules above, so


### PR DESCRIPTION
- Fixes the date field in the Add Transaction modal on Chrome, where opening the calendar switched the cursor to a pointer and made clicks anywhere on the modal fail to close the picker or reach other fields
- Shows a calendar icon on the date field in Chrome and Safari, matching what Firefox already displayed
- Opens the date picker from the calendar icon in every browser, while keeping the day, month, and year segments directly editable

This resolves #103 