### PR TITLE
Stop modals opening with stale or wrongly scaled values

### DIFF
--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -6,7 +6,7 @@ import {
   useUpdateAccount,
   type Account,
 } from '@/api/accounts'
-import { useCurrencies } from '@/api/currency'
+import { useCurrencies, type Currency } from '@/api/currency'
 import { useInstitutions } from '@/api/institutions'
 import { useTaxAdvantagedCategories } from '@/api/tax-advantaged-categories'
 import CreateInstitutionModal from '@/components/reference-modals/CreateInstitutionModal'
@@ -39,23 +39,42 @@ type EditAccountIdentityModalProps = {
   onDeleteFailed: () => void
 }
 
+type EditAccountIdentityFormProps = EditAccountIdentityModalProps & {
+  currencies: Currency[]
+}
+
 const MIN_SAVE_SPINNER_MS = 800
 const MIN_DELETE_SPINNER_MS = 1000
 
 /**
+ * Holds the form back until the currency table has arrived
+ *
+ * The form turns the stored credit limit into text using the account currency's decimal places and
+ * seeds that text once, so building it from a table that has not loaded would freeze an amount
+ * scaled by the wrong power of ten
+ */
+export default function EditAccountIdentityModal(props: EditAccountIdentityModalProps) {
+  const { data: currencies } = useCurrencies()
+
+  if (!currencies) return null
+
+  return <EditAccountIdentityForm {...props} currencies={currencies} />
+}
+
+/**
  * Coordinates account identity edits, archive changes, and destructive deletion from one modal workflow
  */
-export default function EditAccountIdentityModal({
+function EditAccountIdentityForm({
   account,
+  currencies,
   onClose,
   onDeleteStarted,
   onDeleted,
   onDeleteFailed,
-}: EditAccountIdentityModalProps) {
+}: EditAccountIdentityFormProps) {
   const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus()
   const updateAccount = useUpdateAccount()
   const deleteAccount = useDeleteAccount({ minimumPendingMs: MIN_DELETE_SPINNER_MS })
-  const { data: currencies = [] } = useCurrencies()
   const { data: institutions = [] } = useInstitutions()
   const { data: taxAdvantagedCategories = [] } = useTaxAdvantagedCategories()
   const [form, setForm] = useState<IdentityFormValues>(() => (

--- a/frontend/src/pages/budgets/BudgetsPage.tsx
+++ b/frontend/src/pages/budgets/BudgetsPage.tsx
@@ -148,25 +148,31 @@ export default function BudgetsPage() {
         )}
       </AnimatePresence>
 
-      <BudgetCreateModal
-        key={`${defaultCurrency}-${userTimeZone}`}
-        open={createOpen}
-        categories={categories ?? []}
-        currencies={currencies ?? []}
-        defaultCurrency={defaultCurrency}
-        timeZone={userTimeZone}
-        onClose={() => setCreateOpen(false)}
-        onCreated={() => undefined}
-      />
+      {/* Held for the currency table so both budget modals follow one rule, though a new budget has
+          no stored amount to convert and could safely start without it */}
+      {currencies && (
+        <BudgetCreateModal
+          key={`${defaultCurrency}-${userTimeZone}`}
+          open={createOpen}
+          categories={categories ?? []}
+          currencies={currencies}
+          defaultCurrency={defaultCurrency}
+          timeZone={userTimeZone}
+          onClose={() => setCreateOpen(false)}
+          onCreated={() => undefined}
+        />
+      )}
 
       <AnimatePresence>
-        {visibleBudgetDetails && (
+        {/* Held for the currency table, since the editor inside turns the stored limit into text
+            using the currency's decimal places and seeds that text once */}
+        {visibleBudgetDetails && currencies && (
           <BudgetDetailsModal
             key={visibleBudgetDetails.baseBudget.id}
             baseBudget={visibleBudgetDetails.baseBudget}
             periods={visibleBudgetDetails.periods}
             categories={categories ?? []}
-            currencies={currencies ?? []}
+            currencies={currencies}
             categoryById={categoryById}
             initialLatestUtilization={
               visibleBudgetDetails.latestPeriod

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import type React from 'react'
 import { useUpdateBaseBudget, useUpdateBudget, type BaseBudget, type Budget } from '@/api/budgets'
 import type { Category } from '@/api/categories'
@@ -110,8 +110,28 @@ export default function BudgetEditModal({
   // Archiving stays outside the shared budget form because only the edit workflow exposes it
   const [isArchived, setIsArchived] = useState(baseBudget.is_archived)
 
-  // Tracks the previous open flag so the edit state only re-syncs on a closed-to-open transition
-  const prevOpen = useRef(open)
+  /**
+   * Restores edit state from the latest budget snapshot after save or close
+   */
+  const resetEditState = useCallback(() => {
+    setForm(initialForm)
+    setIsArchived(baseBudget.is_archived)
+    setFieldErrors({})
+    setTouched(EDIT_INITIAL_TOUCHED)
+    setFormError(null)
+    setCategorySearch('')
+    setSaveInProgress(false)
+  }, [baseBudget.is_archived, initialForm])
+
+  // The edit modal stays mounted, so reopening must reseed form and archive state from the current
+  // base budget, otherwise a stale archive toggle would silently unarchive on the next save. This
+  // adjusts state during render rather than in an effect so the reseed lands before the reopened
+  // modal paints
+  const [wasOpen, setWasOpen] = useState(open)
+  if (open !== wasOpen) {
+    setWasOpen(open)
+    if (open) resetEditState()
+  }
 
   // Preserve the budget's ownership scope so shared and personal budgets cannot cross category boundaries
   const categoryOptions = useMemo(
@@ -161,32 +181,12 @@ export default function BudgetEditModal({
   const showError: BudgetEditorModalErrorGetter = (field) => touched[field] ? fieldErrors[field] : undefined
 
   /**
-   * Restores edit state from the latest budget snapshot after save or close
-   */
-  const resetEditState = useCallback(() => {
-    setForm(initialForm)
-    setIsArchived(baseBudget.is_archived)
-    setFieldErrors({})
-    setTouched(EDIT_INITIAL_TOUCHED)
-    setFormError(null)
-    setCategorySearch('')
-    setSaveInProgress(false)
-  }, [baseBudget.is_archived, initialForm])
-
-  /**
    * Closes the nested edit dialog and clears any transient form state immediately
    */
   const closeAndReset = useCallback(() => {
     onClose()
     resetEditState()
   }, [onClose, resetEditState])
-
-  useEffect(() => {
-    // The edit modal stays mounted, so reopening must reseed form and archive state from the current
-    // base budget, otherwise a stale archive toggle would silently unarchive on the next save
-    if (open && !prevOpen.current) resetEditState()
-    prevOpen.current = open
-  }, [open, resetEditState])
 
   useEffect(() => {
     if (!open) return

--- a/frontend/src/utils/moneyInput.ts
+++ b/frontend/src/utils/moneyInput.ts
@@ -57,6 +57,10 @@ export function readMoneyInputChange(value: string, typed: string, exponent: num
 /**
  * Returns the number of decimal places a currency uses, falling back to two when the code is not
  * in the table
+ *
+ * The fallback cannot tell an unrecognized code from a table that has not loaded yet, so a field
+ * whose text is frozen at mount must wait for the currencies query to resolve. A field that
+ * recomputes its text every render corrects itself once the table arrives and needs no wait
  */
 export function getCurrencyExponent(currencies: Currency[], code: string): number {
   return currencies.find((currency) => currency.id === code)?.minor_unit_exponent ?? DEFAULT_MINOR_UNIT_EXPONENT


### PR DESCRIPTION
Two modal forms took their values at the wrong moment. The budget editor rebuilt itself after the browser had already painted, so reopening it showed a frame of the previous session's values. The account edit form built its credit limit from a currency list that had not downloaded yet, and on a currency with no decimal places that fills the field with one hundredth of the real limit, which the next save writes back.

- Reopening the budget editor rebuilds its form during render rather than after the browser has painted, so the previous session's values never reach the screen
- The account edit modal waits for the currency list before building its form, so a credit limit on a currency with no decimal places is no longer filled at one hundredth of its value
- The budgets page holds its create and details modals until the currency list arrives instead of standing in an empty one
- The function that reports a currency's decimal places carries a note that its two-place answer cannot tell an unrecognized code from a list that has not loaded, so only a value frozen at mount has to wait
