### PR TITLE
Show valid money placeholders and refuse crossed bounds in filter

### DIFF
--- a/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
@@ -17,6 +17,10 @@ type MobileFilterGlassPanelProps = {
   seedDraftFromFilters: () => void
   clearAll: () => void
   applyFilters: () => void
+
+  // Greys out Apply while the body holds an entry the draft will refuse, so the button never looks
+  // live for a commit that cannot happen
+  isApplyDisabled?: boolean
   children: ReactNode
 }
 
@@ -36,6 +40,7 @@ export function MobileFilterGlassPanel({
   seedDraftFromFilters,
   clearAll,
   applyFilters,
+  isApplyDisabled = false,
   children,
 }: MobileFilterGlassPanelProps) {
   // The full-screen modal covers the page, so the page-content dim is left off to keep the glass
@@ -109,7 +114,7 @@ export function MobileFilterGlassPanel({
             >
               Clear all
             </button>
-            <button type="button" className="app-glass-button-primary" onClick={applyFilters}>
+            <button type="button" className="app-glass-button-primary" disabled={isApplyDisabled} onClick={applyFilters}>
               Apply filters
             </button>
           </div>

--- a/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
@@ -293,7 +293,6 @@ export default function BudgetCreateModal({
             ids={CREATE_FIELD_IDS}
             selectedCurrencySymbol={currencySymbol(currencies, form.currency)}
             namePlaceholder="e.g. Groceries"
-            limitPlaceholder="0.00"
             currencyReadOnly={false}
             currencyTooltip
             limitDisabled={false}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -351,7 +351,7 @@ export default function BudgetEditModal({
             options={options}
             ids={EDIT_FIELD_IDS}
             selectedCurrencySymbol={currencySymbol(currencies, form.currency)}
-            limitPlaceholder={latestPeriod ? '0.00' : 'No period yet'}
+            limitPlaceholder={latestPeriod ? undefined : 'No period yet'}
             currencyReadOnly
             currencyTooltip={false}
             limitDisabled={!latestPeriod}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -3,7 +3,7 @@ import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
 import type { BudgetEditorModalErrorGetter, BudgetEditorModalFieldIds, BudgetEditorModalHandlers, BudgetEditorModalOptions, BudgetEditorModalViewState } from '@/pages/budgets/components/budget-editor-modal/types'
 import BudgetEditorFieldLabelRow from '@/pages/budgets/components/shared/EditorFieldLabelRow'
-import { getCurrencyExponent } from '@/utils/moneyInput'
+import { getCurrencyExponent, getMoneyPlaceholder } from '@/utils/moneyInput'
 
 interface BudgetEditorModalScopeSectionProps {
   state: BudgetEditorModalViewState
@@ -11,7 +11,10 @@ interface BudgetEditorModalScopeSectionProps {
   ids: BudgetEditorModalFieldIds
   selectedCurrencySymbol: string
   namePlaceholder?: string
-  limitPlaceholder: string
+
+  // Stands in for the amount format when the field cannot take a limit at all, such as a budget
+  // with no period yet
+  limitPlaceholder?: string
   currencyReadOnly: boolean
   currencyTooltip: boolean
   limitDisabled: boolean
@@ -42,9 +45,10 @@ export default function BudgetEditorModalScopeSection({
   const { form } = state
   const { currencies } = options
   const { setField, onBlur } = handlers
+  const limitExponent = getCurrencyExponent(currencies, form.currency)
   const limitInput = useMoneyInput({
     value: form.limit,
-    exponent: getCurrencyExponent(currencies, form.currency),
+    exponent: limitExponent,
     onChange: (value) => setField('limit', value),
     onBlur: () => onBlur('limit'),
   })
@@ -132,7 +136,7 @@ export default function BudgetEditorModalScopeSection({
               <input
                 id={ids.limit}
                 className={`app-input disabled:cursor-not-allowed disabled:opacity-60 ${selectedCurrencySymbol ? 'pl-8' : ''} ${showError('limit') ? 'app-input-error' : ''}`}
-                placeholder={limitPlaceholder}
+                placeholder={limitPlaceholder ?? getMoneyPlaceholder(limitExponent)}
                 disabled={limitDisabled || fieldsLocked}
                 {...limitInput}
               />

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/controls/FormControls.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/controls/FormControls.tsx
@@ -5,7 +5,7 @@ import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
 import { TAX_TREATMENT_OPTIONS } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/constants'
 import { currencySymbol } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/utils/categoryUtils'
-import { getCurrencyExponent } from '@/utils/moneyInput'
+import { getCurrencyExponent, getMoneyPlaceholder } from '@/utils/moneyInput'
 
 /**
  * Tooltip icon warning that tax-advantaged categories only link accounts sharing the category's
@@ -48,14 +48,18 @@ export function CurrencyInput({
   id?: string
   onBlur?: () => void
   onChange: (value: string) => void
+
+  // Left out to show the currency's own zero. A word is passed instead where telling the user the
+  // field is required or optional helps more than showing the amount format
   placeholder?: string
   required?: boolean
   value: string
 }) {
   const symbol = currencySymbol(currencies, currency)
+  const exponent = getCurrencyExponent(currencies, currency)
   const moneyInput = useMoneyInput({
     value,
-    exponent: getCurrencyExponent(currencies, currency),
+    exponent,
     onChange,
     onBlur,
   })
@@ -79,7 +83,7 @@ export function CurrencyInput({
         aria-label={ariaLabel}
         id={id}
         className={`app-input w-full ${symbol ? 'pl-8' : ''}`}
-        placeholder={placeholder}
+        placeholder={placeholder ?? getMoneyPlaceholder(exponent)}
         required={required}
         {...moneyInput}
       />
@@ -105,13 +109,17 @@ export function CompactCurrencyInput({
   currency: string
   onBlur?: () => void
   onChange: (value: string) => void
+
+  // Left out to show the currency's own zero. A word is passed instead where telling the user the
+  // field is required or optional helps more than showing the amount format
   placeholder?: string
   value: string
 }) {
   const symbol = currencySymbol(currencies, currency)
+  const exponent = getCurrencyExponent(currencies, currency)
   const moneyInput = useMoneyInput({
     value,
-    exponent: getCurrencyExponent(currencies, currency),
+    exponent,
     onChange,
     onBlur,
   })
@@ -130,7 +138,7 @@ export function CompactCurrencyInput({
         aria-label={ariaLabel}
         className="block h-8 min-w-0 flex-1 bg-transparent text-[0.9375rem] font-medium leading-8 outline-none"
         style={{ color: 'var(--app-text)' }}
-        placeholder={placeholder}
+        placeholder={placeholder ?? getMoneyPlaceholder(exponent)}
         {...moneyInput}
       />
       <Pencil

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryDetailsModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryDetailsModal.tsx
@@ -171,7 +171,6 @@ export default function TaxAdvantagedCategoryDetailsModal({
                           currency={plan.currency}
                           value={planForm.accrued_contributions}
                           onChange={(value) => onPlanFieldChange('accrued_contributions', value)}
-                          placeholder="0"
                         />
                       </div>
                     </div>

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal.tsx
@@ -218,7 +218,6 @@ export default function CreateTaxAdvantagedCategoryModal({
                           currency={selectedCurrency}
                           value={form.accrued_contributions}
                           onChange={(value) => setField('accrued_contributions', value)}
-                          placeholder="0"
                         />
                       </div>
                     </div>

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/LimitDetailsModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/LimitDetailsModal.tsx
@@ -141,14 +141,14 @@ export default function TaxAdvantagedLimitDetailsModal({
                       <p className="text-sm font-medium">Contribution</p>
                       <div className="grid grid-cols-2 gap-3">
                         {renderNewLimitEditorField('contribution_limit', 'Limit', 'New tax-year contribution limit', currencies, plan, newLimitForm, onNewLimitFieldChange, 'Required')}
-                        {renderNewLimitEditorField('accrued_contributions', 'Opening', 'New tax-year opening contributions', currencies, plan, newLimitForm, onNewLimitFieldChange, '0')}
+                        {renderNewLimitEditorField('accrued_contributions', 'Opening', 'New tax-year opening contributions', currencies, plan, newLimitForm, onNewLimitFieldChange)}
                       </div>
                     </div>
                     <div className="space-y-2">
                       <p className="text-sm font-medium">Withdrawal</p>
                       <div className="grid grid-cols-2 gap-3">
                         {renderNewLimitEditorField('withdrawal_limit', 'Limit', 'New tax-year withdrawal limit', currencies, plan, newLimitForm, onNewLimitFieldChange, 'Optional')}
-                        {renderNewLimitEditorField('accrued_withdrawals', 'Opening', 'New tax-year opening withdrawals', currencies, plan, newLimitForm, onNewLimitFieldChange, '0')}
+                        {renderNewLimitEditorField('accrued_withdrawals', 'Opening', 'New tax-year opening withdrawals', currencies, plan, newLimitForm, onNewLimitFieldChange)}
                       </div>
                     </div>
                     {limitError && (
@@ -162,15 +162,15 @@ export default function TaxAdvantagedLimitDetailsModal({
                     <div className="space-y-2">
                       <p className="text-sm font-medium">Contribution</p>
                       <div className="grid grid-cols-2 gap-3">
-                        {renderLimitEditorField(selectedLimit.year, 'contribution_limit', 'Limit', 'Contribution limit', selectedDraft.contribution_limit, currencies, plan, onLimitFieldChange)}
-                        {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Opening', 'Opening contributions', selectedDraft.accrued_contributions, currencies, plan, onLimitFieldChange, '0')}
+                        {renderLimitEditorField(selectedLimit.year, 'contribution_limit', 'Limit', 'Contribution limit', selectedDraft.contribution_limit, currencies, plan, onLimitFieldChange, 'Required')}
+                        {renderLimitEditorField(selectedLimit.year, 'accrued_contributions', 'Opening', 'Opening contributions', selectedDraft.accrued_contributions, currencies, plan, onLimitFieldChange)}
                       </div>
                     </div>
                     <div className="space-y-2">
                       <p className="text-sm font-medium">Withdrawal</p>
                       <div className="grid grid-cols-2 gap-3">
                         {renderLimitEditorField(selectedLimit.year, 'withdrawal_limit', 'Limit', 'Withdrawal limit', selectedDraft.withdrawal_limit, currencies, plan, onLimitFieldChange, 'Optional')}
-                        {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Opening', 'Opening withdrawals', selectedDraft.accrued_withdrawals, currencies, plan, onLimitFieldChange, '0')}
+                        {renderLimitEditorField(selectedLimit.year, 'accrued_withdrawals', 'Opening', 'Opening withdrawals', selectedDraft.accrued_withdrawals, currencies, plan, onLimitFieldChange)}
                       </div>
                     </div>
                     {limitError && (

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -7,6 +7,7 @@ import { MultiSelectChecklist } from '@/components/filters/MultiSelectChecklist'
 import { FacetSelectDropdown } from '@/components/list-controls/FacetSelectDropdown'
 import { FILTER_GLASS_SPRING } from '@/components/list-controls/toolbarStyles'
 import { joinClassNames } from '@/utils/classNames'
+import { getMoneyPlaceholder } from '@/utils/moneyInput'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
 import { ReferenceFacet } from '@/pages/transactions/components/toolbar/ReferenceFacet'
 import {
@@ -342,7 +343,7 @@ function FacetEditor({
                 )}
                 <input
                   className={joinClassNames('app-input', amountSymbol && 'pl-8')}
-                  placeholder="0.00"
+                  placeholder={getMoneyPlaceholder(amountExponent)}
                   {...minAmountInput}
                 />
               </div>

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -52,6 +52,8 @@ export function FilterPanelBody({
   )
   // Scopes the sliding-thumb layout animation to this instance
   const segId = useId()
+  // Names the crossed-bounds message so the amount fields can point at it from the facet editor
+  const amountRangeMessageId = useId()
   const shouldReduceMotion = useReducedMotion()
   const transition = shouldReduceMotion ? { duration: 0 } : FILTER_GLASS_SPRING
   const activeFacet = FILTER_FACETS.find((facet) => facet.id === activeFacetId) ?? FILTER_FACETS[0]
@@ -141,6 +143,8 @@ export function FilterPanelBody({
               amountSymbol={draft.amountSymbol}
               amountCurrencyNote={draft.amountCurrencyNote}
               amountExponent={draft.amountExponent}
+              hasCrossedAmountBounds={draft.hasCrossedAmountBounds}
+              amountRangeMessageId={amountRangeMessageId}
               currencyOptions={draft.getFacetOptions('currency')}
               currencyValue={draft.currencyLocked ? draft.amountCurrency : draft.selections.currency[0] ?? ''}
               currencyLocked={draft.currencyLocked}
@@ -171,9 +175,17 @@ export function FilterPanelBody({
       </motion.div>
 
       <motion.div layout={blockLayout} transition={transition}>
-        <p className="mt-2 px-0.5 text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-          Transactions must match every filter you apply
-        </p>
+        {/* The crossed-bounds message takes this line rather than sitting in the amount editor, so
+            the reason Apply is unavailable stays on screen whichever facet is open */}
+        {draft.hasCrossedAmountBounds ? (
+          <p id={amountRangeMessageId} className="mt-2 px-0.5 text-xs" style={{ color: 'var(--app-negative)' }}>
+            Enter a minimum at or below the maximum
+          </p>
+        ) : (
+          <p className="mt-2 px-0.5 text-xs" style={{ color: 'var(--app-text-subtle)' }}>
+            Transactions must match every filter you apply
+          </p>
+        )}
       </motion.div>
 
       {showFooter && (
@@ -187,7 +199,12 @@ export function FilterPanelBody({
           >
             Clear all
           </button>
-          <button type="button" className="app-glass-button-primary" onClick={draft.applyFilters}>
+          <button
+            type="button"
+            className="app-glass-button-primary"
+            disabled={draft.hasCrossedAmountBounds}
+            onClick={draft.applyFilters}
+          >
             Apply filters
           </button>
         </motion.div>
@@ -227,6 +244,11 @@ type FacetEditorProps = {
   amountCurrencyNote: string
   // Decimal places of the currency the amount range matches, for parsing and normalizing input
   amountExponent: number
+  // True while the minimum sits above the maximum once both are rounded to the currency's minor
+  // units, which no transaction can satisfy
+  hasCrossedAmountBounds: boolean
+  // Names the message explaining the crossed bounds, which the panel renders outside this editor
+  amountRangeMessageId: string
   // The currency the amount range matches, chosen inside the amount section
   currencyOptions: OptionItem[]
   currencyValue: string
@@ -257,6 +279,8 @@ function FacetEditor({
   amountSymbol,
   amountCurrencyNote,
   amountExponent,
+  hasCrossedAmountBounds,
+  amountRangeMessageId,
   currencyOptions,
   currencyValue,
   currencyLocked,
@@ -342,8 +366,10 @@ function FacetEditor({
                   </span>
                 )}
                 <input
-                  className={joinClassNames('app-input', amountSymbol && 'pl-8')}
+                  className={joinClassNames('app-input', amountSymbol && 'pl-8', hasCrossedAmountBounds && 'app-input-error')}
                   placeholder={getMoneyPlaceholder(amountExponent)}
+                  aria-invalid={hasCrossedAmountBounds}
+                  aria-describedby={hasCrossedAmountBounds ? amountRangeMessageId : undefined}
                   {...minAmountInput}
                 />
               </div>
@@ -363,8 +389,10 @@ function FacetEditor({
                   </span>
                 )}
                 <input
-                  className={joinClassNames('app-input', amountSymbol && 'pl-8')}
+                  className={joinClassNames('app-input', amountSymbol && 'pl-8', hasCrossedAmountBounds && 'app-input-error')}
                   placeholder="Any"
+                  aria-invalid={hasCrossedAmountBounds}
+                  aria-describedby={hasCrossedAmountBounds ? amountRangeMessageId : undefined}
                   {...maxAmountInput}
                 />
               </div>

--- a/frontend/src/pages/transactions/components/toolbar/MobileFilterPanel.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/MobileFilterPanel.tsx
@@ -47,6 +47,7 @@ export function MobileFilterPanel({
       seedDraftFromFilters={draft.seedDraftFromFilters}
       clearAll={draft.clearAll}
       applyFilters={draft.applyFilters}
+      isApplyDisabled={draft.hasCrossedAmountBounds}
     >
       <FilterPanelBody draft={draft} showFooter={false} mobile fillHeight showAccountFilter={showAccountFilter} />
     </MobileFilterGlassPanel>

--- a/frontend/src/pages/transactions/components/toolbar/useTransactionFilterDraft.ts
+++ b/frontend/src/pages/transactions/components/toolbar/useTransactionFilterDraft.ts
@@ -8,6 +8,7 @@ import { useMerchantDetails } from '@/api/merchants'
 import { useTagDetails } from '@/api/tags'
 import { useAuth } from '@/hooks/useAuth'
 import { fromMinorUnits, getCurrencyExponent, toMinorUnits } from '@/utils/moneyInput'
+import { isAmountRangeCrossed } from '@/pages/transactions/utils/amountRange'
 import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
 import type { TransactionFilterSetter } from '@/pages/transactions/components/toolbar/types'
 
@@ -113,6 +114,7 @@ export function useTransactionFilterDraft({
   const amountCurrency = lockedCurrency ?? selections.currency[0] ?? baseCurrency
   const amountSymbol = currencies.find((currency) => currency.id === amountCurrency)?.symbol ?? ''
   const amountExponent = getCurrencyExponent(currencies, amountCurrency)
+  const hasCrossedAmountBounds = isAmountRangeCrossed(amount, amountExponent)
   const amountCurrencyNote = currencyLocked
     ? `Amounts are matched in ${amountCurrency}, this account's currency`
     : selections.currency[0]
@@ -220,9 +222,12 @@ export function useTransactionFilterDraft({
 
   /**
    * Commits the draft to the applied filters, converting the amount bounds into the matched
-   * currency's minor units, then closes the surface
+   * currency's minor units, then closes the surface. Bounds that exclude each other are refused,
+   * leaving the panel open on the message rather than closing on a list that cannot have results
    */
   function applyFilters() {
+    if (hasCrossedAmountBounds) return
+
     // toMinorUnits returns null rather than undefined for a blank amount, so the setFilter payload
     // below converts it back to keep min_amount and max_amount optional
     const toMinor = (value: string) => toMinorUnits(value, amountExponent) ?? undefined
@@ -255,6 +260,7 @@ export function useTransactionFilterDraft({
     amountSymbol,
     amountExponent,
     amountCurrencyNote,
+    hasCrossedAmountBounds,
     currencyLocked,
     getFacetOptions,
     countFacet,

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -4,6 +4,7 @@ import DateField from '@/components/date-field/DateField'
 import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
+import { getMoneyPlaceholder } from '@/utils/moneyInput'
 
 interface TransactionDetailsSectionProps {
   date: string
@@ -103,7 +104,7 @@ export default function TransactionDetailsSection({
             <input
               id="txn-amount"
               className={`app-input w-full disabled:cursor-not-allowed disabled:opacity-60 ${selectedCurrencySymbol ? 'pl-8' : ''} ${amountError ? 'app-input-error' : ''}`}
-              placeholder="0.00"
+              placeholder={getMoneyPlaceholder(currencyExponent)}
               disabled={readOnly}
               {...amountInput}
             />

--- a/frontend/src/pages/transactions/utils/amountRange.ts
+++ b/frontend/src/pages/transactions/utils/amountRange.ts
@@ -1,0 +1,18 @@
+import { toMinorUnits } from '@/utils/moneyInput'
+
+/**
+ * Reports whether the amount filter's bounds exclude each other, which no transaction can satisfy
+ *
+ * Both bounds are converted to the stored minor units first, so the values compared are the ones
+ * the list endpoint would receive rather than the typed text. A bound left blank, or holding text
+ * naming no amount, cannot cross the other
+ *
+ * @param amount - The minimum and maximum as the fields hold them
+ * @param exponent - Decimal places of the currency the range matches in
+ */
+export function isAmountRangeCrossed(amount: { min: string; max: string }, exponent: number): boolean {
+  const min = toMinorUnits(amount.min, exponent)
+  const max = toMinorUnits(amount.max, exponent)
+
+  return min !== null && max !== null && min > max
+}

--- a/frontend/src/utils/moneyInput.ts
+++ b/frontend/src/utils/moneyInput.ts
@@ -101,6 +101,14 @@ export function fromMinorUnits(minorUnits: number | null, exponent: number): str
 }
 
 /**
+ * Returns the zero a money field shows as its placeholder, carrying the currency's decimal places
+ * so the field demonstrates a form it will actually take
+ */
+export function getMoneyPlaceholder(exponent: number): string {
+  return fromMinorUnits(0, exponent)
+}
+
+/**
  * Settles a money value to the currency's decimal places, so the amount left on screen once the
  * field loses focus is the amount that will be stored
  */

--- a/frontend/tests/transactions/amountRange.test.ts
+++ b/frontend/tests/transactions/amountRange.test.ts
@@ -1,0 +1,38 @@
+/**
+ * Tests the amount filter's bounds check, which keeps a minimum above the maximum from being
+ * applied and coming back as an empty list with no reason given
+ */
+import { describe, expect, it } from 'vitest'
+import { isAmountRangeCrossed } from '@/pages/transactions/utils/amountRange'
+
+const CENTS = 2
+const WHOLE_UNITS = 0
+
+describe('bounds that exclude each other', () => {
+  it('reports a minimum above the maximum', () => {
+    expect(isAmountRangeCrossed({ min: '500', max: '5' }, CENTS)).toBe(true)
+    expect(isAmountRangeCrossed({ min: '10.01', max: '10.00' }, CENTS)).toBe(true)
+    expect(isAmountRangeCrossed({ min: '23000', max: '2300' }, WHOLE_UNITS)).toBe(true)
+  })
+
+  it('allows a range in order, including bounds naming the same amount', () => {
+    expect(isAmountRangeCrossed({ min: '5', max: '500' }, CENTS)).toBe(false)
+    expect(isAmountRangeCrossed({ min: '10.00', max: '10.00' }, CENTS)).toBe(false)
+  })
+
+  it('compares the stored amount rather than the typed text', () => {
+    expect(isAmountRangeCrossed({ min: '9', max: '10' }, CENTS)).toBe(false)
+    expect(isAmountRangeCrossed({ min: '1.5', max: '1.50' }, CENTS)).toBe(false)
+  })
+
+  it('rounds each bound the way applying it would', () => {
+    expect(isAmountRangeCrossed({ min: '10.006', max: '10.01' }, CENTS)).toBe(false)
+    expect(isAmountRangeCrossed({ min: '10.006', max: '10.004' }, CENTS)).toBe(true)
+  })
+
+  it('leaves a bound alone that names no amount to compare', () => {
+    expect(isAmountRangeCrossed({ min: '500', max: '' }, CENTS)).toBe(false)
+    expect(isAmountRangeCrossed({ min: '', max: '5' }, CENTS)).toBe(false)
+    expect(isAmountRangeCrossed({ min: '500', max: '.' }, CENTS)).toBe(false)
+  })
+})

--- a/frontend/tests/utils/moneyInput.test.ts
+++ b/frontend/tests/utils/moneyInput.test.ts
@@ -7,6 +7,7 @@ import type { Currency } from '@/api/currency'
 import {
   fromMinorUnits,
   getCurrencyExponent,
+  getMoneyPlaceholder,
   isAcceptedMoneyInput,
   isValidMoneyInput,
   normalizeMoneyInput,
@@ -151,6 +152,14 @@ describe('currency decimal places', () => {
     expect(getCurrencyExponent(currencies, 'CAD')).toBe(2)
     expect(getCurrencyExponent(currencies, 'JPY')).toBe(0)
     expect(getCurrencyExponent(currencies, 'XXX')).toBe(2)
+  })
+})
+
+describe('the placeholder a field shows', () => {
+  it('shows a zero carrying the currency decimal places', () => {
+    expect(getMoneyPlaceholder(CENTS)).toBe('0.00')
+    expect(getMoneyPlaceholder(WHOLE_UNITS)).toBe('0')
+    expect(getMoneyPlaceholder(MILS)).toBe('0.000')
   })
 })
 


### PR DESCRIPTION
Money fields printed the same placeholder whatever currency they were in, and the transaction amount filter took a minimum above its maximum.

- Every money field takes its placeholder from the currency: `0` for yen, `0.00` for a dollar, `0.000` for a dinar, etc.
- The transaction amount filter no longer applies a minimum above its maximum
- The contribution limit for an existing tax year reads Required, matching the same field in the add-year form
