### PR TITLE
Fix stale test fixtures failing the frontend build

### DIFF
--- a/frontend/tests/api/auth.test.ts
+++ b/frontend/tests/api/auth.test.ts
@@ -24,6 +24,7 @@ const authResponse: AuthResponse = {
     tz: 'America/Toronto',
     base_currency: 'CAD',
     created_at: '2026-06-12T00:00:00Z',
+    second_factor_reenrollment_required: false,
   },
   access_token: 'access-token',
   token_type: 'bearer',

--- a/frontend/tests/api/client.test.ts
+++ b/frontend/tests/api/client.test.ts
@@ -15,6 +15,7 @@ const refreshedAuthResponse: AuthResponse = {
     tz: 'America/Toronto',
     base_currency: 'CAD',
     created_at: '2026-06-12T00:00:00Z',
+    second_factor_reenrollment_required: false,
   },
   access_token: 'new-access-token',
   token_type: 'bearer',

--- a/frontend/tests/api/insights.test.ts
+++ b/frontend/tests/api/insights.test.ts
@@ -85,12 +85,12 @@ describe('saved insights range functions', () => {
     expect(authenticatedFetchMock).toHaveBeenCalledWith('/insights/saved-ranges');
   });
 
-  it('creates a saved range with the name, amount, and unit', async () => {
-    await createSavedInsightsRange({ name: 'Half-year', amount: 6, unit: 'month' });
+  it('creates a saved range with the name, amount, unit, and qualifier', async () => {
+    await createSavedInsightsRange({ name: 'Half-year', amount: 6, unit: 'month', qualifier: 'past' });
 
     expect(authenticatedFetchMock).toHaveBeenCalledWith('/insights/saved-ranges', {
       method: 'POST',
-      body: JSON.stringify({ name: 'Half-year', amount: 6, unit: 'month' }),
+      body: JSON.stringify({ name: 'Half-year', amount: 6, unit: 'month', qualifier: 'past' }),
     });
   });
 

--- a/frontend/tests/api/transactions.test.ts
+++ b/frontend/tests/api/transactions.test.ts
@@ -35,7 +35,7 @@ describe('transaction fetch functions', () => {
 
   it('requests filtered transaction lists', async () => {
     await fetchTransactions({
-      account_id: 'acc_123',
+      account_id: ['acc_123'],
       q: 'coffee shop',
       from_date: '2026-01-01',
       to_date: '2026-01-31',
@@ -50,7 +50,7 @@ describe('transaction fetch functions', () => {
 
   it('omits empty transaction filters', async () => {
     await fetchTransactions({
-      account_id: '',
+      account_id: [],
       category_id: undefined,
     });
 
@@ -58,7 +58,7 @@ describe('transaction fetch functions', () => {
   });
 
   it('requests paginated transaction lists with offset options', async () => {
-    await fetchTransactionPage({ category_id: 'cat_123' }, 50, 100);
+    await fetchTransactionPage({ category_id: ['cat_123'] }, 50, 100);
 
     expect(authenticatedFetchMock).toHaveBeenCalledWith(
       '/transactions?category_id=cat_123&limit=50&offset=100',

--- a/frontend/tests/components/navigation/navigationLabels.test.ts
+++ b/frontend/tests/components/navigation/navigationLabels.test.ts
@@ -18,6 +18,7 @@ const user: User = {
   tz: 'America/Toronto',
   base_currency: 'CAD',
   created_at: '2026-01-01T00:00:00Z',
+  second_factor_reenrollment_required: false,
 }
 
 describe('navigation labels', () => {

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -169,6 +169,8 @@ describe('transaction modal helpers', () => {
       notes: '',
       date: '',
       tag_ids: [],
+      symmetric_transfer: false,
+      to_account_id: '',
     })).toEqual({
       account_id: 'Select an account',
       category_id: 'Select a category',
@@ -189,6 +191,8 @@ describe('transaction modal helpers', () => {
       notes: ' Weekly groceries ',
       date: '2026-06-11',
       tag_ids: ['tax'],
+      symmetric_transfer: false,
+      to_account_id: '',
     }, 2)).toEqual({
       account_id: 'checking',
       dt: '2026-06-11',

--- a/frontend/tests/transactions/transactionsLogic.test.ts
+++ b/frontend/tests/transactions/transactionsLogic.test.ts
@@ -62,13 +62,13 @@ describe('filter option helpers', () => {
 
   it('does not count the account filter on fixed-account transaction lists', () => {
     expect(getActiveFilterCount({
-      account_id: 'checking',
-      category_id: 'food',
+      account_id: ['checking'],
+      category_id: ['food'],
       from_date: '2026-06-01',
     }, false)).toBe(2)
     expect(getActiveFilterCount({
-      account_id: 'checking',
-      category_id: 'food',
+      account_id: ['checking'],
+      category_id: ['food'],
       from_date: '2026-06-01',
     }, true)).toBe(3)
   })


### PR DESCRIPTION
- Add the second-factor re-enrolment flag to the user fixtures in the auth, client, and navigation-label tests
- Add the saved-range qualifier to the insights saved-range test
- Switch the transaction filter tests from single string values to the array-based account, category, and tag filters
- Add the symmetric-transfer fields to the transaction modal test fixtures