### PR TITLE
feat: offer passkey setup first during signup 2FA enrolment

### DIFF
--- a/frontend/src/components/passkeys/PasskeyEnrollment.tsx
+++ b/frontend/src/components/passkeys/PasskeyEnrollment.tsx
@@ -1,0 +1,193 @@
+import { useState } from 'react';
+import { KeyRound } from 'lucide-react';
+import { useConfirmPasskeyRegistration, useRegisterPasskey } from '@/api/passkeys';
+import type { StepUpPayload } from '@/api/twoFactor/types';
+import { RecoveryCodesPanel } from '@/components/twoFactor/RecoveryCodesPanel';
+import { StepTransition } from '@/components/twoFactor/StepTransition';
+import { getPasskeyRegistrationMessage, isPasskeyCeremonyCancelled } from '@/utils/passkeyErrors';
+
+interface PasskeyEnrollmentProps {
+  /** Called once the passkey is active and, for a first passkey, its recovery codes are acknowledged */
+  onComplete: () => void;
+  /** Optional skip affordance, shown during signup but not in settings */
+  onSkip?: () => void;
+  /** Optional switch to authenticator-app enrolment, shown when both methods are on offer */
+  onSwitchToTotp?: () => void;
+  /**
+   * Password-only reauthorization for minting the registration challenge, used at signup where the
+   * just-set password gates the account's first factor
+   */
+  setupStepUp: StepUpPayload;
+}
+
+/**
+ * Drives passkey enrolment at signup: the naming and browser ceremony, then the one-time recovery codes
+ */
+export function PasskeyEnrollment({ onComplete, onSkip, onSwitchToTotp, setupStepUp }: PasskeyEnrollmentProps) {
+  const register = useRegisterPasskey();
+  const confirmRegistration = useConfirmPasskeyRegistration();
+  const [name, setName] = useState('');
+  const [error, setError] = useState('');
+  const [recoveryCodes, setRecoveryCodes] = useState<string[] | null>(null);
+  const [savedAcknowledged, setSavedAcknowledged] = useState(false);
+  const [lockoutAcknowledged, setLockoutAcknowledged] = useState(false);
+
+  /**
+   * Runs the registration ceremony, staging the recovery codes to acknowledge when a batch is issued
+   *
+   * A cancelled browser prompt is a deliberate choice, so it stays silent and leaves the user free to
+   * retry, switch method, or skip
+   */
+  const handleRegister = async () => {
+    const trimmed = name.trim();
+    if (!trimmed || register.isPending) return;
+
+    setError('');
+    try {
+      const result = await register.mutateAsync({ name: trimmed, step_up: setupStepUp });
+      if (result.recovery_codes) {
+        setRecoveryCodes(result.recovery_codes);
+      } else {
+        onComplete();
+      }
+    } catch (registrationError) {
+      if (isPasskeyCeremonyCancelled(registrationError)) return;
+      setError(getPasskeyRegistrationMessage(registrationError));
+    }
+  };
+
+  /**
+   * Activates the staged passkey once the recovery codes are acknowledged, then hands back to the caller
+   */
+  const handleActivate = async () => {
+    if (!savedAcknowledged || !lockoutAcknowledged || confirmRegistration.isPending) return;
+
+    setError('');
+    try {
+      await confirmRegistration.mutateAsync();
+      onComplete();
+    } catch {
+      setError('Could not finish setup. Try again.');
+    }
+  };
+
+  return (
+    <StepTransition stepKey={recoveryCodes ? 'recovery-codes' : 'passkey-register'}>
+      {recoveryCodes ? (
+        <div className="space-y-5">
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">Save your recovery codes</h3>
+            <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+              Each code works once if you lose your passkey. Store them somewhere safe, you won't see them again.
+            </p>
+          </div>
+
+          <RecoveryCodesPanel codes={recoveryCodes} />
+
+          <div className="space-y-2">
+            <label className="flex items-center gap-2 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+              <input
+                type="checkbox"
+                checked={savedAcknowledged}
+                onChange={(event) => setSavedAcknowledged(event.target.checked)}
+              />
+              I've saved my recovery codes
+            </label>
+
+            <label className="flex items-start gap-2 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+              <input
+                type="checkbox"
+                className="mt-1 shrink-0"
+                checked={lockoutAcknowledged}
+                onChange={(event) => setLockoutAcknowledged(event.target.checked)}
+              />
+              I understand I may be permanently locked out if I lose both my passkey and these codes
+            </label>
+          </div>
+
+          {error && (
+            <p className="text-center text-sm" style={{ color: 'var(--app-negative)' }}>
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={handleActivate}
+              disabled={!savedAcknowledged || !lockoutAcknowledged || confirmRegistration.isPending}
+              className={`app-primary-button transition-all duration-300 ${confirmRegistration.isPending ? 'app-primary-button-loading' : 'w-full'}`}
+            >
+              {confirmRegistration.isPending ? <div className="app-spinner" /> : 'Done'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-5">
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold">Protect your account with a passkey</h3>
+            <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+              Verify with your fingerprint, face, or device PIN when you sign in. Name it so you can tell
+              your passkeys apart later.
+            </p>
+          </div>
+
+          <input
+            className="app-input w-full"
+            placeholder="Name this passkey"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            disabled={register.isPending}
+            aria-label="New passkey name"
+          />
+
+          {error && (
+            <p className="text-center text-sm" style={{ color: 'var(--app-negative)' }}>
+              {error}
+            </p>
+          )}
+
+          <div className="flex justify-center">
+            <button
+              type="button"
+              onClick={handleRegister}
+              disabled={register.isPending || !name.trim()}
+              className={`app-primary-button transition-all duration-300 ${register.isPending ? 'app-primary-button-loading' : 'flex w-full items-center justify-center gap-2'}`}
+            >
+              {register.isPending ? (
+                <div className="app-spinner" />
+              ) : (
+                <>
+                  <KeyRound size={16} aria-hidden />
+                  Set up a passkey
+                </>
+              )}
+            </button>
+          </div>
+
+          {onSwitchToTotp && (
+            <button
+              type="button"
+              onClick={onSwitchToTotp}
+              className="block w-full text-center text-sm font-medium underline underline-offset-2 transition-colors duration-200"
+              style={{ color: 'var(--app-accent)' }}
+            >
+              Use an authenticator app instead
+            </button>
+          )}
+
+          {onSkip && (
+            <button
+              type="button"
+              onClick={onSkip}
+              className="block w-full text-center text-sm font-medium underline underline-offset-2 transition-colors duration-200"
+              style={{ color: 'var(--app-accent)' }}
+            >
+              Skip for now
+            </button>
+          )}
+        </div>
+      )}
+    </StepTransition>
+  );
+}

--- a/frontend/src/components/twoFactor/TotpEnrollment.tsx
+++ b/frontend/src/components/twoFactor/TotpEnrollment.tsx
@@ -20,6 +20,8 @@ interface TotpEnrollmentProps {
   onComplete: () => void;
   /** Optional skip affordance, shown during signup but not in settings */
   onSkip?: () => void;
+  /** Optional switch back to passkey enrolment, shown at signup when the origin supports passkeys */
+  onSwitchToPasskey?: () => void;
   /**
    * A secret already minted after stepping up, used in settings where the step-up prompt ran and
    * fetched it before opening enrolment. When set, enrolment does not mint its own
@@ -35,7 +37,7 @@ interface TotpEnrollmentProps {
 /**
  * Drives the shared TOTP enrolment flow: the QR and code confirmation, then the one-time recovery codes
  */
-export function TotpEnrollment({ onComplete, onSkip, initialSetup, setupStepUp }: TotpEnrollmentProps) {
+export function TotpEnrollment({ onComplete, onSkip, onSwitchToPasskey, initialSetup, setupStepUp }: TotpEnrollmentProps) {
   // Settings supplies a secret it already stepped up for, so this only mints one for signup and re-enrol
   const setup = useSetupTotp({ enabled: !initialSetup, stepUp: setupStepUp });
   const setupData = initialSetup ?? setup.data;
@@ -269,6 +271,17 @@ export function TotpEnrollment({ onComplete, onSkip, initialSetup, setupStepUp }
               {confirming ? <div className="app-spinner" /> : 'Confirm'}
             </button>
           </div>
+
+          {onSwitchToPasskey && (
+            <button
+              type="button"
+              onClick={onSwitchToPasskey}
+              className="block w-full text-center text-sm font-medium underline underline-offset-2 transition-colors duration-200"
+              style={{ color: 'var(--app-accent)' }}
+            >
+              Use a passkey instead
+            </button>
+          )}
 
           {onSkip && (
             <button

--- a/frontend/src/pages/auth/AuthPage.tsx
+++ b/frontend/src/pages/auth/AuthPage.tsx
@@ -5,7 +5,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { useCurrencies } from '@/api/currency';
 import { useOidcProviders } from '@/api/oidc';
 import { OtpInput, OTP_LENGTH } from '@/components/OtpInput';
-import { TotpEnrollment } from '@/components/twoFactor/TotpEnrollment';
+import { SignupFactorSetup } from '@/pages/auth/components/SignupFactorSetup';
 import { WarningCallout } from '@/components/twoFactor/WarningCallout';
 import { AuthAnimatedTitle } from '@/pages/auth/components/AnimatedTitle';
 import { AuthConfirmPasswordField } from '@/pages/auth/components/fields/ConfirmPasswordField';
@@ -139,9 +139,13 @@ const AuthPage = () => {
 
         <AnimatePresence mode="wait" initial={false}>
           {enrolling ? (
-            <motion.div key="totp-enrollment" className="mt-5" {...AUTH_VIEW_TRANSITION}>
+            <motion.div key="factor-enrollment" className="mt-5" {...AUTH_VIEW_TRANSITION}>
               {/* Opt-in 2FA at signup is the account's first factor, so it steps up with the password just set */}
-              <TotpEnrollment onComplete={finishEnrollment} onSkip={finishEnrollment} setupStepUp={{ password: form.password }} />
+              <SignupFactorSetup
+                passkeysSupported={canUsePasskeys}
+                setupStepUp={{ password: form.password }}
+                onFinish={finishEnrollment}
+              />
             </motion.div>
           ) : mfaActive ? (
             <motion.div

--- a/frontend/src/pages/auth/components/SignupFactorSetup.tsx
+++ b/frontend/src/pages/auth/components/SignupFactorSetup.tsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { motion } from 'motion/react';
+import type { StepUpPayload } from '@/api/twoFactor/types';
+import { PasskeyEnrollment } from '@/components/passkeys/PasskeyEnrollment';
+import { TotpEnrollment } from '@/components/twoFactor/TotpEnrollment';
+import { TwoFactorModalShell } from '@/components/twoFactor/TwoFactorModalShell';
+import { AUTH_VIEW_TRANSITION } from '@/pages/auth/constants/authAnimations';
+
+interface SignupFactorSetupProps {
+  /** Whether this origin can run a passkey ceremony, deciding whether passkey setup is offered first */
+  passkeysSupported: boolean;
+  /** Password-only reauthorization carried into whichever enrolment the user picks */
+  setupStepUp: StepUpPayload;
+  /** Called when a factor is set up or the user confirms skipping */
+  onFinish: () => void;
+}
+
+/**
+ * The post-signup second-factor step. A passkey is the stronger and simpler factor, so it leads when
+ * the origin supports one, with the authenticator app as the alternative. Skipping asks once more
+ * before letting the user into the app unprotected
+ */
+export function SignupFactorSetup({ passkeysSupported, setupStepUp, onFinish }: SignupFactorSetupProps) {
+  const [method, setMethod] = useState<'passkey' | 'totp'>(passkeysSupported ? 'passkey' : 'totp');
+  const [skipConfirmOpen, setSkipConfirmOpen] = useState(false);
+
+  /**
+   * Confirms the skip and leaves the setup step for the app
+   */
+  const confirmSkip = () => {
+    setSkipConfirmOpen(false);
+    onFinish();
+  };
+
+  return (
+    <>
+      {/* A keyed remount with an entrance fade swaps methods without an exit animation, since a nested
+          wait-mode AnimatePresence inside the auth page's own can wedge and never finish the swap */}
+      <motion.div
+        key={method}
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={AUTH_VIEW_TRANSITION.transition}
+      >
+        {method === 'passkey' ? (
+          <PasskeyEnrollment
+            onComplete={onFinish}
+            onSkip={() => setSkipConfirmOpen(true)}
+            onSwitchToTotp={() => setMethod('totp')}
+            setupStepUp={setupStepUp}
+          />
+        ) : (
+          <TotpEnrollment
+            onComplete={onFinish}
+            onSkip={() => setSkipConfirmOpen(true)}
+            onSwitchToPasskey={passkeysSupported ? () => setMethod('passkey') : undefined}
+            setupStepUp={setupStepUp}
+          />
+        )}
+      </motion.div>
+
+      <TwoFactorModalShell open={skipConfirmOpen} onClose={() => setSkipConfirmOpen(false)}>
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold">Skip two-factor setup?</h3>
+          <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+            Your password would be the only thing standing between your financial data and anyone who
+            gets hold of it. A passkey or authenticator app keeps your account safe even if your
+            password is compromised, and setup only takes a minute.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <button type="button" onClick={() => setSkipConfirmOpen(false)} className="app-primary-button w-full">
+            Go back
+          </button>
+
+          <button
+            type="button"
+            onClick={confirmSkip}
+            className="block w-full text-center text-sm font-medium underline underline-offset-2 transition-colors duration-200"
+            style={{ color: 'var(--app-text-muted)' }}
+          >
+            I still want to skip
+          </button>
+        </div>
+      </TwoFactorModalShell>
+    </>
+  );
+}

--- a/frontend/src/utils/passkeyErrors.ts
+++ b/frontend/src/utils/passkeyErrors.ts
@@ -27,14 +27,21 @@ export function getPasskeySignInMessage(error: unknown): string {
 /**
  * Turns a failed passkey registration into a message the user can act on
  *
- * A cancelled prompt and an already-registered authenticator are the common cases and read more
- * clearly than the raw library text, while anything else falls back to the server or library message
+ * A cancelled prompt, a declined prompt, and an already-registered authenticator are the common cases
+ * and read more clearly than the raw library text, while anything else falls back to the server or
+ * library message
  */
 export function getPasskeyRegistrationMessage(error: unknown): string {
   if (error instanceof WebAuthnError) {
     if (error.code === 'ERROR_CEREMONY_ABORTED') return 'Passkey setup was cancelled or timed out.';
     if (error.code === 'ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED') {
       return 'This device already has a passkey for your account.';
+    }
+
+    // The library only passes an error through when the browser reports NotAllowedError, which is how
+    // a declined permission prompt surfaces, so the raw browser text is replaced with a clear message
+    if (error.code === 'ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY') {
+      return 'The passkey prompt was declined or timed out, so no passkey was added. Try again to set one up.';
     }
   }
   return error instanceof Error && error.message ? error.message : 'Could not add this passkey.';

--- a/frontend/tests/utils/passkeyErrors.test.ts
+++ b/frontend/tests/utils/passkeyErrors.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Tests the passkey registration error mapping so the common prompt outcomes keep reading as clear
+ * guidance instead of raw browser or library text
+ */
+import { describe, expect, it } from 'vitest'
+
+import { WebAuthnError } from '@simplewebauthn/browser'
+import { getPasskeyRegistrationMessage, isPasskeyCeremonyCancelled } from '@/utils/passkeyErrors'
+
+/**
+ * Builds the wrapped error the library raises for a given failure code
+ */
+function buildWebAuthnError(code: ConstructorParameters<typeof WebAuthnError>[0]['code'], causeName: string) {
+  const cause = new Error('raw browser text')
+  cause.name = causeName
+  return new WebAuthnError({ message: 'raw browser text', code, cause })
+}
+
+describe('getPasskeyRegistrationMessage', () => {
+  it('explains a declined or timed-out prompt instead of passing the browser text through', () => {
+    const error = buildWebAuthnError('ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY', 'NotAllowedError')
+    expect(getPasskeyRegistrationMessage(error)).toBe(
+      'The passkey prompt was declined or timed out, so no passkey was added. Try again to set one up.',
+    )
+  })
+
+  it('explains an aborted ceremony', () => {
+    const error = buildWebAuthnError('ERROR_CEREMONY_ABORTED', 'AbortError')
+    expect(getPasskeyRegistrationMessage(error)).toBe('Passkey setup was cancelled or timed out.')
+  })
+
+  it('explains an authenticator that already holds a passkey', () => {
+    const error = buildWebAuthnError('ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED', 'InvalidStateError')
+    expect(getPasskeyRegistrationMessage(error)).toBe('This device already has a passkey for your account.')
+  })
+
+  it('falls back to the thrown message for other errors', () => {
+    expect(getPasskeyRegistrationMessage(new Error('server refused the attestation'))).toBe(
+      'server refused the attestation',
+    )
+  })
+
+  it('falls back to a generic message when there is nothing to show', () => {
+    expect(getPasskeyRegistrationMessage(undefined)).toBe('Could not add this passkey.')
+  })
+})
+
+describe('isPasskeyCeremonyCancelled', () => {
+  it('treats only an aborted ceremony as a silent cancel', () => {
+    expect(isPasskeyCeremonyCancelled(buildWebAuthnError('ERROR_CEREMONY_ABORTED', 'AbortError'))).toBe(true)
+    expect(isPasskeyCeremonyCancelled(buildWebAuthnError('ERROR_PASSTHROUGH_SEE_CAUSE_PROPERTY', 'NotAllowedError'))).toBe(
+      false,
+    )
+  })
+})


### PR DESCRIPTION
- After creating an account with email and password, the two-factor step now leads with passkey setup, with the authenticator app offered as an alternative and links to switch between the two
- On origins where passkeys cannot work, such as a bare IP address, signup falls back to the authenticator app setup as before
- The first passkey added at signup issues recovery codes the user must save and acknowledge before it activates, matching the authenticator flow
- Skipping two-factor setup now asks for confirmation, explaining that a password alone protects the account, with a "Go back" button and an "I still want to skip" option that continues into the app
- Declining the browser passkey prompt now shows a clear message instead of raw browser text, during signup, in settings, and during forced re-enrolment