### PR TITLE
fix: fail fast when configured and persisted encryption keys conflict

### DIFF
--- a/backend/app/encryption.py
+++ b/backend/app/encryption.py
@@ -32,14 +32,26 @@ def resolve_encryption_key(*, generate: bool) -> str:
         The url-safe base64 Fernet key
 
     Raises:
-        RuntimeError: No key is configured or persisted and generation is not allowed
+        RuntimeError: The configured and persisted keys conflict, or no key is configured
+            or persisted and generation is not allowed
     """
     configured_key = os.getenv(_KEY_ENV_VAR)
+    persisted_key = _KEY_FILE.read_text().strip() if _KEY_FILE.exists() else None
+
+    # A configured key that differs from the persisted one would silently win and every
+    # secret encrypted under the persisted key would fail to decrypt at runtime, so refuse
+    # to start instead of picking a winner
+    if configured_key and persisted_key and configured_key != persisted_key:
+        raise RuntimeError(
+            f"{_KEY_ENV_VAR} does not match the key persisted at {_KEY_FILE}. "
+            f"Remove the environment variable, remove the stale key file, or make them match"
+        )
+
     if configured_key:
         return configured_key
 
-    if _KEY_FILE.exists():
-        return _KEY_FILE.read_text().strip()
+    if persisted_key:
+        return persisted_key
 
     if not generate:
         raise RuntimeError(f"No application encryption key. Set {_KEY_ENV_VAR} or provision it first")

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -1,6 +1,9 @@
 """Application encryption helper tests"""
 
-from app.encryption import decrypt, encrypt
+import pytest
+
+from app import encryption
+from app.encryption import decrypt, encrypt, generate_encryption_key, resolve_encryption_key
 
 
 def test_encrypt_round_trips_to_the_original_plaintext():
@@ -17,3 +20,36 @@ def test_encrypt_is_non_deterministic():
     secret = "JBSWY3DPEHPK3PXP"
 
     assert encrypt(secret) != encrypt(secret)
+
+
+def test_resolve_raises_when_configured_and_persisted_keys_conflict(tmp_path, monkeypatch):
+    """A configured key that differs from the persisted key aborts instead of silently winning"""
+    key_file = tmp_path / "app_encryption_key"
+    key_file.write_text(generate_encryption_key())
+    monkeypatch.setattr(encryption, "_KEY_FILE", key_file)
+    monkeypatch.setenv("APP_ENCRYPTION_KEY", generate_encryption_key())
+
+    with pytest.raises(RuntimeError, match="does not match"):
+        resolve_encryption_key(generate=False)
+
+
+def test_resolve_returns_the_key_when_configured_and_persisted_keys_match(tmp_path, monkeypatch):
+    """Supplying the same key through both sources is not a conflict"""
+    key = generate_encryption_key()
+    key_file = tmp_path / "app_encryption_key"
+    key_file.write_text(key)
+    monkeypatch.setattr(encryption, "_KEY_FILE", key_file)
+    monkeypatch.setenv("APP_ENCRYPTION_KEY", key)
+
+    assert resolve_encryption_key(generate=False) == key
+
+
+def test_resolve_returns_the_persisted_key_without_a_configured_key(tmp_path, monkeypatch):
+    """The persisted key resolves on its own when the environment variable is absent"""
+    key = generate_encryption_key()
+    key_file = tmp_path / "app_encryption_key"
+    key_file.write_text(key)
+    monkeypatch.setattr(encryption, "_KEY_FILE", key_file)
+    monkeypatch.delenv("APP_ENCRYPTION_KEY", raising=False)
+
+    assert resolve_encryption_key(generate=False) == key


### PR DESCRIPTION
- The app now refuses to start when `APP_ENCRYPTION_KEY` is set but does not match the encryption key already persisted on the data volume, with an error telling the operator to remove the environment variable, remove the stale key file, or make them match
- Previously the environment value silently took precedence, so secrets already encrypted under the persisted key, such as authenticator app secrets and OIDC client secrets, would only fail later when someone signed in
- Deployments that use a single source are unaffected, a key is still generated and persisted automatically on first start when nothing is configured