### PR TITLE
Catch render errors that blanked the app

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { useCacheValidation } from '@/hooks/useCacheValidation'
 import { useTheme } from '@/hooks/useTheme'
 import Navigation from '@/components/navigation/Navigation'
+import ErrorBoundary from '@/components/errors/Boundary'
 import LoadingScreen from '@/components/loading/Screen'
 import ForcedReenrollScreen from '@/components/two-factor/ForcedReenrollScreen'
 
@@ -191,8 +192,17 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
               <Suspense fallback={null}>
                 {contentMounted && (
                   <>
+                    {/* The notifier stays outside the boundary so a route that throws still
+                        reports itself as displayed. Inside it, the transition would never leave
+                        the loading phase and the recovery screen would sit invisible at zero
+                        opacity under a route loader that never fades out */}
                     <RouteReadyNotifier path={displayLocation.pathname} onReady={onContentReady} />
-                    <Outlet />
+                    {/* A focused page covers the viewport above the navigation, so a card there
+                        would float over a menu the user cannot reach. It gets the standalone
+                        screen instead, which is what that route already looks like */}
+                    <ErrorBoundary variant={isFocusedPage ? 'screen' : 'card'}>
+                      <Outlet />
+                    </ErrorBoundary>
                   </>
                 )}
               </Suspense>
@@ -212,9 +222,11 @@ function PublicRoute() {
   if (user) return <Navigate to="/" replace />;
 
   return (
-    <Suspense fallback={null}>
-      <Outlet />
-    </Suspense>
+    <ErrorBoundary variant="screen">
+      <Suspense fallback={null}>
+        <Outlet />
+      </Suspense>
+    </ErrorBoundary>
   );
 }
 
@@ -323,9 +335,11 @@ function AnimatedRoutes() {
         <Route
           path="/auth/oidc/callback"
           element={
-            <Suspense fallback={null}>
-              <OidcCallbackPage />
-            </Suspense>
+            <ErrorBoundary variant="screen">
+              <Suspense fallback={null}>
+                <OidcCallbackPage />
+              </Suspense>
+            </ErrorBoundary>
           }
         />
 

--- a/frontend/src/components/errors/Boundary.tsx
+++ b/frontend/src/components/errors/Boundary.tsx
@@ -1,0 +1,46 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import Fallback, { type FallbackVariant } from '@/components/errors/Fallback';
+
+interface BoundaryProps {
+  children: ReactNode;
+  variant: FallbackVariant;
+}
+
+interface BoundaryState {
+  componentStack: string | null;
+  error: unknown;
+  hasError: boolean;
+}
+
+/**
+ * Catches a render error below it and shows the recovery screen in place of the subtree
+ *
+ * A class because React offers no hook that can catch a render error. There is no reset: the app
+ * level has nothing to fall back to, and the per-route level is thrown away and rebuilt whenever
+ * the user navigates, since the route subtree is keyed by path
+ */
+export default class Boundary extends Component<BoundaryProps, BoundaryState> {
+  state: BoundaryState = { componentStack: null, error: null, hasError: false };
+
+  static getDerivedStateFromError(error: unknown): Partial<BoundaryState> {
+    return { error, hasError: true };
+  }
+
+  // React passes the list of components that were rendering here and nowhere else, so the fallback
+  // gets it on the second render rather than the first
+  componentDidCatch(_error: unknown, info: ErrorInfo) {
+    this.setState({ componentStack: info.componentStack ?? null });
+  }
+
+  render() {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <Fallback
+        componentStack={this.state.componentStack}
+        error={this.state.error}
+        variant={this.props.variant}
+      />
+    );
+  }
+}

--- a/frontend/src/components/errors/Fallback.tsx
+++ b/frontend/src/components/errors/Fallback.tsx
@@ -1,4 +1,4 @@
-import { AlertTriangle } from 'lucide-react';
+import { AlertTriangle, Check, Copy, RefreshCw } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 import { useServerReachability } from '@/hooks/useServerReachability';
 import { copyText } from '@/utils/clipboard';
@@ -15,7 +15,9 @@ const COPY_LABELS: Record<CopyStatus, string> = {
   failed: 'Could not copy',
 };
 
-const BUG_REPORT_URL = 'https://github.com/Lumina-Finance/lumina-finance/issues/new';
+// The issue list rather than a blank new issue, so the repository's own template picker is what
+// the user lands on
+const BUG_REPORT_URL = 'https://github.com/Lumina-Finance/lumina-finance/issues';
 
 // How long the copy button confirms before returning to its usual label
 const COPY_CONFIRMATION_MS = 2000;
@@ -79,18 +81,21 @@ export default function Fallback({ componentStack, error, variant }: FallbackPro
 
   const content = (
     <>
-      <AlertTriangle
-        size={variant === 'screen' ? 22 : 20}
-        strokeWidth={2}
-        style={{ color: 'var(--app-accent)' }}
-        aria-hidden
-      />
+      <div className="flex items-center gap-3">
+        <AlertTriangle
+          size={variant === 'screen' ? 26 : 22}
+          strokeWidth={2}
+          className="shrink-0"
+          style={{ color: 'var(--app-accent)' }}
+          aria-hidden
+        />
 
-      <h1
-        className={`mt-3 font-serif font-normal tracking-tight ${variant === 'screen' ? 'text-4xl' : 'text-2xl'}`}
-      >
-        OK this was not in the plan <span aria-hidden>:(</span>
-      </h1>
+        <h1
+          className={`font-serif font-normal tracking-tight ${variant === 'screen' ? 'text-3xl' : 'text-2xl'}`}
+        >
+          OK this was not in the plan <span aria-hidden>:(</span>
+        </h1>
+      </div>
 
       <p className="mt-4 text-sm leading-relaxed" style={{ color: 'var(--app-text-muted)' }}>
         {serverUnreachable ? (
@@ -118,15 +123,21 @@ export default function Fallback({ componentStack, error, variant }: FallbackPro
 
       <div className="mt-6 flex flex-wrap items-center gap-4">
         <button type="button" className="app-primary-button" onClick={handleReload}>
+          <RefreshCw size={15} strokeWidth={2} aria-hidden />
           Reload
         </button>
 
         <button
           type="button"
-          className="text-xs font-medium underline underline-offset-2 transition-colors duration-200"
+          className="inline-flex items-center gap-1.5 text-xs font-medium underline underline-offset-2 transition-colors duration-200"
           style={{ color: 'var(--app-text-muted)' }}
           onClick={handleCopy}
         >
+          {copyStatus === 'copied' ? (
+            <Check size={14} strokeWidth={2.5} style={{ color: 'var(--app-positive)' }} aria-hidden />
+          ) : (
+            <Copy size={14} strokeWidth={2} aria-hidden />
+          )}
           {COPY_LABELS[copyStatus]}
         </button>
       </div>
@@ -136,16 +147,18 @@ export default function Fallback({ componentStack, error, variant }: FallbackPro
   if (variant === 'screen') {
     return (
       <div
-        className="flex min-h-[100dvh] items-start justify-center px-4 pt-[10dvh] lg:pt-[20dvh]"
+        className="flex min-h-[100dvh] items-center justify-center px-4"
         style={{ backgroundColor: 'var(--app-bg)' }}
       >
-        <div className="w-full max-w-sm">{content}</div>
+        <div className="w-full max-w-md">{content}</div>
       </div>
     );
   }
 
   return (
-    <div className="flex justify-center py-10">
+    // The page area is taller than the card, so the height gives it something to sit in the middle
+    // of rather than hugging the top of the content column
+    <div className="flex min-h-[70dvh] items-center justify-center">
       <div
         className="w-full max-w-md rounded-2xl border p-6"
         style={{ backgroundColor: 'var(--app-surface-soft)', borderColor: 'var(--app-border)' }}

--- a/frontend/src/components/errors/Fallback.tsx
+++ b/frontend/src/components/errors/Fallback.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
+import { useServerReachability } from '@/hooks/useServerReachability';
 import { copyText } from '@/utils/clipboard';
 import { buildErrorReport } from '@/utils/errorReport';
 import { clearStoredData } from '@/utils/storedData';
@@ -35,6 +36,9 @@ interface FallbackProps {
 export default function Fallback({ componentStack, error, variant }: FallbackProps) {
   const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
   const copyResetTimer = useRef<number | null>(null);
+  // Until the probe comes back the message assumes a bug, since that is the only thing the user
+  // can act on. An unreachable server rewrites it rather than the other way round
+  const serverUnreachable = useServerReachability() === 'unreachable';
 
   useEffect(() => () => {
     if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
@@ -89,18 +93,27 @@ export default function Fallback({ componentStack, error, variant }: FallbackPro
       </h1>
 
       <p className="mt-4 text-sm leading-relaxed" style={{ color: 'var(--app-text-muted)' }}>
-        The app ran into an issue while trying to respond to your request. Your data is fine, and
-        reloading usually fixes it. If it persists, please try again in a bit and submit a{' '}
-        <a
-          href={BUG_REPORT_URL}
-          target="_blank"
-          rel="noreferrer"
-          className="underline underline-offset-2"
-          style={{ color: 'var(--app-accent)' }}
-        >
-          bug report
-        </a>{' '}
-        if it still doesn&apos;t resolve.
+        {serverUnreachable ? (
+          <>
+            The app can&apos;t reach the server right now. Your data is fine. Reload once your
+            connection is back.
+          </>
+        ) : (
+          <>
+            The app ran into an issue while trying to respond to your request. Your data is fine,
+            and reloading usually fixes it. If it persists, please try again in a bit and submit a{' '}
+            <a
+              href={BUG_REPORT_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2"
+              style={{ color: 'var(--app-accent)' }}
+            >
+              bug report
+            </a>{' '}
+            if it still doesn&apos;t resolve.
+          </>
+        )}
       </p>
 
       <div className="mt-6 flex flex-wrap items-center gap-4">

--- a/frontend/src/components/errors/Fallback.tsx
+++ b/frontend/src/components/errors/Fallback.tsx
@@ -1,0 +1,144 @@
+import { AlertTriangle } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+import { copyText } from '@/utils/clipboard';
+import { buildErrorReport } from '@/utils/errorReport';
+import { clearStoredData } from '@/utils/storedData';
+
+export type FallbackVariant = 'card' | 'screen';
+
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+const COPY_LABELS: Record<CopyStatus, string> = {
+  idle: 'Copy error details',
+  copied: 'Copied',
+  failed: 'Could not copy',
+};
+
+const BUG_REPORT_URL = 'https://github.com/Lumina-Finance/lumina-finance/issues/new';
+
+// How long the copy button confirms before returning to its usual label
+const COPY_CONFIRMATION_MS = 2000;
+
+interface FallbackProps {
+  componentStack: string | null;
+  error: unknown;
+  variant: FallbackVariant;
+}
+
+/**
+ * The recovery screen shown in place of whatever failed to render
+ *
+ * The card variant sits in the page area with the navigation still beside it, the screen variant
+ * stands alone when there is no app left around it. Both carry the same message and actions, since
+ * from the user's side the difference is only how much of the app is still there
+ */
+export default function Fallback({ componentStack, error, variant }: FallbackProps) {
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+  const copyResetTimer = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
+  }, []);
+
+  /**
+   * Reloads onto empty storage, because state saved in this browser can be what broke the render
+   * and a plain reload would restore it
+   */
+  const handleReload = () => {
+    clearStoredData();
+    window.location.reload();
+  };
+
+  /**
+   * Puts the technical detail on the clipboard for a bug report, keeping it off the screen
+   *
+   * The report is built here rather than when the error was caught so the time reflects the moment
+   * the user asked for it, which is what they will have seen in the app
+   */
+  const handleCopy = async () => {
+    const report = buildErrorReport({
+      componentStack,
+      error,
+      // The query string is left out on purpose. A password reset link carries its token there and
+      // the provider callback carries an authorization code, and this text is written to be pasted
+      // into a public bug report
+      path: window.location.pathname,
+      occurredAt: new Date(),
+      userAgent: navigator.userAgent,
+    });
+
+    setCopyStatus((await copyText(report)) ? 'copied' : 'failed');
+
+    if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
+    copyResetTimer.current = window.setTimeout(() => setCopyStatus('idle'), COPY_CONFIRMATION_MS);
+  };
+
+  const content = (
+    <>
+      <AlertTriangle
+        size={variant === 'screen' ? 22 : 20}
+        strokeWidth={2}
+        style={{ color: 'var(--app-accent)' }}
+        aria-hidden
+      />
+
+      <h1
+        className={`mt-3 font-serif font-normal tracking-tight ${variant === 'screen' ? 'text-4xl' : 'text-2xl'}`}
+      >
+        OK this was not in the plan <span aria-hidden>:(</span>
+      </h1>
+
+      <p className="mt-4 text-sm leading-relaxed" style={{ color: 'var(--app-text-muted)' }}>
+        The app ran into an issue while trying to respond to your request. Your data is fine, and
+        reloading usually fixes it. If it persists, please try again in a bit and submit a{' '}
+        <a
+          href={BUG_REPORT_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="underline underline-offset-2"
+          style={{ color: 'var(--app-accent)' }}
+        >
+          bug report
+        </a>{' '}
+        if it still doesn&apos;t resolve.
+      </p>
+
+      <div className="mt-6 flex flex-wrap items-center gap-4">
+        <button type="button" className="app-primary-button" onClick={handleReload}>
+          Reload
+        </button>
+
+        <button
+          type="button"
+          className="text-xs font-medium underline underline-offset-2 transition-colors duration-200"
+          style={{ color: 'var(--app-text-muted)' }}
+          onClick={handleCopy}
+        >
+          {COPY_LABELS[copyStatus]}
+        </button>
+      </div>
+    </>
+  );
+
+  if (variant === 'screen') {
+    return (
+      <div
+        className="flex min-h-[100dvh] items-start justify-center px-4 pt-[10dvh] lg:pt-[20dvh]"
+        style={{ backgroundColor: 'var(--app-bg)' }}
+      >
+        <div className="w-full max-w-sm">{content}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex justify-center py-10">
+      <div
+        className="w-full max-w-md rounded-2xl border p-6"
+        style={{ backgroundColor: 'var(--app-surface-soft)', borderColor: 'var(--app-border)' }}
+      >
+        {content}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -35,7 +35,7 @@ export interface AuthContextValue extends AuthState {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
-const SESSION_KEY = 'lumina:has_session';
+export const SESSION_KEY = 'lumina:has_session';
 const RELOAD_SESSION_RESTORE_DELAY_MS = 750;
 
 /**

--- a/frontend/src/hooks/useServerReachability.ts
+++ b/frontend/src/hooks/useServerReachability.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { fetchAppVersion } from '@/api/version';
+
+export type ServerReachability = 'checking' | 'reachable' | 'unreachable';
+
+// Long enough to survive a slow connection, short enough that the screen is not still deciding
+// what to say once the user has read it
+const PROBE_TIMEOUT_MS = 3000;
+
+/**
+ * Reports whether the backend answers, so an error screen can tell a broken app from a lost connection
+ *
+ * The version endpoint is the probe because it needs no session and already exists. A browser
+ * reporting itself as offline is believed without a request, since that reading is only ever wrong
+ * in the other direction: having a network says nothing about our server being on the far end of it
+ *
+ * @returns The current verdict, starting at `checking` unless the browser is already known to be offline
+ */
+export function useServerReachability(): ServerReachability {
+  const [reachability, setReachability] = useState<ServerReachability>(() =>
+    navigator.onLine ? 'checking' : 'unreachable'
+  );
+
+  useEffect(() => {
+    if (!navigator.onLine) return;
+
+    let cancelled = false;
+    let timer: number | undefined;
+
+    // The request carries no way to abort it, so the timeout races it rather than cancelling it.
+    // A probe left running against an unreachable server costs nothing on a screen this is
+    const expiry = new Promise<never>((_, reject) => {
+      timer = window.setTimeout(reject, PROBE_TIMEOUT_MS);
+    });
+
+    Promise.race([fetchAppVersion(), expiry])
+      .then(() => {
+        if (!cancelled) setReachability('reachable');
+      })
+      .catch(() => {
+        if (!cancelled) setReachability('unreachable');
+      });
+
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, []);
+
+  return reachability;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,6 +5,7 @@ import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
 import '@/styles/tailwind.css'
 import App from '@/App.tsx'
+import ErrorBoundary from '@/components/errors/Boundary'
 import { hasUncacheableFxStatus } from '@/api/shared/fxCache'
 
 const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000;
@@ -34,15 +35,19 @@ function shouldDehydrateQuery(query: Query) {
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <PersistQueryClientProvider
-      client={queryClient}
-      persistOptions={{
-        persister,
-        maxAge: SIX_MONTHS_MS,
-        dehydrateOptions: { shouldDehydrateQuery },
-      }}
-    >
-      <App />
-    </PersistQueryClientProvider>
+    {/* Above the providers, so a provider that throws while starting up is caught too. React logs
+        every caught error to the console on its own, so nothing is wired up for reporting here */}
+    <ErrorBoundary variant="screen">
+      <PersistQueryClientProvider
+        client={queryClient}
+        persistOptions={{
+          persister,
+          maxAge: SIX_MONTHS_MS,
+          dehydrateOptions: { shouldDehydrateQuery },
+        }}
+      >
+        <App />
+      </PersistQueryClientProvider>
+    </ErrorBoundary>
   </StrictMode>,
 )

--- a/frontend/src/utils/errorReport.ts
+++ b/frontend/src/utils/errorReport.ts
@@ -1,0 +1,40 @@
+interface ErrorReportDetails {
+  componentStack: string | null;
+  error: unknown;
+  occurredAt: Date;
+  path: string;
+  userAgent: string;
+}
+
+/**
+ * Assembles the plain-text report a user copies off an error screen and pastes into a bug report
+ *
+ * The stacks go last and the short fields first, so the useful part survives a reader who stops
+ * reading partway. Everything is passed in rather than read from the page, so the caller decides
+ * what a report may contain
+ *
+ * @param details - The caught error, where and when it happened, and the browser it happened in
+ * @returns The report as newline-separated text
+ */
+export function buildErrorReport({ componentStack, error, occurredAt, path, userAgent }: ErrorReportDetails): string {
+  // A thrown value is not necessarily an Error, and String() is the only description a bare
+  // throw can offer
+  const description = error instanceof Error ? `${error.name}: ${error.message}` : String(error);
+
+  const lines = [
+    `Time: ${occurredAt.toISOString()}`,
+    `Page: ${path}`,
+    `Error: ${description}`,
+    `Browser: ${userAgent}`,
+  ];
+
+  if (error instanceof Error && error.stack) {
+    lines.push('', 'Stack:', error.stack.trim());
+  }
+
+  if (componentStack) {
+    lines.push('', 'Components:', componentStack.trim());
+  }
+
+  return lines.join('\n');
+}

--- a/frontend/src/utils/storedData.ts
+++ b/frontend/src/utils/storedData.ts
@@ -1,0 +1,27 @@
+import { SESSION_KEY } from '@/contexts/AuthContext';
+
+/**
+ * Clears everything this browser holds for the app, so a reload starts from nothing
+ *
+ * The error screens reload through here because a render error can be caused by stored state, and a
+ * plain reload would feed that state straight back in and fail the same way
+ *
+ * The flag saying a session exists is put back afterwards. It carries no data, and without it the
+ * next load skips the silent token refresh and drops the user at the login screen, which turns a
+ * recoverable crash into signing in again
+ */
+export function clearStoredData() {
+  try {
+    const hadSession = window.localStorage.getItem(SESSION_KEY);
+
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+
+    if (hadSession !== null) {
+      window.localStorage.setItem(SESSION_KEY, hadSession);
+    }
+  } catch {
+    // Storage access itself throws where the browser has it disabled. The reload this precedes is
+    // the only recovery the user has left, so an unusable store must not take that with it
+  }
+}

--- a/frontend/tests/utils/errorReport.test.ts
+++ b/frontend/tests/utils/errorReport.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Tests the report a user copies off an error screen, so a pasted bug report carries what is needed
+ * to place the error and nothing that depends on the page still being there
+ */
+import { describe, expect, it } from 'vitest'
+import { buildErrorReport } from '@/utils/errorReport'
+
+const OCCURRED_AT = new Date('2026-07-28T12:34:56.000Z')
+const USER_AGENT = 'Mozilla/5.0 (Macintosh) TestBrowser/1.0'
+
+describe('buildErrorReport', () => {
+  it('carries the error, where it happened and both stacks', () => {
+    const error = new TypeError('Cannot read properties of undefined')
+    error.stack = 'TypeError: Cannot read properties of undefined\n    at Dashboard'
+
+    const report = buildErrorReport({
+      componentStack: '\n    at Dashboard\n    at Boundary',
+      error,
+      occurredAt: OCCURRED_AT,
+      path: '/accounts?tab=all',
+      userAgent: USER_AGENT,
+    })
+
+    expect(report).toContain('Time: 2026-07-28T12:34:56.000Z')
+    expect(report).toContain('Page: /accounts?tab=all')
+    expect(report).toContain('Error: TypeError: Cannot read properties of undefined')
+    expect(report).toContain(`Browser: ${USER_AGENT}`)
+    expect(report).toContain('Stack:\nTypeError: Cannot read properties of undefined\n    at Dashboard')
+    expect(report).toContain('Components:\nat Dashboard\n    at Boundary')
+  })
+
+  it('describes a thrown value that is not an error and leaves the stack out', () => {
+    const report = buildErrorReport({
+      componentStack: null,
+      error: 'boom',
+      occurredAt: OCCURRED_AT,
+      path: '/',
+      userAgent: USER_AGENT,
+    })
+
+    expect(report).toContain('Error: boom')
+    expect(report).not.toContain('Stack:')
+    expect(report).not.toContain('Components:')
+  })
+})


### PR DESCRIPTION
An error thrown while a component renders currently takes the whole interface down, leaving a blank page with no message and no way back, and one that reloading cannot fix when the cause is something stored on the device.

- A failure on one screen stays in the page area, so the navigation and every other page keep working
- A backstop above the providers catches what the per-screen boundaries cannot reach, including a provider that throws while it starts up
- The screen checks whether the backend answers before deciding what to say, so a lost connection is not presented as a bug to report
- Reloading from the error screen empties what the browser has saved first, so a failure caused by stored state does not come back with it, while the user stays signed in
- The technical detail goes to the clipboard on request rather than onto the page, without the query string, so a password reset token cannot reach a public tracker
