### PR TITLE
fix: drop the insights preset fallback that caught Custom

### DIFF
--- a/frontend/src/pages/insights/types/range.ts
+++ b/frontend/src/pages/insights/types/range.ts
@@ -1,5 +1,9 @@
 export type InsightsRangePreset = 'THIS_MONTH' | 'LAST_MONTH' | 'LAST_30_DAYS' | 'LAST_90_DAYS' | 'THIS_YEAR' | 'CUSTOM'
 
+// A custom range is built from an amount, a unit and a qualifier, so its dates cannot be worked
+// out from the preset name alone the way every other preset's can
+export type InsightsFixedRangePreset = Exclude<InsightsRangePreset, 'CUSTOM'>
+
 export type InsightsRangeInputDates = {
   from: string
   to: string

--- a/frontend/src/pages/insights/utils/range.ts
+++ b/frontend/src/pages/insights/utils/range.ts
@@ -3,7 +3,11 @@ import type {
   SavedInsightsRangeQualifier,
   SavedInsightsRangeUnit,
 } from '@/api/insights'
-import type { InsightsRangeInputDates, InsightsRangePreset } from '@/pages/insights/types/range'
+import type {
+  InsightsFixedRangePreset,
+  InsightsRangeInputDates,
+  InsightsRangePreset,
+} from '@/pages/insights/types/range'
 import {
   DATE_FORMATS,
   addDays,
@@ -22,7 +26,7 @@ const MONTHS_PER_UNIT: Record<'month' | 'quarter' | 'year', number> = {
   year: 12,
 }
 
-function getFixedPresetBounds(preset: InsightsRangePreset, timeZone?: string): { start: Date; end: Date } {
+function getFixedPresetBounds(preset: InsightsFixedRangePreset, timeZone?: string): { start: Date; end: Date } {
   const today = getTodayDate(timeZone)
 
   switch (preset) {
@@ -34,10 +38,10 @@ function getFixedPresetBounds(preset: InsightsRangePreset, timeZone?: string): {
       const start = new Date(today.getFullYear(), today.getMonth() - 1, 1)
       return { start, end: new Date(today.getFullYear(), today.getMonth(), 0) }
     }
+    case 'LAST_30_DAYS':
+      return { start: addDays(today, -29), end: today }
     case 'LAST_90_DAYS':
       return { start: addDays(today, -89), end: today }
-    default:
-      return { start: addDays(today, -29), end: today }
   }
 }
 
@@ -59,7 +63,7 @@ export function getCustomRangeDays(from: string, to: string) {
  * @param timeZone - Zone deciding which day the window ends on, defaulting to the browser's
  */
 export function getRangeInputDates(
-  preset: InsightsRangePreset,
+  preset: InsightsFixedRangePreset,
   timeZone?: string,
 ): InsightsRangeInputDates {
   const { start, end } = getFixedPresetBounds(preset, timeZone)
@@ -186,7 +190,9 @@ export function getRangeComparisonPeriod(preset: InsightsRangePreset): InsightsC
       return 'previous_month'
     case 'THIS_YEAR':
       return 'previous_year'
-    default:
+    case 'LAST_30_DAYS':
+    case 'LAST_90_DAYS':
+    case 'CUSTOM':
       return 'same_length'
   }
 }

--- a/frontend/tests/pages/insights/insightsRange.test.ts
+++ b/frontend/tests/pages/insights/insightsRange.test.ts
@@ -92,6 +92,12 @@ describe('getRangeInputDates', () => {
   });
 });
 
+// Nothing calls this, because the type is the whole guard: the suppression fails the type-check
+// as an unused directive if a custom range is ever allowed back into the call that resolves a
+// preset to its dates. Vitest strips types without checking them, so the suite cannot cover it
+// @ts-expect-error A custom range cannot be resolved from a preset name
+'CUSTOM' satisfies Parameters<typeof getRangeInputDates>[0];
+
 describe('getRelativeRangeLabel', () => {
   it('labels the current period without a count', () => {
     expect(getRelativeRangeLabel(1, 'month', 'this')).toBe('This month');


### PR DESCRIPTION
A catch-all branch in the function that turns an insights range preset into dates answered for Custom with a trailing 30-day window, even though a custom range is built from an amount, a unit and a qualifier and has no window its name alone can resolve. Nothing reaches that branch today, so this closes the gap before a new call site does.