### PR TITLE
fix: anchor date sensitive backend tests to the run date

### DIFF
--- a/backend/tests/routes/accounts/test_account_listing.py
+++ b/backend/tests/routes/accounts/test_account_listing.py
@@ -1,5 +1,5 @@
 import importlib
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from uuid import UUID
 
@@ -108,17 +108,20 @@ async def test_list_accounts_current_balance_uses_latest_snapshot(client):
     create_resp = await _create_account(client, headers)
     account_id = UUID(create_resp.json()["id"])
 
-    # Insert two snapshots after the zero anchor: the older of the two (12345)
-    # and the newer (98765). Helper should return the most recent.
+    # Insert two snapshots after the creation-day zero anchor: the older of the two (12345)
+    # and the newer (98765). Both are dated relative to today with margin so they stay after
+    # the anchor on any run date, letting the helper return the most recent.
+    older_dt = date.today() + timedelta(days=30)
+    newer_dt = date.today() + timedelta(days=60)
     async with TestSession() as session:
         session.add(AccountBalanceSnapshot(
             account_id=account_id,
-            dt=date(2027, 1, 1),
+            dt=older_dt,
             balance=12345,
         ))
         session.add(AccountBalanceSnapshot(
             account_id=account_id,
-            dt=date(2027, 6, 1),
+            dt=newer_dt,
             balance=98765,
         ))
         await session.commit()

--- a/backend/tests/routes/accounts/test_balance_snapshot_events.py
+++ b/backend/tests/routes/accounts/test_balance_snapshot_events.py
@@ -1,6 +1,6 @@
 """Route tests for the account balance snapshot endpoints and lifecycle hooks."""
 import uuid
-from datetime import date
+from datetime import date, timedelta
 
 from sqlalchemy import select
 
@@ -106,10 +106,11 @@ async def test_create_transaction_after_creation_day_keeps_zero_anchor(client):
     cat_resp = await _create_category(client, headers)
     category_id = cat_resp.json()["id"]
 
-    # Far-future date so the recompute window starts well after the creation day
+    # Date well after the creation day so the recompute window starts past the zero anchor on any run date
+    future_dt = creation_day + timedelta(days=30)
     await _create_transaction(
         client, headers, str(account_id), category_id,
-        dt="2026-12-15", amount=5000,
+        dt=future_dt.isoformat(), amount=5000,
     )
 
     snapshots = await _get_snapshots_for(account_id)
@@ -117,7 +118,7 @@ async def test_create_transaction_after_creation_day_keeps_zero_anchor(client):
     # Zero anchor is preserved as the earliest snapshot
     assert snapshot_map[creation_day] == 0
     # New txn day carries the running balance from the anchor (0 + 5000)
-    assert snapshot_map[date(2026, 12, 15)] == 5000
+    assert snapshot_map[future_dt] == 5000
     assert len(snapshots) == 2
 
 

--- a/backend/tests/routes/insights/test_period_glance.py
+++ b/backend/tests/routes/insights/test_period_glance.py
@@ -1,6 +1,6 @@
 """Route tests for insights period-glance endpoint."""
 
-from datetime import date
+from datetime import date, timedelta
 from decimal import Decimal
 from uuid import UUID, uuid4
 
@@ -749,16 +749,23 @@ async def test_period_glance_returns_net_worth_change_without_period_transaction
     headers = _get_auth_header(signup_resp)
     account_id = UUID((await _create_account(client, headers, name="Investment")).json()["id"])
 
+    # Account creation writes a zero-balance snapshot dated today, so the quiet month is
+    # anchored two calendar months back to keep the seeded baseline snapshot as the latest
+    # balance before the period on any run date
+    previous_month_end = date.today().replace(day=1) - timedelta(days=1)
+    quiet_month_end = previous_month_end.replace(day=1) - timedelta(days=1)
+    quiet_month_start = quiet_month_end.replace(day=1)
+
     async with TestSession() as session:
         session.add_all([
-            _snapshot(account_id, date(2026, 7, 15), 1_000_000),
-            _snapshot(account_id, date(2026, 8, 20), 1_125_000),
+            _snapshot(account_id, quiet_month_start - timedelta(days=16), 1_000_000),
+            _snapshot(account_id, quiet_month_start + timedelta(days=19), 1_125_000),
         ])
         await session.commit()
 
     resp = await client.get(
         "/insights/period-glance",
-        params={"from_date": "2026-08-01", "to_date": "2026-08-31"},
+        params={"from_date": quiet_month_start.isoformat(), "to_date": quiet_month_end.isoformat()},
         headers=headers,
     )
 


### PR DESCRIPTION
Fixes a period at a glance test that started failing once today's date caught up to its hardcoded snapshot dates, plus two more with the same latent issue, by anchoring all three to the run date instead