### PR TITLE
fix: fill the mobile filter sheet in before it is drawn

### DIFF
--- a/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
@@ -1,4 +1,3 @@
-import { useEffect, useRef } from 'react'
 import type { ReactNode } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
@@ -14,7 +13,6 @@ type MobileFilterGlassPanelProps = {
   // Accessible name for the modal dialog, naming the domain being filtered
   ariaLabel: string
   activeFacetCount: number
-  seedDraftFromFilters: () => void
   clearAll: () => void
   applyFilters: () => void
 
@@ -37,7 +35,6 @@ export function MobileFilterGlassPanel({
   onExitComplete,
   ariaLabel,
   activeFacetCount,
-  seedDraftFromFilters,
   clearAll,
   applyFilters,
   isApplyDisabled = false,
@@ -47,14 +44,6 @@ export function MobileFilterGlassPanel({
   // toolbar from breaking and because nothing behind the modal is visible anyway
   const panelRef = useMobileFilterSheetEffects({ isOpen, onClose, dimPageContent: false, lockScroll: false })
   const shouldReduceMotion = useReducedMotion()
-
-  // Seed the draft only on the rising edge of opening, so an async data load or a re-render never
-  // wipes the edits the user is making in the open modal
-  const wasOpen = useRef(false)
-  useEffect(() => {
-    if (isOpen && !wasOpen.current) seedDraftFromFilters()
-    wasOpen.current = isOpen
-  }, [isOpen, seedDraftFromFilters])
 
   // Hold the page still behind the full-screen modal without overflow: hidden, which would strip the
   // sticky toolbar back to its in-flow position

--- a/frontend/src/components/list-controls/useSeedDraftOnOpen.ts
+++ b/frontend/src/components/list-controls/useSeedDraftOnOpen.ts
@@ -1,0 +1,23 @@
+import { useState } from 'react'
+
+/**
+ * Seeds a filter draft from the applied filters each time a surface opens on an `isOpen` prop
+ *
+ * @param isOpen - Whether the surface is open, counting the mount it opens on as a rising edge
+ * @param seedDraft - Copies the applied filters into the draft
+ */
+export function useSeedDraftOnOpen(isOpen: boolean, seedDraft: () => void): void {
+  // Call this from the component owning the draft. The state below lands on the calling component,
+  // so seeding from one of its children would update a different component mid-render, which React
+  // logs an error for and then defers past the paint this exists to precede. The desktop pill needs
+  // none of this, since it holds its own open state and seeds in the handler that opens it
+  //
+  // Seed only on the rising edge, so an async data load or a re-render never wipes the edits the
+  // user is making in the open surface. Adjusting state during render rather than in an effect is
+  // what puts the seeded draft in the first painted frame
+  const [wasOpen, setWasOpen] = useState(false)
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen)
+    if (isOpen) seedDraft()
+  }
+}

--- a/frontend/src/pages/accounts/components/toolbar/MobileFilterPanel.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/MobileFilterPanel.tsx
@@ -1,5 +1,6 @@
 import type { OptionItem } from '@/components/filters/OptionList'
 import { MobileFilterGlassPanel } from '@/components/list-controls/MobileFilterGlassPanel'
+import { useSeedDraftOnOpen } from '@/components/list-controls/useSeedDraftOnOpen'
 import { FilterPanelBody } from '@/pages/accounts/components/toolbar/FilterPanelBody'
 import { useAccountFilterDraft } from '@/pages/accounts/components/toolbar/useAccountFilterDraft'
 import type { AccountFilterSetter } from '@/pages/accounts/components/toolbar/types'
@@ -33,6 +34,8 @@ export function MobileFilterPanel({
 }: MobileFilterPanelProps) {
   const draft = useAccountFilterDraft({ filters, setFilter, institutionOptions, kindOptions, typeOptions, onClose })
 
+  useSeedDraftOnOpen(isOpen, draft.seedDraftFromFilters)
+
   return (
     <MobileFilterGlassPanel
       isOpen={isOpen}
@@ -40,7 +43,6 @@ export function MobileFilterPanel({
       onExitComplete={onExitComplete}
       ariaLabel="Account filters"
       activeFacetCount={draft.activeFacetCount}
-      seedDraftFromFilters={draft.seedDraftFromFilters}
       clearAll={draft.clearAll}
       applyFilters={draft.applyFilters}
     >

--- a/frontend/src/pages/transactions/components/toolbar/MobileFilterPanel.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/MobileFilterPanel.tsx
@@ -1,5 +1,6 @@
 import type { OptionItem } from '@/components/filters/OptionList'
 import { MobileFilterGlassPanel } from '@/components/list-controls/MobileFilterGlassPanel'
+import { useSeedDraftOnOpen } from '@/components/list-controls/useSeedDraftOnOpen'
 import { FilterPanelBody } from '@/pages/transactions/components/toolbar/FilterPanelBody'
 import { useTransactionFilterDraft } from '@/pages/transactions/components/toolbar/useTransactionFilterDraft'
 import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
@@ -37,6 +38,8 @@ export function MobileFilterPanel({
 }: MobileFilterPanelProps) {
   const draft = useTransactionFilterDraft({ filters, setFilter, accountOptions, categoryOptions, showAccountFilter, lockedCurrency, onClose })
 
+  useSeedDraftOnOpen(isOpen, draft.seedDraftFromFilters)
+
   return (
     <MobileFilterGlassPanel
       isOpen={isOpen}
@@ -44,7 +47,6 @@ export function MobileFilterPanel({
       onExitComplete={onExitComplete}
       ariaLabel="Transaction filters"
       activeFacetCount={draft.activeFacetCount}
-      seedDraftFromFilters={draft.seedDraftFromFilters}
       clearAll={draft.clearAll}
       applyFilters={draft.applyFilters}
       isApplyDisabled={draft.hasCrossedAmountBounds}


### PR DESCRIPTION
Opening the filter sheet on a phone showed one frame with no filters applied, even when the list was filtered. The sheet was copying the current filters into its controls only after the browser had drawn it.
