### PR TITLE
Import archived budgets from Firefly III and refine how archived budgets are displayed

### DIFF
--- a/backend/app/schemas/firefly_import.py
+++ b/backend/app/schemas/firefly_import.py
@@ -71,13 +71,15 @@ class FireflyBudgetImport(BaseModel):
 
     Every limit period becomes one budget period with its exported dates and
     amount, so the history arrives as it was lived rather than reshaped onto
-    a single cadence
+    a single cadence. An archived budget arrives with its history frozen and
+    stays out of the active list
     """
 
     name: str = Field(min_length=1, max_length=256)
     currency: str = Field(min_length=3, max_length=3)
     category_ids: list[uuid.UUID] = Field(min_length=1)
     limits: list[FireflyBudgetLimit] = Field(min_length=1, max_length=MAX_BUDGET_LIMIT_PERIODS)
+    is_archived: bool = False
 
 
 class FireflyBudgetImportRequest(BaseModel):

--- a/backend/app/services/importers/firefly/budgets.py
+++ b/backend/app/services/importers/firefly/budgets.py
@@ -107,6 +107,7 @@ async def _create_imported_budget(
         group_id=None,
         name=budget.name.strip(),
         currency=budget.currency.upper(),
+        is_archived=budget.is_archived,
         **_cadence_from_latest_period(limit_periods),
     )
     db.add(base_budget)

--- a/backend/tests/routes/transactions/test_firefly_budget_imports.py
+++ b/backend/tests/routes/transactions/test_firefly_budget_imports.py
@@ -16,7 +16,7 @@ async def _get_category_id(client, headers, name):
     return next(category["id"] for category in resp.json() if category["name"] == name)
 
 
-async def _import_one_budget(client, headers, category_id, limits, name="Groceries"):
+async def _import_one_budget(client, headers, category_id, limits, name="Groceries", is_archived=None):
     """Import one budget and return the created base budget and its instances
 
     Args:
@@ -25,17 +25,23 @@ async def _import_one_budget(client, headers, category_id, limits, name="Groceri
         category_id: Tracked category for the budget.
         limits: Limit periods for the import payload.
         name: Budget name.
+        is_archived: Archived flag for the payload, omitted when None so the
+            default is exercised.
 
     Returns:
         Base budget response paired with its instance list
     """
+    payload = {
+        "name": name,
+        "currency": "CAD",
+        "category_ids": [category_id],
+        "limits": limits,
+    }
+    if is_archived is not None:
+        payload["is_archived"] = is_archived
+
     resp = await client.post("/transactions/import/firefly/budgets", json={
-        "budgets": [{
-            "name": name,
-            "currency": "CAD",
-            "category_ids": [category_id],
-            "limits": limits,
-        }],
+        "budgets": [payload],
     }, headers=headers)
     assert resp.status_code == 201
     result = resp.json()["results"][0]
@@ -65,12 +71,34 @@ async def test_firefly_budget_import_mirrors_limit_periods(client):
     assert base["recurs"] is True
     assert base["category_ids"] == [groceries_id]
 
+    # is_archived is omitted from the payload, so the budget imports active
+    assert base["is_archived"] is False
+
     # February carried no limit and today's month never did, so neither gets
     # an instance and the history ends where the export ends
     periods = {(b["period_start"], b["period_end"]): b["overall_limit"] for b in own}
     assert periods == {
         ("2025-01-01", "2025-01-31"): 60000,
         ("2025-03-01", "2025-03-31"): 65050,
+    }
+
+
+async def test_firefly_budget_import_carries_archived_flag(client):
+    """An archived Firefly budget imports archived with its full period history"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    groceries_id = await _get_category_id(client, headers, "Groceries")
+
+    base, own = await _import_one_budget(client, headers, groceries_id, [
+        {"start": "2025-01-01", "end": "2025-01-31", "amount": "600.00"},
+        {"start": "2025-02-01", "end": "2025-02-28", "amount": "620.00"},
+    ], is_archived=True)
+
+    assert base["is_archived"] is True
+    periods = {(b["period_start"], b["period_end"]): b["overall_limit"] for b in own}
+    assert periods == {
+        ("2025-01-01", "2025-01-31"): 60000,
+        ("2025-02-01", "2025-02-28"): 62000,
     }
 
 

--- a/dev/firefly-iii/seed_firefly_iii.py
+++ b/dev/firefly-iii/seed_firefly_iii.py
@@ -566,9 +566,10 @@ def fixed_length_limit_rows(first: date, length_days: int,
 
 
 def imported_as(freq: str, *, length: int = 1, weekday: int | None = None,
-                dom: int | None = None, month: int | None = None, recurs: bool = True) -> dict:
+                dom: int | None = None, month: int | None = None, recurs: bool = True,
+                archived: bool = False) -> dict:
     """Describe the Lumina cadence an imported budget is expected to carry"""
-    return {"outcome": "imported", "cadence": {
+    return {"outcome": "imported", "is_archived": archived, "cadence": {
         "recurrence_freq": freq, "instance_length": length, "recurrence_weekday": weekday,
         "recurrence_dom": dom, "recurrence_month": month, "recurs": recurs,
     }}
@@ -604,8 +605,9 @@ TRAVEL_LIMIT_SCHEDULE = [
 #
 # The expected import outcome rides along for the verify tooling: budgets
 # whose latest period fits a Lumina cadence import with that cadence, a lone
-# irregular window imports as a one-off, and archived, transaction-less,
-# mixed-currency, and oddly recurring budgets are skipped with a reason code
+# irregular window imports as a one-off, archived budgets import as archived
+# base budgets, and transaction-less, mixed-currency, and oddly recurring
+# budgets are skipped with a reason code
 BUDGET_DEFINITIONS = {
 
     # Groceries carried transactions for a month before its first limit, so
@@ -725,17 +727,24 @@ BUDGET_DEFINITIONS = {
                     "amount": "3500.00", "currency": "CAD"}],
         "import": imported_as("monthly", dom=1, recurs=False),
     },
+
+    # Its limits are whole calendar months anchored on day 1, so the cadence
+    # reads monthly dom 1 with recurs True
     "Home Office": {
         "active": False,
         "limits": month_limit_rows(date(2021, 1, 1), 1, [(date(2021, 1, 1), "280.00")],
                                    last=date(2021, 12, 1)),
-        "import": skipped_as("archived"),
+        "import": imported_as("monthly", dom=1, archived=True),
     },
+
+    # Its one limit window spans two whole calendar months anchored on day 1,
+    # so the cadence reads monthly with length 2 and recurs True even though
+    # the budget arrives archived
     "Apartment Furnishing": {
         "active": False,
         "limits": [{"start": APARTMENT_MOVE_DATE, "end": date(2023, 9, 30),
                     "amount": "1800.00", "currency": "CAD"}],
-        "import": skipped_as("archived"),
+        "import": imported_as("monthly", length=2, dom=1, archived=True),
     },
 
     # Created with limits but never assigned a transaction, so there is

--- a/dev/firefly-iii/verify_lumina_import.py
+++ b/dev/firefly-iii/verify_lumina_import.py
@@ -6,8 +6,9 @@ into Lumina Finance through the app:
 - Firefly III account balances, budget limit periods, archived flags,
   categories, and tags from its API against the manifest
 - Lumina account balances and transaction rows against the manifest
-- Lumina imported budgets against the manifest cadence and limit periods,
-  including that every budget the manifest marks as skipped stayed out
+- Lumina imported budgets against the manifest cadence, archived flag, and
+  limit periods, including that every budget the manifest marks as skipped
+  stayed out
 
 Lumina reads use the app API for balances and budgets plus direct SQL for
 row-count aggregates. Run with the backend virtual environment so asyncpg is
@@ -317,8 +318,8 @@ def verify_lumina_budgets(manifest: dict, token: str) -> None:
     """Compare imported budgets and their periods with the manifest
 
     Budgets the manifest marks as skipped must be absent, and every imported
-    budget must carry the expected cadence and one period per exported limit
-    with the same dates and amount
+    budget must carry the expected archived flag, cadence, and one period per
+    exported limit with the same dates and amount
     """
     print("Lumina budgets vs manifest")
     base_budgets = {budget["name"]: budget for budget in fetch_lumina("/base-budgets", token)}
@@ -338,6 +339,8 @@ def verify_lumina_budgets(manifest: dict, token: str) -> None:
             continue
 
         check(f"budget currency {name}", expected["currencies"][0], base["currency"])
+
+        check(f"budget archived {name}", expected["import"]["is_archived"], base["is_archived"])
 
         # The cadence is read off the latest limit period on import, so every
         # recurrence field has to match what the seed declared for the shape

--- a/frontend/src/api/fireflyImports/types.ts
+++ b/frontend/src/api/fireflyImports/types.ts
@@ -67,6 +67,11 @@ export interface FireflyBudgetImportBudget {
   currency: string;
   category_ids: string[];
   limits: FireflyBudgetImportLimit[];
+
+  /**
+   * An archived budget arrives with its history frozen and stays out of the active budget list
+   */
+  is_archived: boolean;
 }
 
 export interface FireflyBudgetImportPayload {

--- a/frontend/src/pages/budgets/components/budget-card/Card.tsx
+++ b/frontend/src/pages/budgets/components/budget-card/Card.tsx
@@ -1,7 +1,7 @@
-import { EyeOff } from 'lucide-react'
 import type { BaseBudget, Budget, BudgetUtilization } from '@/api/budgets'
 import { formatCurrency } from '@/utils/formatCurrency'
 import BudgetCategoryRow from '@/pages/budgets/components/budget-card/CategoryRow'
+import ArchivedPill from '@/pages/budgets/components/shared/ArchivedPill'
 import BudgetAttentionIcon from '@/pages/budgets/components/shared/AttentionIcon'
 import BudgetFxStatusBadge from '@/pages/budgets/components/shared/FxStatusBadge'
 import { budgetCadenceLabel, formatBudgetPeriod, nextBudgetPeriods } from '@/pages/budgets/utils/budgetPeriods'
@@ -71,13 +71,7 @@ export default function BudgetCard({
           </p>
         </div>
         {isArchived ? (
-          <span
-            className="inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-sm font-medium"
-            style={{ background: 'var(--app-accent-soft)', color: 'var(--app-text-muted)' }}
-          >
-            <EyeOff size={14} aria-hidden />
-            Archived
-          </span>
+          <ArchivedPill />
         ) : (
           <span
             className="inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-sm font-medium"

--- a/frontend/src/pages/budgets/components/budget-card/Card.tsx
+++ b/frontend/src/pages/budgets/components/budget-card/Card.tsx
@@ -1,3 +1,4 @@
+import { EyeOff } from 'lucide-react'
 import type { BaseBudget, Budget, BudgetUtilization } from '@/api/budgets'
 import { formatCurrency } from '@/utils/formatCurrency'
 import BudgetCategoryRow from '@/pages/budgets/components/budget-card/CategoryRow'
@@ -37,8 +38,8 @@ export default function BudgetCard({
 
   return (
     <article
-      className={`app-card app-budget-card flex min-h-[21.5rem] w-full min-w-0 cursor-pointer flex-col transition-transform duration-150 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-[var(--app-accent-soft)] ${
-        isArchived ? 'opacity-80 transition-opacity hover:opacity-100' : ''
+      className={`app-card app-budget-card flex w-full min-w-0 cursor-pointer flex-col transition-transform duration-150 hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-[var(--app-accent-soft)] ${
+        isArchived ? 'opacity-80 transition-opacity hover:opacity-100' : 'min-h-[21.5rem]'
       }`}
       style={{
         borderTop: `5px solid ${isArchived ? 'var(--app-text-muted)' : attention.indicatorColor}`,
@@ -69,38 +70,51 @@ export default function BudgetCard({
             {budgetCadenceLabel(baseBudget)} · {baseBudget.group_id ? 'Shared' : 'Personal'} · {baseBudget.currency}
           </p>
         </div>
-        <span
-          className="inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-sm font-medium"
-          style={{ background: attention.background, color: attention.textColor }}
-        >
-          <BudgetAttentionIcon label={attention.label} />
-          {attention.label}
-        </span>
+        {isArchived ? (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-sm font-medium"
+            style={{ background: 'var(--app-accent-soft)', color: 'var(--app-text-muted)' }}
+          >
+            <EyeOff size={14} aria-hidden />
+            Archived
+          </span>
+        ) : (
+          <span
+            className="inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-sm font-medium"
+            style={{ background: attention.background, color: attention.textColor }}
+          >
+            <BudgetAttentionIcon label={attention.label} />
+            {attention.label}
+          </span>
+        )}
       </div>
 
-      <div className="mt-5">
-        <div className="app-budget-card-summary">
-          <p className="flex min-w-0 items-baseline gap-2 text-3xl font-semibold tracking-tight" style={{ color: 'var(--app-text)' }}>
-            <span className="truncate">{latestPeriod ? formatCurrency(displayBalance, baseBudget.currency) : 'Not set'}</span>
-            {latestPeriod && (
-              <span className="shrink-0 text-lg font-bold uppercase">
-                {isOverBudget ? 'over' : 'left'}
-              </span>
-            )}
-          </p>
-          <p className="app-budget-card-used text-sm" style={{ color: 'var(--app-text-subtle)' }}>
-            {latestPeriod
-              ? `${formatCurrency(spent, baseBudget.currency)} used of ${formatCurrency(latestPeriod.overall_limit, baseBudget.currency)}`
-              : 'Create a period to start tracking spending.'}
-          </p>
+      {/* An archived budget no longer tracks a live period, so an over or left reading would be stale noise */}
+      {!isArchived && (
+        <div className="mt-5">
+          <div className="app-budget-card-summary">
+            <p className="flex min-w-0 items-baseline gap-2 text-3xl font-semibold tracking-tight" style={{ color: 'var(--app-text)' }}>
+              <span className="truncate">{latestPeriod ? formatCurrency(displayBalance, baseBudget.currency) : 'Not set'}</span>
+              {latestPeriod && (
+                <span className="shrink-0 text-lg font-bold uppercase">
+                  {isOverBudget ? 'over' : 'left'}
+                </span>
+              )}
+            </p>
+            <p className="app-budget-card-used text-sm" style={{ color: 'var(--app-text-subtle)' }}>
+              {latestPeriod
+                ? `${formatCurrency(spent, baseBudget.currency)} used of ${formatCurrency(latestPeriod.overall_limit, baseBudget.currency)}`
+                : 'Create a period to start tracking spending.'}
+            </p>
+          </div>
+          <div className="mt-3 h-2 rounded-full" style={{ background: 'var(--app-border)' }}>
+            <div
+              className="h-full rounded-full"
+              style={{ width: `${progress}%`, background: attention.indicatorColor }}
+            />
+          </div>
         </div>
-        <div className="mt-3 h-2 rounded-full" style={{ background: 'var(--app-border)' }}>
-          <div
-            className="h-full rounded-full"
-            style={{ width: `${progress}%`, background: attention.indicatorColor }}
-          />
-        </div>
-      </div>
+      )}
 
       <div className="app-budget-card-details mt-5">
         <div className="app-budget-card-periods min-w-0">

--- a/frontend/src/pages/budgets/components/budget-cards/ArchivedSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-cards/ArchivedSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { ChevronDown, EyeOff } from 'lucide-react'
 import { motion, useReducedMotion } from 'motion/react'
 import type { BudgetUtilization } from '@/api/budgets'
@@ -34,7 +34,7 @@ type BudgetArchivedSectionProps = {
 }
 
 /**
- * Renders archived budgets behind a collapsible section and scrolls the expanded grid into view
+ * Renders archived budgets behind a collapsible section and scrolls the grid into view once it finishes expanding
  *
  * The caller mounts this inside AnimatePresence, so its own appearance easing plays when the first budget
  * is archived and its exit easing plays when the last budget is unarchived
@@ -48,19 +48,6 @@ export default function BudgetArchivedSection({
   const [cardsMounted, setCardsMounted] = useState(false)
   const sectionRef = useRef<HTMLElement>(null)
   const prefersReducedMotion = useReducedMotion()
-
-  useEffect(() => {
-    if (!expanded) return
-
-    const animationFrameId = window.requestAnimationFrame(() => {
-      const section = sectionRef.current
-      if (!section) return
-
-      scrollArchivedBudgetsIntoView(section, prefersReducedMotion)
-    })
-
-    return () => window.cancelAnimationFrame(animationFrameId)
-  }, [expanded, prefersReducedMotion])
 
   /**
    * Toggles archived cards while keeping closing cards mounted until their height animation finishes
@@ -76,10 +63,20 @@ export default function BudgetArchivedSection({
   }
 
   /**
-   * Removes collapsed cards after their closing height animation finishes
+   * Scrolls the archived grid into view once its expand animation finishes, since only then does the
+   * page height reflect the expanded layout and let the scroll clamp land on the real bottom
+   *
+   * Removes collapsed cards once the collapse animation finishes instead, so their closing height
+   * transition can play before they unmount
    */
-  function handleCollapseComplete() {
-    if (expanded) return
+  function handleExpansionAnimationComplete() {
+    if (expanded) {
+      const section = sectionRef.current
+      if (!section) return
+
+      scrollArchivedBudgetsIntoView(section, prefersReducedMotion)
+      return
+    }
 
     setCardsMounted(false)
   }
@@ -134,7 +131,7 @@ export default function BudgetArchivedSection({
         }}
         aria-hidden={!expanded}
         inert={!expanded}
-        onAnimationComplete={handleCollapseComplete}
+        onAnimationComplete={handleExpansionAnimationComplete}
       >
         {cardsMounted && (
           <div className="min-h-0 overflow-hidden pt-1">

--- a/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
@@ -155,7 +155,9 @@ function getMobileAxisLabelKeys(chartData: BudgetChartPoint[]): Set<string> | nu
  * a single centred label
  *
  * Recharts exposes plot geometry through hooks, so the band is derived from the categorical scale
- * directly instead of measured DOM coordinates, keeping it aligned inside responsive charts
+ * directly instead of measured DOM coordinates, keeping it aligned inside responsive charts. The
+ * band scale maps a category to its slot's left edge, so the shaded band spans from the first
+ * slot's left edge to the last slot's right edge
  */
 function ArchivedBandsLayer({ stretches }: { stretches: ArchivedChartStretch[] }) {
   const plotArea = usePlotArea()
@@ -167,12 +169,12 @@ function ArchivedBandsLayer({ stretches }: { stretches: ArchivedChartStretch[] }
   return (
     <g>
       {stretches.map((stretch) => {
-        const firstCenter = xScale(stretch.firstKey)
-        const lastCenter = xScale(stretch.lastKey)
-        if (typeof firstCenter !== 'number' || typeof lastCenter !== 'number') return null
+        const firstSlotLeftEdge = xScale(stretch.firstKey)
+        const lastSlotLeftEdge = xScale(stretch.lastKey)
+        if (typeof firstSlotLeftEdge !== 'number' || typeof lastSlotLeftEdge !== 'number') return null
 
-        const leftEdge = firstCenter - bandwidth / 2 + ARCHIVED_BAND_INSET_PX / 2
-        const rightEdge = lastCenter + bandwidth / 2 - ARCHIVED_BAND_INSET_PX / 2
+        const leftEdge = firstSlotLeftEdge + ARCHIVED_BAND_INSET_PX / 2
+        const rightEdge = lastSlotLeftEdge + bandwidth - ARCHIVED_BAND_INSET_PX / 2
         const shadeWidth = Math.max(rightEdge - leftEdge, ARCHIVED_BAND_MIN_WIDTH_PX)
         const shadeCenter = (leftEdge + rightEdge) / 2
 
@@ -220,15 +222,11 @@ function CurrentPeriodBoundary({ currentPeriodKey }: { currentPeriodKey: string 
   const xScale = useXAxisScale() as ((label: string) => number) & { bandwidth?: () => number }
   if (!currentPeriodKey || !plotArea || !xScale) return null
 
-  const center = xScale(currentPeriodKey)
-  if (typeof center !== 'number' || !Number.isFinite(center)) return null
+  const leftEdge = xScale(currentPeriodKey)
+  if (typeof leftEdge !== 'number' || !Number.isFinite(leftEdge)) return null
 
-  const bandwidth = xScale.bandwidth ? xScale.bandwidth() : 0
-
-  // Category scales report the band center, so use the left edge so the divider marks where the
-  // current period begins, not the middle of its bar
-  const leftEdge = center - bandwidth / 2
-
+  // The band scale maps a category to its slot's left edge, which is exactly where the current
+  // period begins, so that value is used directly as the divider's x position
   return (
     <line
       x1={leftEdge}

--- a/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
@@ -11,6 +11,7 @@ import {
   YAxis,
   usePlotArea,
   useXAxisScale,
+  type ScaleFunction,
   type XAxisTickContentProps,
   type YAxisTickContentProps,
 } from 'recharts'
@@ -156,25 +157,31 @@ function getMobileAxisLabelKeys(chartData: BudgetChartPoint[]): Set<string> | nu
  *
  * Recharts exposes plot geometry through hooks, so the band is derived from the categorical scale
  * directly instead of measured DOM coordinates, keeping it aligned inside responsive charts. The
- * band scale maps a category to its slot's left edge, so the shaded band spans from the first
- * slot's left edge to the last slot's right edge
+ * hook only exposes the scale's map function, not its bandwidth, so the last slot's right edge
+ * comes from calling the map with the 'end' position option rather than a bandwidth lookup. The
+ * band spans from the first slot's left edge to the last slot's right edge
  */
 function ArchivedBandsLayer({ stretches }: { stretches: ArchivedChartStretch[] }) {
   const plotArea = usePlotArea()
-  const xScale = useXAxisScale() as ((label: string) => number) & { bandwidth?: () => number }
+  const xScale: ScaleFunction | undefined = useXAxisScale()
   if (!plotArea || !xScale || stretches.length === 0) return null
-
-  const bandwidth = xScale.bandwidth ? xScale.bandwidth() : 0
 
   return (
     <g>
       {stretches.map((stretch) => {
         const firstSlotLeftEdge = xScale(stretch.firstKey)
-        const lastSlotLeftEdge = xScale(stretch.lastKey)
-        if (typeof firstSlotLeftEdge !== 'number' || typeof lastSlotLeftEdge !== 'number') return null
+        const lastSlotRightEdge = xScale(stretch.lastKey, { position: 'end' })
+        if (
+          typeof firstSlotLeftEdge !== 'number' ||
+          typeof lastSlotRightEdge !== 'number' ||
+          !Number.isFinite(firstSlotLeftEdge) ||
+          !Number.isFinite(lastSlotRightEdge)
+        ) {
+          return null
+        }
 
         const leftEdge = firstSlotLeftEdge + ARCHIVED_BAND_INSET_PX / 2
-        const rightEdge = lastSlotLeftEdge + bandwidth - ARCHIVED_BAND_INSET_PX / 2
+        const rightEdge = lastSlotRightEdge - ARCHIVED_BAND_INSET_PX / 2
         const shadeWidth = Math.max(rightEdge - leftEdge, ARCHIVED_BAND_MIN_WIDTH_PX)
         const shadeCenter = (leftEdge + rightEdge) / 2
 
@@ -219,7 +226,7 @@ function ArchivedBandsLayer({ stretches }: { stretches: ArchivedChartStretch[] }
  */
 function CurrentPeriodBoundary({ currentPeriodKey }: { currentPeriodKey: string | undefined }) {
   const plotArea = usePlotArea()
-  const xScale = useXAxisScale() as ((label: string) => number) & { bandwidth?: () => number }
+  const xScale: ScaleFunction | undefined = useXAxisScale()
   if (!currentPeriodKey || !plotArea || !xScale) return null
 
   const leftEdge = xScale(currentPeriodKey)

--- a/frontend/src/pages/budgets/components/budget-details-modal/Sidebar.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/Sidebar.tsx
@@ -4,6 +4,7 @@ import type { BaseBudget, Budget, BudgetUtilization } from '@/api/budgets'
 import { formatCurrency } from '@/utils/formatCurrency'
 import MarqueeText from '@/components/display/MarqueeText'
 import ScrollableListMoreButton from '@/components/list-controls/MoreButton'
+import ArchivedPill from '@/pages/budgets/components/shared/ArchivedPill'
 import BudgetAttentionIcon from '@/pages/budgets/components/shared/AttentionIcon'
 import BudgetFxStatusBadge from '@/pages/budgets/components/shared/FxStatusBadge'
 import { budgetCadenceLabel, formatBudgetPeriod } from '@/pages/budgets/utils/budgetPeriods'
@@ -120,13 +121,17 @@ export default function BudgetDetailsSidebar({
           <h2 className="pr-11 text-2xl font-semibold min-[1050px]:pr-0">
             <MarqueeText active>{baseBudget.name}</MarqueeText>
           </h2>
-          <span
-            className="mt-2 inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-sm font-medium"
-            style={{ background: attention.background, color: attention.textColor }}
-          >
-            <BudgetAttentionIcon label={attention.label} />
-            {attention.label}
-          </span>
+          {baseBudget.is_archived ? (
+            <ArchivedPill className="mt-2" />
+          ) : (
+            <span
+              className="mt-2 inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-sm font-medium"
+              style={{ background: attention.background, color: attention.textColor }}
+            >
+              <BudgetAttentionIcon label={attention.label} />
+              {attention.label}
+            </span>
+          )}
           <p className="mt-2 min-w-0 truncate text-sm" style={{ color: 'var(--app-text-subtle)' }}>
             {budgetCadenceLabel(baseBudget)} · {baseBudget.group_id ? 'Shared' : 'Personal'} · {baseBudget.currency}
           </p>
@@ -148,22 +153,25 @@ export default function BudgetDetailsSidebar({
             />
           </div>
         </div>
+        {/* An archived budget has no live period, so the current-budget figures do not apply */}
         <div className="mt-2 flex items-baseline gap-2 min-[750px]:mt-3">
           <p className="min-w-0 text-3xl font-semibold leading-none tracking-tight min-[750px]:text-4xl">
-            {latestPeriod ? formatCurrency(Math.abs(remaining), baseBudget.currency) : 'Not set'}
+            {baseBudget.is_archived ? 'N/A' : latestPeriod ? formatCurrency(Math.abs(remaining), baseBudget.currency) : 'Not set'}
           </p>
-          {latestPeriod && (
+          {!baseBudget.is_archived && latestPeriod && (
             <span className="shrink-0 text-base font-bold uppercase min-[750px]:text-lg" style={{ color: 'var(--app-text)' }}>
               {isOverBudget ? 'over' : 'left'}
             </span>
           )}
         </div>
         <p className="mt-3 text-sm" style={{ color: 'var(--app-text-muted)' }}>
-          {latestPeriod
-            ? `${formatCurrency(spent, baseBudget.currency)} used of ${formatCurrency(limit, baseBudget.currency)}`
-            : 'No periods have been created yet.'}
+          {!latestPeriod
+            ? 'No periods have been created yet.'
+            : baseBudget.is_archived
+              ? `N/A used of ${formatCurrency(limit, baseBudget.currency)}`
+              : `${formatCurrency(spent, baseBudget.currency)} used of ${formatCurrency(limit, baseBudget.currency)}`}
         </p>
-        {latestPeriod && (
+        {!baseBudget.is_archived && latestPeriod && (
           <div className="mt-4 flex items-center gap-3 min-[750px]:mt-5">
             <div className="h-2 flex-1 rounded-full" style={{ background: 'var(--app-border)' }}>
               <div
@@ -176,12 +184,14 @@ export default function BudgetDetailsSidebar({
             </span>
           </div>
         )}
-        <div className="mt-4 flex justify-between gap-4 border-t pt-3 text-sm min-[750px]:mt-5 min-[750px]:pt-4" style={{ borderColor: 'var(--app-border)' }}>
-          <span style={{ color: 'var(--app-text-subtle)' }}>Current period</span>
-          <span className="text-right" style={{ color: 'var(--app-text-muted)' }}>
-            {latestPeriod ? formatBudgetPeriod(latestPeriod) : 'None'}
-          </span>
-        </div>
+        {!baseBudget.is_archived && (
+          <div className="mt-4 flex justify-between gap-4 border-t pt-3 text-sm min-[750px]:mt-5 min-[750px]:pt-4" style={{ borderColor: 'var(--app-border)' }}>
+            <span style={{ color: 'var(--app-text-subtle)' }}>Current period</span>
+            <span className="text-right" style={{ color: 'var(--app-text-muted)' }}>
+              {latestPeriod ? formatBudgetPeriod(latestPeriod) : 'None'}
+            </span>
+          </div>
+        )}
       </section>
 
       <section className="border-t pt-6 min-[1050px]:flex min-[1050px]:min-h-0 min-[1050px]:flex-1 min-[1050px]:flex-col" style={{ borderColor: 'var(--app-border)' }}>

--- a/frontend/src/pages/budgets/components/budget-details-modal/Sidebar.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/Sidebar.tsx
@@ -194,7 +194,7 @@ export default function BudgetDetailsSidebar({
         )}
       </section>
 
-      <section className="border-t pt-6 min-[1050px]:flex min-[1050px]:min-h-0 min-[1050px]:flex-1 min-[1050px]:flex-col" style={{ borderColor: 'var(--app-border)' }}>
+      <section className={`${!baseBudget.is_archived ? 'border-t ' : ''}pt-6 min-[1050px]:flex min-[1050px]:min-h-0 min-[1050px]:flex-1 min-[1050px]:flex-col`} style={{ borderColor: 'var(--app-border)' }}>
         <div className="flex items-center justify-between gap-3">
           <h3 className="text-xs font-semibold uppercase" style={{ color: 'var(--app-text-subtle)' }}>
             Tracked categories

--- a/frontend/src/pages/budgets/components/shared/ArchivedPill.tsx
+++ b/frontend/src/pages/budgets/components/shared/ArchivedPill.tsx
@@ -1,0 +1,16 @@
+import { EyeOff } from 'lucide-react'
+
+/**
+ * Renders the pill marking a budget as archived, shared by the budget card and details sidebar
+ */
+export default function ArchivedPill({ className = '' }: { className?: string }) {
+  return (
+    <span
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full px-2.5 py-0.5 text-sm font-medium ${className}`}
+      style={{ background: 'var(--app-accent-soft)', color: 'var(--app-text-muted)' }}
+    >
+      <EyeOff size={14} aria-hidden />
+      Archived
+    </span>
+  )
+}

--- a/frontend/src/pages/dashboard/components/SavingsCurrentBoundary.tsx
+++ b/frontend/src/pages/dashboard/components/SavingsCurrentBoundary.tsx
@@ -12,22 +12,18 @@ export function SavingsCurrentBoundary({ currentLabel }: { currentLabel: string 
   // Recharts v3 exposes plot geometry through hooks, so drawing the marker here
   // keeps the current-month boundary aligned after responsive chart resizing
   const plotArea = usePlotArea()
-  const xScale = useXAxisScale() as ((label: string) => number) & { bandwidth?: () => number }
+  const xScale = useXAxisScale() as ((label: string) => number)
   if (!plotArea || !xScale) return null
 
-  const center = xScale(currentLabel)
-  if (typeof center !== 'number' || !Number.isFinite(center)) return null
+  const slotLeft = xScale(currentLabel)
+  if (typeof slotLeft !== 'number' || !Number.isFinite(slotLeft)) return null
 
-  const bandwidth = xScale.bandwidth ? xScale.bandwidth() : 0
-
-  // Category scales can report the band center, so use the left edge so the
-  // divider marks where the current period begins, not the middle of the bar
-  const leftEdge = center - bandwidth / 2
-
+  // The band scale maps a category to its slot's left edge, which is exactly
+  // where the current month begins
   return (
     <line
-      x1={leftEdge}
-      x2={leftEdge}
+      x1={slotLeft}
+      x2={slotLeft}
       y1={plotArea.y}
       y2={plotArea.y + plotArea.height}
       stroke="var(--app-text-subtle)"

--- a/frontend/src/pages/imports/firefly/constants.ts
+++ b/frontend/src/pages/imports/firefly/constants.ts
@@ -35,8 +35,8 @@ export const FIREFLY_BUDGETS_REQUIRED_HEADERS = [
 
 /**
  * Value the budgets export carries for a budget that is not archived, with
- * anything else read as archived so a value we do not recognise leaves the
- * budget visibly skipped rather than quietly imported
+ * anything else read as archived so a value we do not recognise imports the
+ * budget archived rather than active, the safer of the two directions
  */
 export const FIREFLY_BUDGET_ACTIVE_VALUE = '1'
 
@@ -50,15 +50,6 @@ export const FIREFLY_BUDGET_ACTIVE_VALUE = '1'
 export const FIREFLY_TAG_NAME_MAX_LENGTH = 64
 
 export const FIREFLY_TAG_TOO_LONG_REASON = 'Tag name is too long'
-
-/**
- * Why an archived budget is listed but never imported
- *
- * Lumina Finance has no archived budgets, so importing one would raise a budget
- * the user retired. The reason stops at what is true today rather than hinting
- * at support that is not committed to
- */
-export const FIREFLY_BUDGET_ARCHIVED_REASON = 'Archived in Firefly III, which Lumina Finance does not support'
 
 /**
  * Why a budget no transaction references is never imported, since its tracked
@@ -93,9 +84,9 @@ export const FIREFLY_BUDGET_MIXED_CURRENCIES_REASON = 'Its limit periods mix mor
  * Why a budget repeating on a period length no Lumina Finance cadence can
  * express is never imported
  *
- * Its history would arrive intact, but the budget could never continue on its
- * own rhythm here, which is the same distortion an archived budget would
- * suffer, so it is skipped rather than imported frozen
+ * A live budget repeating on a shape no Lumina Finance cadence expresses
+ * could never continue on its own rhythm here, so it is skipped rather than
+ * imported on a wrong cadence
  */
 export const FIREFLY_BUDGET_UNSUPPORTED_CADENCE_REASON = 'Repeats on a period length Lumina Finance budgets do not support'
 

--- a/frontend/src/pages/imports/firefly/sections/FireflyBudgetImportStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyBudgetImportStep.tsx
@@ -1,3 +1,4 @@
+import { EyeOff } from 'lucide-react'
 import { EmptyState, ImportCheckbox, ImportInfoCard, ImportStep } from '../../components'
 import { FireflySkippedBudgetsTable } from '../components'
 import type { FireflyImportWorkflow } from '../hooks'
@@ -120,7 +121,22 @@ export function FireflyBudgetImportStep({
                       />
                     </td>
                     <td className="truncate px-4 py-2.5 align-middle font-medium">
-                      {draft.name}
+                      <span className="inline-flex max-w-full min-w-0 items-center gap-2">
+                        <span className="truncate">{draft.name}</span>
+                        {draft.isArchived && (
+                          <span
+                            className="inline-flex shrink-0 items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium"
+                            style={{
+                              background: 'var(--app-surface-soft)',
+                              color: 'var(--app-text-muted)',
+                              border: '1px solid var(--app-border)',
+                            }}
+                          >
+                            <EyeOff size={11} aria-hidden />
+                            Archived
+                          </span>
+                        )}
+                      </span>
                       {status === 'error' && (
                         <div role="alert" className="text-xs font-normal" style={{ color: 'var(--app-negative)' }}>
                           {budgetImportErrors[draft.name] ?? 'Budget import failed.'}

--- a/frontend/src/pages/imports/firefly/sections/FireflyExpectationsCard.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyExpectationsCard.tsx
@@ -36,6 +36,10 @@ const CONVERTED_MAPPINGS: ConceptMapping[] = [
     firefly: 'Budget limit periods, whatever their length',
     lumina: 'One budget period each, with the original dates and amounts, continuing on the cadence of the latest period, or as a one-off when no cadence fits',
   },
+  {
+    firefly: 'A budget you archived',
+    lumina: 'An archived budget here too, keeping every limit period it ever ran',
+  },
 ]
 
 /**
@@ -58,7 +62,6 @@ const LEFT_BEHIND: { group: string; items: string[] }[] = [
   {
     group: 'Budgets that are',
     items: [
-      'Archived in Firefly III',
       'Repeating on period lengths Lumina Finance has no cadence for',
       'Mixing more than one currency across their limit periods',
     ],

--- a/frontend/src/pages/imports/firefly/utils/budgets.ts
+++ b/frontend/src/pages/imports/firefly/utils/budgets.ts
@@ -2,7 +2,6 @@ import type { FireflyBudgetImportBudget, FireflyBudgetImportLimit } from '@/api/
 import type { CsvRow, ImportFileDraft } from '../../types'
 import {
   FIREFLY_BUDGET_ACTIVE_VALUE,
-  FIREFLY_BUDGET_ARCHIVED_REASON,
   FIREFLY_BUDGET_MIXED_CURRENCIES_REASON,
   FIREFLY_BUDGET_NO_CATEGORIES_REASON,
   FIREFLY_BUDGET_NO_LIMITS_REASON,
@@ -138,6 +137,7 @@ export function buildFireflyBudgetImportBudgets(
       currency: draft.currencyCode,
       category_ids: categoryIds,
       limits: draft.limits,
+      is_archived: draft.isArchived,
     }
   })
 }
@@ -209,23 +209,19 @@ function buildBudgetDraft(
     .sort((a, b) => a.start.localeCompare(b.start))
     .pop()?.currencyCode ?? ''
 
-  // Being archived is checked before the rest because it settles the budget
-  // on its own, whatever its transactions and limit periods look like
-  const disabledReason = budget.isArchived
-    ? FIREFLY_BUDGET_ARCHIVED_REASON
-    : !usage || !usage.earliestDate
-      ? FIREFLY_BUDGET_NO_TRANSACTIONS_REASON
-      : categoryNames.length === 0
-        ? FIREFLY_BUDGET_NO_CATEGORIES_REASON
-        : hasUnreadableDates
-          ? FIREFLY_BUDGET_UNREADABLE_DATES_REASON
-          : !latest
-            ? FIREFLY_BUDGET_NO_LIMITS_REASON
-            : currencyCodes.length > 1
-              ? FIREFLY_BUDGET_MIXED_CURRENCIES_REASON
-              : repeatsOnUnsupportedCadence(limits)
-                ? FIREFLY_BUDGET_UNSUPPORTED_CADENCE_REASON
-                : null
+  const disabledReason = !usage || !usage.earliestDate
+    ? FIREFLY_BUDGET_NO_TRANSACTIONS_REASON
+    : categoryNames.length === 0
+      ? FIREFLY_BUDGET_NO_CATEGORIES_REASON
+      : hasUnreadableDates
+        ? FIREFLY_BUDGET_UNREADABLE_DATES_REASON
+        : !latest
+          ? FIREFLY_BUDGET_NO_LIMITS_REASON
+          : currencyCodes.length > 1
+            ? FIREFLY_BUDGET_MIXED_CURRENCIES_REASON
+            : repeatsOnUnsupportedCadence(limits)
+              ? FIREFLY_BUDGET_UNSUPPORTED_CADENCE_REASON
+              : null
 
   return {
     name,

--- a/frontend/src/pages/imports/sections/ImportSourceStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportSourceStep.tsx
@@ -2,12 +2,12 @@ import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
 import { ImportStep } from '../components'
 import type { ImportDataSource } from '../types'
 
-// The Firefly III flow converts most of an export but leaves some of it
-// behind, so the option says so up front rather than letting the limitations
-// only surface once a file is staged
+// The Firefly III flow is newer and converts most of an export but not all of
+// it, so the option is flagged as beta up front rather than letting that only
+// surface once a file is staged
 const DATA_SOURCE_OPTIONS: DropdownOption[] = [
   { value: 'generic', label: 'Generic CSV' },
-  { value: 'firefly', label: 'Firefly III', badge: 'Limited' },
+  { value: 'firefly', label: 'Firefly III', badge: 'Beta' },
 ]
 
 export function ImportSourceStep({

--- a/frontend/tests/imports/fireflyBudgets.test.ts
+++ b/frontend/tests/imports/fireflyBudgets.test.ts
@@ -5,7 +5,6 @@ import { describe, expect, it } from 'vitest'
 import type { CsvRow, ImportFileDraft } from '@/pages/imports/types'
 import type { FireflyBudgetDraft } from '@/pages/imports/firefly/types'
 import {
-  FIREFLY_BUDGET_ARCHIVED_REASON,
   FIREFLY_BUDGET_MIXED_CURRENCIES_REASON,
   FIREFLY_BUDGET_NO_CATEGORIES_REASON,
   FIREFLY_BUDGET_NO_LIMITS_REASON,
@@ -65,7 +64,7 @@ function createTransactionRow(overrides: Partial<CsvRow> = {}): CsvRow {
 }
 
 describe('buildFireflyBudgetDrafts', () => {
-  it('disables an archived budget even when it is otherwise importable', () => {
+  it('imports an archived budget as importable, with the flag carried on the draft', () => {
     const budgetsFile = createBudgetsFile([createLimitRow({ active: '0' })])
 
     const [draft] = buildFireflyBudgetDrafts({
@@ -74,7 +73,7 @@ describe('buildFireflyBudgetDrafts', () => {
     })
 
     expect(draft.isArchived).toBe(true)
-    expect(draft.disabledReason).toBe(FIREFLY_BUDGET_ARCHIVED_REASON)
+    expect(draft.disabledReason).toBeNull()
   })
 
   it('reads the archived flag off any of a budget\'s limit rows', () => {
@@ -90,12 +89,12 @@ describe('buildFireflyBudgetDrafts', () => {
     })
 
     const byName = Object.fromEntries(drafts.map((draft) => [draft.name, draft]))
-    expect(byName['Home Office'].disabledReason).toBe(FIREFLY_BUDGET_ARCHIVED_REASON)
-    expect(byName.Groceries.disabledReason).toBeNull()
+    expect(byName['Home Office'].isArchived).toBe(true)
+    expect(byName.Groceries.isArchived).toBe(false)
   })
 
-  // An unrecognised flag leaves the budget visibly skipped rather than
-  // silently importing a budget the user may have retired
+  // An unrecognised flag reads as archived rather than silently importing a
+  // budget the user may have retired as if it were still active
   it('treats an unrecognised active value as archived', () => {
     const budgetsFile = createBudgetsFile([createLimitRow({ active: '' })])
 
@@ -104,7 +103,21 @@ describe('buildFireflyBudgetDrafts', () => {
       transactionRows: [createTransactionRow()],
     })
 
-    expect(draft.disabledReason).toBe(FIREFLY_BUDGET_ARCHIVED_REASON)
+    expect(draft.isArchived).toBe(true)
+  })
+
+  // Being archived no longer settles a budget on its own, so it must still
+  // fall through to another skip reason when one applies
+  it('skips an archived budget for another reason when one applies', () => {
+    const budgetsFile = createBudgetsFile([createLimitRow({ active: '0' })])
+
+    const [draft] = buildFireflyBudgetDrafts({
+      budgetsFile,
+      transactionRows: [],
+    })
+
+    expect(draft.isArchived).toBe(true)
+    expect(draft.disabledReason).toBe(FIREFLY_BUDGET_NO_TRANSACTIONS_REASON)
   })
 
   it('derives a sorted limit period schedule and displays the latest amount', () => {
@@ -389,7 +402,14 @@ describe('buildFireflyBudgetImportBudgets', () => {
       currency: 'CAD',
       category_ids: ['category-food', 'category-restaurants'],
       limits: [{ start: '2024-01-01', end: '2024-01-31', amount: '600.00' }],
+      is_archived: false,
     })
+  })
+
+  it('carries the archived flag into the payload', () => {
+    const [budget] = buildFireflyBudgetImportBudgets([createDraft({ isArchived: true })], {})
+
+    expect(budget.is_archived).toBe(true)
   })
 
   it('drops a category name the commit response does not report', () => {


### PR DESCRIPTION
- Budgets archived in Firefly III now import instead of being skipped, arriving as archived budgets that keep every limit period exactly as exported and stay out of the active budget list
- The budget import step marks which budgets will arrive archived, and the What To Expect card lists archived budgets as converted instead of left behind
- Archived budget cards drop the spending progress row and show a soft Archived pill in place of the status pill
- Updated the details view for an archived budget to show the Archived pill, with N/A in place of current spending figures, and no current period row
- Expanding the archived budgets section scrolls it to the top of the page once it finishes opening
- The archived shading on the budget history chart now extends through the final month of the archived stretch
- Updated the importer development seed and verification tooling to expect the two retired demo budgets to import as archived