### PR TITLE
Fix the date picker in the transaction filter

### DIFF
--- a/frontend/src/components/date-field/CalendarPopover.tsx
+++ b/frontend/src/components/date-field/CalendarPopover.tsx
@@ -5,6 +5,7 @@ import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { parseIsoDate } from '@/components/date-field/dateSegments'
 import { useAuth } from '@/hooks/useAuth'
 import { formatYmd, getTodayYmd, getWeekdayIndex } from '@/utils/date'
+import { FLOATING_LAYER_PROPS } from '@/utils/floatingLayer'
 
 interface CalendarPopoverProps {
   open: boolean
@@ -16,6 +17,10 @@ interface CalendarPopoverProps {
 }
 
 const POPOVER_WIDTH = 264
+
+// The popover portals to the body, so it has to clear the full-screen sheets and modals at 100 to
+// draw above whatever opened it. Nothing in the app renders above this
+const POPOVER_Z_INDEX = 110
 const POPOVER_ESTIMATED_HEIGHT = 320
 const VIEWPORT_MARGIN = 8
 const WEEKDAY_LABELS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
@@ -121,8 +126,21 @@ export default function CalendarPopover({ open, anchorRef, value, onSelect, onCl
       onClose()
     }
 
+    // Escape is taken here rather than on the grid, because opening the popover with the mouse
+    // leaves focus in the date field and the surface underneath would otherwise answer the key
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return
+
+      event.preventDefault()
+      onClose()
+    }
+
     document.addEventListener('pointerdown', handlePointerDown)
-    return () => document.removeEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('keydown', handleEscape)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('keydown', handleEscape)
+    }
   }, [open, anchorRef, onClose])
 
   const monthKey = `${viewMonth.year}-${viewMonth.month}`
@@ -191,10 +209,6 @@ export default function CalendarPopover({ open, anchorRef, value, onSelect, onCl
         event.preventDefault()
         changeMonth(1)
         break
-      case 'Escape':
-        event.preventDefault()
-        onClose()
-        break
       default:
         break
     }
@@ -209,11 +223,13 @@ export default function CalendarPopover({ open, anchorRef, value, onSelect, onCl
           ref={gridRef}
           role="dialog"
           aria-label="Choose date"
-          className="fixed z-[70] rounded-xl p-3"
+          {...FLOATING_LAYER_PROPS}
+          className="fixed rounded-xl p-3"
           style={{
             top: position.top,
             left: position.left,
             width: POPOVER_WIDTH,
+            zIndex: POPOVER_Z_INDEX,
             background: 'var(--app-input-bg)',
             border: '1px solid var(--app-border-strong)',
             boxShadow: 'var(--app-shadow-soft)',

--- a/frontend/src/components/date-field/DateField.tsx
+++ b/frontend/src/components/date-field/DateField.tsx
@@ -33,7 +33,10 @@ interface DateFieldProps {
 
 const SEGMENT_PLACEHOLDER: Record<DateSegmentName, string> = { year: 'yyyy', month: 'mm', day: 'dd' }
 const SEGMENT_LABEL: Record<DateSegmentName, string> = { year: 'Year', month: 'Month', day: 'Day' }
-const SEGMENT_WIDTH: Record<DateSegmentName, string> = { year: 'w-[4ch]', month: 'w-[2ch]', day: 'w-[2ch]' }
+// Sized for the yyyy, mm and dd placeholders rather than for digits, since a letter is wider than a
+// figure and an input clips whatever does not fit. Measured in the interface font, they need 3.40ch,
+// 2.68ch and 1.89ch, and month and day share a width so the two dashes sit symmetrically
+const SEGMENT_WIDTH: Record<DateSegmentName, string> = { year: 'w-[4ch]', month: 'w-[3ch]', day: 'w-[3ch]' }
 
 /**
  * Pads a single filled digit to two characters so month and day read tidily once focus leaves

--- a/frontend/src/components/filters/hooks/useMobileSheetEffects.ts
+++ b/frontend/src/components/filters/hooks/useMobileSheetEffects.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react'
+import { isInsideFloatingLayer } from '@/utils/floatingLayer'
 
 type MobileFilterSheetEffectsOptions = {
   isOpen: boolean
@@ -28,7 +29,11 @@ export function useMobileFilterSheetEffects({
 
     const dismissOnOutsidePointer = (event: PointerEvent) => {
       const panel = panelRef.current
-      if (!panel || panel.contains(event.target as Node)) return
+
+      // A popover opened from inside the sheet portals out of it, so a press on one lands outside
+      // the panel node while still belonging to the sheet
+      if (!panel || panel.contains(event.target as Node) || isInsideFloatingLayer(event.target)) return
+
       onClose()
     }
 

--- a/frontend/src/components/list-controls/FilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/FilterGlassPanel.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from 'react'
 import { motion, useReducedMotion } from 'motion/react'
 import { ChevronDown, SlidersHorizontal, X } from 'lucide-react'
 import { FILTER_GLASS_SPRING, FILTER_PANEL_BODY_TRANSITION, FILTER_PILL_HEAD_STYLE } from '@/components/list-controls/toolbarStyles'
+import { isFloatingLayerOpen, isInsideFloatingLayer } from '@/utils/floatingLayer'
 
 // Collapsed footprint used before the head is measured, so the toolbar slot does not jump on mount
 const COLLAPSED_FALLBACK = { width: 140, height: 34 }
@@ -116,12 +117,20 @@ export function FilterGlassPanel({
     if (!open) return
 
     function handlePointerDown(event: PointerEvent) {
+      // A popover this panel opened portals out of the wrapper, so a press on one lands outside the
+      // wrapper node while still belonging to the panel
+      if (isInsideFloatingLayer(event.target)) return
+
       if (wrapperRef.current && !wrapperRef.current.contains(event.target as Node)) {
         dismiss()
       }
     }
 
     function handleKeyDown(event: KeyboardEvent) {
+      // The topmost layer answers Escape, and an open popover closes itself on it wherever focus
+      // sits, so the panel only takes the key once nothing is layered over it
+      if (isFloatingLayerOpen()) return
+
       if (event.key === 'Escape') dismiss()
     }
 

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -154,6 +154,7 @@ export function FilterPanelBody({
               currencyLocked={draft.currencyLocked}
               dateRange={draft.dateRange}
               fillHeight={fillHeight}
+              mobile={mobile}
               onToggle={(value, label) => draft.toggleSelection(activeFacet.id, value, label)}
               onCurrencyToggle={(value) => draft.toggleSelection('currency', value)}
               onTagMatchChange={draft.setTagMatch}
@@ -285,6 +286,8 @@ type FacetEditorProps = {
   currencyLocked: boolean
   dateRange: { from: string; to: string }
   fillHeight: boolean
+  // True in the mobile sheet, where the date range stacks into two rows rather than sharing one
+  mobile: boolean
   onToggle: (value: string, label?: string) => void
   onCurrencyToggle: (value: string) => void
   onTagMatchChange: (value: 'all' | 'any') => void
@@ -317,6 +320,7 @@ function FacetEditor({
   currencyLocked,
   dateRange,
   fillHeight,
+  mobile,
   onToggle,
   onCurrencyToggle,
   onTagMatchChange,
@@ -439,7 +443,7 @@ function FacetEditor({
 
   if (facet.kind === 'date') {
     return (
-      <div className="flex items-end gap-2">
+      <div className={joinClassNames('flex gap-2', mobile ? 'flex-col' : 'items-end')}>
         <DateFacetInput
           label="From"
           value={dateRange.from}
@@ -447,9 +451,13 @@ function FacetEditor({
           describedById={dateRangeMessageId}
           onValueChange={(value) => onDateRangeChange({ ...dateRange, from: value })}
         />
-        <span className="pb-2.5 text-sm" style={{ color: 'var(--app-text-subtle)' }}>
-          to
-        </span>
+        {/* Each field carries its own From or To label, so the joining word only reads as one while
+            the two sit side by side */}
+        {!mobile && (
+          <span className="pb-2.5 text-sm" style={{ color: 'var(--app-text-subtle)' }}>
+            to
+          </span>
+        )}
         <DateFacetInput
           label="To"
           value={dateRange.to}

--- a/frontend/src/utils/floatingLayer.ts
+++ b/frontend/src/utils/floatingLayer.ts
@@ -1,0 +1,25 @@
+// Marks an element portalled out of the surface that opened it, so a surface dismissing on an
+// outside press can tell its own floating layers apart from the page behind it
+const FLOATING_LAYER_ATTRIBUTE = 'data-floating-layer'
+
+// Spread onto the root of a portalled popover to claim it as a floating layer
+export const FLOATING_LAYER_PROPS = { [FLOATING_LAYER_ATTRIBUTE]: '' }
+
+/**
+ * Reports whether an event landed inside a floating layer
+ *
+ * @param target - The node the event was aimed at, which is null for an event with no target
+ */
+export function isInsideFloatingLayer(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false
+
+  return Boolean(target.closest(`[${FLOATING_LAYER_ATTRIBUTE}]`))
+}
+
+/**
+ * Reports whether any floating layer is open, which decides who takes a key that is not aimed at an
+ * element, since the topmost layer answers Escape wherever focus happens to sit
+ */
+export function isFloatingLayerOpen(): boolean {
+  return document.querySelector(`[${FLOATING_LAYER_ATTRIBUTE}]`) !== null
+}


### PR DESCRIPTION
The date picker in the transaction filter was unusable. Clicking a day closed the whole filter panel and discarded the draft, and on a phone the calendar opened behind the filter sheet where it could not be read.