### PR TITLE
Implement support for archiving budgets

### DIFF
--- a/backend/alembic/versions/b60d4ea6d7e2_add_base_budget_is_archived.py
+++ b/backend/alembic/versions/b60d4ea6d7e2_add_base_budget_is_archived.py
@@ -1,0 +1,30 @@
+"""add base budget is archived
+
+Revision ID: b60d4ea6d7e2
+Revises: 2c12fe09ae65
+Create Date: 2026-07-16 17:54:25.824533
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "b60d4ea6d7e2"
+down_revision: str | Sequence[str] | None = "2c12fe09ae65"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add the archived flag that hides a base budget and stops period instance generation"""
+    op.add_column(
+        "base_budgets",
+        sa.Column("is_archived", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+
+def downgrade() -> None:
+    """Drop the base budget archived flag"""
+    op.drop_column("base_budgets", "is_archived")

--- a/backend/app/models/budget.py
+++ b/backend/app/models/budget.py
@@ -67,6 +67,7 @@ class BaseBudget(Base):
     recurrence_dom: Mapped[int | None] = mapped_column(SmallInteger)  # 1..31, required iff freq in (monthly, yearly)
     recurrence_month: Mapped[int | None] = mapped_column(SmallInteger)  # 1..12, required iff freq=yearly
     recurs: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)  # True = frontend auto-suggests next instance
+    is_archived: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
 

--- a/backend/app/routes/base_budgets/instance_helpers.py
+++ b/backend/app/routes/base_budgets/instance_helpers.py
@@ -61,6 +61,8 @@ def add_initial_budget_instances(
         overall_limit: Optional limit applied to each initial instance
         today: Current date in the user's timezone
     """
+    _raise_if_base_budget_archived(base_budget)
+
     if period_start is None or overall_limit is None:
         return
 
@@ -103,6 +105,7 @@ async def create_budget_instance_and_get_response(
         HTTPException: User lacks admin access, period start is invalid, or period overlaps
     """
     base_budget = await check_base_budget_access(db, base_budget_id, user_id, PermissionLevel.ADMIN)
+    _raise_if_base_budget_archived(base_budget)
     _validate_budget_instance_period_start(base_budget, data)
     period_end = compute_period_end(
         data.period_start,
@@ -181,4 +184,20 @@ async def _raise_for_overlapping_budget_instance(
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
             detail="A budget instance already exists for this period",
+        )
+
+
+def _raise_if_base_budget_archived(base_budget: BaseBudget) -> None:
+    """Raise when a base budget is archived and cannot generate period instances
+
+    Args:
+        base_budget: Base budget whose archived state gates instance generation
+
+    Raises:
+        HTTPException: Base budget is archived
+    """
+    if base_budget.is_archived:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot generate budget instances for an archived base budget",
         )

--- a/backend/app/routes/base_budgets/instance_helpers.py
+++ b/backend/app/routes/base_budgets/instance_helpers.py
@@ -201,3 +201,67 @@ def _raise_if_base_budget_archived(base_budget: BaseBudget) -> None:
             status_code=status.HTTP_409_CONFLICT,
             detail="Cannot generate budget instances for an archived base budget",
         )
+
+
+async def resume_budget_generation_at_current_period(
+    db: AsyncSession,
+    base_budget: BaseBudget,
+    today: date,
+) -> None:
+    """Create the current-period budget instance when a base budget is unarchived
+
+    Args:
+        db: Active database session
+        base_budget: Base budget being unarchived
+        today: Current date in the user's timezone
+    """
+    _raise_if_base_budget_archived(base_budget)
+
+    latest_budget_query = (
+        select(Budget)
+        .where(Budget.base_budget_id == base_budget.id)
+        .order_by(Budget.period_start.desc(), Budget.created_at.desc())
+        .limit(1)
+    )
+
+    # The newest instance supplies both the series phase origin and the carry-forward cap
+    latest_result = await db.execute(latest_budget_query)
+    latest_budget = latest_result.scalar_one_or_none()
+
+    # A base budget with no prior instance has no phase and no series to resume
+    if latest_budget is None:
+        return
+
+    # Walk contiguous full-length periods forward from the series phase until one contains today
+    # so the resumed period stays aligned with the real series rather than a single-unit anchor
+    current_period_start = latest_budget.period_start
+    current_period_end = latest_budget.period_end
+    while current_period_end < today:
+        current_period_start = current_period_end + timedelta(days=1)
+        current_period_end = compute_period_end(
+            current_period_start,
+            base_budget.recurrence_freq,
+            base_budget.instance_length,
+            dom=base_budget.recurrence_dom,
+            month=base_budget.recurrence_month,
+        )
+
+    overlapping_budget_query = select(Budget).where(
+        Budget.base_budget_id == base_budget.id,
+        Budget.period_start <= current_period_end,
+        Budget.period_end >= current_period_start,
+    )
+
+    # Skip creation when an existing instance already covers the current period so resume stays idempotent
+    overlap_result = await db.execute(overlapping_budget_query)
+    if overlap_result.scalar_one_or_none():
+        return
+
+    db.add(
+        Budget(
+            base_budget_id=base_budget.id,
+            period_start=current_period_start,
+            period_end=current_period_end,
+            overall_limit=latest_budget.overall_limit,
+        ),
+    )

--- a/backend/app/routes/base_budgets/update_helpers.py
+++ b/backend/app/routes/base_budgets/update_helpers.py
@@ -9,6 +9,7 @@ from app.models.base import PermissionLevel
 from app.models.user import User
 from app.permissions import check_base_budget_access
 from app.routes.base_budgets.category_helpers import update_tracked_category_links
+from app.routes.base_budgets.instance_helpers import resume_budget_generation_at_current_period
 from app.routes.base_budgets.response_helpers import get_base_budget_response
 from app.schemas.budget import BaseBudgetResponse, UpdateBaseBudgetRequest
 from app.services.cache_state import mark_cache_changed_for_scope
@@ -44,6 +45,10 @@ async def update_base_budget_and_get_response(
 
     # Handle tracked categories separately from simple field updates
     new_category_ids = changed_fields.pop("category_ids", None)
+
+    # Capture the unarchive transition before applying fields so resumption can key off the prior state
+    is_unarchiving = changed_fields.get("is_archived") is False and base_budget.is_archived
+
     for field, value in changed_fields.items():
         setattr(base_budget, field, value)
 
@@ -56,6 +61,10 @@ async def update_base_budget_and_get_response(
             base_budget.group_id,
             today,
         )
+
+    # Resume generation only after the archived flag is cleared so the guard permits the current period
+    if is_unarchiving:
+        await resume_budget_generation_at_current_period(db, base_budget, today)
 
     await mark_cache_changed_for_scope(db, user_id=base_budget.owner_id, group_id=base_budget.group_id)
     await db.commit()

--- a/backend/app/routes/base_budgets/update_helpers.py
+++ b/backend/app/routes/base_budgets/update_helpers.py
@@ -3,6 +3,7 @@
 import uuid
 from datetime import date
 
+from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import PermissionLevel
@@ -42,6 +43,16 @@ async def update_base_budget_and_get_response(
     if not changed_fields:
         response = await get_base_budget_response(db, base_budget)
         return response
+
+    # Evaluate the stored archived state before applying the patch so an unarchive request is not self-permitting
+    fields_other_than_archived_flag = set(changed_fields) - {"is_archived"}
+
+    # While archived a base budget only accepts clearing its archived flag so historical periods stay frozen
+    if base_budget.is_archived and fields_other_than_archived_flag:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot edit an archived base budget",
+        )
 
     # Handle tracked categories separately from simple field updates
     new_category_ids = changed_fields.pop("category_ids", None)

--- a/backend/app/schemas/budget.py
+++ b/backend/app/schemas/budget.py
@@ -61,6 +61,7 @@ class UpdateBaseBudgetRequest(BaseModel):
 
     name: str | None = Field(None, min_length=1, max_length=256)
     recurs: bool | None = None
+    is_archived: bool | None = None
     category_ids: list[uuid.UUID] | None = Field(None, min_length=1)
 
 
@@ -78,6 +79,7 @@ class BaseBudgetResponse(BaseModel):
     recurrence_dom: int | None
     recurrence_month: int | None
     recurs: bool
+    is_archived: bool
     created_at: datetime
     category_ids: list[uuid.UUID] = []  # Currently active tracked categories
 

--- a/backend/app/services/budgets/updates.py
+++ b/backend/app/services/budgets/updates.py
@@ -33,6 +33,13 @@ async def update_budget_instance(
     if not updates:
         return await get_budget_response(db, budget, base_budget)
 
+    # An archived base budget freezes its instances so the current-period limit cannot change while archived
+    if base_budget.is_archived:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Cannot update a budget instance for an archived base budget",
+        )
+
     # Reject explicit null because overall_limit is non-nullable on the model
     if "overall_limit" in updates and updates["overall_limit"] is None:
         raise HTTPException(

--- a/backend/tests/models/test_base_budget.py
+++ b/backend/tests/models/test_base_budget.py
@@ -140,6 +140,11 @@ async def test_recurs_defaults_to_false(db, base_budget):
     assert base_budget.recurs is False
 
 
+async def test_is_archived_defaults_to_false(db, base_budget):
+    """is_archived defaults to False when not explicitly set."""
+    assert base_budget.is_archived is False
+
+
 # --- BaseBudget: Recurring ---
 
 

--- a/backend/tests/routes/base_budgets/_helpers.py
+++ b/backend/tests/routes/base_budgets/_helpers.py
@@ -49,3 +49,18 @@ async def _create_base_budget(client, headers, *, category_ids=None, **overrides
         **overrides,
     }
     return await client.post("/base-budgets", json=payload, headers=headers)
+
+async def _create_budget_instance(client, headers, base_budget_id, **overrides):
+    """Create a budget instance via POST /base-budgets/{id}/budgets.
+
+    Defaults: period_start=2026-03-01, overall_limit=100000. period_end is
+    computed by the backend from the base's cadence
+    """
+    payload = {
+        "period_start": "2026-03-01",
+        "overall_limit": 100000,
+        **overrides,
+    }
+    return await client.post(
+        f"/base-budgets/{base_budget_id}/budgets", json=payload, headers=headers,
+    )

--- a/backend/tests/routes/base_budgets/test_listing.py
+++ b/backend/tests/routes/base_budgets/test_listing.py
@@ -28,6 +28,27 @@ async def test_list_base_budgets_returns_200(client):
     assert [b["name"] for b in data] == ["April Budget", "March Budget"]
 
 
+async def test_list_base_budgets_includes_archived(client):
+    """Archiving a base budget does not hide it from the listing."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+
+    resp = await client.get("/base-budgets", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["id"] == base_budget_id
+    assert data[0]["is_archived"] is True
+
+
 async def test_list_base_budgets_empty(client):
     """User with no base budgets gets an empty list."""
     signup_resp = await _create_user(client)

--- a/backend/tests/routes/base_budgets/test_updates.py
+++ b/backend/tests/routes/base_budgets/test_updates.py
@@ -800,3 +800,108 @@ async def test_unarchive_multi_unit_base_budget_resumes_phase_aligned_period(cli
     assert resumed.period_start.day == newest_period_start.day
     assert resumed.period_start <= date(2026, 12, 15) <= resumed.period_end
 
+
+# --- PATCH /base-budgets/{base_budget_id} — archived edit guard ---
+
+
+async def test_update_archived_base_budget_name_returns_409(client):
+    """Renaming an archived base budget is rejected so historical periods stay frozen."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    resp = await client.patch(
+        f"/base-budgets/{base_budget_id}",
+        json={"name": "Renamed"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Cannot edit an archived base budget"
+
+
+async def test_update_archived_base_budget_category_ids_returns_409(client):
+    """Changing tracked categories on an archived base budget is rejected the same as any other field."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    cat_id = await _create_category(client, headers)
+    create_resp = await _create_base_budget(client, headers, category_ids=[cat_id])
+    base_budget_id = create_resp.json()["id"]
+    other_cat_id = await _create_category(client, headers, name="Test Takeout")
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    resp = await client.patch(
+        f"/base-budgets/{base_budget_id}",
+        json={"category_ids": [other_cat_id]},
+        headers=headers,
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Cannot edit an archived base budget"
+
+
+async def test_update_archived_base_budget_combined_unarchive_and_edit_returns_409(client):
+    """Combining is_archived False with another field in the same patch is rejected.
+
+    The guard reads the stored archived state before the patch applies, so bundling an edit
+    with the unarchive flag cannot use the unarchive to bypass the block
+    """
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    resp = await client.patch(
+        f"/base-budgets/{base_budget_id}",
+        json={"is_archived": False, "name": "Renamed"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Cannot edit an archived base budget"
+
+
+async def test_update_archived_base_budget_unarchive_only_returns_200(client):
+    """An unarchive-only patch is not blocked by the archived-edit guard."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    resp = await client.patch(
+        f"/base-budgets/{base_budget_id}",
+        json={"is_archived": False},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["is_archived"] is False
+
+
+async def test_update_non_archived_base_budget_name_returns_200(client):
+    """The archived-edit guard does not fire when the base budget is not archived."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+
+    resp = await client.patch(
+        f"/base-budgets/{base_budget_id}",
+        json={"name": "Renamed"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Renamed"

--- a/backend/tests/routes/base_budgets/test_updates.py
+++ b/backend/tests/routes/base_budgets/test_updates.py
@@ -1,13 +1,15 @@
 import importlib
-from datetime import UTC, datetime
+import uuid
+from datetime import UTC, date, datetime
 
 import sqlalchemy as sa
 
-from app.models.budget import BudgetTrackedCategory
+from app.models.budget import Budget, BudgetTrackedCategory
 from tests.conftest import TestSession
 from tests.routes.base_budgets._helpers import (
     NONEXISTENT_ID,
     _create_base_budget,
+    _create_budget_instance,
     _create_category,
     _create_group,
     _create_second_user,
@@ -602,3 +604,199 @@ async def test_update_base_budget_unauthenticated_returns_401(client):
     )
 
     assert resp.status_code == 401
+
+
+# --- PATCH /base-budgets/{base_budget_id} — unarchive resume ---
+
+
+async def test_unarchive_base_budget_resumes_current_period_only(client, monkeypatch):
+    """Unarchiving materializes only the current period and carries the newest cap forward.
+
+    The archived gap between the last prior instance and the current period is never backfilled
+    """
+    base_budget_routes = importlib.import_module("app.routes.base_budgets.router")
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            instant = datetime(2026, 5, 4, 16, 0, tzinfo=UTC)
+            return instant.astimezone(tz) if tz else instant
+
+    monkeypatch.setattr(base_budget_routes, "datetime", FixedDateTime)
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+
+    # Two prior instances with distinct caps so the carried limit proves resume took the newest
+    await _create_budget_instance(
+        client, headers, base_budget_id, period_start="2026-02-01", overall_limit=80000,
+    )
+    await _create_budget_instance(
+        client, headers, base_budget_id, period_start="2026-03-01", overall_limit=100000,
+    )
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    resume_resp = await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": False}, headers=headers,
+    )
+
+    assert resume_resp.status_code == 200
+    assert resume_resp.json()["is_archived"] is False
+
+    async with TestSession() as session:
+        instances = (await session.execute(
+            sa.select(Budget)
+            .where(Budget.base_budget_id == uuid.UUID(base_budget_id))
+            .order_by(Budget.period_start),
+        )).scalars().all()
+
+    # The May current period is added at the newest cap while the archived April gap stays unfilled
+    assert [
+        (budget.period_start.isoformat(), budget.period_end.isoformat(), budget.overall_limit)
+        for budget in instances
+    ] == [
+        ("2026-02-01", "2026-02-28", 80000),
+        ("2026-03-01", "2026-03-31", 100000),
+        ("2026-05-01", "2026-05-31", 100000),
+    ]
+
+
+async def test_unarchive_base_budget_with_existing_current_period_is_idempotent(client, monkeypatch):
+    """Unarchiving creates no duplicate when an instance already covers the current period."""
+    base_budget_routes = importlib.import_module("app.routes.base_budgets.router")
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            instant = datetime(2026, 5, 4, 16, 0, tzinfo=UTC)
+            return instant.astimezone(tz) if tz else instant
+
+    monkeypatch.setattr(base_budget_routes, "datetime", FixedDateTime)
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+
+    # The sole instance already covers the current (May) period that resume would target
+    instance_resp = await _create_budget_instance(
+        client, headers, base_budget_id, period_start="2026-05-01", overall_limit=100000,
+    )
+    current_period_instance_id = instance_resp.json()["id"]
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    resume_resp = await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": False}, headers=headers,
+    )
+
+    assert resume_resp.status_code == 200
+
+    async with TestSession() as session:
+        instances = (await session.execute(
+            sa.select(Budget).where(Budget.base_budget_id == uuid.UUID(base_budget_id)),
+        )).scalars().all()
+
+    assert len(instances) == 1
+    assert str(instances[0].id) == current_period_instance_id
+    assert instances[0].overall_limit == 100000
+
+
+async def test_unarchive_base_budget_without_prior_instances_creates_nothing(client):
+    """Unarchiving a base budget that never had instances resumes nothing and does not error."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    resume_resp = await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": False}, headers=headers,
+    )
+
+    assert resume_resp.status_code == 200
+    assert resume_resp.json()["is_archived"] is False
+
+    async with TestSession() as session:
+        instances = (await session.execute(
+            sa.select(Budget).where(Budget.base_budget_id == uuid.UUID(base_budget_id)),
+        )).scalars().all()
+
+    assert instances == []
+
+
+async def test_unarchive_multi_unit_base_budget_resumes_phase_aligned_period(client, monkeypatch):
+    """A quarterly budget resumes on a period phase-aligned to its series, skipping the gap.
+
+    Resumption steps forward in whole three-month periods from the newest instance so the
+    resumed period stays on the same cadence phase rather than anchoring to a single month
+    """
+    base_budget_routes = importlib.import_module("app.routes.base_budgets.router")
+
+    class FixedDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            instant = datetime(2026, 12, 15, 16, 0, tzinfo=UTC)
+            return instant.astimezone(tz) if tz else instant
+
+    monkeypatch.setattr(base_budget_routes, "datetime", FixedDateTime)
+
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    # Quarterly cadence: monthly recurrence spanning three months per instance, dom kept <= 28
+    create_resp = await _create_base_budget(client, headers, instance_length=3)
+    base_budget_id = create_resp.json()["id"]
+
+    # Two contiguous quarters with distinct caps so the carried cap proves it took the newest
+    await _create_budget_instance(
+        client, headers, base_budget_id, period_start="2026-01-01", overall_limit=80000,
+    )
+    await _create_budget_instance(
+        client, headers, base_budget_id, period_start="2026-04-01", overall_limit=120000,
+    )
+
+    await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    resume_resp = await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": False}, headers=headers,
+    )
+
+    assert resume_resp.status_code == 200
+
+    async with TestSession() as session:
+        instances = (await session.execute(
+            sa.select(Budget)
+            .where(Budget.base_budget_id == uuid.UUID(base_budget_id))
+            .order_by(Budget.period_start),
+        )).scalars().all()
+
+    # Exactly one Q4 instance is added at the newest cap while the intermediate Q3 gap stays unfilled
+    assert [
+        (budget.period_start.isoformat(), budget.period_end.isoformat(), budget.overall_limit)
+        for budget in instances
+    ] == [
+        ("2026-01-01", "2026-03-31", 80000),
+        ("2026-04-01", "2026-06-30", 120000),
+        ("2026-10-01", "2026-12-31", 120000),
+    ]
+
+    # The resumed start advances the newest phase origin by a whole multiple of the three-month cadence
+    newest_period_start = date(2026, 4, 1)
+    resumed = instances[-1]
+    months_advanced = (
+        (resumed.period_start.year - newest_period_start.year) * 12
+        + resumed.period_start.month - newest_period_start.month
+    )
+    assert months_advanced % 3 == 0
+    assert resumed.period_start.day == newest_period_start.day
+    assert resumed.period_start <= date(2026, 12, 15) <= resumed.period_end
+

--- a/backend/tests/routes/base_budgets/test_updates.py
+++ b/backend/tests/routes/base_budgets/test_updates.py
@@ -64,6 +64,34 @@ async def test_update_base_budget_recurs_returns_200(client):
     assert resp.json()["recurs"] is True
 
 
+async def test_update_base_budget_archive_toggle_returns_200(client):
+    """Archiving then clearing is_archived round-trips through the column in both directions."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    create_resp = await _create_base_budget(client, headers)
+    base_budget_id = create_resp.json()["id"]
+    assert create_resp.json()["is_archived"] is False
+
+    archive_resp = await client.patch(
+        f"/base-budgets/{base_budget_id}",
+        json={"is_archived": True},
+        headers=headers,
+    )
+
+    assert archive_resp.status_code == 200
+    assert archive_resp.json()["is_archived"] is True
+
+    unarchive_resp = await client.patch(
+        f"/base-budgets/{base_budget_id}",
+        json={"is_archived": False},
+        headers=headers,
+    )
+
+    assert unarchive_resp.status_code == 200
+    assert unarchive_resp.json()["is_archived"] is False
+
+
 async def test_update_base_budget_add_categories(client):
     """Adding a tracked category via PATCH returns the updated category_ids."""
     signup_resp = await _create_user(client)

--- a/backend/tests/routes/budgets/test_creation.py
+++ b/backend/tests/routes/budgets/test_creation.py
@@ -40,6 +40,33 @@ async def test_create_budget_instance_returns_201(client):
     assert base["category_ids"] == [cat_id]
 
 
+async def test_create_budget_instance_archived_base_returns_409(client):
+    """An archived base rejects new period instances while a live base still accepts them."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    base_resp = await _create_base_budget(client, headers)
+    base_budget_id = base_resp.json()["id"]
+
+    # Control: a live base budget still materializes an instance
+    control = await _create_budget_instance(
+        client, headers, base_budget_id, period_start="2026-03-01",
+    )
+    assert control.status_code == 201
+
+    # Archiving the base blocks any further instance generation
+    archive_resp = await client.patch(
+        f"/base-budgets/{base_budget_id}", json={"is_archived": True}, headers=headers,
+    )
+    assert archive_resp.status_code == 200
+
+    blocked = await _create_budget_instance(
+        client, headers, base_budget_id, period_start="2026-04-01",
+    )
+
+    assert blocked.status_code == 409
+    assert blocked.json()["detail"] == "Cannot generate budget instances for an archived base budget"
+
+
 async def test_create_budget_instance_updates_cache_status(client):
     """Creating a budget instance marks app data changed for cache validation."""
     signup_resp = await _create_user(client)

--- a/backend/tests/routes/budgets/test_retrieval.py
+++ b/backend/tests/routes/budgets/test_retrieval.py
@@ -38,7 +38,7 @@ async def test_get_budget_returns_200(client):
     assert set(data["base_budget"].keys()) == {
         "id", "owner_id", "group_id", "name", "currency",
         "recurrence_freq", "instance_length", "recurrence_weekday",
-        "recurrence_dom", "recurrence_month", "recurs",
+        "recurrence_dom", "recurrence_month", "recurs", "is_archived",
         "created_at", "category_ids",
     }
     # Instance fields

--- a/backend/tests/routes/budgets/test_updates.py
+++ b/backend/tests/routes/budgets/test_updates.py
@@ -357,3 +357,51 @@ async def test_update_budget_ignores_unknown_fields(client):
     assert data["overall_limit"] == 55555
     # Unknown smuggled field had no effect
     assert data["base_budget_id"] == base_budget_id
+
+
+# --- PATCH /budgets/{budget_id} — archived base budget guard ---
+
+
+async def test_update_budget_overall_limit_returns_409_for_archived_base_budget(client):
+    """Updating overall_limit on an instance whose base budget is archived is rejected.
+
+    A non-archived base budget's instance is patched in the same test as a control, proving
+    the 409 comes from the archived flag and not some other blocker
+    """
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    # A single tracked category is reused across both base budgets to avoid the per-owner unique name collision
+    cat_id = await _create_category(client, headers)
+
+    archived_base_resp = await _create_base_budget(client, headers, category_ids=[cat_id])
+    archived_base_id = archived_base_resp.json()["id"]
+    archived_instance_id = (await _create_budget_instance(
+        client, headers, archived_base_id,
+    )).json()["id"]
+    await client.patch(
+        f"/base-budgets/{archived_base_id}", json={"is_archived": True}, headers=headers,
+    )
+
+    active_base_resp = await _create_base_budget(
+        client, headers, name="Active Budget", category_ids=[cat_id],
+    )
+    active_instance_id = (await _create_budget_instance(
+        client, headers, active_base_resp.json()["id"],
+    )).json()["id"]
+
+    archived_resp = await client.patch(
+        f"/budgets/{archived_instance_id}",
+        json={"overall_limit": 250000},
+        headers=headers,
+    )
+    active_resp = await client.patch(
+        f"/budgets/{active_instance_id}",
+        json={"overall_limit": 250000},
+        headers=headers,
+    )
+
+    assert archived_resp.status_code == 409
+    assert archived_resp.json()["detail"] == "Cannot update a budget instance for an archived base budget"
+    assert active_resp.status_code == 200
+    assert active_resp.json()["overall_limit"] == 250000

--- a/backend/tests/routes/budgets/test_utilization_listing.py
+++ b/backend/tests/routes/budgets/test_utilization_listing.py
@@ -56,6 +56,32 @@ async def test_list_latest_budget_utilizations_returns_latest_period_only(client
     assert data[0]["fx_status"] == {"state": "none", "missing_pairs": []}
 
 
+async def test_list_latest_budget_utilizations_includes_archived_base(client):
+    """Archiving a base budget keeps its latest instance in the utilization roll-up."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    account_id = (await _create_account(client, headers)).json()["id"]
+    groceries = await _create_category(client, headers)
+
+    base_id, budget_id = await _create_base_with_instance(
+        client, headers, category_ids=[groceries],
+    )
+    await _create_transaction(client, headers, account_id, groceries, amount=-5000)
+
+    await client.patch(
+        f"/base-budgets/{base_id}", json={"is_archived": True}, headers=headers,
+    )
+
+    resp = await client.get("/budgets/latest-utilizations", headers=headers)
+    assert resp.status_code == 200
+
+    data = resp.json()
+    assert [item["budget_id"] for item in data] == [budget_id]
+    assert data[0]["base_budget_id"] == base_id
+    assert data[0]["total_spent"] == 5000
+
+
 async def test_list_latest_budget_utilizations_excludes_inaccessible_budgets(client):
     """Only budgets readable by the caller are included."""
     signup_resp = await _create_user(client)

--- a/dev/dev-db/seed_demo_data.py
+++ b/dev/dev-db/seed_demo_data.py
@@ -1020,12 +1020,27 @@ async def _seed_budgets(db, users, categories):
         recurrence_freq=RecurrenceFreq.MONTHLY, instance_length=1, recurrence_dom=1, recurs=True,
         created_at=window_created_at,
     )
+
+    # Ran continuously, was archived for two months, then reactivated this
+    # month, purely so the history chart has a real ARCHIVED gap to render
+    fitness = BaseBudget(
+        owner_id=alex.id, name="Fitness", currency="CAD",
+        recurrence_freq=RecurrenceFreq.MONTHLY, instance_length=1, recurrence_dom=1, recurs=True,
+        created_at=window_created_at,
+    )
     weekly_food = BaseBudget(
         owner_id=marco.id, name="Weekly Food", currency="CAD",
         recurrence_freq=RecurrenceFreq.WEEKLY, instance_length=1, recurrence_weekday=0, recurs=True,
         created_at=window_created_at,
     )
-    db.add_all([groceries, getaway, utilities, weekly_food])
+
+    # Marco's counterpart to Fitness above, same archived-then-reactivated shape
+    phone_plan = BaseBudget(
+        owner_id=marco.id, name="Phone Plan", currency="CAD",
+        recurrence_freq=RecurrenceFreq.MONTHLY, instance_length=1, recurrence_dom=1, recurs=True,
+        created_at=window_created_at,
+    )
+    db.add_all([groceries, getaway, utilities, fitness, weekly_food, phone_plan])
     await db.flush()
 
     # The internet category was tracked for a while and later removed, leaving
@@ -1041,9 +1056,13 @@ async def _seed_budgets(db, users, categories):
                               added_at=WINDOW_START),
         BudgetTrackedCategory(base_budget_id=utilities.id, category_id=system["Internet"].id,
                               added_at=WINDOW_START, removed_at=_add_months(WINDOW_START, 9)),
+        BudgetTrackedCategory(base_budget_id=fitness.id, category_id=system["Health"].id,
+                              added_at=WINDOW_START),
         BudgetTrackedCategory(base_budget_id=weekly_food.id, category_id=system["Groceries"].id,
                               added_at=WINDOW_START),
         BudgetTrackedCategory(base_budget_id=weekly_food.id, category_id=system["Dining"].id,
+                              added_at=WINDOW_START),
+        BudgetTrackedCategory(base_budget_id=phone_plan.id, category_id=system["Phone Plan"].id,
                               added_at=WINDOW_START),
     ])
 
@@ -1065,6 +1084,22 @@ async def _seed_budgets(db, users, categories):
         getaway, current_month,
         compute_period_end(current_month, RecurrenceFreq.MONTHLY, 1, dom=1), 40_000,
     ))
+
+    # Fitness and Phone Plan had contiguous monthly instances, then sat
+    # archived (no instance generated) for the two months right before this
+    # one, then were reactivated this month, leaving a two-month gap in
+    # their period history for the ARCHIVED band to render around
+    archived_months = (_add_months(current_month, -2), _add_months(current_month, -1))
+    for month_start in _month_starts():
+        if month_start in archived_months or month_start == current_month:
+            continue
+        gap_period_end = compute_period_end(month_start, RecurrenceFreq.MONTHLY, 1, dom=1)
+        instances.append(instance(fitness, month_start, gap_period_end, 6_000))
+        instances.append(instance(phone_plan, month_start, gap_period_end, 4_000))
+
+    current_month_end = compute_period_end(current_month, RecurrenceFreq.MONTHLY, 1, dom=1)
+    instances.append(instance(fitness, current_month, current_month_end, 6_000))
+    instances.append(instance(phone_plan, current_month, current_month_end, 4_000))
 
     week_start = _weekly_dates(0)[0]
     while week_start <= TODAY:

--- a/frontend/src/api/budgets/hooks.ts
+++ b/frontend/src/api/budgets/hooks.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueries, useQuery, useQueryClient } from '@tanstack/react-query';
-import { invalidateBudgetActivity } from '@/api/cache/updates/budgets';
+import { invalidateBudgetActivity, updateCachedBaseBudget } from '@/api/cache/updates/budgets';
 import {
   createBaseBudget,
   createBudgetInstance,
@@ -119,7 +119,9 @@ export function useUpdateBaseBudget() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: updateBaseBudget,
-    onSuccess: () => {
+    onSuccess: (baseBudget) => {
+      // Reflect the saved budget right away so an archive toggle moves its card before the refetch resolves
+      updateCachedBaseBudget(queryClient, baseBudget);
       invalidateBudgetActivity(queryClient);
     },
   });

--- a/frontend/src/api/budgets/types.ts
+++ b/frontend/src/api/budgets/types.ts
@@ -15,6 +15,9 @@ export interface BaseBudget {
   recurrence_month: number | null;
   recurs: boolean;
   created_at: string;
+
+  // True while the budget is hidden and the backend has paused generating new periods
+  is_archived: boolean;
   category_ids: string[];
 }
 
@@ -75,6 +78,7 @@ export interface UpdateBaseBudgetPayload {
     name?: string;
     recurs?: boolean;
     category_ids?: string[];
+    is_archived?: boolean;
   };
 }
 

--- a/frontend/src/api/cache/updates/budgets.ts
+++ b/frontend/src/api/cache/updates/budgets.ts
@@ -1,5 +1,7 @@
 import type { QueryClient } from '@tanstack/react-query';
 import { invalidateBudgets, invalidateDashboardBudgets } from '@/api/cache/invalidation';
+import { budgetKeys } from '@/api/cache/queryKeys';
+import type { BaseBudget, Budget } from '@/api/budgets/types';
 
 /**
  * Invalidates budget views after budget mutations change dashboard rollups
@@ -7,4 +9,23 @@ import { invalidateBudgets, invalidateDashboardBudgets } from '@/api/cache/inval
 export function invalidateBudgetActivity(queryClient: QueryClient) {
   invalidateBudgets(queryClient);
   invalidateDashboardBudgets(queryClient);
+}
+
+/**
+ * Writes an updated base budget into the base-budget list and every cached period that embeds it
+ */
+export function updateCachedBaseBudget(queryClient: QueryClient, baseBudget: BaseBudget) {
+  // Base-budget list drives the budgets page split between active and archived cards
+  queryClient.setQueryData<BaseBudget[]>(budgetKeys.baseBudgets(), (baseBudgets) => {
+    if (!baseBudgets) return baseBudgets;
+    return baseBudgets.map((item) => (item.id === baseBudget.id ? baseBudget : item));
+  });
+
+  // Period rows carry a base_budget copy that budget cards prefer over the list entry, so keep both aligned
+  queryClient.setQueryData<Budget[]>(budgetKeys.periods(), (periods) => {
+    if (!periods) return periods;
+    return periods.map((period) =>
+      period.base_budget_id === baseBudget.id ? { ...period, base_budget: baseBudget } : period,
+    );
+  });
 }

--- a/frontend/src/pages/budgets/BudgetsPage.tsx
+++ b/frontend/src/pages/budgets/BudgetsPage.tsx
@@ -13,6 +13,7 @@ import { useCategories } from '@/api/categories'
 import { useCurrencies } from '@/api/currency'
 import { useAuth } from '@/hooks/useAuth'
 import BudgetCardsSection from '@/pages/budgets/components/budget-cards/Section'
+import BudgetArchivedSection from '@/pages/budgets/components/budget-cards/ArchivedSection'
 import BudgetCreateModal from '@/pages/budgets/components/budget-editor-modal/CreateModal'
 import BudgetDetailsModal from '@/pages/budgets/components/budget-details-modal/Modal'
 import { useBudgetCards } from '@/pages/budgets/hooks/useBudgetCards'
@@ -48,6 +49,14 @@ export default function BudgetsPage() {
     periods: budgetsQuery.data,
     categoryById,
   })
+  const activeBudgetCards = useMemo(
+    () => budgetCards.filter((card) => !card.baseBudget.is_archived),
+    [budgetCards],
+  )
+  const archivedBudgetCards = useMemo(
+    () => budgetCards.filter((card) => card.baseBudget.is_archived),
+    [budgetCards],
+  )
   const latestUtilizationByBudgetId = useMemo(
     () => new Map(
       (latestUtilizationsQuery.data ?? [])
@@ -116,13 +125,23 @@ export default function BudgetsPage() {
       </div>
 
       <BudgetCardsSection
-        budgetCards={budgetCards}
+        budgetCards={activeBudgetCards}
         latestUtilizationByBudgetId={latestUtilizationByBudgetId}
         loading={budgetsLoading}
         error={budgetsError}
         formOptionsLoading={categoriesLoading || currenciesLoading}
         onOpenBudget={openBudget}
       />
+
+      <AnimatePresence initial={false}>
+        {archivedBudgetCards.length > 0 && (
+          <BudgetArchivedSection
+            budgetCards={archivedBudgetCards}
+            latestUtilizationByBudgetId={latestUtilizationByBudgetId}
+            onOpenBudget={openBudget}
+          />
+        )}
+      </AnimatePresence>
 
       <BudgetCreateModal
         key={`${defaultCurrency}-${userTimeZone}`}

--- a/frontend/src/pages/budgets/BudgetsPage.tsx
+++ b/frontend/src/pages/budgets/BudgetsPage.tsx
@@ -102,7 +102,12 @@ export default function BudgetsPage() {
   const refetchBudgets = useCallback(() => budgetsQuery.refetch(), [budgetsQuery])
 
   useRecurringBudgetBackfill({
-    enabled: Boolean(user) && !baseBudgetsQuery.isLoading && !budgetsQuery.isLoading,
+    // Wait for both budget queries to settle so backfill never acts on the stale pre-archive periods that
+    // linger between an unarchive and its refetch, which would otherwise recreate the suppressed gap periods
+    enabled:
+      Boolean(user)
+      && !baseBudgetsQuery.isFetching
+      && !budgetsQuery.isFetching,
     budgetCards,
     today,
     createBudgetInstance,

--- a/frontend/src/pages/budgets/components/budget-card/Card.tsx
+++ b/frontend/src/pages/budgets/components/budget-card/Card.tsx
@@ -15,12 +15,14 @@ export default function BudgetCard({
   latestPeriod,
   categoryNames,
   utilization,
+  isArchived = false,
   onOpen,
 }: {
   baseBudget: BaseBudget
   latestPeriod: Budget | undefined
   categoryNames: string[]
   utilization: BudgetUtilization | undefined
+  isArchived?: boolean
   onOpen: () => void
 }) {
   const shownCategories = categoryNames.length > 3 ? categoryNames.slice(0, 2) : categoryNames.slice(0, 3)
@@ -35,9 +37,11 @@ export default function BudgetCard({
 
   return (
     <article
-      className="app-card app-budget-card flex min-h-[21.5rem] w-full min-w-0 cursor-pointer flex-col transition-transform duration-150 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-[var(--app-accent-soft)]"
+      className={`app-card app-budget-card flex min-h-[21.5rem] w-full min-w-0 cursor-pointer flex-col transition-transform duration-150 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-[var(--app-accent-soft)] ${
+        isArchived ? 'opacity-80 transition-opacity hover:opacity-100' : ''
+      }`}
       style={{
-        borderTop: `5px solid ${attention.indicatorColor}`,
+        borderTop: `5px solid ${isArchived ? 'var(--app-text-muted)' : attention.indicatorColor}`,
       }}
       role="button"
       tabIndex={0}

--- a/frontend/src/pages/budgets/components/budget-cards/ArchivedSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-cards/ArchivedSection.tsx
@@ -1,0 +1,163 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronDown, EyeOff } from 'lucide-react'
+import { motion, useReducedMotion } from 'motion/react'
+import type { BudgetUtilization } from '@/api/budgets'
+import BudgetCard from '@/pages/budgets/components/budget-card/Card'
+import { EASE } from '@/pages/budgets/constants'
+import type { BudgetCardViewModel } from '@/pages/budgets/types'
+
+const ARCHIVED_BUDGETS_SCROLL_OFFSET_PX = 24
+const ARCHIVED_BUDGETS_TRANSITION_SECONDS = 0.24
+
+// Matches the mt-6 spacing the section used before its appearance became animated
+const ARCHIVED_SECTION_MARGIN_TOP_PX = 24
+const ARCHIVED_SECTION_APPEAR_SECONDS = 0.28
+
+/**
+ * Scrolls the archived section near the top of the viewport while the page bottom clamps the target
+ */
+function scrollArchivedBudgetsIntoView(section: HTMLElement, prefersReducedMotion: boolean | null) {
+  const sectionTop = section.getBoundingClientRect().top + window.scrollY
+  const maxScrollTop = Math.max(document.documentElement.scrollHeight - window.innerHeight, 0)
+  const targetTop = Math.min(Math.max(sectionTop - ARCHIVED_BUDGETS_SCROLL_OFFSET_PX, 0), maxScrollTop)
+
+  window.scrollTo({
+    top: targetTop,
+    behavior: prefersReducedMotion ? 'auto' : 'smooth',
+  })
+}
+
+type BudgetArchivedSectionProps = {
+  budgetCards: BudgetCardViewModel[]
+  latestUtilizationByBudgetId: Map<string, BudgetUtilization>
+  onOpenBudget: (budget: BudgetCardViewModel) => void
+}
+
+/**
+ * Renders archived budgets behind a collapsible section and scrolls the expanded grid into view
+ *
+ * The caller mounts this inside AnimatePresence, so its own appearance easing plays when the first budget
+ * is archived and its exit easing plays when the last budget is unarchived
+ */
+export default function BudgetArchivedSection({
+  budgetCards,
+  latestUtilizationByBudgetId,
+  onOpenBudget,
+}: BudgetArchivedSectionProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [cardsMounted, setCardsMounted] = useState(false)
+  const sectionRef = useRef<HTMLElement>(null)
+  const prefersReducedMotion = useReducedMotion()
+
+  useEffect(() => {
+    if (!expanded) return
+
+    const animationFrameId = window.requestAnimationFrame(() => {
+      const section = sectionRef.current
+      if (!section) return
+
+      scrollArchivedBudgetsIntoView(section, prefersReducedMotion)
+    })
+
+    return () => window.cancelAnimationFrame(animationFrameId)
+  }, [expanded, prefersReducedMotion])
+
+  /**
+   * Toggles archived cards while keeping closing cards mounted until their height animation finishes
+   */
+  function toggleExpanded() {
+    if (expanded) {
+      setExpanded(false)
+      return
+    }
+
+    setCardsMounted(true)
+    setExpanded(true)
+  }
+
+  /**
+   * Removes collapsed cards after their closing height animation finishes
+   */
+  function handleCollapseComplete() {
+    if (expanded) return
+
+    setCardsMounted(false)
+  }
+
+  return (
+    <motion.section
+      ref={sectionRef}
+      className="overflow-hidden"
+      initial={{ height: 0, opacity: 0, marginTop: 0 }}
+      animate={{ height: 'auto', opacity: 1, marginTop: ARCHIVED_SECTION_MARGIN_TOP_PX }}
+      exit={{ height: 0, opacity: 0, marginTop: 0 }}
+      transition={{
+        duration: prefersReducedMotion ? 0 : ARCHIVED_SECTION_APPEAR_SECONDS,
+        ease: EASE,
+      }}
+    >
+      <button
+        type="button"
+        className="flex w-full items-center gap-3 py-2 text-left transition-colors hover:text-[var(--app-text)]"
+        style={{
+          borderTop: '1px solid var(--app-border)',
+          color: 'var(--app-text-muted)',
+        }}
+        aria-expanded={expanded}
+        onClick={toggleExpanded}
+      >
+        <EyeOff size={16} aria-hidden />
+        <span className="font-medium">Archived budgets</span>
+        <span
+          className="rounded-full px-2 py-0.5 text-xs font-semibold"
+          style={{ background: 'var(--app-accent-soft)' }}
+        >
+          {budgetCards.length}
+        </span>
+        <ChevronDown
+          size={16}
+          className={`ml-auto transition-transform ${expanded ? 'rotate-180' : ''}`}
+          aria-hidden
+        />
+      </button>
+
+      <motion.div
+        className="grid overflow-hidden"
+        initial={false}
+        animate={{
+          gridTemplateRows: expanded ? '1fr' : '0fr',
+          opacity: expanded ? 1 : 0,
+        }}
+        transition={{
+          duration: prefersReducedMotion ? 0 : ARCHIVED_BUDGETS_TRANSITION_SECONDS,
+          ease: EASE,
+        }}
+        aria-hidden={!expanded}
+        inert={!expanded}
+        onAnimationComplete={handleCollapseComplete}
+      >
+        {cardsMounted && (
+          <div className="min-h-0 overflow-hidden pt-1">
+            <div className="app-budget-grid">
+              {budgetCards.map((budgetCard) => {
+                const { baseBudget, latestPeriod, categoryNames } = budgetCard
+
+                return (
+                  <BudgetCard
+                    key={baseBudget.id}
+                    baseBudget={baseBudget}
+                    latestPeriod={latestPeriod}
+                    categoryNames={categoryNames}
+                    utilization={latestPeriod ? latestUtilizationByBudgetId.get(latestPeriod.id) : undefined}
+                    isArchived
+                    onOpen={() => onOpenBudget(budgetCard)}
+                  />
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </motion.div>
+    </motion.section>
+  )
+}

--- a/frontend/src/pages/budgets/components/budget-cards/Section.tsx
+++ b/frontend/src/pages/budgets/components/budget-cards/Section.tsx
@@ -1,12 +1,20 @@
-import { motion, useReducedMotion } from 'motion/react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import type { BudgetUtilization } from '@/api/budgets'
 import { LoadingOverlay } from '@/components/loading/Transition'
 import BudgetCard from '@/pages/budgets/components/budget-card/Card'
+import { EASE } from '@/pages/budgets/constants'
 import type { BudgetCardViewModel } from '@/pages/budgets/types'
 
 const BUDGET_CARDS_LOADING_AREA_HEIGHT = 'max(0px, calc(100dvh - 15rem))'
 const BUDGET_CARD_ENTER_OFFSET_PX = 12
 const BUDGET_CARD_STAGGER_SECONDS = 0.055
+const BUDGET_CARD_ENTER_SECONDS = 0.24
+const BUDGET_CARD_ENTER_EASE = [0.22, 1, 0.36, 1] as const
+
+// Archiving on save removes a card from the active list, so it fades and shrinks out while the grid reflows
+const BUDGET_CARD_EXIT_SCALE = 0.92
+const BUDGET_CARD_EXIT_SECONDS = 0.2
+const BUDGET_CARD_REFLOW_SECONDS = 0.28
 
 type BudgetCardsSectionProps = {
   budgetCards: BudgetCardViewModel[]
@@ -53,31 +61,44 @@ export default function BudgetCardsSection({
     return (
       <section className="relative" aria-busy={loading}>
         <section className="app-budget-grid">
-          {budgetCards.map((budgetCard, index) => {
-            const { baseBudget, latestPeriod, categoryNames } = budgetCard
+          {/* popLayout pulls the exiting card out of layout flow immediately so the remaining cards reflow during its exit instead of after it unmounts */}
+          <AnimatePresence mode="popLayout">
+            {budgetCards.map((budgetCard, index) => {
+              const { baseBudget, latestPeriod, categoryNames } = budgetCard
 
-            return (
-              <motion.div
-                key={baseBudget.id}
-                className="min-w-0"
-                initial={shouldReduceMotion ? false : { opacity: 0, y: BUDGET_CARD_ENTER_OFFSET_PX }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{
-                  duration: shouldReduceMotion ? 0 : 0.24,
-                  ease: [0.22, 1, 0.36, 1],
-                  delay: shouldReduceMotion ? 0 : index * BUDGET_CARD_STAGGER_SECONDS,
-                }}
-              >
-                <BudgetCard
-                  baseBudget={baseBudget}
-                  latestPeriod={latestPeriod}
-                  categoryNames={categoryNames}
-                  utilization={latestPeriod ? latestUtilizationByBudgetId.get(latestPeriod.id) : undefined}
-                  onOpen={() => onOpenBudget(budgetCard)}
-                />
-              </motion.div>
-            )
-          })}
+              return (
+                <motion.div
+                  key={baseBudget.id}
+                  layout
+                  className="min-w-0"
+                  initial={shouldReduceMotion ? false : { opacity: 0, y: BUDGET_CARD_ENTER_OFFSET_PX }}
+                  animate={{
+                    opacity: 1,
+                    y: 0,
+                    transition: {
+                      duration: shouldReduceMotion ? 0 : BUDGET_CARD_ENTER_SECONDS,
+                      ease: BUDGET_CARD_ENTER_EASE,
+                      delay: shouldReduceMotion ? 0 : index * BUDGET_CARD_STAGGER_SECONDS,
+                    },
+                  }}
+                  exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, scale: BUDGET_CARD_EXIT_SCALE }}
+                  transition={{
+                    duration: shouldReduceMotion ? 0 : BUDGET_CARD_EXIT_SECONDS,
+                    ease: EASE,
+                    layout: { duration: shouldReduceMotion ? 0 : BUDGET_CARD_REFLOW_SECONDS, ease: EASE },
+                  }}
+                >
+                  <BudgetCard
+                    baseBudget={baseBudget}
+                    latestPeriod={latestPeriod}
+                    categoryNames={categoryNames}
+                    utilization={latestPeriod ? latestUtilizationByBudgetId.get(latestPeriod.id) : undefined}
+                    onOpen={() => onOpenBudget(budgetCard)}
+                  />
+                </motion.div>
+              )
+            })}
+          </AnimatePresence>
         </section>
         <BudgetCardsLoadingLayer
           visible={loading}

--- a/frontend/src/pages/budgets/components/budget-details-modal/ChartTooltip.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/ChartTooltip.tsx
@@ -9,6 +9,9 @@ export interface BudgetChartPoint {
   spent: number
   limit: number
   utilizationPct: number
+
+  // Marks a synthetic slot that renders a shaded archived band instead of a utilization bar
+  archived?: boolean
   categories?: Array<{
     id: string
     name: string

--- a/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
@@ -1,4 +1,4 @@
-import { useRef, type MouseEvent as ReactMouseEvent } from 'react'
+import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   Bar,
   BarChart,
@@ -20,6 +20,7 @@ import {
 import BudgetChartTooltip, { type BudgetChartPoint } from '@/pages/budgets/components/budget-details-modal/ChartTooltip'
 import { MODAL_SURFACE_TRANSITION_MS } from '@/pages/budgets/constants'
 import {
+  ARCHIVED_SLOT_LABEL_PREFIX,
   BUDGET_CHART_HOVER_HIGHLIGHT_WIDTH,
   BUDGET_CHART_LAYOUT,
   getBudgetChartGuideMaxWidth,
@@ -27,6 +28,69 @@ import {
 } from '@/pages/budgets/utils/budgetDetails'
 
 const CHART_INITIAL_DIMENSION = { width: 1, height: 192 }
+
+// Rounds only the top corners of a utilization bar
+const BUDGET_BAR_TOP_CORNER_RADIUS: [number, number, number, number] = [4, 4, 0, 0]
+
+const ARCHIVED_BAND_LABEL = 'ARCHIVED'
+const ARCHIVED_BAND_INSET_PX = 10
+const ARCHIVED_BAND_MIN_WIDTH_PX = 18
+const ARCHIVED_BAND_LABEL_MIN_WIDTH_PX = 52
+const ARCHIVED_BAND_LABEL_FONT_SIZE = 10
+const ARCHIVED_BAND_FILL_OPACITY = 0.12
+const ARCHIVED_BAND_CORNER_RADIUS_PX = 6
+
+type ArchivedBandBackgroundProps = {
+  x?: number
+  y?: number
+  width?: number
+  height?: number
+  payload?: BudgetChartPoint
+  bandWidth: number
+}
+
+/**
+ * Shades an archived chart slot across the full plot height, centring the label when the band is wide enough
+ *
+ * Recharts supplies the bar geometry and the full-height background rectangle, so the band is centred on the
+ * slot and then widened to the categorical band size that the hover guide already relies on
+ */
+function ArchivedBandBackground({ x, y, width, height, payload, bandWidth }: ArchivedBandBackgroundProps) {
+  if (!payload?.archived || x == null || y == null || width == null || height == null) {
+    return null
+  }
+
+  const slotCenter = x + width / 2
+  const shadeWidth = Math.max(bandWidth - ARCHIVED_BAND_INSET_PX, ARCHIVED_BAND_MIN_WIDTH_PX)
+
+  return (
+    <g>
+      <rect
+        x={slotCenter - shadeWidth / 2}
+        y={y}
+        width={shadeWidth}
+        height={height}
+        rx={ARCHIVED_BAND_CORNER_RADIUS_PX}
+        fill="var(--app-text-muted)"
+        fillOpacity={ARCHIVED_BAND_FILL_OPACITY}
+      />
+      {shadeWidth >= ARCHIVED_BAND_LABEL_MIN_WIDTH_PX && (
+        <text
+          x={slotCenter}
+          y={y + height / 2}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fill="var(--app-text-subtle)"
+          fontSize={ARCHIVED_BAND_LABEL_FONT_SIZE}
+          fontWeight={600}
+          letterSpacing={1.5}
+        >
+          {ARCHIVED_BAND_LABEL}
+        </text>
+      )}
+    </g>
+  )
+}
 
 /**
  * Rounds the axis maximum up to the next multiple of 25 strictly above the data, so a bar that lands
@@ -59,7 +123,7 @@ function StackedBarSegment({ category, chartCategories, x, y, width, height, fil
     .find((entry) => Number((payload as Record<string, unknown> | undefined)?.[entry.dataKey] ?? 0) > 0)
   const isTopSegment = topSegment?.id === category.id
 
-  return <Rectangle x={x} y={y} width={width} height={height} fill={fill} radius={isTopSegment ? [4, 4, 0, 0] : 0} />
+  return <Rectangle x={x} y={y} width={width} height={height} fill={fill} radius={isTopSegment ? BUDGET_BAR_TOP_CORNER_RADIUS : 0} />
 }
 
 type BudgetHistoryChartProps = {
@@ -87,6 +151,27 @@ export default function BudgetHistoryChart({
   const chartRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<BudgetChartPoint>>(null)
   const showStackedCategoryChart = chartCategories.length > 1
+  const [measuredChartWidth, setMeasuredChartWidth] = useState(0)
+  const hasArchivedSlots = chartData.some((point) => point.archived)
+
+  // Track the plot width so archived bands match the categorical band size recharts renders
+  useEffect(() => {
+    const element = chartRef.current
+    if (!element) return
+
+    const observer = new ResizeObserver((entries) => {
+      setMeasuredChartWidth(entries[0].contentRect.width)
+    })
+    observer.observe(element)
+    return () => observer.disconnect()
+  }, [])
+
+  const archivedBandWidth = getBudgetChartGuideMaxWidth(measuredChartWidth, chartData.length)
+  const renderArchivedBand = hasArchivedSlots
+    ? (props: Omit<ArchivedBandBackgroundProps, 'bandWidth'>) => (
+        <ArchivedBandBackground {...props} bandWidth={archivedBandWidth} />
+      )
+    : undefined
 
   /**
    * Resolves the hovered Recharts bar and forwards it to the shared deferred tooltip overlay
@@ -102,7 +187,8 @@ export default function BudgetHistoryChart({
     })
     const pointer = getRechartsTooltipPointer(state, event)
 
-    if (!point) {
+    // Archived slots are shaded gaps rather than periods, so they never surface a utilization tooltip
+    if (!point || point.archived) {
       tooltipRef.current?.show(null, pointer)
       return
     }
@@ -147,6 +233,7 @@ export default function BudgetHistoryChart({
                 tickLine={false}
                 axisLine={false}
                 tick={{ fill: 'var(--app-text-subtle)', fontSize: 13 }}
+                tickFormatter={(label: string) => (label.startsWith(ARCHIVED_SLOT_LABEL_PREFIX) ? '' : label)}
               />
               <YAxis
                 tickLine={false}
@@ -156,21 +243,27 @@ export default function BudgetHistoryChart({
                 tickFormatter={(value) => `${Number(value)}%`}
                 width={BUDGET_CHART_LAYOUT.yAxisWidth}
               />
-              {showStackedCategoryChart ? chartCategories.map((category) => (
+              {showStackedCategoryChart ? chartCategories.map((category, index) => (
                 <Bar
                   key={category.id}
                   dataKey={category.dataKey}
                   stackId="category-spending"
                   fill={category.color}
                   shape={(props) => <StackedBarSegment {...props} category={category} chartCategories={chartCategories} />}
+                  background={index === 0 ? renderArchivedBand : undefined}
                   barSize={28}
                   animationBegin={MODAL_SURFACE_TRANSITION_MS}
                 />
               )) : (
+
+                // A custom shape keeps recharts from dropping the zero-height archived columns that carry the background band
                 <Bar
                   dataKey="utilizationPct"
                   fill="var(--app-accent)"
-                  radius={[4, 4, 0, 0]}
+                  shape={({ x, y, width, height, fill }) => (
+                    <Rectangle x={x} y={y} width={width} height={height} fill={fill} radius={BUDGET_BAR_TOP_CORNER_RADIUS} />
+                  )}
+                  background={renderArchivedBand}
                   barSize={28}
                   animationBegin={MODAL_SURFACE_TRANSITION_MS}
                 />

--- a/frontend/src/pages/budgets/components/budget-details-modal/Modal.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/Modal.tsx
@@ -89,8 +89,8 @@ export default function BudgetDetailsModal({
   const isOverBudget = remaining < 0
   const showStackedCategoryChart = chartCategories.length > 1
   const chartData = useMemo(
-    () => getBudgetDetailsChartData({ sortedPeriods, utilizationByBudgetId, chartCategories }),
-    [chartCategories, sortedPeriods, utilizationByBudgetId],
+    () => getBudgetDetailsChartData({ sortedPeriods, utilizationByBudgetId, chartCategories, baseBudget }),
+    [baseBudget, chartCategories, sortedPeriods, utilizationByBudgetId],
   )
   const periodHistory = useMemo(
     () => getBudgetPeriodHistory(sortedPeriods, utilizationByBudgetId),
@@ -255,9 +255,13 @@ export default function BudgetDetailsModal({
         categories={categories}
         currencies={currencies}
         onClose={() => setEditOpen(false)}
-        onSaved={() => {
+        onSaved={(archiveChanged) => {
           refetchUtilizationHistory()
           onSaved()
+
+          // Archiving is the only trigger for the card exit and archived-section animations, so close
+          // this full-screen modal on an archive change to let them play on the visible budgets page
+          if (archiveChanged) onClose()
         }}
       />
     </>,

--- a/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
@@ -297,6 +297,7 @@ export default function BudgetCreateModal({
             currencyReadOnly={false}
             currencyTooltip
             limitDisabled={false}
+            fieldsLocked={false}
             showError={showError}
             handlers={handlers}
           />
@@ -306,6 +307,7 @@ export default function BudgetCreateModal({
             ids={CREATE_FIELD_IDS}
             periodStartLabel="First period start"
             recurrenceControlsLocked={false}
+            fieldsLocked={false}
             showError={showError}
             handlers={handlers}
           />
@@ -317,6 +319,7 @@ export default function BudgetCreateModal({
           ids={CREATE_FIELD_IDS}
           emptyMessage="Create an expense category before adding a budget."
           animateOptions={false}
+          fieldsLocked={false}
           showError={showError}
           handlers={handlers}
         />

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -1,8 +1,9 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type React from 'react'
 import { useUpdateBaseBudget, useUpdateBudget, type BaseBudget, type Budget } from '@/api/budgets'
 import type { Category } from '@/api/categories'
 import type { Currency } from '@/api/currency'
+import BudgetEditorModalArchiveSection from '@/pages/budgets/components/budget-editor-modal/sections/ArchiveSection'
 import BudgetEditorModalCadenceSection from '@/pages/budgets/components/budget-editor-modal/sections/CadenceSection'
 import BudgetEditorModalCategorySection from '@/pages/budgets/components/budget-editor-modal/sections/CategorySection'
 import BudgetEditorModalFooter from '@/pages/budgets/components/budget-editor-modal/layout/Footer'
@@ -88,7 +89,9 @@ export default function BudgetEditModal({
   categories: Category[]
   currencies: Currency[]
   onClose: () => void
-  onSaved: () => void
+
+  // Reports whether the save flipped the archived flag so callers can reveal the archive animations
+  onSaved: (archiveChanged: boolean) => void
 }) {
   const updateBaseBudget = useUpdateBaseBudget()
   const updateBudget = useUpdateBudget()
@@ -102,6 +105,12 @@ export default function BudgetEditModal({
   const [saveInProgress, setSaveInProgress] = useState(false)
   const [categorySearch, setCategorySearch] = useState('')
   const [form, setForm] = useState<BudgetFormState>(initialForm)
+
+  // Archiving stays outside the shared budget form because only the edit workflow exposes it
+  const [isArchived, setIsArchived] = useState(baseBudget.is_archived)
+
+  // Tracks the previous open flag so the edit state only re-syncs on a closed-to-open transition
+  const prevOpen = useRef(open)
 
   // Preserve the budget's ownership scope so shared and personal budgets cannot cross category boundaries
   const categoryOptions = useMemo(
@@ -135,12 +144,13 @@ export default function BudgetEditModal({
     || form.recurs !== baseBudget.recurs
     || !sameStringSet(form.categoryIds, baseBudget.category_ids)
   const periodChanged = Boolean(latestPeriod && limitMinorUnits !== null && limitMinorUnits !== latestPeriod.overall_limit)
+  const archiveChanged = isArchived !== baseBudget.is_archived
   const canSave =
     !isPending
     && form.name.trim().length > 0
     && hasCategory
     && (!latestPeriod || limitMinorUnits !== null)
-    && (baseChanged || periodChanged)
+    && (baseChanged || periodChanged || archiveChanged)
   const state: BudgetEditorModalViewState = { form, formError, fieldErrors, touched, categorySearch }
   const options: BudgetEditorModalOptions = { categories: categoryOptions, filteredCategories, currencies }
   const showError: BudgetEditorModalErrorGetter = (field) => touched[field] ? fieldErrors[field] : undefined
@@ -150,12 +160,13 @@ export default function BudgetEditModal({
    */
   const resetEditState = useCallback(() => {
     setForm(initialForm)
+    setIsArchived(baseBudget.is_archived)
     setFieldErrors({})
     setTouched(EDIT_INITIAL_TOUCHED)
     setFormError(null)
     setCategorySearch('')
     setSaveInProgress(false)
-  }, [initialForm])
+  }, [baseBudget.is_archived, initialForm])
 
   /**
    * Closes the nested edit dialog and clears any transient form state immediately
@@ -164,6 +175,13 @@ export default function BudgetEditModal({
     onClose()
     resetEditState()
   }, [onClose, resetEditState])
+
+  useEffect(() => {
+    // The edit modal stays mounted, so reopening must reseed form and archive state from the current
+    // base budget, otherwise a stale archive toggle would silently unarchive on the next save
+    if (open && !prevOpen.current) resetEditState()
+    prevOpen.current = open
+  }, [open, resetEditState])
 
   useEffect(() => {
     if (!open) return
@@ -247,10 +265,12 @@ export default function BudgetEditModal({
       name?: string
       recurs?: boolean
       category_ids?: string[]
+      is_archived?: boolean
     } = {}
     if (form.name.trim() !== baseBudget.name) basePatch.name = form.name.trim()
     if (form.recurs !== baseBudget.recurs) basePatch.recurs = form.recurs
     if (!sameStringSet(form.categoryIds, baseBudget.category_ids)) basePatch.category_ids = form.categoryIds
+    if (isArchived !== baseBudget.is_archived) basePatch.is_archived = isArchived
 
     setSaveInProgress(true)
 
@@ -273,7 +293,7 @@ export default function BudgetEditModal({
         waitForMilliseconds(1000),
       ])
       closeAndReset()
-      onSaved()
+      onSaved(archiveChanged)
     } catch (error) {
       setFormError(error instanceof Error ? error.message : 'Could not save budget.')
       setSaveInProgress(false)
@@ -335,6 +355,11 @@ export default function BudgetEditModal({
             recurrenceControlsLocked
             showError={showError}
             handlers={handlers}
+          />
+
+          <BudgetEditorModalArchiveSection
+            isArchived={isArchived}
+            onToggle={setIsArchived}
           />
         </div>
 

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -145,6 +145,10 @@ export default function BudgetEditModal({
     || !sameStringSet(form.categoryIds, baseBudget.category_ids)
   const periodChanged = Boolean(latestPeriod && limitMinorUnits !== null && limitMinorUnits !== latestPeriod.overall_limit)
   const archiveChanged = isArchived !== baseBudget.is_archived
+
+  // The backend rejects any non-unarchive change to an archived budget, so every other field is locked
+  // against the persisted archived state rather than the staged toggle until the unarchive is saved
+  const fieldsLocked = baseBudget.is_archived
   const canSave =
     !isPending
     && form.name.trim().length > 0
@@ -332,6 +336,12 @@ export default function BudgetEditModal({
         />
       )}
     >
+      {fieldsLocked && (
+        <p className="mb-5 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+          Unarchive this budget to edit its details.
+        </p>
+      )}
+
       <div className="grid min-h-0 items-stretch gap-7 min-[1050px]:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
         <div className="flex min-h-0 flex-col gap-5">
           <BudgetEditorModalScopeSection
@@ -343,6 +353,7 @@ export default function BudgetEditModal({
             currencyReadOnly
             currencyTooltip={false}
             limitDisabled={!latestPeriod}
+            fieldsLocked={fieldsLocked}
             showError={showError}
             handlers={handlers}
           />
@@ -353,6 +364,7 @@ export default function BudgetEditModal({
             periodStartLabel="Period start"
             cadenceSummaryText={`${budgetCadenceLabel(baseBudget)}${latestPeriod ? ` · ${formatBudgetPeriod(latestPeriod)}` : ''}`}
             recurrenceControlsLocked
+            fieldsLocked={fieldsLocked}
             showError={showError}
             handlers={handlers}
           />
@@ -369,6 +381,7 @@ export default function BudgetEditModal({
           ids={EDIT_FIELD_IDS}
           emptyMessage="Create an expense category before editing this budget."
           animateOptions
+          fieldsLocked={fieldsLocked}
           showError={showError}
           handlers={handlers}
         />

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -320,6 +320,7 @@ export default function BudgetEditModal({
       title="Edit Budget"
       titleId="budget-edit-title"
       eyebrow={form.recurs ? 'Recurring budget' : 'One-off budget'}
+      headerStatus={fieldsLocked ? 'Archived budget' : undefined}
       sideLabel="Edit"
       formError={formError}
       warning="Changes apply from now forward. Past periods stay unchanged. To back propagate changes, create a new budget instead."

--- a/frontend/src/pages/budgets/components/budget-editor-modal/layout/Shell.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/layout/Shell.tsx
@@ -37,6 +37,7 @@ interface BudgetEditorModalShellProps {
   title: string
   titleId: string
   eyebrow: string
+  headerStatus?: string
   sideLabel: string
   warning?: string
   formError: string | null
@@ -55,6 +56,7 @@ export default function BudgetEditorModalShell({
   title,
   titleId,
   eyebrow,
+  headerStatus,
   sideLabel,
   warning,
   formError,
@@ -127,8 +129,21 @@ export default function BudgetEditorModalShell({
                 <div className={appearance.headerClassName} style={{ borderBottom: '1px solid var(--app-border)' }}>
                   <div className="flex items-start justify-between gap-6">
                     <div className="min-w-0">
-                      <p className="mb-2 text-xs font-semibold uppercase" style={{ color: 'var(--app-accent)' }}>
-                        {eyebrow}
+                      <p
+                        className="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1 text-xs font-semibold uppercase"
+                        style={{ color: 'var(--app-accent)' }}
+                      >
+                        <span>{eyebrow}</span>
+                        {headerStatus && (
+                          <>
+                            <span aria-hidden style={{ color: 'var(--app-text-subtle)' }}>
+                              &middot;
+                            </span>
+                            <span style={{ color: 'var(--app-warning-text)' }}>
+                              {headerStatus}
+                            </span>
+                          </>
+                        )}
                       </p>
                       <h2 id={titleId} className="font-serif text-3xl font-normal">
                         {title}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ArchiveSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ArchiveSection.tsx
@@ -1,0 +1,76 @@
+import { EyeOff } from 'lucide-react'
+
+const ARCHIVE_FIELD_ID = 'budget-edit-archive'
+
+interface BudgetEditorModalArchiveSectionProps {
+  isArchived: boolean
+  onToggle: (checked: boolean) => void
+}
+
+/**
+ * Renders the archive toggle that stages a budget's archived state for the next save
+ *
+ * Archived budgets stay in spending aggregates, so no balance-adjustment warning is shown
+ */
+export default function BudgetEditorModalArchiveSection({
+  isArchived,
+  onToggle,
+}: BudgetEditorModalArchiveSectionProps) {
+  return (
+    <div className="grid grid-cols-[1rem_minmax(0,1fr)] gap-x-2 min-[1050px]:gap-x-3">
+      <div className="flex min-h-0 flex-col items-center">
+        <span className="flex h-4 shrink-0 items-center text-xs font-semibold leading-none" style={{ color: 'var(--app-accent)' }} aria-hidden>
+          03
+        </span>
+        <span
+          className="mt-1 w-px flex-1"
+          style={{ backgroundColor: 'var(--app-border-strong)' }}
+          aria-hidden
+        />
+      </div>
+
+      <div className="min-w-0 space-y-3">
+        <p className="flex h-4 items-center text-base font-bold leading-none" style={{ color: 'var(--app-accent)' }}>Archive</p>
+
+        <label
+          htmlFor={ARCHIVE_FIELD_ID}
+          className="flex cursor-pointer items-center justify-between gap-4 rounded-xl p-4"
+          style={{
+            background: 'var(--app-input-bg)',
+            border: '1px solid var(--app-input-border)',
+          }}
+        >
+          <span className="min-w-0">
+            <span className="flex items-center gap-2 font-medium">
+              <EyeOff size={16} style={{ color: 'var(--app-text-muted)' }} aria-hidden />
+              Archive budget
+            </span>
+            <span className="mt-0.5 block text-sm" style={{ color: 'var(--app-text-muted)' }}>
+              Move this budget out of active lists while keeping its history.
+            </span>
+          </span>
+          <span className="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors">
+            <input
+              id={ARCHIVE_FIELD_ID}
+              type="checkbox"
+              role="switch"
+              checked={isArchived}
+              onChange={(event) => onToggle(event.target.checked)}
+              className="peer sr-only"
+            />
+            <span
+              className="absolute inset-0 rounded-full transition-colors peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2"
+              style={{ background: isArchived ? 'var(--app-accent)' : 'var(--app-border-strong)' }}
+              aria-hidden
+            />
+            <span
+              className="relative h-5 w-5 rounded-full bg-white shadow-sm transition-transform"
+              style={{ transform: isArchived ? 'translateX(1.25rem)' : 'translateX(0)' }}
+              aria-hidden
+            />
+          </span>
+        </label>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/CadenceSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/CadenceSection.tsx
@@ -10,6 +10,9 @@ interface BudgetEditorModalCadenceSectionProps {
   periodStartLabel: string
   cadenceSummaryText?: string
   recurrenceControlsLocked: boolean
+
+  // Locks the recurrence type toggle while the budget is archived so no cadence edit can be staged
+  fieldsLocked: boolean
   showError: BudgetEditorModalErrorGetter
   handlers: BudgetEditorModalHandlers
 }
@@ -23,6 +26,7 @@ export default function BudgetEditorModalCadenceSection({
   periodStartLabel,
   cadenceSummaryText,
   recurrenceControlsLocked,
+  fieldsLocked,
   showError,
   handlers,
 }: BudgetEditorModalCadenceSectionProps) {
@@ -48,18 +52,20 @@ export default function BudgetEditorModalCadenceSection({
         <div className="grid gap-2.5 md:grid-cols-[10rem_minmax(0,1fr)] md:items-end">
           <div>
             <span className="app-label mb-1.5 block text-[0.9375rem] leading-5">Type</span>
-            <div className="app-segmented-control w-full">
+            <div className={`app-segmented-control w-full ${fieldsLocked ? 'opacity-60' : ''}`}>
               <button
                 type="button"
-                className={`app-segmented-option flex-1 text-sm ${form.recurs ? 'app-segmented-option-active' : ''}`}
+                className={`app-segmented-option flex-1 text-sm ${fieldsLocked ? 'cursor-not-allowed' : ''} ${form.recurs ? 'app-segmented-option-active' : ''}`}
                 onClick={() => onRecursChange(true)}
+                disabled={fieldsLocked}
               >
                 Recurring
               </button>
               <button
                 type="button"
-                className={`app-segmented-option flex-1 text-sm ${!form.recurs ? 'app-segmented-option-active' : ''}`}
+                className={`app-segmented-option flex-1 text-sm ${fieldsLocked ? 'cursor-not-allowed' : ''} ${!form.recurs ? 'app-segmented-option-active' : ''}`}
                 onClick={() => onRecursChange(false)}
+                disabled={fieldsLocked}
               >
                 Once
               </button>

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/CategorySection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/CategorySection.tsx
@@ -12,6 +12,9 @@ interface BudgetEditorModalCategorySectionProps {
   ids: BudgetEditorModalFieldIds
   emptyMessage: string
   animateOptions: boolean
+
+  // Locks category search and selection while the budget is archived so tracked categories cannot change
+  fieldsLocked: boolean
   showError: BudgetEditorModalErrorGetter
   handlers: BudgetEditorModalHandlers
 }
@@ -25,6 +28,7 @@ export default function BudgetEditorModalCategorySection({
   ids,
   emptyMessage,
   animateOptions,
+  fieldsLocked,
   showError,
   handlers,
 }: BudgetEditorModalCategorySectionProps) {
@@ -38,6 +42,7 @@ export default function BudgetEditorModalCategorySection({
       category={category}
       selected={form.categoryIds.includes(category.id)}
       animateOptions={animateOptions}
+      disabled={fieldsLocked}
       onToggle={handlers.onCategoryToggle}
     />
   ))
@@ -94,6 +99,7 @@ export default function BudgetEditorModalCategorySection({
               onValueChange={handlers.onCategorySearchChange}
               placeholder="Search categories..."
               wrapperClassName="mt-3"
+              disabled={fieldsLocked}
             />
             <div className="relative mb-1 mt-3 min-h-0 min-[1050px]:flex-1">
               <motion.div
@@ -128,11 +134,13 @@ function BudgetCategoryOption({
   category,
   selected,
   animateOptions,
+  disabled,
   onToggle,
 }: {
   category: Category
   selected: boolean
   animateOptions: boolean
+  disabled: boolean
   onToggle: (categoryId: string) => void
 }) {
   const OptionComponent = animateOptions ? motion.button : 'button'
@@ -141,8 +149,9 @@ function BudgetCategoryOption({
     <OptionComponent
       {...(animateOptions ? { layout: true, transition: { layout: { duration: 0.22, ease: EASE } } } : {})}
       type="button"
-      className={`app-selection-option grid-cols-[1.25rem_1.25rem_minmax(0,1fr)] ${selected ? 'app-selection-option-active' : ''}`}
+      className={`app-selection-option grid-cols-[1.25rem_1.25rem_minmax(0,1fr)] ${disabled ? 'cursor-not-allowed opacity-60' : ''} ${selected ? 'app-selection-option-active' : ''}`}
       onClick={() => onToggle(category.id)}
+      disabled={disabled}
     >
       <span className={`app-selection-check ${selected ? 'app-selection-check-active' : ''}`}>
         <Check size={13} strokeWidth={3} aria-hidden />

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -14,6 +14,9 @@ interface BudgetEditorModalScopeSectionProps {
   currencyReadOnly: boolean
   currencyTooltip: boolean
   limitDisabled: boolean
+
+  // Locks every editable field while the budget is archived so only the archive toggle stays live
+  fieldsLocked: boolean
   showError: BudgetEditorModalErrorGetter
   handlers: BudgetEditorModalHandlers
 }
@@ -31,6 +34,7 @@ export default function BudgetEditorModalScopeSection({
   currencyReadOnly,
   currencyTooltip,
   limitDisabled,
+  fieldsLocked,
   showError,
   handlers,
 }: BudgetEditorModalScopeSectionProps) {
@@ -58,11 +62,12 @@ export default function BudgetEditorModalScopeSection({
           <BudgetEditorFieldLabelRow htmlFor={ids.name} label="Name" error={showError('name')} />
           <input
             id={ids.name}
-            className={`app-input ${showError('name') ? 'app-input-error' : ''}`}
+            className={`app-input disabled:cursor-not-allowed disabled:opacity-60 ${showError('name') ? 'app-input-error' : ''}`}
             placeholder={namePlaceholder}
             value={form.name}
             onChange={(event) => setField('name', event.target.value)}
             onBlur={() => onBlur('name')}
+            disabled={fieldsLocked}
           />
         </div>
 
@@ -125,7 +130,7 @@ export default function BudgetEditorModalScopeSection({
                 value={form.limit}
                 onChange={(event) => setField('limit', formatMoneyInputLive(sanitizeMoneyInput(event.target.value)))}
                 onBlur={() => onBlur('limit')}
-                disabled={limitDisabled}
+                disabled={limitDisabled || fieldsLocked}
               />
             </div>
           </div>

--- a/frontend/src/pages/budgets/hooks/useRecurringBudgetBackfill.ts
+++ b/frontend/src/pages/budgets/hooks/useRecurringBudgetBackfill.ts
@@ -28,6 +28,9 @@ export function useRecurringBudgetBackfill({
     // Remember attempted base/start pairs so rerenders do not duplicate mutation attempts
     const missingPeriods = budgetCards.flatMap(({ baseBudget, latestPeriod }) => {
       if (!latestPeriod) return []
+
+      // Archiving pauses period generation on the backend, so the client must not recreate the skipped periods
+      if (baseBudget.is_archived) return []
       return missingRecurringPeriodStarts(baseBudget, latestPeriod, today).map((periodStart) => ({
         key: `${baseBudget.id}:${periodStart}`,
         baseBudgetId: baseBudget.id,

--- a/frontend/src/pages/budgets/utils/budgetDetails.ts
+++ b/frontend/src/pages/budgets/utils/budgetDetails.ts
@@ -1,9 +1,22 @@
 import type { BaseBudget, Budget, BudgetUtilization } from '@/api/budgets'
 import type { Category } from '@/api/categories'
 import type { BudgetChartPoint } from '@/pages/budgets/components/budget-details-modal/ChartTooltip'
+import { nextRecurringPeriodStart } from '@/pages/budgets/utils/budgetPeriods'
 import { formatCalendarDate, parseYmd } from '@/pages/budgets/utils/date'
 import { getBudgetUtilizationPercent } from '@/pages/budgets/utils/utilization'
 import { getCategoryColorMap } from '@/utils/chartColor'
+
+const BUDGET_CHART_MAX_PERIODS = 6
+
+// Distinguishes synthetic archived slots from real period labels on the categorical axis
+export const ARCHIVED_SLOT_LABEL_PREFIX = 'archived:'
+
+export type BudgetArchivedChartSlot = {
+  // Unique categorical axis label that positions the shaded band between two bars
+  label: string
+  // Id of the period the shaded band is inserted after
+  afterPeriodId: string
+}
 
 export type BudgetChartCategory = {
   id: string
@@ -88,18 +101,64 @@ export function getBudgetChartCategories({
 }
 
 /**
+ * Detects archived stretches inside a chart period window and returns the shaded slots to insert between bars
+ *
+ * Archiving pauses period generation, so a stored period that starts later than the recurrence cadence would
+ * place it marks a skipped, archived stretch. When the base budget is still archived the final slot shades from
+ * the last stored period onward since no later period brackets the gap
+ */
+export function getBudgetArchivedChartSlots(
+  shownPeriods: Budget[],
+  baseBudget: BaseBudget,
+): BudgetArchivedChartSlot[] {
+  // One-off budgets never generate follow-on periods, so a gap cannot signal archiving
+  if (!baseBudget.recurs) return []
+
+  const slots: BudgetArchivedChartSlot[] = []
+  for (let index = 0; index < shownPeriods.length - 1; index += 1) {
+    const current = shownPeriods[index]
+    const next = shownPeriods[index + 1]
+
+    // A later-than-expected next start means at least one cycle was skipped while archived
+    if (next.period_start > nextRecurringPeriodStart(baseBudget, current.period_start)) {
+      slots.push({ label: `${ARCHIVED_SLOT_LABEL_PREFIX}${current.id}`, afterPeriodId: current.id })
+    }
+  }
+
+  const lastPeriod = shownPeriods[shownPeriods.length - 1]
+  if (baseBudget.is_archived && lastPeriod) {
+    slots.push({ label: `${ARCHIVED_SLOT_LABEL_PREFIX}${lastPeriod.id}-current`, afterPeriodId: lastPeriod.id })
+  }
+
+  return slots
+}
+
+/**
  * Converts budget periods and utilization results into the chart rows shown in the details modal
  */
 export function getBudgetDetailsChartData({
   sortedPeriods,
   utilizationByBudgetId,
   chartCategories,
+  baseBudget,
 }: {
   sortedPeriods: Budget[]
   utilizationByBudgetId: Map<string, BudgetUtilization>
   chartCategories: BudgetChartCategory[]
+  baseBudget: BaseBudget
 }): BudgetChartPoint[] {
-  return sortedPeriods.slice(-6).map((period) => {
+  const shownPeriods = sortedPeriods.slice(-BUDGET_CHART_MAX_PERIODS)
+  const archivedSlotByPeriodId = new Map(
+    getBudgetArchivedChartSlots(shownPeriods, baseBudget).map((slot) => [slot.afterPeriodId, slot]),
+  )
+
+  // Archived slots carry zeroed category values so their empty column renders no bar behind the shaded band
+  const zeroedCategoryValues = chartCategories.reduce<Record<string, number>>((values, category) => {
+    values[category.dataKey] = 0
+    return values
+  }, {})
+
+  return shownPeriods.flatMap((period) => {
     const utilization = utilizationByBudgetId.get(period.id)
     const periodSpent = utilization?.total_spent ?? 0
     const categorySpentById = new Map(
@@ -110,7 +169,7 @@ export function getBudgetDetailsChartData({
       return values
     }, {})
 
-    return {
+    const periodPoint: BudgetChartPoint = {
       label: formatCalendarDate(parseYmd(period.period_start)),
       spent: periodSpent,
       limit: period.overall_limit,
@@ -128,6 +187,20 @@ export function getBudgetDetailsChartData({
       }),
       ...categoryValues,
     }
+
+    const archivedSlot = archivedSlotByPeriodId.get(period.id)
+    if (!archivedSlot) return [periodPoint]
+
+    const archivedPoint: BudgetChartPoint = {
+      label: archivedSlot.label,
+      archived: true,
+      spent: 0,
+      limit: 0,
+      utilizationPct: 0,
+      categories: [],
+      ...zeroedCategoryValues,
+    }
+    return [periodPoint, archivedPoint]
   })
 }
 

--- a/frontend/src/pages/budgets/utils/budgetPeriods.ts
+++ b/frontend/src/pages/budgets/utils/budgetPeriods.ts
@@ -145,7 +145,8 @@ export function nextRecurringPeriodStart(baseBudget: BaseBudget, periodStart: st
  * Returns the next two recurrence ranges shown on budget cards
  */
 export function nextBudgetPeriods(baseBudget: BaseBudget, latestPeriod: Budget | undefined) {
-  if (!baseBudget.recurs || !latestPeriod) return []
+  // Archived budgets stop generating periods, so there is nothing upcoming to preview
+  if (!baseBudget.recurs || !latestPeriod || baseBudget.is_archived) return []
 
   const nextStart = addBudgetPeriod(parseYmd(latestPeriod.period_start), baseBudget)
   const followingStart = addBudgetPeriod(nextStart, baseBudget)

--- a/frontend/src/pages/budgets/utils/budgetPeriods.ts
+++ b/frontend/src/pages/budgets/utils/budgetPeriods.ts
@@ -101,7 +101,11 @@ function addBudgetPeriod(start: CalendarDate, baseBudget: BaseBudget) {
     return addDays(start, baseBudget.instance_length * 7)
   }
 
-  return addMonths(start, periodLengthInMonths(baseBudget))
+  // The backend re-anchors every period to recurrence_dom capped to the target month, so a dom-31 series
+  // re-expands after a short month (Feb28 -> Mar31) instead of sticking at the clamped day addMonths returned
+  const advanced = addMonths(start, periodLengthInMonths(baseBudget))
+  const anchorDom = baseBudget.recurrence_dom ?? start.day
+  return { ...advanced, day: anchorDay(advanced.year, advanced.month, anchorDom) }
 }
 
 /**
@@ -128,6 +132,13 @@ function formatYmd(date: CalendarDate) {
 function formatPeriodRange(start: CalendarDate, baseBudget: BaseBudget) {
   const nextStart = addBudgetPeriod(start, baseBudget)
   return `${formatCalendarDate(start)} - ${formatCalendarDate(addDays(nextStart, -1))}`
+}
+
+/**
+ * Returns the period start that immediately follows the supplied start after one recurrence cycle
+ */
+export function nextRecurringPeriodStart(baseBudget: BaseBudget, periodStart: string) {
+  return formatYmd(addBudgetPeriod(parseYmd(periodStart), baseBudget))
 }
 
 /**

--- a/frontend/styles/tailwind.css
+++ b/frontend/styles/tailwind.css
@@ -1487,7 +1487,14 @@
     order: 2;
   }
 
-  @container budget-card (min-width: 32rem) {
+  /*
+   * The threshold sits below 32rem because container queries measure the
+   * content box, and app-card padding removes ~2rem from a card's border
+   * box. A minimum-size grid card is 32rem border-box, so its content is
+   * only ~30rem, which is still above 28rem, letting the roomy layout
+   * trigger across the whole desktop grid
+   */
+  @container budget-card (min-width: 28rem) {
     .app-budget-card-summary {
       @apply flex-row items-baseline justify-between gap-4;
     }

--- a/frontend/tests/api/budgetCacheUpdates.test.ts
+++ b/frontend/tests/api/budgetCacheUpdates.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Tests the base-budget cache write helper that the archive toggle relies on for its optimistic update
+ *
+ * useUpdateBaseBudget itself calls useMutation and useQueryClient, which need a live React tree to
+ * invoke, so this covers updateCachedBaseBudget directly against a real QueryClient instead
+ */
+import { describe, expect, it } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import type { BaseBudget, Budget } from '@/api/budgets';
+import { budgetKeys } from '@/api/cache/queryKeys';
+import { updateCachedBaseBudget } from '@/api/cache/updates/budgets';
+
+/**
+ * Creates a base budget fixture with valid recurring monthly defaults
+ */
+function createBaseBudget(overrides: Partial<BaseBudget> = {}): BaseBudget {
+  return {
+    id: overrides.id ?? 'base',
+    owner_id: null,
+    group_id: null,
+    name: 'Groceries',
+    currency: 'CAD',
+    recurrence_freq: 'monthly',
+    instance_length: 1,
+    recurrence_weekday: null,
+    recurrence_dom: 1,
+    recurrence_month: null,
+    recurs: true,
+    created_at: '2026-01-01T00:00:00Z',
+    is_archived: false,
+    category_ids: ['groceries'],
+    ...overrides,
+  };
+}
+
+/**
+ * Creates a budget period fixture that embeds the supplied base budget
+ */
+function createBudget(baseBudget: BaseBudget, overrides: Partial<Budget> = {}): Budget {
+  return {
+    id: overrides.id ?? 'budget',
+    base_budget_id: baseBudget.id,
+    period_start: '2026-06-01',
+    period_end: '2026-06-30',
+    overall_limit: 100000,
+    created_at: '2026-06-01T00:00:00Z',
+    base_budget: baseBudget,
+    ...overrides,
+  };
+}
+
+describe('updateCachedBaseBudget', () => {
+  it('replaces the matching entry in the cached base-budget list and leaves others untouched', () => {
+    const queryClient = new QueryClient();
+    const archived = createBaseBudget({ id: 'base-1' });
+    const other = createBaseBudget({ id: 'base-2', name: 'Rent' });
+    queryClient.setQueryData(budgetKeys.baseBudgets(), [archived, other]);
+
+    const updated = { ...archived, is_archived: true };
+    updateCachedBaseBudget(queryClient, updated);
+
+    expect(queryClient.getQueryData<BaseBudget[]>(budgetKeys.baseBudgets())).toEqual([updated, other]);
+  });
+
+  it('does not create a base-budget list cache entry when none was cached yet', () => {
+    const queryClient = new QueryClient();
+
+    updateCachedBaseBudget(queryClient, createBaseBudget({ id: 'base-1', is_archived: true }));
+
+    expect(queryClient.getQueryData(budgetKeys.baseBudgets())).toBeUndefined();
+  });
+
+  it('updates the base_budget embedded in every cached period for that base budget', () => {
+    const queryClient = new QueryClient();
+    const baseBudget = createBaseBudget({ id: 'base-1' });
+    const otherBaseBudget = createBaseBudget({ id: 'base-2', name: 'Rent' });
+    const firstPeriod = createBudget(baseBudget, { id: 'period-1', period_start: '2026-05-01' });
+    const secondPeriod = createBudget(baseBudget, { id: 'period-2', period_start: '2026-06-01' });
+    const unrelatedPeriod = createBudget(otherBaseBudget, { id: 'period-3' });
+    queryClient.setQueryData(budgetKeys.periods(), [firstPeriod, secondPeriod, unrelatedPeriod]);
+
+    const updatedBaseBudget = { ...baseBudget, is_archived: true };
+    updateCachedBaseBudget(queryClient, updatedBaseBudget);
+
+    const cachedPeriods = queryClient.getQueryData<Budget[]>(budgetKeys.periods());
+    expect(cachedPeriods?.[0].base_budget).toEqual(updatedBaseBudget);
+    expect(cachedPeriods?.[1].base_budget).toEqual(updatedBaseBudget);
+    expect(cachedPeriods?.[2].base_budget).toEqual(otherBaseBudget);
+  });
+
+  it('does not create a periods cache entry when none was cached yet', () => {
+    const queryClient = new QueryClient();
+
+    updateCachedBaseBudget(queryClient, createBaseBudget({ id: 'base-1', is_archived: true }));
+
+    expect(queryClient.getQueryData(budgetKeys.periods())).toBeUndefined();
+  });
+});

--- a/frontend/tests/api/budgets.test.ts
+++ b/frontend/tests/api/budgets.test.ts
@@ -113,6 +113,22 @@ describe('budget API functions', () => {
     });
   });
 
+  it('sends the archive toggle as a base budget patch', async () => {
+    await updateBaseBudget({
+      id: 'base_123',
+      patch: {
+        is_archived: true,
+      },
+    });
+
+    expect(authenticatedFetchMock).toHaveBeenCalledWith('/base-budgets/base_123', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        is_archived: true,
+      }),
+    });
+  });
+
   it('deletes base budgets by ID', async () => {
     await deleteBaseBudget('base_123');
 

--- a/frontend/tests/budgets/budgetDetails.test.ts
+++ b/frontend/tests/budgets/budgetDetails.test.ts
@@ -5,7 +5,9 @@ import { describe, expect, it } from 'vitest'
 import type { BaseBudget, Budget, BudgetUtilization } from '@/api/budgets'
 import type { Category } from '@/api/categories'
 import {
+  ARCHIVED_SLOT_LABEL_PREFIX,
   BUDGET_CHART_HOVER_HIGHLIGHT_WIDTH,
+  getBudgetArchivedChartSlots,
   getBudgetChartCategories,
   getBudgetChartGuideMaxWidth,
   getBudgetDetailsChartData,
@@ -32,6 +34,7 @@ function createBaseBudget(overrides: Partial<BaseBudget> = {}): BaseBudget {
     recurrence_month: null,
     recurs: true,
     created_at: '2026-01-01T00:00:00Z',
+    is_archived: false,
     category_ids: ['groceries', 'travel'],
     ...overrides,
   }
@@ -143,7 +146,12 @@ describe('budget details helpers', () => {
       })],
     ])
 
-    const chartData = getBudgetDetailsChartData({ sortedPeriods, utilizationByBudgetId, chartCategories: categories })
+    const chartData = getBudgetDetailsChartData({
+      sortedPeriods,
+      utilizationByBudgetId,
+      chartCategories: categories,
+      baseBudget: createBaseBudget(),
+    })
 
     expect(sortedPeriods.map((period) => period.id)).toEqual([
       'budget-1',
@@ -187,5 +195,89 @@ describe('budget details helpers', () => {
   it('clamps chart guide width to the plot area', () => {
     expect(getBudgetChartGuideMaxWidth(40, 3)).toBe(1)
     expect(getBudgetChartGuideMaxWidth(500, 0)).toBe(BUDGET_CHART_HOVER_HIGHLIGHT_WIDTH)
+  })
+
+  it('finds no archived slot between contiguous monthly periods', () => {
+    const baseBudget = createBaseBudget()
+    const periods = [
+      createBudget({ id: 'jan', period_start: '2026-01-01' }),
+      createBudget({ id: 'feb', period_start: '2026-02-01' }),
+      createBudget({ id: 'mar', period_start: '2026-03-01' }),
+    ]
+
+    expect(getBudgetArchivedChartSlots(periods, baseBudget)).toEqual([])
+  })
+
+  it('finds no archived slot for a contiguous dom-31 monthly series crossing February', () => {
+    const baseBudget = createBaseBudget({ recurrence_dom: 31 })
+    const periods = [
+      createBudget({ id: 'jan', period_start: '2026-01-31' }),
+      createBudget({ id: 'feb', period_start: '2026-02-28' }),
+      createBudget({ id: 'mar', period_start: '2026-03-31' }),
+    ]
+
+    expect(getBudgetArchivedChartSlots(periods, baseBudget)).toEqual([])
+  })
+
+  it('inserts an archived slot between periods separated by more than one monthly cycle', () => {
+    const baseBudget = createBaseBudget()
+    const periods = [
+      createBudget({ id: 'jan', period_start: '2026-01-01' }),
+
+      // Skips February and March, so the gap is wider than one monthly cycle
+      createBudget({ id: 'apr', period_start: '2026-04-01' }),
+    ]
+
+    expect(getBudgetArchivedChartSlots(periods, baseBudget)).toEqual([
+      { label: `${ARCHIVED_SLOT_LABEL_PREFIX}jan`, afterPeriodId: 'jan' },
+    ])
+  })
+
+  it('appends a trailing archived slot after the last period while the base budget is still archived', () => {
+    const baseBudget = createBaseBudget({ is_archived: true })
+    const periods = [
+      createBudget({ id: 'jan', period_start: '2026-01-01' }),
+      createBudget({ id: 'feb', period_start: '2026-02-01' }),
+    ]
+
+    expect(getBudgetArchivedChartSlots(periods, baseBudget)).toEqual([
+      { label: `${ARCHIVED_SLOT_LABEL_PREFIX}feb-current`, afterPeriodId: 'feb' },
+    ])
+  })
+
+  it('never produces archived slots for one-off budgets, even when archived', () => {
+    const baseBudget = createBaseBudget({ recurs: false, is_archived: true })
+    const periods = [
+      createBudget({ id: 'jan', period_start: '2026-01-01' }),
+      createBudget({ id: 'apr', period_start: '2026-04-01' }),
+    ]
+
+    expect(getBudgetArchivedChartSlots(periods, baseBudget)).toEqual([])
+  })
+
+  it('interleaves a synthetic archived slot between bracketing bars while keeping real spend values', () => {
+    const baseBudget = createBaseBudget()
+    const sortedPeriods = [
+      createBudget({ id: 'jan', period_start: '2026-01-01', overall_limit: 100000 }),
+      createBudget({ id: 'apr', period_start: '2026-04-01', overall_limit: 100000 }),
+    ]
+    const utilizationByBudgetId = new Map([
+      ['jan', createUtilization({ budget_id: 'jan', total_spent: 40000 })],
+      ['apr', createUtilization({ budget_id: 'apr', total_spent: 25000 })],
+    ])
+
+    const chartData = getBudgetDetailsChartData({
+      sortedPeriods,
+      utilizationByBudgetId,
+      chartCategories: [],
+      baseBudget,
+    })
+
+    expect(chartData).toHaveLength(3)
+    expect(chartData[0]).toMatchObject({ label: 'Jan 1, 2026', spent: 40000 })
+    expect(chartData[0].archived).toBeFalsy()
+    expect(chartData[1]).toMatchObject({ label: `${ARCHIVED_SLOT_LABEL_PREFIX}jan`, archived: true, spent: 0, limit: 0 })
+    expect(chartData[2]).toMatchObject({ label: 'Apr 1, 2026', spent: 25000 })
+    expect(chartData[2].archived).toBeFalsy()
   })
 })

--- a/frontend/tests/budgets/budgetPeriods.test.ts
+++ b/frontend/tests/budgets/budgetPeriods.test.ts
@@ -110,6 +110,13 @@ describe('budget period helpers', () => {
     ])
   })
 
+  it('returns no upcoming periods for an archived recurring budget', () => {
+    const baseBudget = createBaseBudget({ is_archived: true })
+    const latestPeriod = createBudget(baseBudget)
+
+    expect(nextBudgetPeriods(baseBudget, latestPeriod)).toEqual([])
+  })
+
   it('lists every elapsed recurring period start that needs backfill', () => {
     const baseBudget = createBaseBudget()
     const latestPeriod = createBudget(baseBudget)

--- a/frontend/tests/budgets/budgetPeriods.test.ts
+++ b/frontend/tests/budgets/budgetPeriods.test.ts
@@ -9,6 +9,7 @@ import {
   cadenceSummary,
   missingRecurringPeriodStarts,
   nextBudgetPeriods,
+  nextRecurringPeriodStart,
   oneOffPeriodEnd,
   recurrenceAnchorsFromStart,
 } from '@/pages/budgets/utils/budgetPeriods'
@@ -30,6 +31,7 @@ function createBaseBudget(overrides: Partial<BaseBudget> = {}): BaseBudget {
     recurrence_month: null,
     recurs: true,
     created_at: '2026-01-01T00:00:00Z',
+    is_archived: false,
     category_ids: ['groceries'],
     ...overrides,
   }
@@ -116,5 +118,34 @@ describe('budget period helpers', () => {
       '2026-07-01',
       '2026-08-01',
     ])
+  })
+
+  it('advances a monthly period start by exactly one recurrence cycle', () => {
+    const baseBudget = createBaseBudget()
+
+    expect(nextRecurringPeriodStart(baseBudget, '2026-01-01')).toBe('2026-02-01')
+    expect(nextRecurringPeriodStart(createBaseBudget({ instance_length: 2 }), '2026-01-01')).toBe('2026-03-01')
+  })
+
+  it('re-anchors to recurrence_dom across short months for a dom-31 monthly budget', () => {
+    const baseBudget = createBaseBudget({ recurrence_dom: 31 })
+
+    expect(nextRecurringPeriodStart(baseBudget, '2026-01-31')).toBe('2026-02-28')
+    expect(nextRecurringPeriodStart(baseBudget, '2026-02-28')).toBe('2026-03-31')
+    expect(nextRecurringPeriodStart(baseBudget, '2026-04-30')).toBe('2026-05-31')
+  })
+
+  it('re-anchors to recurrence_dom for a dom-30 monthly budget', () => {
+    const baseBudget = createBaseBudget({ recurrence_dom: 30 })
+
+    expect(nextRecurringPeriodStart(baseBudget, '2026-01-30')).toBe('2026-02-28')
+    expect(nextRecurringPeriodStart(baseBudget, '2026-02-28')).toBe('2026-03-30')
+  })
+
+  it('re-anchors to recurrence_dom for a dom-29 monthly budget across a leap year', () => {
+    const baseBudget = createBaseBudget({ recurrence_dom: 29 })
+
+    expect(nextRecurringPeriodStart(baseBudget, '2024-01-29')).toBe('2024-02-29')
+    expect(nextRecurringPeriodStart(baseBudget, '2024-02-29')).toBe('2024-03-29')
   })
 })

--- a/frontend/tests/budgets/budgetStatus.test.ts
+++ b/frontend/tests/budgets/budgetStatus.test.ts
@@ -29,6 +29,7 @@ function createBudget(overrides: Partial<Budget> = {}): Budget {
       recurrence_month: null,
       recurs: true,
       created_at: '2026-01-01T00:00:00Z',
+      is_archived: false,
       category_ids: ['groceries'],
     },
     ...overrides,


### PR DESCRIPTION
Adds the ability to archive recurring budgets, with a workflow mirroring how accounts are archived.

### Budget archiving

- Add an archive toggle to the recurring budget edit modal, applied on save, mirroring how accounts are archived
- Move archived budgets into a separate collapsible "Archived budgets" section on the budgets page
- Lock every field in the edit modal while a budget is archived and show an archived indicator in the modal header, matching the transaction modal
- Keep archived budgets in spending totals and utilization aggregates, but stop generating new periods for them
- Resume period generation at the current period when a budget is unarchived, without backfilling the months it was archived
- Hide upcoming periods for archived budgets
- Shade the archived stretch of a budget's history with a greyed "ARCHIVED" band in the details chart

### Backend and API

- Add an `is_archived` flag to base budgets with a database migration
- Accept and return the archive flag through the base budget API
- Reject edits to an archived budget and skip archived budgets during period backfill