### PR TITLE
fix: stop chart colours differing between devices

### DIFF
--- a/frontend/src/utils/chartColor.ts
+++ b/frontend/src/utils/chartColor.ts
@@ -183,6 +183,19 @@ function getCollisionSafePaletteIndex(preferredIndex: number, usedIndexes: Set<n
   return bestCandidate?.index ?? preferredIndex
 }
 
+/**
+ * Orders two keys by their code units, settling a tie the same way on every device
+ *
+ * This is machine ordering rather than a list anyone reads, and locale-aware collation varies with the
+ * browser's locale and its collation data, which would hand the same categories different colours on a
+ * phone and a desktop
+ */
+function compareKeys(a: string, b: string) {
+  if (a === b) return 0
+
+  return a < b ? -1 : 1
+}
+
 function reserveFixedColor(color: string, usedIndexes: Set<number>) {
   const colorIndex = CURATED_CHART_COLORS.findIndex((paletteColor) => (
     paletteColor.toLowerCase() === color.toLowerCase()
@@ -230,7 +243,7 @@ export function getDeterministicChartColorMap(entries: ChartColorMapInput[]) {
         preferredIndex: hash % CURATED_CHART_COLORS.length,
       }
     })
-    .sort((a, b) => a.preferredIndex - b.preferredIndex || a.hash - b.hash || a.key.localeCompare(b.key))
+    .sort((a, b) => a.preferredIndex - b.preferredIndex || a.hash - b.hash || compareKeys(a.key, b.key))
     .forEach((entry) => {
       const colorIndex = getCollisionSafePaletteIndex(entry.preferredIndex, usedIndexes)
 

--- a/frontend/tests/utils/chartColor.test.ts
+++ b/frontend/tests/utils/chartColor.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Verifies the chart colour map settles a tie the same way on every device, whatever collation the
+ * browser would apply
+ */
+import { describe, expect, it } from 'vitest'
+import { getDeterministicChartColorMap } from '@/utils/chartColor'
+
+// The key only decides an entry's colour when two seeds hash to the same value, which is the one case
+// the old locale-aware comparison could answer differently on a phone and a desktop. These two seeds
+// were found by searching the hash for a collision
+const COLLIDING_ENTRIES = [
+  { key: 'category-a', seed: 'glbvs' },
+  { key: 'category-b', seed: 'yacxa' },
+]
+
+/**
+ * Runs something with string collation reversed, so anything consulting the browser's locale gives the
+ * opposite answer to the one it gives normally
+ */
+function withReversedCollation<T>(run: () => T): T {
+  const original = String.prototype.localeCompare
+
+  String.prototype.localeCompare = function reversed(this: string, that: string) {
+    return -original.call(this, that)
+  }
+
+  try {
+    return run()
+  } finally {
+    String.prototype.localeCompare = original
+  }
+}
+
+function buildColorMap(entries: { key: string, seed: string }[]) {
+  return Object.fromEntries(getDeterministicChartColorMap(entries))
+}
+
+describe('getDeterministicChartColorMap', () => {
+  it('gives entries with colliding seeds different colours', () => {
+    const colors = buildColorMap(COLLIDING_ENTRIES)
+
+    expect(colors['category-a']).not.toBe(colors['category-b'])
+  })
+
+  it('assigns the same colours when collation is reversed', () => {
+    const colors = buildColorMap(COLLIDING_ENTRIES)
+
+    expect(withReversedCollation(() => buildColorMap(COLLIDING_ENTRIES))).toEqual(colors)
+  })
+
+  it('assigns the same colours whatever order the entries arrive in', () => {
+    const colors = buildColorMap(COLLIDING_ENTRIES)
+
+    expect(buildColorMap([...COLLIDING_ENTRIES].reverse())).toEqual(colors)
+  })
+})


### PR DESCRIPTION
The chart colour map settled ties between categories with locale-aware string comparison. That varies with the browser's locale and its ICU version, so the same categories could come out different colours on a user's phone and their desktop. Ties are now settled by comparing the raw keys, which every browser answers the same way.
