### PR TITLE
fix: revalidate frontend index.html so browsers pick up new builds

### DIFF
--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -7,6 +7,12 @@
 	}
 
 	handle {
+		@hashed_assets path /assets/*
+		header @hashed_assets Cache-Control "public, max-age=31536000, immutable"
+
+		@revalidate not path /assets/*
+		header @revalidate Cache-Control "no-cache"
+
 		try_files {path} /index.html
 		file_server
 	}


### PR DESCRIPTION
- After an update, browsers could keep showing the previous version because the
  frontend entry document (index.html) was served with no caching policy, so it
  was reused from the browser cache without being re-checked
- The entry document is now served with no-cache, so the browser revalidates it
  on every load and always loads the current build's assets
- Fingerprinted bundles under /assets/ are now cached long-term and marked
  immutable, since each build gives them new filenames and they never change
- Scoped the caching rules to static file serving only, so API responses are
  unaffected
