### PR TITLE
Take today from the user profile's time zone everywhere

### DIFF
--- a/frontend/src/components/date-field/DateField.tsx
+++ b/frontend/src/components/date-field/DateField.tsx
@@ -12,6 +12,8 @@ import {
   type DateSegmentName,
   type DateSegments,
 } from '@/components/date-field/dateSegments'
+import { useAuth } from '@/hooks/useAuth'
+import { getTodayDate } from '@/utils/date'
 
 interface DateFieldProps {
   // Selected date as an ISO yyyy-mm-dd string, empty while the date is incomplete
@@ -53,6 +55,7 @@ export default function DateField({
   readOnly = false,
   error = false,
 }: DateFieldProps) {
+  const { user } = useAuth()
   const [segments, setSegments] = useState<DateSegments>(() => parseIsoDate(value))
   const [popoverOpen, setPopoverOpen] = useState(false)
   const lastEmittedRef = useRef(value)
@@ -128,11 +131,11 @@ export default function DateField({
     switch (event.key) {
       case 'ArrowUp':
         event.preventDefault()
-        commit(stepSegment(segments, segment, 1, new Date()))
+        commit(stepSegment(segments, segment, 1, getTodayDate(user?.tz)))
         break
       case 'ArrowDown':
         event.preventDefault()
-        commit(stepSegment(segments, segment, -1, new Date()))
+        commit(stepSegment(segments, segment, -1, getTodayDate(user?.tz)))
         break
       case 'ArrowRight':
         if ((input.selectionEnd ?? 0) >= input.value.length) {

--- a/frontend/src/components/passkeys/PasskeyRow.tsx
+++ b/frontend/src/components/passkeys/PasskeyRow.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { AnimatePresence, motion } from 'motion/react';
 import type { Passkey } from '@/api/passkeys';
 import { OverflowMenu } from '@/components/passkeys/OverflowMenu';
+import { useAuth } from '@/hooks/useAuth';
 import { formatRelativeTime } from '@/utils/relativeTime';
 import { DATE_FORMATS, formatDate } from '@/utils/date';
 
@@ -23,6 +24,7 @@ interface PasskeyRowProps {
  * the backend re-checks a current second factor before deleting a passkey
  */
 export function PasskeyRow({ passkey, onRename, onRemove, disabled }: PasskeyRowProps) {
+  const { user } = useAuth();
   const [isRenaming, setIsRenaming] = useState(false);
   const [draftName, setDraftName] = useState(passkey.name);
   const [error, setError] = useState<string | null>(null);
@@ -55,7 +57,7 @@ export function PasskeyRow({ passkey, onRename, onRemove, disabled }: PasskeyRow
     }
   }
 
-  const addedLabel = `Added ${formatDate(new Date(passkey.created_at), DATE_FORMATS.monthDayYear)}`;
+  const addedLabel = `Added ${formatDate(new Date(passkey.created_at), DATE_FORMATS.monthDayYear, user?.tz)}`;
   const usageLabel = passkey.last_used_at ? `last used ${formatRelativeTime(passkey.last_used_at)}` : 'not used yet';
 
   return (

--- a/frontend/src/pages/accounts/detail/components/balance-chart/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/balance-chart/Card.tsx
@@ -4,6 +4,7 @@ import {
   LoadingContent,
   LoadingOverlay,
 } from '@/components/loading/Transition'
+import { useAuth } from '@/hooks/useAuth'
 import { useLoadingSnapshot } from '@/hooks/useLoadingSnapshot'
 import type {
   BalanceChartMode,
@@ -25,10 +26,11 @@ import { BalanceValueSummary } from './ValueSummary'
 export default function BalanceChartCard({ account }: { account: Account }) {
   const [range, setRange] = useState<BalanceRange>('30D')
   const [chartMode, setChartMode] = useState<BalanceChartMode>('balance')
+  const { user } = useAuth()
 
   const { fromDate, toDate, granularity } = useMemo(
-    () => getBalanceRangeWindow(range),
-    [range],
+    () => getBalanceRangeWindow(range, user?.tz),
+    [range, user?.tz],
   )
 
   const { data: snapshots, isFetching } = useAccountSnapshots(account.id, {

--- a/frontend/src/pages/accounts/detail/utils/balanceChartViewModel.ts
+++ b/frontend/src/pages/accounts/detail/utils/balanceChartViewModel.ts
@@ -11,6 +11,7 @@ import {
   rezeroSeriesToPeriod,
   type BalanceChartPoint,
 } from '@/pages/accounts/detail/utils/balanceChartSeries'
+import { getTodayDate } from '@/utils/date'
 
 export type BalanceChartDataPoint = BalanceChartPoint & {
   periodBalance?: number
@@ -60,15 +61,22 @@ type BalanceChartSnapshotOptions = {
 }
 
 /**
- * Derives the local-day snapshot query window from the selected balance range
+ * Derives the snapshot query window from the selected balance range
+ *
+ * The window has to be read in the profile's zone rather than the browser's, because the backend
+ * computes each daily balance row on the account owner's own calendar date
+ *
+ * @param range - The selected range, deciding how many days the window spans
+ * @param timeZone - Zone deciding where the window ends, typically the profile setting
+ * @param now - Instant to read the day from, overridable so tests can pin it
  */
 export function getBalanceRangeWindow(
   range: BalanceRange,
-  today: Date = new Date(),
+  timeZone: string | undefined,
+  now = new Date(),
 ): BalanceRangeWindow {
   const config = RANGE_CONFIG[range]
-  const toDate = new Date(today)
-  toDate.setHours(0, 0, 0, 0)
+  const toDate = getTodayDate(timeZone, now)
   const fromDate = new Date(toDate)
   fromDate.setDate(fromDate.getDate() - (config.days - 1))
 

--- a/frontend/src/pages/auth/AuthPage.tsx
+++ b/frontend/src/pages/auth/AuthPage.tsx
@@ -17,9 +17,10 @@ import { PasswordRequirements } from '@/components/PasswordRequirements';
 import { AUTH_VIEW_TRANSITION, SIGNUP_FIELD_ANIMATION } from '@/pages/auth/constants/authAnimations';
 import { useAuthFormWorkflow } from '@/pages/auth/hooks/useAuthFormWorkflow';
 import { getAuthMode } from '@/pages/auth/utils/authForm';
+import { getBrowserTimeZone } from '@/utils/date';
 import { isNewPasswordValid } from '@/utils/passwordPolicy';
 
-const DETECTED_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const DETECTED_TZ = getBrowserTimeZone();
 
 const TIMEZONES = Intl.supportedValuesOf('timeZone').map((tz) => ({
   value: tz,

--- a/frontend/src/pages/auth/OidcCallbackPage.tsx
+++ b/frontend/src/pages/auth/OidcCallbackPage.tsx
@@ -20,8 +20,9 @@ import { AuthTextField } from '@/pages/auth/components/fields/TextField'
 import { AUTH_VIEW_TRANSITION } from '@/pages/auth/constants/authAnimations'
 import { consumeOidcIntent, type OidcSignedInIntent } from '@/utils/oidcIntent'
 import { buildCurrencyOptions, getCurrencyPlaceholder } from '@/pages/auth/utils/authForm'
+import { getBrowserTimeZone } from '@/utils/date'
 
-const DETECTED_TZ = Intl.DateTimeFormat().resolvedOptions().timeZone
+const DETECTED_TZ = getBrowserTimeZone()
 
 const TIMEZONES = Intl.supportedValuesOf('timeZone').map((tz) => ({
   value: tz,

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { useAccounts } from '@/api/accounts'
 import { useCategories } from '@/api/categories'
 import { useCurrencies } from '@/api/currency'
+import { useAuth } from '@/hooks/useAuth'
 import { KIND_LABELS } from '@/pages/transactions/components/transaction-modal/constants'
 import { buildInitialTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/initialForm'
 import { buildCurrencyOptions } from '@/pages/transactions/components/transaction-modal/utils/options'
@@ -47,6 +48,7 @@ export default function CreateTransactionModal({
   readOnly: readOnlyProp = false,
 }: CreateTransactionModalProps) {
   const editing = !!transaction
+  const { user } = useAuth()
   const { data: accounts = [] } = useAccounts()
   const { data: categories = [] } = useCategories()
   const { data: currencies = [] } = useCurrencies()
@@ -64,8 +66,9 @@ export default function CreateTransactionModal({
       selectableAccounts,
       defaultAccountId,
       defaultCurrency,
+      timeZone: user?.tz,
     })
-  }, [transaction, categories, currencies, defaultAccountId, defaultCurrency, selectableAccounts])
+  }, [transaction, categories, currencies, defaultAccountId, defaultCurrency, selectableAccounts, user?.tz])
 
   const {
     form,

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
@@ -3,11 +3,12 @@ import type { Category } from '@/api/categories'
 import type { Currency } from '@/api/currency'
 import type { Transaction } from '@/api/transactions'
 import { INITIAL_TRANSACTION_FORM } from '@/pages/transactions/components/transaction-modal/constants'
-import { amountToInputString, getTodayLocalDateInputValue } from '@/pages/transactions/components/transaction-modal/utils/money'
+import { amountToInputString } from '@/pages/transactions/components/transaction-modal/utils/money'
 import type {
   TransactionFormValues,
   TransactionModalKind,
 } from '@/pages/transactions/components/transaction-modal/types'
+import { getTodayYmd } from '@/utils/date'
 
 interface BuildInitialTransactionFormOptions {
   transaction?: Transaction
@@ -16,6 +17,10 @@ interface BuildInitialTransactionFormOptions {
   selectableAccounts: AccountsOverview[]
   defaultAccountId?: string
   defaultCurrency?: string
+  // Required rather than optional so a call site has to name the zone it means, since an omitted
+  // one falls back to the browser's calendar and dates a new transaction on the wrong day for
+  // anyone away from the region their profile names
+  timeZone: string | undefined
 }
 
 /**
@@ -28,6 +33,7 @@ export function buildInitialTransactionForm({
   selectableAccounts,
   defaultAccountId,
   defaultCurrency,
+  timeZone,
 }: BuildInitialTransactionFormOptions): TransactionFormValues {
   if (!transaction) {
     const defaultAccount = defaultAccountId
@@ -37,7 +43,7 @@ export function buildInitialTransactionForm({
       ...INITIAL_TRANSACTION_FORM,
       account_id: defaultAccount?.id ?? INITIAL_TRANSACTION_FORM.account_id,
       currency: defaultAccount?.currency ?? defaultCurrency ?? INITIAL_TRANSACTION_FORM.currency,
-      date: getTodayLocalDateInputValue(),
+      date: getTodayYmd(timeZone),
     }
   }
 

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/money.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/money.ts
@@ -2,15 +2,6 @@ import { fromMinorUnits, toMinorUnits } from '@/utils/moneyInput'
 import type { TransactionDirection } from '@/pages/transactions/components/transaction-modal/types'
 
 /**
- * Builds the date input value using the browser's local calendar day
- */
-export function getTodayLocalDateInputValue(): string {
-  const date = new Date()
-  const pad = (value: number) => String(value).padStart(2, '0')
-  return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
-}
-
-/**
  * Converts a stored signed minor-unit amount into a positive canonical input value
  */
 export function amountToInputString(amountMinor: number, exponent: number): string {

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -31,8 +31,11 @@ const resolvedTimeZones = new Map<string, string>()
 
 /**
  * Returns the timezone the browser is running in
+ *
+ * Sign-up reads this directly, having no profile yet to take a zone from. Anywhere a user exists,
+ * the profile setting is passed to resolveTimeZone or to one of the getToday helpers instead
  */
-function getBrowserTimeZone(): string {
+export function getBrowserTimeZone(): string {
   return Intl.DateTimeFormat().resolvedOptions().timeZone
 }
 

--- a/frontend/tests/accounts/accountDetailLogic.test.ts
+++ b/frontend/tests/accounts/accountDetailLogic.test.ts
@@ -169,12 +169,17 @@ describe('identity form helpers', () => {
 })
 
 describe('balance chart view model helpers', () => {
-  it('derives the selected range window from a local-day anchor date', () => {
-    const window = getBalanceRangeWindow('30D', new Date(2026, 5, 13, 14, 30))
+  it('ends the selected range window on the profile timezone day rather than the browser calendar', () => {
+    // Late evening in Toronto on 30 June, already 1 July in UTC, so a zone mix-up shows up as a
+    // different day and a different month
+    const lateJuneEvening = new Date('2026-07-01T02:00:00Z')
+    const window = getBalanceRangeWindow('30D', 'America/Toronto', lateJuneEvening)
 
-    expect(formatYmd(window.fromDate)).toBe('2026-05-15')
-    expect(formatYmd(window.toDate)).toBe('2026-06-13')
+    expect(formatYmd(window.fromDate)).toBe('2026-06-01')
+    expect(formatYmd(window.toDate)).toBe('2026-06-30')
     expect(window.granularity).toBe('day')
+
+    expect(formatYmd(getBalanceRangeWindow('30D', 'UTC', lateJuneEvening).toDate)).toBe('2026-07-01')
   })
 
   it('calculates absolute and percentage movement from the first and last chart points', () => {

--- a/frontend/tests/pages/insights/insightsRange.test.ts
+++ b/frontend/tests/pages/insights/insightsRange.test.ts
@@ -1,6 +1,6 @@
 /**
- * Covers the relative range resolver that turns a saved "last N units" window into the
- * inclusive from/to dates the insights cards query
+ * Covers the two resolvers that turn an insights range into the inclusive from/to dates the cards
+ * query, one for a saved "last N units" window and one for a fixed preset
  *
  * The system clock is pinned so trailing-window arithmetic and month-end clamping are
  * asserted against known dates
@@ -8,9 +8,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   formatResolvedRangeLabel,
+  getRangeInputDates,
   getRelativeRangeInputDates,
   getRelativeRangeLabel,
 } from '@/pages/insights/utils/range';
+
+// Late evening in Toronto on 30 June, already 1 July in UTC, so a zone mix-up shows up as a
+// different day and a different month
+const LATE_JUNE_EVENING = new Date('2026-07-01T02:00:00Z');
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -60,6 +65,30 @@ describe('getRelativeRangeInputDates', () => {
     expect(getRelativeRangeInputDates(1, 'quarter', 'this')).toEqual({ from: '2026-04-01', to: '2026-06-18' });
     expect(getRelativeRangeInputDates(1, 'year', 'this')).toEqual({ from: '2026-01-01', to: '2026-06-18' });
     expect(getRelativeRangeInputDates(1, 'week', 'this')).toEqual({ from: '2026-06-15', to: '2026-06-18' });
+  });
+
+  it('ends the window on the given zone\'s day rather than the browser calendar', () => {
+    vi.setSystemTime(LATE_JUNE_EVENING);
+
+    expect(getRelativeRangeInputDates(1, 'day', 'past', 'America/Toronto')).toEqual({ from: '2026-06-30', to: '2026-06-30' });
+    expect(getRelativeRangeInputDates(1, 'day', 'past', 'UTC')).toEqual({ from: '2026-07-01', to: '2026-07-01' });
+  });
+});
+
+describe('getRangeInputDates', () => {
+  it('resolves the presets that name their own window against today', () => {
+    expect(getRangeInputDates('THIS_MONTH')).toEqual({ from: '2026-06-01', to: '2026-06-18' });
+    expect(getRangeInputDates('LAST_MONTH')).toEqual({ from: '2026-05-01', to: '2026-05-31' });
+    expect(getRangeInputDates('LAST_30_DAYS')).toEqual({ from: '2026-05-20', to: '2026-06-18' });
+    expect(getRangeInputDates('LAST_90_DAYS')).toEqual({ from: '2026-03-21', to: '2026-06-18' });
+    expect(getRangeInputDates('THIS_YEAR')).toEqual({ from: '2026-01-01', to: '2026-06-18' });
+  });
+
+  it('reads which period is current from the given zone rather than the browser calendar', () => {
+    vi.setSystemTime(LATE_JUNE_EVENING);
+
+    expect(getRangeInputDates('THIS_MONTH', 'America/Toronto')).toEqual({ from: '2026-06-01', to: '2026-06-30' });
+    expect(getRangeInputDates('THIS_MONTH', 'UTC')).toEqual({ from: '2026-07-01', to: '2026-07-01' });
   });
 });
 

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -134,6 +134,7 @@ describe('transaction modal helpers', () => {
       currencies,
       selectableAccounts: accounts,
       defaultAccountId: 'checking',
+      timeZone: undefined,
     })).toMatchObject({
       account_id: 'checking',
       currency: 'CAD',
@@ -149,12 +150,29 @@ describe('transaction modal helpers', () => {
       categories,
       currencies,
       selectableAccounts: accounts,
+      timeZone: undefined,
     })).toMatchObject({
       kind: 'expense',
       direction: 'debit',
       amount: '98.76',
       tag_ids: ['tax'],
     })
+  })
+
+  it('opens a new transaction on the profile timezone day rather than the browser calendar', () => {
+    vi.useFakeTimers()
+    // Late evening in Toronto on 30 June, already 1 July in UTC, so a zone mix-up shows up as a
+    // different day and a different month
+    vi.setSystemTime(new Date('2026-07-01T02:00:00Z'))
+    const options = {
+      categories: [createCategory({ id: 'groceries', kind: 'expense' })],
+      currencies,
+      selectableAccounts: [createAccount({ id: 'checking', currency: 'CAD' })],
+      defaultAccountId: 'checking',
+    }
+
+    expect(buildInitialTransactionForm({ ...options, timeZone: 'America/Toronto' }).date).toBe('2026-06-30')
+    expect(buildInitialTransactionForm({ ...options, timeZone: 'UTC' }).date).toBe('2026-07-01')
   })
 
   it('validates required fields and positive amounts before creating payloads', () => {
@@ -218,6 +236,7 @@ describe('transaction modal helpers', () => {
       categories: [createCategory({ id: 'groceries' })],
       currencies,
       selectableAccounts: [createAccount({ id: 'checking' })],
+      timeZone: undefined,
     })
 
     expect(buildUpdateTransactionPatch(unchangedForm, transaction, 2)).toBeNull()


### PR DESCRIPTION
The app takes its idea of today from the user profile's time zone, and several screens were still taking it from the browser's clock instead, so anyone using the app away from the time zone their profile names could see the wrong day. This fixes those screens and settles the rule as the user profile's time zone everywhere.

- A new transaction opens on today in the user profile's time zone rather than the browser's
- The balance chart asks for its snapshot window in the user profile's time zone, the same one the backend computes each daily balance row on, so it no longer requests days that were never recorded that way
- Arrow keys on an empty date segment fill it from today in the user profile's time zone, so it agrees with the value the field opens on and with the day its calendar marks
- A passkey's added date renders in the user profile's time zone
- The sign-up pages take the browser's time zone from the shared date layer rather than building it themselves, which is the one place the browser's is still the right answer, since there is no profile yet to read a time zone from
