### PR TITLE
fix: keep the money forms usable when the currency list fails

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation, type Locat
 import { AnimatePresence, motion } from 'motion/react'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { NavCollapseProvider } from '@/contexts/NavCollapseContext'
+import { ToastProvider } from '@/contexts/ToastContext'
 import { useNavCollapse } from '@/hooks/useNavCollapse'
 import { useAuth } from '@/hooks/useAuth'
 import { useCacheValidation } from '@/hooks/useCacheValidation'
@@ -374,7 +375,9 @@ function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
-        <AppShell />
+        <ToastProvider>
+          <AppShell />
+        </ToastProvider>
       </AuthProvider>
     </BrowserRouter>
   )

--- a/frontend/src/api/currency/requests.ts
+++ b/frontend/src/api/currency/requests.ts
@@ -1,11 +1,20 @@
 import { API_BASE } from '@/api/config';
 import type { Currency } from '@/api/currency/types';
 
+// A request left hanging is worse here than one that fails, since every form waiting on the list shows
+// that it is still loading and would say so forever. Aborting turns that into a failure the forms can
+// report and the user can act on
+const CURRENCY_REQUEST_TIMEOUT_MS = 10_000;
+
 /**
  * Fetches static ISO currency metadata used by money inputs and displays
+ *
+ * @throws Error when the response is not ok, and a TimeoutError when the request outlives the timeout
  */
 export async function fetchCurrencies(): Promise<Currency[]> {
-  const res = await fetch(`${API_BASE}/currencies`);
+  const res = await fetch(`${API_BASE}/currencies`, {
+    signal: AbortSignal.timeout(CURRENCY_REQUEST_TIMEOUT_MS),
+  });
   if (!res.ok) {
     throw new Error(`Failed to load currencies (${res.status})`);
   }

--- a/frontend/src/components/feedback/Toast.tsx
+++ b/frontend/src/components/feedback/Toast.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'motion/react'
-import { CircleCheck, TriangleAlert } from 'lucide-react'
+import { CircleCheck, TriangleAlert, X } from 'lucide-react'
 
 export type ToastStatus = 'error' | 'success'
 
@@ -22,16 +22,15 @@ const statusColor: Record<ToastStatus, string> = {
  * Shows a short message in the bottom-right corner until it is dismissed
  *
  * An error is announced assertively, since it reports that something the user just asked for did not
- * happen and waiting for a pause in the screen reader's queue would lose that
+ * happen and waiting for a pause in the screen reader's queue would lose that. The dismiss control is a
+ * button inside the region rather than the region itself, so the message is what gets read out rather
+ * than the name of the control
  */
 export default function Toast({ toast, onDismiss }: ToastProps) {
   return (
     <AnimatePresence>
       {toast && (
-        <motion.button
-          type="button"
-          onClick={onDismiss}
-          aria-label="Dismiss message"
+        <motion.div
           role={toast.status === 'error' ? 'alert' : 'status'}
           aria-live={toast.status === 'error' ? 'assertive' : 'polite'}
           className="fixed bottom-5 right-5 z-[110] flex max-w-[min(24rem,calc(100vw-2.5rem))] items-start gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium shadow-lg"
@@ -54,7 +53,15 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
               : <CircleCheck size={14} strokeWidth={3} aria-hidden />}
           </span>
           <span className="leading-6">{toast.text}</span>
-        </motion.button>
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss message"
+            className="app-icon-button -mr-1 -mt-1 h-6 w-6 shrink-0"
+          >
+            <X size={14} aria-hidden />
+          </button>
+        </motion.div>
       )}
     </AnimatePresence>
   )

--- a/frontend/src/components/feedback/Toast.tsx
+++ b/frontend/src/components/feedback/Toast.tsx
@@ -1,0 +1,61 @@
+import { AnimatePresence, motion } from 'motion/react'
+import { CircleCheck, TriangleAlert } from 'lucide-react'
+
+export type ToastStatus = 'error' | 'success'
+
+export interface ToastMessage {
+  status: ToastStatus
+  text: string
+}
+
+interface ToastProps {
+  toast: ToastMessage | null
+  onDismiss: () => void
+}
+
+const statusColor: Record<ToastStatus, string> = {
+  error: 'var(--app-negative)',
+  success: 'var(--app-positive)',
+}
+
+/**
+ * Shows a short message in the bottom-right corner until it is dismissed
+ *
+ * An error is announced assertively, since it reports that something the user just asked for did not
+ * happen and waiting for a pause in the screen reader's queue would lose that
+ */
+export default function Toast({ toast, onDismiss }: ToastProps) {
+  return (
+    <AnimatePresence>
+      {toast && (
+        <motion.button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss message"
+          role={toast.status === 'error' ? 'alert' : 'status'}
+          aria-live={toast.status === 'error' ? 'assertive' : 'polite'}
+          className="fixed bottom-5 right-5 z-[110] flex max-w-[min(24rem,calc(100vw-2.5rem))] items-start gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium shadow-lg"
+          style={{
+            background: 'var(--app-bg)',
+            border: '1px solid var(--app-border-strong)',
+            color: 'var(--app-text)',
+          }}
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 8 }}
+          transition={{ duration: 0.16 }}
+        >
+          <span
+            className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+            style={{ background: statusColor[toast.status], color: 'var(--app-bg)' }}
+          >
+            {toast.status === 'error'
+              ? <TriangleAlert size={14} strokeWidth={3} aria-hidden />
+              : <CircleCheck size={14} strokeWidth={3} aria-hidden />}
+          </span>
+          <span className="leading-6">{toast.text}</span>
+        </motion.button>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/components/tooltips/IconTooltip.tsx
+++ b/frontend/src/components/tooltips/IconTooltip.tsx
@@ -19,6 +19,10 @@ interface IconTooltipProps {
   fxTone?: IconTooltipFxTone
   size?: number
   strokeWidth?: number
+
+  // Joins the Tab order inside a modal, whose focus handling only visits fields and anything carrying
+  // this marker, so an explanation attached to a field label stays reachable without a mouse
+  modalFieldTabStop?: boolean
 }
 
 const placementClass: Record<IconTooltipPlacement, string> = {
@@ -140,6 +144,7 @@ export default function IconTooltip({
   fxTone = 'blue',
   size = 15,
   strokeWidth = 2.5,
+  modalFieldTabStop = false,
 }: IconTooltipProps) {
   const { Icon: DefaultIcon, color } = levelConfig[level]
   const isFxIcon = IconOverride === 'fx'
@@ -200,6 +205,7 @@ export default function IconTooltip({
         type="button"
         aria-label={label}
         aria-expanded={isOpen}
+        data-modal-field-tab-stop={modalFieldTabStop ? 'true' : undefined}
         className={triggerClassName}
         style={isFxIcon ? undefined : { color: iconColor ?? color }}
         onClick={() => {

--- a/frontend/src/contexts/ToastContext.tsx
+++ b/frontend/src/contexts/ToastContext.tsx
@@ -1,0 +1,54 @@
+import { createContext, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import Toast, { type ToastMessage } from '@/components/feedback/Toast'
+
+// Long enough to read a sentence without the message becoming furniture
+const TOAST_VISIBLE_MS = 6000
+
+export interface ToastValue {
+  /** Replaces whatever is showing, so the newest message is always the visible one */
+  showToast: (toast: ToastMessage) => void
+  dismissToast: () => void
+}
+
+const ToastContext = createContext<ToastValue | null>(null)
+
+/**
+ * Holds the one message showing in the bottom-right corner, so any page can raise one without owning
+ * the markup or the dismissal timer
+ *
+ * Only one shows at a time. A second message replaces the first rather than stacking, since these
+ * report the action the user just took and an older one is already answered
+ */
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toast, setToast] = useState<ToastMessage | null>(null)
+  const timeoutRef = useRef<number | undefined>(undefined)
+
+  const clearTimer = useCallback(() => {
+    if (timeoutRef.current !== undefined) window.clearTimeout(timeoutRef.current)
+    timeoutRef.current = undefined
+  }, [])
+
+  useEffect(() => clearTimer, [clearTimer])
+
+  const dismissToast = useCallback(() => {
+    clearTimer()
+    setToast(null)
+  }, [clearTimer])
+
+  const showToast = useCallback((next: ToastMessage) => {
+    clearTimer()
+    setToast(next)
+    timeoutRef.current = window.setTimeout(() => setToast(null), TOAST_VISIBLE_MS)
+  }, [clearTimer])
+
+  const value = useMemo<ToastValue>(() => ({ showToast, dismissToast }), [dismissToast, showToast])
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <Toast toast={toast} onDismiss={dismissToast} />
+    </ToastContext.Provider>
+  )
+}
+
+export { ToastContext }

--- a/frontend/src/hooks/useCurrencyGuard.ts
+++ b/frontend/src/hooks/useCurrencyGuard.ts
@@ -1,7 +1,7 @@
 import { useCallback } from 'react'
-import { useCurrencies } from '@/api/currency'
+import { useCurrencyListState } from '@/hooks/useCurrencyListState'
 import { useToast } from '@/hooks/useToast'
-import { CURRENCY_LIST_REFUSAL } from '@/utils/currencyStatus'
+import { CURRENCY_LIST_REFUSAL, CURRENCY_LOADING_REFUSAL } from '@/utils/currencyStatus'
 
 /**
  * Returns a function that runs an action only while the currency list is in hand, and otherwise says why
@@ -9,18 +9,22 @@ import { CURRENCY_LIST_REFUSAL } from '@/utils/currencyStatus'
  *
  * Every form that creates something with an amount needs the list: there is no stored value to fall back
  * on and no way to convert what the user types without the currency's decimal places. Opening such a form
- * anyway would give the user fields that cannot be submitted, so the click is answered rather than spent
+ * anyway would give the user fields that cannot be submitted, so the click is answered rather than spent.
+ * A list still on its way says so instead, since telling the user to reload would be wrong
  */
 export function useCurrencyGuard(): (action: () => void) => void {
-  const { data: currencies } = useCurrencies()
+  const currencyState = useCurrencyListState()
   const { showToast } = useToast()
 
   return useCallback((action: () => void) => {
-    if (!currencies?.length) {
-      showToast({ status: 'error', text: CURRENCY_LIST_REFUSAL })
+    if (currencyState === 'ready') {
+      action()
       return
     }
 
-    action()
-  }, [currencies, showToast])
+    showToast({
+      status: 'error',
+      text: currencyState === 'loading' ? CURRENCY_LOADING_REFUSAL : CURRENCY_LIST_REFUSAL,
+    })
+  }, [currencyState, showToast])
 }

--- a/frontend/src/hooks/useCurrencyGuard.ts
+++ b/frontend/src/hooks/useCurrencyGuard.ts
@@ -1,0 +1,27 @@
+import { useCallback } from 'react'
+import { useCurrencies } from '@/api/currency'
+import { useToast } from '@/hooks/useToast'
+
+const CURRENCY_UNAVAILABLE_MESSAGE = "We can't load the currency list right now. Refresh the page to try again."
+
+/**
+ * Returns a function that runs an action only while the currency list is in hand, and otherwise says why
+ * it did not
+ *
+ * Every form that creates something with an amount needs the list: there is no stored value to fall back
+ * on and no way to convert what the user types without the currency's decimal places. Opening such a form
+ * anyway would give the user fields that cannot be submitted, so the click is answered rather than spent
+ */
+export function useCurrencyGuard(): (action: () => void) => void {
+  const { data: currencies } = useCurrencies()
+  const { showToast } = useToast()
+
+  return useCallback((action: () => void) => {
+    if (!currencies?.length) {
+      showToast({ status: 'error', text: CURRENCY_UNAVAILABLE_MESSAGE })
+      return
+    }
+
+    action()
+  }, [currencies, showToast])
+}

--- a/frontend/src/hooks/useCurrencyGuard.ts
+++ b/frontend/src/hooks/useCurrencyGuard.ts
@@ -1,8 +1,7 @@
 import { useCallback } from 'react'
 import { useCurrencies } from '@/api/currency'
 import { useToast } from '@/hooks/useToast'
-
-const CURRENCY_UNAVAILABLE_MESSAGE = "We can't load the currency list right now. Refresh the page to try again."
+import { CURRENCY_LIST_REFUSAL } from '@/utils/currencyStatus'
 
 /**
  * Returns a function that runs an action only while the currency list is in hand, and otherwise says why
@@ -18,7 +17,7 @@ export function useCurrencyGuard(): (action: () => void) => void {
 
   return useCallback((action: () => void) => {
     if (!currencies?.length) {
-      showToast({ status: 'error', text: CURRENCY_UNAVAILABLE_MESSAGE })
+      showToast({ status: 'error', text: CURRENCY_LIST_REFUSAL })
       return
     }
 

--- a/frontend/src/hooks/useCurrencyListState.ts
+++ b/frontend/src/hooks/useCurrencyListState.ts
@@ -1,0 +1,17 @@
+import { useCurrencies } from '@/api/currency'
+import type { CurrencyListState } from '@/utils/currencyStatus'
+
+/**
+ * Reports whether the currency list is in hand, still on its way, or not coming
+ *
+ * Every surface that stands a field down or refuses a form reads this one rule, so a list that has not
+ * arrived yet is never reported as one that failed. A request that hangs is aborted by the fetch's own
+ * timeout, so loading always ends
+ */
+export function useCurrencyListState(): CurrencyListState {
+  const { data, isFetching } = useCurrencies()
+
+  if (data?.length) return 'ready'
+
+  return isFetching ? 'loading' : 'unavailable'
+}

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,11 @@
+import { useContext } from 'react'
+import { ToastContext, type ToastValue } from '@/contexts/ToastContext'
+
+/**
+ * Exposes the bottom-right message surface
+ */
+export function useToast(): ToastValue {
+  const context = useContext(ToastContext)
+  if (!context) throw new Error('useToast must be used within a ToastProvider')
+  return context
+}

--- a/frontend/src/pages/accounts/AccountsPage.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.tsx
@@ -3,6 +3,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { useAccounts } from '@/api/accounts'
 import { useTaxAdvantagedCategories } from '@/api/tax-advantaged-categories'
 import CreateAccountModal from '@/pages/accounts/components/create-account-modal/Modal'
+import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 import AccountListToolbar from '@/pages/accounts/components/toolbar/ListToolbar'
 import AccountListSection from '@/pages/accounts/components/ListSection'
 import SummaryStatement from '@/pages/accounts/components/summary/Statement'
@@ -24,6 +25,7 @@ import { useTaxAdvantagedLimitSummaries } from '@/pages/accounts/hooks/useTaxAdv
  */
 export default function AccountsPage() {
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const requireCurrencies = useCurrencyGuard()
   const [createModalKey, setCreateModalKey] = useState(0)
   const { user } = useAuth()
   const { data: accounts, isFetching: accountsLoading, error } = useAccounts()
@@ -93,10 +95,10 @@ export default function AccountsPage() {
         institutionOptions={institutionOptions}
         kindOptions={kindOptions}
         typeOptions={typeOptions}
-        onAddAccount={() => {
+        onAddAccount={() => requireCurrencies(() => {
           setCreateModalKey((key) => key + 1)
           setShowCreateModal(true)
-        }}
+        })}
       />
 
       <div className="space-y-4">

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -14,6 +14,7 @@ import { TopMerchantsBySpendingCard } from '@/pages/accounts/detail/components/s
 import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
 import TransactionListSection from '@/pages/transactions/components/ListSection'
 import CreateTransactionModal from '@/pages/transactions/components/transaction-modal/Modal'
+import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 
 type DeleteExitPhase = 'idle' | 'pending' | 'modal' | 'page'
 
@@ -29,6 +30,7 @@ export default function AccountDetailPage() {
   const navigate = useNavigate()
   const { accountId } = useParams<{ accountId: string }>()
   const { data: account, error } = useAccount(accountId)
+  const requireCurrencies = useCurrencyGuard()
 
   const [showTxnModal, setShowTxnModal] = useState(false)
   const [txnModalKey, setTxnModalKey] = useState(0)
@@ -47,9 +49,11 @@ export default function AccountDetailPage() {
   const openCreateTransaction = () => {
     if (visibleAccount?.is_archived) return
 
-    setEditingTransaction(null)
-    setTxnModalKey((key) => key + 1)
-    setShowTxnModal(true)
+    requireCurrencies(() => {
+      setEditingTransaction(null)
+      setTxnModalKey((key) => key + 1)
+      setShowTxnModal(true)
+    })
   }
 
   const openEditTransaction = (transaction: Transaction) => {

--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
 import { createPortal } from 'react-dom'
 import { AnimatePresence, motion } from 'motion/react'
 import {
@@ -6,13 +6,17 @@ import {
   useUpdateAccount,
   type Account,
 } from '@/api/accounts'
-import { useCurrencies, type Currency } from '@/api/currency'
+import { useCurrencies } from '@/api/currency'
 import { useInstitutions } from '@/api/institutions'
 import { useTaxAdvantagedCategories } from '@/api/tax-advantaged-categories'
 import CreateInstitutionModal from '@/components/reference-modals/CreateInstitutionModal'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import { useModalFieldFocus } from '@/components/modal/useModalFieldFocus'
-import { getCurrencyExponent } from '@/utils/moneyInput'
+import {
+  DEFAULT_MINOR_UNIT_EXPONENT,
+  findCurrencyExponent,
+  fromMinorUnits,
+} from '@/utils/moneyInput'
 import { waitForMilliseconds } from '@/utils/timing'
 import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
 import {
@@ -39,39 +43,24 @@ type EditAccountIdentityModalProps = {
   onDeleteFailed: () => void
 }
 
-type EditAccountIdentityFormProps = EditAccountIdentityModalProps & {
-  currencies: Currency[]
-}
-
 const MIN_SAVE_SPINNER_MS = 800
 const MIN_DELETE_SPINNER_MS = 1000
 
 /**
- * Holds the form back until the currency table has arrived
- *
- * The form turns the stored credit limit into text using the account currency's decimal places and
- * seeds that text once, so building it from a table that has not loaded would freeze an amount
- * scaled by the wrong power of ten
- */
-export default function EditAccountIdentityModal(props: EditAccountIdentityModalProps) {
-  const { data: currencies } = useCurrencies()
-
-  if (!currencies) return null
-
-  return <EditAccountIdentityForm {...props} currencies={currencies} />
-}
-
-/**
  * Coordinates account identity edits, archive changes, and destructive deletion from one modal workflow
+ *
+ * Opens whether or not the currency table arrived. Everything except the credit limit is independent of
+ * it, and that one field stands down when the account's currency is missing from the table, since its
+ * stored amount can only be read or written through that currency's decimal places
  */
-function EditAccountIdentityForm({
+export default function EditAccountIdentityModal({
   account,
-  currencies,
   onClose,
   onDeleteStarted,
   onDeleted,
   onDeleteFailed,
-}: EditAccountIdentityFormProps) {
+}: EditAccountIdentityModalProps) {
+  const { data: currencies = [] } = useCurrencies()
   const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus()
   const updateAccount = useUpdateAccount()
   const deleteAccount = useDeleteAccount({ minimumPendingMs: MIN_DELETE_SPINNER_MS })
@@ -93,7 +82,23 @@ function EditAccountIdentityForm({
   const isRevolving = account.account_kind === 'revolving'
   const canLinkTaxAdvantagedCategory = account.account_kind === 'asset' && account.group_id === null && !account.is_archived
   const selectedCurrencySymbol = currencies.find((currency) => currency.id === account.currency)?.symbol ?? ''
-  const creditLimitExponent = getCurrencyExponent(currencies, account.currency)
+  const knownCreditLimitExponent = findCurrencyExponent(currencies, account.currency)
+  const isCreditLimitLocked = isRevolving && knownCreditLimitExponent === null
+
+  // The modal can open before the currency table arrives, which seeds the credit limit blank. Fill it in
+  // when the table lands so the field does not sit editable and empty over a stored limit, which a save
+  // would then clear. The field is disabled until this runs, so no typing can be overwritten
+  const seededWithoutExponentRef = useRef(knownCreditLimitExponent === null)
+
+  useEffect(() => {
+    if (knownCreditLimitExponent === null || !seededWithoutExponentRef.current) return
+
+    seededWithoutExponentRef.current = false
+    setForm((current) => ({
+      ...current,
+      credit_limit: fromMinorUnits(account.credit_limit, knownCreditLimitExponent),
+    }))
+  }, [account.credit_limit, knownCreditLimitExponent])
 
   const institutionOptions = useMemo<DropdownOption[]>(
     () => [
@@ -320,8 +325,9 @@ function EditAccountIdentityForm({
                         fieldErrors={fieldErrors}
                         canLinkTaxAdvantagedCategory={canLinkTaxAdvantagedCategory}
                         isRevolving={isRevolving}
+                        isCreditLimitLocked={isCreditLimitLocked}
                         selectedCurrencySymbol={selectedCurrencySymbol}
-                        creditLimitExponent={creditLimitExponent}
+                        creditLimitExponent={knownCreditLimitExponent ?? DEFAULT_MINOR_UNIT_EXPONENT}
                         taxAdvantagedCategoryOptions={taxAdvantagedCategoryOptions}
                         setField={setField}
                       />

--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -88,7 +88,7 @@ export default function EditAccountIdentityModal({
   // The modal can open before the currency table arrives, which seeds the credit limit blank. Fill it in
   // when the table lands so the field does not sit editable and empty over a stored limit, which a save
   // would then clear. The field is disabled until this runs, so no typing can be overwritten
-  const seededWithoutExponentRef = useRef(knownCreditLimitExponent === null)
+  const seededWithoutExponentRef = useRef(isCreditLimitLocked && account.credit_limit !== null)
 
   useEffect(() => {
     if (knownCreditLimitExponent === null || !seededWithoutExponentRef.current) return

--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -7,6 +7,7 @@ import {
   type Account,
 } from '@/api/accounts'
 import { useCurrencies } from '@/api/currency'
+import { useCurrencyListState } from '@/hooks/useCurrencyListState'
 import { useInstitutions } from '@/api/institutions'
 import { useTaxAdvantagedCategories } from '@/api/tax-advantaged-categories'
 import CreateInstitutionModal from '@/components/reference-modals/CreateInstitutionModal'
@@ -61,6 +62,7 @@ export default function EditAccountIdentityModal({
   onDeleteFailed,
 }: EditAccountIdentityModalProps) {
   const { data: currencies = [] } = useCurrencies()
+  const currencyState = useCurrencyListState()
   const { panelRef, handleModalFieldKeyDown } = useModalFieldFocus()
   const updateAccount = useUpdateAccount()
   const deleteAccount = useDeleteAccount({ minimumPendingMs: MIN_DELETE_SPINNER_MS })
@@ -325,7 +327,7 @@ export default function EditAccountIdentityModal({
                         fieldErrors={fieldErrors}
                         canLinkTaxAdvantagedCategory={canLinkTaxAdvantagedCategory}
                         isRevolving={isRevolving}
-                        isCreditLimitLocked={isCreditLimitLocked}
+                        currencyState={currencyState}
                         selectedCurrencySymbol={selectedCurrencySymbol}
                         creditLimitExponent={knownCreditLimitExponent ?? DEFAULT_MINOR_UNIT_EXPONENT}
                         taxAdvantagedCategoryOptions={taxAdvantagedCategoryOptions}

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
@@ -2,6 +2,7 @@ import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import Dropdown from '@/components/dropdown/Dropdown'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
+import { CURRENCY_LIST_FIELD_NOTICE } from '@/utils/currencyStatus'
 import { EDIT_ACCOUNT_IDENTITY_FIELD_IDS } from '@/pages/accounts/detail/constants/accountDetail'
 import type {
   IdentityFieldErrors,
@@ -71,9 +72,8 @@ export function AccountDetailsSection({
             label={isCreditLimitLocked ? (
               <span className="inline-flex items-center gap-2">
                 Credit Limit
-                <IconTooltip label="Currency list unavailable" level="important">
-                  We can't load the currency list right now, so this amount can't be shown or changed.
-                  Refresh the page to try again.
+                <IconTooltip label="Currency list unavailable" level="important" modalFieldTabStop>
+                  {CURRENCY_LIST_FIELD_NOTICE}
                 </IconTooltip>
               </span>
             ) : 'Credit Limit'}

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
@@ -71,7 +71,7 @@ export function AccountDetailsSection({
             label={isCreditLimitLocked ? (
               <span className="inline-flex items-center gap-2">
                 Credit Limit
-                <IconTooltip label="Currency list unavailable" level="warn">
+                <IconTooltip label="Currency list unavailable" level="important">
                   We can't load the currency list right now, so this amount can't be shown or changed.
                   Refresh the page to try again.
                 </IconTooltip>

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
@@ -1,5 +1,6 @@
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import Dropdown from '@/components/dropdown/Dropdown'
+import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
 import { EDIT_ACCOUNT_IDENTITY_FIELD_IDS } from '@/pages/accounts/detail/constants/accountDetail'
 import type {
@@ -15,6 +16,10 @@ type AccountDetailsSectionProps = {
   fieldErrors: IdentityFieldErrors
   canLinkTaxAdvantagedCategory: boolean
   isRevolving: boolean
+
+  // Stands the credit limit down when the account's currency is missing from the currency table, whose
+  // decimal places the stored amount can only be read or written through
+  isCreditLimitLocked: boolean
   selectedCurrencySymbol: string
   // Decimal places of the account's currency, used to settle the credit limit field on blur
   creditLimitExponent: number
@@ -30,6 +35,7 @@ export function AccountDetailsSection({
   fieldErrors,
   canLinkTaxAdvantagedCategory,
   isRevolving,
+  isCreditLimitLocked,
   selectedCurrencySymbol,
   creditLimitExponent,
   taxAdvantagedCategoryOptions,
@@ -60,7 +66,19 @@ export function AccountDetailsSection({
 
       {isRevolving && (
         <div>
-          <AccountIdentityFieldLabelRow htmlFor={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.creditLimit} label="Credit Limit" error={fieldErrors.credit_limit} />
+          <AccountIdentityFieldLabelRow
+            htmlFor={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.creditLimit}
+            label={isCreditLimitLocked ? (
+              <span className="inline-flex items-center gap-2">
+                Credit Limit
+                <IconTooltip label="Currency list unavailable" level="warn">
+                  We can't load the currency list right now, so this amount can't be shown or changed.
+                  Refresh the page to try again.
+                </IconTooltip>
+              </span>
+            ) : 'Credit Limit'}
+            error={fieldErrors.credit_limit}
+          />
           <div className="relative">
             {selectedCurrencySymbol && (
               <span
@@ -73,8 +91,9 @@ export function AccountDetailsSection({
             )}
             <input
               id={EDIT_ACCOUNT_IDENTITY_FIELD_IDS.creditLimit}
-              className={`app-input ${selectedCurrencySymbol ? 'pl-8' : ''} ${fieldErrors.credit_limit ? 'app-input-error' : ''}`}
+              className={`app-input disabled:cursor-not-allowed disabled:opacity-60 ${selectedCurrencySymbol ? 'pl-8' : ''} ${fieldErrors.credit_limit ? 'app-input-error' : ''}`}
               placeholder="Optional"
+              disabled={isCreditLimitLocked}
               {...creditLimitInput}
             />
           </div>

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
@@ -2,7 +2,11 @@ import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import Dropdown from '@/components/dropdown/Dropdown'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
-import { CURRENCY_LIST_FIELD_NOTICE } from '@/utils/currencyStatus'
+import {
+  CURRENCY_AMOUNT_NOTICE,
+  CURRENCY_LIST_LOADING,
+  type CurrencyListState,
+} from '@/utils/currencyStatus'
 import { EDIT_ACCOUNT_IDENTITY_FIELD_IDS } from '@/pages/accounts/detail/constants/accountDetail'
 import type {
   IdentityFieldErrors,
@@ -18,9 +22,9 @@ type AccountDetailsSectionProps = {
   canLinkTaxAdvantagedCategory: boolean
   isRevolving: boolean
 
-  // Stands the credit limit down when the account's currency is missing from the currency table, whose
-  // decimal places the stored amount can only be read or written through
-  isCreditLimitLocked: boolean
+  // Stands the credit limit down unless the currency table is in hand, since its decimal places are the
+  // only way to read or write the stored amount, and says which of the two reasons applies
+  currencyState: CurrencyListState
   selectedCurrencySymbol: string
   // Decimal places of the account's currency, used to settle the credit limit field on blur
   creditLimitExponent: number
@@ -36,12 +40,13 @@ export function AccountDetailsSection({
   fieldErrors,
   canLinkTaxAdvantagedCategory,
   isRevolving,
-  isCreditLimitLocked,
+  currencyState,
   selectedCurrencySymbol,
   creditLimitExponent,
   taxAdvantagedCategoryOptions,
   setField,
 }: AccountDetailsSectionProps) {
+  const isCreditLimitLocked = currencyState !== 'ready'
   const creditLimitInput = useMoneyInput({
     value: form.credit_limit,
     exponent: creditLimitExponent,
@@ -72,9 +77,15 @@ export function AccountDetailsSection({
             label={isCreditLimitLocked ? (
               <span className="inline-flex items-center gap-2">
                 Credit Limit
-                <IconTooltip label="Currency list unavailable" level="important" modalFieldTabStop>
-                  {CURRENCY_LIST_FIELD_NOTICE}
-                </IconTooltip>
+                {currencyState === 'loading' ? (
+                  <IconTooltip label="Loading currencies" modalFieldTabStop>
+                    {CURRENCY_LIST_LOADING}
+                  </IconTooltip>
+                ) : (
+                  <IconTooltip label="Credit limit unavailable" level="important" modalFieldTabStop>
+                    {CURRENCY_AMOUNT_NOTICE}
+                  </IconTooltip>
+                )}
               </span>
             ) : 'Credit Limit'}
             error={fieldErrors.credit_limit}

--- a/frontend/src/pages/accounts/detail/utils/identityForm.ts
+++ b/frontend/src/pages/accounts/detail/utils/identityForm.ts
@@ -1,8 +1,8 @@
 import type { Account, UpdateAccountPayload } from '@/api/accounts'
 import type { Currency } from '@/api/currency'
 import {
+  findCurrencyExponent,
   fromMinorUnits,
-  getCurrencyExponent,
   isValidMoneyInput,
   toMinorUnits,
 } from '@/utils/moneyInput'
@@ -19,16 +19,23 @@ export type IdentityFieldErrors = Partial<Record<keyof IdentityFormValues, strin
 
 /**
  * Creates form state from the backend account shape while keeping optional links editable as blank fields
+ *
+ * The credit limit is left blank when the account's currency is not in the table, since the stored
+ * amount can only be turned into text through that currency's decimal places
  */
 export function createIdentityFormValues(
   account: Account,
   currencies: Currency[],
 ): IdentityFormValues {
+  const creditLimitExponent = findCurrencyExponent(currencies, account.currency)
+
   return {
     name: account.name,
     institution_id: account.institution?.id ?? '',
     tax_advantaged_category_id: account.tax_advantaged_category_id ?? '',
-    credit_limit: fromMinorUnits(account.credit_limit, getCurrencyExponent(currencies, account.currency)),
+    credit_limit: creditLimitExponent === null
+      ? ''
+      : fromMinorUnits(account.credit_limit, creditLimitExponent),
     is_archived: account.is_archived,
   }
 }
@@ -51,6 +58,10 @@ export function getIdentityFieldErrors(
 
 /**
  * Builds the update payload with only fields the account type is allowed to send
+ *
+ * The credit limit is left out entirely when the account's currency is not in the table. The field is
+ * blank in that state, and a blank converts to null, so sending it would clear a stored limit that the
+ * user was never shown
  */
 export function getIdentityUpdatePayload({
   form,
@@ -65,12 +76,14 @@ export function getIdentityUpdatePayload({
   currencies: Currency[]
   accountCurrency: string
 }): UpdateAccountPayload {
+  const creditLimitExponent = findCurrencyExponent(currencies, accountCurrency)
+
   return {
     name: form.name.trim(),
     institution_id: form.institution_id || null,
     is_archived: form.is_archived,
-    ...(isRevolving
-      ? { credit_limit: toMinorUnits(form.credit_limit, getCurrencyExponent(currencies, accountCurrency)) }
+    ...(isRevolving && creditLimitExponent !== null
+      ? { credit_limit: toMinorUnits(form.credit_limit, creditLimitExponent) }
       : {}),
     ...(canLinkTaxAdvantagedCategory
       ? { tax_advantaged_category_id: form.tax_advantaged_category_id || null }

--- a/frontend/src/pages/budgets/BudgetsPage.tsx
+++ b/frontend/src/pages/budgets/BudgetsPage.tsx
@@ -28,7 +28,7 @@ export default function BudgetsPage() {
   const { user } = useAuth()
   const [searchParams, setSearchParams] = useSearchParams()
   const { data: categories, isLoading: categoriesLoading } = useCategories()
-  const { data: currencies, isLoading: currenciesLoading } = useCurrencies()
+  const { data: currencies } = useCurrencies()
   const baseBudgetsQuery = useBaseBudgets()
   const budgetsQuery = useBudgets()
   const latestUtilizationsQuery = useLatestBudgetUtilizations()
@@ -134,7 +134,7 @@ export default function BudgetsPage() {
         latestUtilizationByBudgetId={latestUtilizationByBudgetId}
         loading={budgetsLoading}
         error={budgetsError}
-        formOptionsLoading={categoriesLoading || currenciesLoading}
+        formOptionsLoading={categoriesLoading}
         onOpenBudget={openBudget}
       />
 
@@ -148,31 +148,29 @@ export default function BudgetsPage() {
         )}
       </AnimatePresence>
 
-      {/* Held for the currency table so both budget modals follow one rule, though a new budget has
-          no stored amount to convert and could safely start without it */}
-      {currencies && (
-        <BudgetCreateModal
-          key={`${defaultCurrency}-${userTimeZone}`}
-          open={createOpen}
-          categories={categories ?? []}
-          currencies={currencies}
-          defaultCurrency={defaultCurrency}
-          timeZone={userTimeZone}
-          onClose={() => setCreateOpen(false)}
-          onCreated={() => undefined}
-        />
-      )}
+      {/* The create modal says why it cannot take a new budget when the currency table is missing, so it
+          is mounted whether or not the table arrived */}
+      <BudgetCreateModal
+        key={`${defaultCurrency}-${userTimeZone}`}
+        open={createOpen}
+        categories={categories ?? []}
+        currencies={currencies ?? []}
+        defaultCurrency={defaultCurrency}
+        timeZone={userTimeZone}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => undefined}
+      />
 
       <AnimatePresence>
-        {/* Held for the currency table, since the editor inside turns the stored limit into text
-            using the currency's decimal places and seeds that text once */}
-        {visibleBudgetDetails && currencies && (
+        {/* Opens without the currency table, since everything the details view shows comes from the budget
+            itself. Only the editor nested inside needs the table, and it stands its limit down instead */}
+        {visibleBudgetDetails && (
           <BudgetDetailsModal
             key={visibleBudgetDetails.baseBudget.id}
             baseBudget={visibleBudgetDetails.baseBudget}
             periods={visibleBudgetDetails.periods}
             categories={categories ?? []}
-            currencies={currencies}
+            currencies={currencies ?? []}
             categoryById={categoryById}
             initialLatestUtilization={
               visibleBudgetDetails.latestPeriod

--- a/frontend/src/pages/budgets/BudgetsPage.tsx
+++ b/frontend/src/pages/budgets/BudgetsPage.tsx
@@ -12,6 +12,7 @@ import {
 import { useCategories } from '@/api/categories'
 import { useCurrencies } from '@/api/currency'
 import { useAuth } from '@/hooks/useAuth'
+import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 import BudgetCardsSection from '@/pages/budgets/components/budget-cards/Section'
 import BudgetArchivedSection from '@/pages/budgets/components/budget-cards/ArchivedSection'
 import BudgetCreateModal from '@/pages/budgets/components/budget-editor-modal/CreateModal'
@@ -33,6 +34,7 @@ export default function BudgetsPage() {
   const budgetsQuery = useBudgets()
   const latestUtilizationsQuery = useLatestBudgetUtilizations()
   const createBackfillBudget = useCreateBudgetInstance()
+  const requireCurrencies = useCurrencyGuard()
   const [createOpen, setCreateOpen] = useState(false)
   const budgetParam = searchParams.get('budget')
   const [budgetDetailsSnapshot, setBudgetDetailsSnapshot] = useState<BudgetCardViewModel | null>(null)
@@ -123,7 +125,7 @@ export default function BudgetsPage() {
             Plan ahead and keep your spending in check.
           </p>
         </header>
-        <button type="button" className="app-primary-button w-full min-[750px]:w-auto" onClick={() => setCreateOpen(true)}>
+        <button type="button" className="app-primary-button w-full min-[750px]:w-auto" onClick={() => requireCurrencies(() => setCreateOpen(true))}>
           <Plus size={18} aria-hidden />
           New Budget
         </button>
@@ -148,8 +150,8 @@ export default function BudgetsPage() {
         )}
       </AnimatePresence>
 
-      {/* The create modal says why it cannot take a new budget when the currency table is missing, so it
-          is mounted whether or not the table arrived */}
+      {/* The New Budget button refuses the click while the currency table is missing, so this only ever
+          opens with the table in hand */}
       <BudgetCreateModal
         key={`${defaultCurrency}-${userTimeZone}`}
         open={createOpen}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
@@ -264,6 +264,31 @@ export default function BudgetCreateModal({
     onBlur: handleBlur,
   }
 
+  // A new budget has no stored amount to fall back on the way an edit does: its limit has to be converted
+  // from what the user types, which needs the currency's decimal places, and the picker has nothing to
+  // offer without the table. So the reason takes the place of the form rather than opening it unusable
+  if (currencies.length === 0) {
+    return (
+      <BudgetEditorModalShell
+        open={open}
+        title="Add Budget"
+        titleId="budget-create-title"
+        eyebrow="Currencies unavailable"
+        sideLabel="Budget"
+        formError={null}
+        appearance={CREATE_SHELL_APPEARANCE}
+        onClose={closeAndReset}
+        onSubmit={(event) => event.preventDefault()}
+        footer={null}
+      >
+        <p className="text-sm leading-6" style={{ color: 'var(--app-text-muted)' }}>
+          We can't load the currency list right now, so a new budget can't be created yet. Refresh the
+          page to try again.
+        </p>
+      </BudgetEditorModalShell>
+    )
+  }
+
   return (
     <BudgetEditorModalShell
       open={open}
@@ -294,6 +319,7 @@ export default function BudgetCreateModal({
             selectedCurrencySymbol={currencySymbol(currencies, form.currency)}
             namePlaceholder="e.g. Groceries"
             currencyReadOnly={false}
+            isLimitLocked={false}
             currencyTooltip
             limitDisabled={false}
             fieldsLocked={false}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
@@ -294,7 +294,7 @@ export default function BudgetCreateModal({
             selectedCurrencySymbol={currencySymbol(currencies, form.currency)}
             namePlaceholder="e.g. Groceries"
             currencyReadOnly={false}
-            isLimitLocked={false}
+            currencyState="ready"
             currencyTooltip
             limitDisabled={false}
             fieldsLocked={false}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
@@ -264,31 +264,6 @@ export default function BudgetCreateModal({
     onBlur: handleBlur,
   }
 
-  // A new budget has no stored amount to fall back on the way an edit does: its limit has to be converted
-  // from what the user types, which needs the currency's decimal places, and the picker has nothing to
-  // offer without the table. So the reason takes the place of the form rather than opening it unusable
-  if (currencies.length === 0) {
-    return (
-      <BudgetEditorModalShell
-        open={open}
-        title="Add Budget"
-        titleId="budget-create-title"
-        eyebrow="Currencies unavailable"
-        sideLabel="Budget"
-        formError={null}
-        appearance={CREATE_SHELL_APPEARANCE}
-        onClose={closeAndReset}
-        onSubmit={(event) => event.preventDefault()}
-        footer={null}
-      >
-        <p className="text-sm leading-6" style={{ color: 'var(--app-text-muted)' }}>
-          We can't load the currency list right now, so a new budget can't be created yet. Refresh the
-          page to try again.
-        </p>
-      </BudgetEditorModalShell>
-    )
-  }
-
   return (
     <BudgetEditorModalShell
       open={open}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -14,6 +14,7 @@ import type { BudgetFormFieldErrors, BudgetFormState } from '@/pages/budgets/typ
 import { budgetCadenceLabel, formatBudgetPeriod } from '@/pages/budgets/utils/budgetPeriods'
 import { sameStringSet } from '@/pages/budgets/utils/form'
 import { currencySymbol, toMinorUnits } from '@/pages/budgets/utils/money'
+import { useCurrencyListState } from '@/hooks/useCurrencyListState'
 import { findCurrencyExponent, fromMinorUnits } from '@/utils/moneyInput'
 import { waitForMilliseconds } from '@/utils/timing'
 
@@ -101,6 +102,7 @@ export default function BudgetEditModal({
   // Reports whether the save flipped the archived flag so callers can reveal the archive animations
   onSaved: (archiveChanged: boolean) => void
 }) {
+  const currencyState = useCurrencyListState()
   const updateBaseBudget = useUpdateBaseBudget()
   const updateBudget = useUpdateBudget()
   const initialForm = useMemo(
@@ -383,7 +385,7 @@ export default function BudgetEditModal({
             selectedCurrencySymbol={currencySymbol(currencies, form.currency)}
             limitPlaceholder={latestPeriod ? undefined : 'No period yet'}
             currencyReadOnly
-            isLimitLocked={isLimitLocked}
+            currencyState={currencyState}
             currencyTooltip={false}
             limitDisabled={!latestPeriod}
             fieldsLocked={fieldsLocked}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type React from 'react'
 import { useUpdateBaseBudget, useUpdateBudget, type BaseBudget, type Budget } from '@/api/budgets'
 import type { Category } from '@/api/categories'
@@ -14,7 +14,7 @@ import type { BudgetFormFieldErrors, BudgetFormState } from '@/pages/budgets/typ
 import { budgetCadenceLabel, formatBudgetPeriod } from '@/pages/budgets/utils/budgetPeriods'
 import { sameStringSet } from '@/pages/budgets/utils/form'
 import { currencySymbol, toMinorUnits } from '@/pages/budgets/utils/money'
-import { fromMinorUnits, getCurrencyExponent } from '@/utils/moneyInput'
+import { findCurrencyExponent, fromMinorUnits } from '@/utils/moneyInput'
 import { waitForMilliseconds } from '@/utils/timing'
 
 const EDIT_FIELD_IDS: BudgetEditorModalFieldIds = {
@@ -58,13 +58,20 @@ const EDIT_INITIAL_TOUCHED = {
 
 /**
  * Converts the saved budget and latest period into editable form state
+ *
+ * The limit stays blank when the budget's currency is missing from the table, since the stored amount
+ * can only be turned into text through that currency's decimal places
  */
 function getInitialEditForm(baseBudget: BaseBudget, latestPeriod: Budget | undefined, currencies: Currency[]): BudgetFormState {
+  const limitExponent = findCurrencyExponent(currencies, baseBudget.currency)
+
   return {
     name: baseBudget.name,
     currency: baseBudget.currency,
     categoryIds: baseBudget.category_ids,
-    limit: latestPeriod ? fromMinorUnits(latestPeriod.overall_limit, getCurrencyExponent(currencies, baseBudget.currency)) : '',
+    limit: latestPeriod && limitExponent !== null
+      ? fromMinorUnits(latestPeriod.overall_limit, limitExponent)
+      : '',
     recurrenceFreq: baseBudget.recurrence_freq,
     instanceLength: String(baseBudget.instance_length),
     periodStart: latestPeriod?.period_start ?? '',
@@ -157,6 +164,7 @@ export default function BudgetEditModal({
   }, [categoryOptions, categorySearch, form.categoryIds])
   const isPending = updateBaseBudget.isPending || updateBudget.isPending || saveInProgress
   const limitMinorUnits = latestPeriod ? toMinorUnits(form.limit, currencies, baseBudget.currency) : null
+  const isLimitLocked = findCurrencyExponent(currencies, baseBudget.currency) === null
   const hasCategory = form.categoryIds.some((categoryId) =>
     categoryOptions.some((category) => category.id === categoryId),
   )
@@ -170,11 +178,14 @@ export default function BudgetEditModal({
   // The backend rejects any non-unarchive change to an archived budget, so every other field is locked
   // against the persisted archived state rather than the staged toggle until the unarchive is saved
   const fieldsLocked = baseBudget.is_archived
+  // A locked limit is blank, which converts to null, so the usual requirement for a readable amount is
+  // waived. Everything else on the form stays editable and saveable, and periodChanged is already false
+  // while the limit is blank, so the period is left alone
   const canSave =
     !isPending
     && form.name.trim().length > 0
     && hasCategory
-    && (!latestPeriod || limitMinorUnits !== null)
+    && (!latestPeriod || isLimitLocked || limitMinorUnits !== null)
     && (baseChanged || periodChanged || archiveChanged)
   const state: BudgetEditorModalViewState = { form, formError, fieldErrors, touched, categorySearch }
   const options: BudgetEditorModalOptions = { categories: categoryOptions, filteredCategories, currencies }
@@ -200,6 +211,22 @@ export default function BudgetEditModal({
     window.addEventListener('keydown', closeOnEscape)
     return () => window.removeEventListener('keydown', closeOnEscape)
   }, [closeAndReset, open])
+
+  // The form can be seeded before the currency table arrives, which leaves the limit blank. Fill it in
+  // when the table lands so the field does not sit editable and empty over a stored limit. The field is
+  // disabled until this runs, so it can never discard something the user typed
+  const seededWithoutExponentRef = useRef(findCurrencyExponent(currencies, baseBudget.currency) === null)
+
+  useEffect(() => {
+    const limitExponent = findCurrencyExponent(currencies, baseBudget.currency)
+    if (limitExponent === null || !seededWithoutExponentRef.current) return
+
+    seededWithoutExponentRef.current = false
+    setForm((current) => ({
+      ...current,
+      limit: latestPeriod ? fromMinorUnits(latestPeriod.overall_limit, limitExponent) : '',
+    }))
+  }, [baseBudget.currency, currencies, latestPeriod])
 
   /**
    * Validates fields that can be edited without changing immutable budget cadence fields
@@ -353,6 +380,7 @@ export default function BudgetEditModal({
             selectedCurrencySymbol={currencySymbol(currencies, form.currency)}
             limitPlaceholder={latestPeriod ? undefined : 'No period yet'}
             currencyReadOnly
+            isLimitLocked={isLimitLocked}
             currencyTooltip={false}
             limitDisabled={!latestPeriod}
             fieldsLocked={fieldsLocked}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -178,9 +178,8 @@ export default function BudgetEditModal({
   // The backend rejects any non-unarchive change to an archived budget, so every other field is locked
   // against the persisted archived state rather than the staged toggle until the unarchive is saved
   const fieldsLocked = baseBudget.is_archived
-  // A locked limit is blank, which converts to null, so the usual requirement for a readable amount is
-  // waived. Everything else on the form stays editable and saveable, and periodChanged is already false
-  // while the limit is blank, so the period is left alone
+  // The same waiver as the validator: a locked limit is blank and stays out of the save, so it must not
+  // hold the button down either. periodChanged is already false while the limit is blank
   const canSave =
     !isPending
     && form.name.trim().length > 0
@@ -215,7 +214,7 @@ export default function BudgetEditModal({
   // The form can be seeded before the currency table arrives, which leaves the limit blank. Fill it in
   // when the table lands so the field does not sit editable and empty over a stored limit. The field is
   // disabled until this runs, so it can never discard something the user typed
-  const seededWithoutExponentRef = useRef(findCurrencyExponent(currencies, baseBudget.currency) === null)
+  const seededWithoutExponentRef = useRef(isLimitLocked && latestPeriod !== undefined)
 
   useEffect(() => {
     const limitExponent = findCurrencyExponent(currencies, baseBudget.currency)
@@ -235,7 +234,11 @@ export default function BudgetEditModal({
     const errors: BudgetFormFieldErrors = {}
     if (!form.name.trim()) errors.name = 'Name is required'
     if (!hasCategory) errors.categoryIds = 'Select at least one category'
-    if (latestPeriod && limitMinorUnits === null) errors.limit = 'Limit must be greater than zero'
+    // A locked limit is blank, disabled and left out of the save, so requiring a readable one here would
+    // refuse every other edit to the budget
+    if (latestPeriod && !isLimitLocked && limitMinorUnits === null) {
+      errors.limit = 'Limit must be greater than zero'
+    }
     return errors
   }
 

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -4,7 +4,12 @@ import { useMoneyInput } from '@/hooks/useMoneyInput'
 import type { BudgetEditorModalErrorGetter, BudgetEditorModalFieldIds, BudgetEditorModalHandlers, BudgetEditorModalOptions, BudgetEditorModalViewState } from '@/pages/budgets/components/budget-editor-modal/types'
 import BudgetEditorFieldLabelRow from '@/pages/budgets/components/shared/EditorFieldLabelRow'
 import { getCurrencyExponent, getMoneyPlaceholder } from '@/utils/moneyInput'
-import { CURRENCY_LIST_FIELD_NOTICE } from '@/utils/currencyStatus'
+import {
+  CURRENCY_AMOUNT_NOTICE,
+  CURRENCY_LIST_LOADING,
+  CURRENCY_LIST_NOTICE,
+  type CurrencyListState,
+} from '@/utils/currencyStatus'
 
 interface BudgetEditorModalScopeSectionProps {
   state: BudgetEditorModalViewState
@@ -20,9 +25,9 @@ interface BudgetEditorModalScopeSectionProps {
   currencyTooltip: boolean
   limitDisabled: boolean
 
-  // Stands the limit down when the budget's currency is missing from the currency table, whose decimal
-  // places the stored amount can only be read or written through
-  isLimitLocked: boolean
+  // Stands the limit down unless the currency table is in hand, since its decimal places are the only way
+  // to read or write the stored amount, and says which of the two reasons applies
+  currencyState: CurrencyListState
 
   // Locks every editable field while the budget is archived so only the archive toggle stays live
   fieldsLocked: boolean
@@ -43,7 +48,7 @@ export default function BudgetEditorModalScopeSection({
   currencyReadOnly,
   currencyTooltip,
   limitDisabled,
-  isLimitLocked,
+  currencyState,
   fieldsLocked,
   showError,
   handlers,
@@ -51,6 +56,7 @@ export default function BudgetEditorModalScopeSection({
   const { form } = state
   const { currencies } = options
   const { setField, onBlur } = handlers
+  const isLimitLocked = currencyState !== 'ready'
   const limitExponent = getCurrencyExponent(currencies, form.currency)
   const limitInput = useMoneyInput({
     value: form.limit,
@@ -100,9 +106,14 @@ export default function BudgetEditorModalScopeSection({
                       Budgets currently track only accounts in the same currency
                     </IconTooltip>
                   )}
-                  {isLimitLocked && (
+                  {currencyState === 'loading' && (
+                    <IconTooltip label="Loading currencies" modalFieldTabStop>
+                      {CURRENCY_LIST_LOADING}
+                    </IconTooltip>
+                  )}
+                  {currencyState === 'unavailable' && (
                     <IconTooltip label="Currency list unavailable" level="important" modalFieldTabStop>
-                      {CURRENCY_LIST_FIELD_NOTICE}
+                      {CURRENCY_LIST_NOTICE}
                     </IconTooltip>
                   )}
                 </span>
@@ -114,6 +125,7 @@ export default function BudgetEditorModalScopeSection({
                 id={ids.currency}
                 className="app-input disabled:cursor-not-allowed disabled:opacity-60"
                 value={form.currency}
+                placeholder={currencyState === 'loading' ? CURRENCY_LIST_LOADING : undefined}
                 disabled
                 readOnly
               />
@@ -140,9 +152,15 @@ export default function BudgetEditorModalScopeSection({
               label={isLimitLocked ? (
                 <span className="inline-flex items-center gap-2">
                   Limit
-                  <IconTooltip label="Limit unavailable" level="important" modalFieldTabStop>
-                    {CURRENCY_LIST_FIELD_NOTICE}
-                  </IconTooltip>
+                  {currencyState === 'loading' ? (
+                    <IconTooltip label="Loading currencies" modalFieldTabStop>
+                      {CURRENCY_LIST_LOADING}
+                    </IconTooltip>
+                  ) : (
+                    <IconTooltip label="Limit unavailable" level="important" modalFieldTabStop>
+                      {CURRENCY_AMOUNT_NOTICE}
+                    </IconTooltip>
+                  )}
                 </span>
               ) : 'Limit'}
               error={showError('limit')}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -4,6 +4,7 @@ import { useMoneyInput } from '@/hooks/useMoneyInput'
 import type { BudgetEditorModalErrorGetter, BudgetEditorModalFieldIds, BudgetEditorModalHandlers, BudgetEditorModalOptions, BudgetEditorModalViewState } from '@/pages/budgets/components/budget-editor-modal/types'
 import BudgetEditorFieldLabelRow from '@/pages/budgets/components/shared/EditorFieldLabelRow'
 import { getCurrencyExponent, getMoneyPlaceholder } from '@/utils/moneyInput'
+import { CURRENCY_LIST_FIELD_NOTICE } from '@/utils/currencyStatus'
 
 interface BudgetEditorModalScopeSectionProps {
   state: BudgetEditorModalViewState
@@ -100,8 +101,8 @@ export default function BudgetEditorModalScopeSection({
                     </IconTooltip>
                   )}
                   {isLimitLocked && (
-                    <IconTooltip label="Currency list unavailable" level="important">
-                      We can't load the currency list right now. Refresh the page to try again.
+                    <IconTooltip label="Currency list unavailable" level="important" modalFieldTabStop>
+                      {CURRENCY_LIST_FIELD_NOTICE}
                     </IconTooltip>
                   )}
                 </span>
@@ -139,9 +140,8 @@ export default function BudgetEditorModalScopeSection({
               label={isLimitLocked ? (
                 <span className="inline-flex items-center gap-2">
                   Limit
-                  <IconTooltip label="Limit unavailable" level="important">
-                    We can't load the currency list right now, so the limit can't be shown or changed.
-                    Refresh the page to try again.
+                  <IconTooltip label="Limit unavailable" level="important" modalFieldTabStop>
+                    {CURRENCY_LIST_FIELD_NOTICE}
                   </IconTooltip>
                 </span>
               ) : 'Limit'}
@@ -160,7 +160,7 @@ export default function BudgetEditorModalScopeSection({
               <input
                 id={ids.limit}
                 className={`app-input disabled:cursor-not-allowed disabled:opacity-60 ${selectedCurrencySymbol ? 'pl-8' : ''} ${showError('limit') ? 'app-input-error' : ''}`}
-                placeholder={limitPlaceholder ?? getMoneyPlaceholder(limitExponent)}
+                placeholder={isLimitLocked ? undefined : limitPlaceholder ?? getMoneyPlaceholder(limitExponent)}
                 disabled={limitDisabled || fieldsLocked || isLimitLocked}
                 {...limitInput}
               />

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -19,6 +19,10 @@ interface BudgetEditorModalScopeSectionProps {
   currencyTooltip: boolean
   limitDisabled: boolean
 
+  // Stands the limit down when the budget's currency is missing from the currency table, whose decimal
+  // places the stored amount can only be read or written through
+  isLimitLocked: boolean
+
   // Locks every editable field while the budget is archived so only the archive toggle stays live
   fieldsLocked: boolean
   showError: BudgetEditorModalErrorGetter
@@ -38,6 +42,7 @@ export default function BudgetEditorModalScopeSection({
   currencyReadOnly,
   currencyTooltip,
   limitDisabled,
+  isLimitLocked,
   fieldsLocked,
   showError,
   handlers,
@@ -86,12 +91,20 @@ export default function BudgetEditorModalScopeSection({
           <div>
             <BudgetEditorFieldLabelRow
               htmlFor={ids.currency}
-              label={currencyTooltip ? (
+              label={currencyTooltip || isLimitLocked ? (
                 <span className="inline-flex items-center gap-2">
                   Currency
-                  <IconTooltip label="Budget currency limitation" level="important">
-                    Budgets currently track only accounts in the same currency
-                  </IconTooltip>
+                  {currencyTooltip && (
+                    <IconTooltip label="Budget currency limitation" level="important">
+                      Budgets currently track only accounts in the same currency
+                    </IconTooltip>
+                  )}
+                  {isLimitLocked && (
+                    <IconTooltip label="Currency list unavailable" level="warn">
+                      We can't load the currency list right now, so the limit can't be shown or changed.
+                      Refresh the page to try again.
+                    </IconTooltip>
+                  )}
                 </span>
               ) : 'Currency'}
               error={showError('currency')}
@@ -137,7 +150,7 @@ export default function BudgetEditorModalScopeSection({
                 id={ids.limit}
                 className={`app-input disabled:cursor-not-allowed disabled:opacity-60 ${selectedCurrencySymbol ? 'pl-8' : ''} ${showError('limit') ? 'app-input-error' : ''}`}
                 placeholder={limitPlaceholder ?? getMoneyPlaceholder(limitExponent)}
-                disabled={limitDisabled || fieldsLocked}
+                disabled={limitDisabled || fieldsLocked || isLimitLocked}
                 {...limitInput}
               />
             </div>

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -100,9 +100,8 @@ export default function BudgetEditorModalScopeSection({
                     </IconTooltip>
                   )}
                   {isLimitLocked && (
-                    <IconTooltip label="Currency list unavailable" level="warn">
-                      We can't load the currency list right now, so the limit can't be shown or changed.
-                      Refresh the page to try again.
+                    <IconTooltip label="Currency list unavailable" level="important">
+                      We can't load the currency list right now. Refresh the page to try again.
                     </IconTooltip>
                   )}
                 </span>
@@ -135,7 +134,19 @@ export default function BudgetEditorModalScopeSection({
           </div>
 
           <div>
-            <BudgetEditorFieldLabelRow htmlFor={ids.limit} label="Limit" error={showError('limit')} />
+            <BudgetEditorFieldLabelRow
+              htmlFor={ids.limit}
+              label={isLimitLocked ? (
+                <span className="inline-flex items-center gap-2">
+                  Limit
+                  <IconTooltip label="Limit unavailable" level="important">
+                    We can't load the currency list right now, so the limit can't be shown or changed.
+                    Refresh the page to try again.
+                  </IconTooltip>
+                </span>
+              ) : 'Limit'}
+              error={showError('limit')}
+            />
             <div className="relative">
               {selectedCurrencySymbol && (
                 <span

--- a/frontend/src/pages/budgets/utils/money.ts
+++ b/frontend/src/pages/budgets/utils/money.ts
@@ -1,5 +1,5 @@
 import type { Currency } from '@/api/currency'
-import { getCurrencyExponent, toMinorUnits as toMinorUnitsCanonical } from '@/utils/moneyInput'
+import { findCurrencyExponent, toMinorUnits as toMinorUnitsCanonical } from '@/utils/moneyInput'
 
 /**
  * Looks up the currency's symbol by code, returning an empty string when the currency isn't found
@@ -11,9 +11,16 @@ export function currencySymbol(currencies: Currency[], code: string) {
 /**
  * Converts a canonical user-entered decimal amount into the currency's minor units, returning null
  * when the amount is blank, unparseable, or not strictly positive
+ *
+ * Also returns null when the currency is missing from the table, rather than scaling by an assumed two
+ * decimal places. An amount converted through a guess is wrong for every currency that does not hold
+ * two, and the caller already treats null as nothing to save
  */
 export function toMinorUnits(value: string, currencies: Currency[], code: string): number | null {
-  const minorUnits = toMinorUnitsCanonical(value, getCurrencyExponent(currencies, code))
+  const exponent = findCurrencyExponent(currencies, code)
+  if (exponent === null) return null
+
+  const minorUnits = toMinorUnitsCanonical(value, exponent)
   if (minorUnits === null || minorUnits <= 0) return null
 
   return minorUnits

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
@@ -8,6 +8,7 @@ import { useTaxAdvantagedCategories } from '@/api/tax-advantaged-categories'
 import SettingsSectionHeader from '@/pages/settings/components/SectionHeader'
 import SettingsCard from '@/pages/settings/components/Card'
 import CreateTaxAdvantagedCategoryModal from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal'
+import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 import TaxAdvantagedCategoriesTable from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/table/CategoriesTable'
 import TaxAdvantagedCategoryModal from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryModal'
 import { useTaxAdvantagedCategoryList } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCategoryList'
@@ -29,6 +30,7 @@ export default function TaxAdvantagedCategoriesSection({
   const { data: plans = [], isLoading } = useTaxAdvantagedCategories()
   const [openCategoryId, setOpenCategoryId] = useState<string | null>(null)
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const requireCurrencies = useCurrencyGuard()
   const [createModalKey, setCreateModalKey] = useState(0)
   const [search, setSearch] = useState('')
   const openCategory = plans.find((plan) => plan.id === openCategoryId) ?? null
@@ -40,8 +42,10 @@ export default function TaxAdvantagedCategoriesSection({
   })
 
   const openCreateModal = () => {
-    setCreateModalKey((key) => key + 1)
-    setShowCreateModal(true)
+    requireCurrencies(() => {
+      setCreateModalKey((key) => key + 1)
+      setShowCreateModal(true)
+    })
   }
 
   return (

--- a/frontend/src/pages/transactions/TransactionsPage.tsx
+++ b/frontend/src/pages/transactions/TransactionsPage.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/api/transactions'
 import TransactionListSection from '@/pages/transactions/components/ListSection'
 import CreateTransactionModal from '@/pages/transactions/components/transaction-modal/Modal'
+import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 import TransactionsTopBand from '@/pages/transactions/components/TopBand'
 import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
 import {
@@ -29,6 +30,7 @@ export default function TransactionsPage() {
   const [filters, setFilters] = useState<TransactionListFilters>({})
   const [filterListLoading, setFilterListLoading] = useState(false)
   const [showCreateModal, setShowCreateModal] = useState(false)
+  const requireCurrencies = useCurrencyGuard()
   const [createModalKey, setCreateModalKey] = useState(0)
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null)
   const [openingOutlierId, setOpeningOutlierId] = useState<string | null>(null)
@@ -38,9 +40,11 @@ export default function TransactionsPage() {
    * Opens the transaction modal in create mode and resets any previous edit state
    */
   const openCreateModal = () => {
-    setEditingTransaction(null)
-    setCreateModalKey((key) => key + 1)
-    setShowCreateModal(true)
+    requireCurrencies(() => {
+      setEditingTransaction(null)
+      setCreateModalKey((key) => key + 1)
+      setShowCreateModal(true)
+    })
   }
 
   /**

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -150,6 +150,10 @@ export default function CreateTransactionModal({
   const selectedCurrency = currencies.find((c) => c.id === form.currency)
   const selectedCurrencySymbol = selectedCurrency?.symbol ?? ''
   const selectedCurrencyExponent = selectedCurrency?.minor_unit_exponent ?? 2
+  // Keyed on the list being absent rather than on the selected currency being unknown, so a form that
+  // has not picked a currency yet is not mistaken for a failed fetch. Only reachable while editing,
+  // since a create click is refused before the modal opens
+  const isAmountLocked = currencies.length === 0
 
   const { openRef, recordCreatedAccountId, flushDeferredRefresh, closeModal } = useDeferredTransactionRefresh({
     open,
@@ -185,6 +189,7 @@ export default function CreateTransactionModal({
     selectedAccount,
     selectedToAccount,
     selectedCurrencyExponent,
+    isAmountLocked,
     deleteLoading,
     openRef,
     recordCreatedAccountId,
@@ -310,6 +315,7 @@ export default function CreateTransactionModal({
             currencyPlaceholder={currencies.length === 0 ? 'Loading...' : 'Select...'}
             selectedCurrencySymbol={selectedCurrencySymbol}
             currencyExponent={selectedCurrencyExponent}
+            isAmountLocked={isAmountLocked}
             amount={form.amount}
             amountError={showError('amount')}
             notes={form.notes}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -2,6 +2,8 @@ import { useMemo } from 'react'
 import { useAccounts } from '@/api/accounts'
 import { useCategories } from '@/api/categories'
 import { useCurrencies } from '@/api/currency'
+import { useCurrencyListState } from '@/hooks/useCurrencyListState'
+import { CURRENCY_LIST_LOADING } from '@/utils/currencyStatus'
 import { useAuth } from '@/hooks/useAuth'
 import { KIND_LABELS } from '@/pages/transactions/components/transaction-modal/constants'
 import { buildInitialTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/initialForm'
@@ -52,6 +54,7 @@ export default function CreateTransactionModal({
   const { data: accounts = [] } = useAccounts()
   const { data: categories = [] } = useCategories()
   const { data: currencies = [] } = useCurrencies()
+  const currencyState = useCurrencyListState()
   const selectableAccounts = useMemo(
     () => accounts.filter((account) => !account.is_archived),
     [accounts],
@@ -150,10 +153,8 @@ export default function CreateTransactionModal({
   const selectedCurrency = currencies.find((c) => c.id === form.currency)
   const selectedCurrencySymbol = selectedCurrency?.symbol ?? ''
   const selectedCurrencyExponent = selectedCurrency?.minor_unit_exponent ?? 2
-  // Keyed on the list being absent rather than on the selected currency being unknown, so a form that
-  // has not picked a currency yet is not mistaken for a failed fetch. Only reachable while editing,
-  // since a create click is refused before the modal opens
-  const isAmountLocked = currencies.length === 0
+  // Only reachable while editing, since a create click is refused before the modal opens
+  const isAmountLocked = currencyState !== 'ready'
 
   const { openRef, recordCreatedAccountId, flushDeferredRefresh, closeModal } = useDeferredTransactionRefresh({
     open,
@@ -312,10 +313,10 @@ export default function CreateTransactionModal({
             dateError={showError('date')}
             currencyOptions={currencyOptions}
             currencyValue={form.currency}
-            currencyPlaceholder={isAmountLocked ? 'Unavailable' : 'Select...'}
+            currencyPlaceholder={isAmountLocked ? CURRENCY_LIST_LOADING : 'Select...'}
             selectedCurrencySymbol={selectedCurrencySymbol}
             currencyExponent={selectedCurrencyExponent}
-            isAmountLocked={isAmountLocked}
+            currencyState={currencyState}
             amount={form.amount}
             amountError={showError('amount')}
             notes={form.notes}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -312,7 +312,7 @@ export default function CreateTransactionModal({
             dateError={showError('date')}
             currencyOptions={currencyOptions}
             currencyValue={form.currency}
-            currencyPlaceholder={currencies.length === 0 ? 'Loading...' : 'Select...'}
+            currencyPlaceholder={isAmountLocked ? 'Unavailable' : 'Select...'}
             selectedCurrencySymbol={selectedCurrencySymbol}
             currencyExponent={selectedCurrencyExponent}
             isAmountLocked={isAmountLocked}

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
@@ -41,6 +41,7 @@ interface UseTransactionSubmitOptions {
   selectedAccount: AccountsOverview | undefined
   selectedToAccount: AccountsOverview | undefined
   selectedCurrencyExponent: number
+  isAmountLocked: boolean
   deleteLoading: boolean
   openRef: MutableRefObject<boolean>
   recordCreatedAccountId: (accountId: string) => void
@@ -75,6 +76,7 @@ export function useTransactionSubmit({
   selectedAccount,
   selectedToAccount,
   selectedCurrencyExponent,
+  isAmountLocked,
   deleteLoading,
   openRef,
   recordCreatedAccountId,
@@ -126,7 +128,7 @@ export function useTransactionSubmit({
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     if (isPending || readOnly) return
-    const errors = validateTransactionForm(form)
+    const errors = validateTransactionForm(form, isAmountLocked)
     // The receiving account needs both accounts loaded to compare currency and group
     if (!editing && isSymmetricTransferForm(form) && !errors.to_account_id) {
       const accountError = getSymmetricTransferAccountError(selectedAccount, selectedToAccount)
@@ -137,7 +139,11 @@ export function useTransactionSubmit({
     if (Object.keys(errors).length > 0) return
 
     if (editing && transaction) {
-      const patch = buildUpdateTransactionPatch(form, transaction, selectedCurrencyExponent)
+      const patch = buildUpdateTransactionPatch(
+        form,
+        transaction,
+        isAmountLocked ? null : selectedCurrencyExponent,
+      )
 
       if (!patch) {
         closeModal()

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -15,6 +15,10 @@ interface TransactionDetailsSectionProps {
   selectedCurrencySymbol: string
   amount: string
   amountError?: string | false
+
+  // Stands the amount down when the selected currency is missing from the currency table, whose decimal
+  // places the stored amount can only be read or written through
+  isAmountLocked: boolean
   currencyExponent: number
   notes: string
   readOnly: boolean
@@ -37,6 +41,7 @@ export default function TransactionDetailsSection({
   selectedCurrencySymbol,
   amount,
   amountError,
+  isAmountLocked,
   currencyExponent,
   notes,
   readOnly,
@@ -86,7 +91,19 @@ export default function TransactionDetailsSection({
           />
         </div>
         <div>
-          <CreateModalFieldLabelRow htmlFor="txn-amount" label="Amount" error={amountError} />
+          <CreateModalFieldLabelRow
+            htmlFor="txn-amount"
+            label={isAmountLocked ? (
+              <span className="inline-flex items-center gap-2">
+                Amount
+                <IconTooltip label="Amount unavailable" level="important">
+                  We can't load the currency list right now, so the amount can't be shown or changed.
+                  Refresh the page to try again.
+                </IconTooltip>
+              </span>
+            ) : 'Amount'}
+            error={amountError}
+          />
           <div className="relative">
             {selectedCurrencySymbol && (
               <span
@@ -105,7 +122,7 @@ export default function TransactionDetailsSection({
               id="txn-amount"
               className={`app-input w-full disabled:cursor-not-allowed disabled:opacity-60 ${selectedCurrencySymbol ? 'pl-8' : ''} ${amountError ? 'app-input-error' : ''}`}
               placeholder={getMoneyPlaceholder(currencyExponent)}
-              disabled={readOnly}
+              disabled={readOnly || isAmountLocked}
               {...amountInput}
             />
           </div>

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -5,7 +5,12 @@ import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
 import { getMoneyPlaceholder } from '@/utils/moneyInput'
-import { CURRENCY_LIST_FIELD_NOTICE } from '@/utils/currencyStatus'
+import {
+  CURRENCY_AMOUNT_NOTICE,
+  CURRENCY_LIST_LOADING,
+  CURRENCY_LIST_NOTICE,
+  type CurrencyListState,
+} from '@/utils/currencyStatus'
 
 interface TransactionDetailsSectionProps {
   date: string
@@ -17,9 +22,9 @@ interface TransactionDetailsSectionProps {
   amount: string
   amountError?: string | false
 
-  // Stands the amount down when the selected currency is missing from the currency table, whose decimal
-  // places the stored amount can only be read or written through
-  isAmountLocked: boolean
+  // Stands the amount down unless the currency table is in hand, since its decimal places are the only way
+  // to read or write the stored amount, and says which of the two reasons applies
+  currencyState: CurrencyListState
   currencyExponent: number
   notes: string
   readOnly: boolean
@@ -42,7 +47,7 @@ export default function TransactionDetailsSection({
   selectedCurrencySymbol,
   amount,
   amountError,
-  isAmountLocked,
+  currencyState,
   currencyExponent,
   notes,
   readOnly,
@@ -52,6 +57,7 @@ export default function TransactionDetailsSection({
   onAmountBlur,
   onNotesChange,
 }: TransactionDetailsSectionProps) {
+  const isAmountLocked = currencyState !== 'ready'
   const amountInput = useMoneyInput({
     value: amount,
     exponent: currencyExponent,
@@ -80,9 +86,14 @@ export default function TransactionDetailsSection({
             <IconTooltip label="Transaction currency limitation">
               Locked to the selected account's currency
             </IconTooltip>
-            {isAmountLocked && (
+            {currencyState === 'loading' && (
+              <IconTooltip label="Loading currencies" modalFieldTabStop>
+                {CURRENCY_LIST_LOADING}
+              </IconTooltip>
+            )}
+            {currencyState === 'unavailable' && (
               <IconTooltip label="Currency list unavailable" level="important" modalFieldTabStop>
-                {CURRENCY_LIST_FIELD_NOTICE}
+                {CURRENCY_LIST_NOTICE}
               </IconTooltip>
             )}
           </div>
@@ -102,9 +113,15 @@ export default function TransactionDetailsSection({
             label={isAmountLocked ? (
               <span className="inline-flex items-center gap-2">
                 Amount
-                <IconTooltip label="Amount unavailable" level="important" modalFieldTabStop>
-                  {CURRENCY_LIST_FIELD_NOTICE}
-                </IconTooltip>
+                {currencyState === 'loading' ? (
+                  <IconTooltip label="Loading currencies" modalFieldTabStop>
+                    {CURRENCY_LIST_LOADING}
+                  </IconTooltip>
+                ) : (
+                  <IconTooltip label="Amount unavailable" level="important" modalFieldTabStop>
+                    {CURRENCY_AMOUNT_NOTICE}
+                  </IconTooltip>
+                )}
               </span>
             ) : 'Amount'}
             error={amountError}

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -80,6 +80,11 @@ export default function TransactionDetailsSection({
             <IconTooltip label="Transaction currency limitation">
               Locked to the selected account's currency
             </IconTooltip>
+            {isAmountLocked && (
+              <IconTooltip label="Currency list unavailable" level="important" modalFieldTabStop>
+                {CURRENCY_LIST_FIELD_NOTICE}
+              </IconTooltip>
+            )}
           </div>
           <Dropdown
             options={currencyOptions}

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -5,6 +5,7 @@ import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
 import { getMoneyPlaceholder } from '@/utils/moneyInput'
+import { CURRENCY_LIST_FIELD_NOTICE } from '@/utils/currencyStatus'
 
 interface TransactionDetailsSectionProps {
   date: string
@@ -96,9 +97,8 @@ export default function TransactionDetailsSection({
             label={isAmountLocked ? (
               <span className="inline-flex items-center gap-2">
                 Amount
-                <IconTooltip label="Amount unavailable" level="important">
-                  We can't load the currency list right now, so the amount can't be shown or changed.
-                  Refresh the page to try again.
+                <IconTooltip label="Amount unavailable" level="important" modalFieldTabStop>
+                  {CURRENCY_LIST_FIELD_NOTICE}
                 </IconTooltip>
               </span>
             ) : 'Amount'}
@@ -121,7 +121,7 @@ export default function TransactionDetailsSection({
             <input
               id="txn-amount"
               className={`app-input w-full disabled:cursor-not-allowed disabled:opacity-60 ${selectedCurrencySymbol ? 'pl-8' : ''} ${amountError ? 'app-input-error' : ''}`}
-              placeholder={getMoneyPlaceholder(currencyExponent)}
+              placeholder={isAmountLocked ? undefined : getMoneyPlaceholder(currencyExponent)}
               disabled={readOnly || isAmountLocked}
               {...amountInput}
             />

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
@@ -4,6 +4,7 @@ import type { Currency } from '@/api/currency'
 import type { Transaction } from '@/api/transactions'
 import { INITIAL_TRANSACTION_FORM } from '@/pages/transactions/components/transaction-modal/constants'
 import { amountToInputString } from '@/pages/transactions/components/transaction-modal/utils/money'
+import { findCurrencyExponent } from '@/utils/moneyInput'
 import type {
   TransactionFormValues,
   TransactionModalKind,
@@ -48,7 +49,9 @@ export function buildInitialTransactionForm({
   }
 
   const category = categories.find((item) => item.id === transaction.category_id)
-  const exponent = currencies.find((currency) => currency.id === transaction.currency)?.minor_unit_exponent ?? 2
+  // Left blank rather than scaled by an assumed two decimal places, since the stored amount can only be
+  // turned into text through the real ones
+  const exponent = findCurrencyExponent(currencies, transaction.currency)
 
   return {
     kind: (category?.kind as TransactionModalKind) ?? 'expense',
@@ -56,7 +59,7 @@ export function buildInitialTransactionForm({
     account_id: transaction.account_id,
     category_id: transaction.category_id,
     merchant_id: transaction.merchant_id ?? '',
-    amount: amountToInputString(transaction.amount, exponent),
+    amount: exponent === null ? '' : amountToInputString(transaction.amount, exponent),
     currency: transaction.currency,
     notes: transaction.notes ?? '',
     date: transaction.dt,

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
@@ -64,17 +64,21 @@ export function buildSymmetricTransferPayloads(
 export function buildUpdateTransactionPatch(
   form: TransactionFormValues,
   transaction: Transaction,
-  selectedCurrencyExponent: number,
+  selectedCurrencyExponent: number | null,
 ): UpdateTransactionPayload | null {
-  const magnitude = amountInputToMinorUnits(form.amount, selectedCurrencyExponent) ?? 0
-  const signedAmount = applyTransactionDirection(magnitude, form.direction)
   const notes = form.notes.trim() || null
   const patch: UpdateTransactionPayload = {}
 
   if (form.account_id !== transaction.account_id) patch.account_id = form.account_id
   if (form.category_id !== transaction.category_id) patch.category_id = form.category_id
   if (form.merchant_id !== (transaction.merchant_id ?? '')) patch.merchant_id = form.merchant_id || null
-  if (signedAmount !== transaction.amount) patch.amount = signedAmount
+  // Left out entirely when the currency's decimal places are unknown. The field is blank in that state,
+  // and a blank converts to zero, so sending it would wipe an amount the user was never shown
+  if (selectedCurrencyExponent !== null) {
+    const magnitude = amountInputToMinorUnits(form.amount, selectedCurrencyExponent) ?? 0
+    const signedAmount = applyTransactionDirection(magnitude, form.direction)
+    if (signedAmount !== transaction.amount) patch.amount = signedAmount
+  }
   if (form.date !== transaction.dt) patch.dt = form.date
   if (notes !== (transaction.notes ?? null)) patch.notes = notes
   if (!sameStringSet(form.tag_ids, transaction.tag_ids)) patch.tag_ids = form.tag_ids

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
@@ -14,15 +14,23 @@ export function isSymmetricTransferForm(form: TransactionFormValues): boolean {
 /**
  * Validates fields required before a transaction can be sent to the API
  */
-export function validateTransactionForm(form: TransactionFormValues): TransactionFormFieldErrors {
+export function validateTransactionForm(
+  form: TransactionFormValues,
+  isAmountLocked = false,
+): TransactionFormFieldErrors {
   const errors: TransactionFormFieldErrors = {}
   if (!form.account_id) errors.account_id = 'Select an account'
   if (!form.category_id) errors.category_id = 'Select a category'
   if (!form.merchant_id) errors.merchant_id = 'Select or create a merchant'
-  if (!form.amount) errors.amount = 'Enter an amount'
-  else {
-    const amount = Number.parseFloat(form.amount)
-    if (!Number.isFinite(amount) || amount <= 0) errors.amount = 'Amount must be greater than zero'
+
+  // A locked amount is blank, disabled and left out of the update, so requiring one here would block
+  // every other edit to the transaction
+  if (!isAmountLocked) {
+    if (!form.amount) errors.amount = 'Enter an amount'
+    else {
+      const amount = Number.parseFloat(form.amount)
+      if (!Number.isFinite(amount) || amount <= 0) errors.amount = 'Amount must be greater than zero'
+    }
   }
   if (!form.currency) errors.currency = 'Select a currency'
   if (!form.date) errors.date = 'Select a date'

--- a/frontend/src/utils/currencyStatus.ts
+++ b/frontend/src/utils/currencyStatus.ts
@@ -1,0 +1,5 @@
+/** Shown when a form that creates something with an amount is refused, since it cannot work at all */
+export const CURRENCY_LIST_REFUSAL = "We can't load the currency list right now. Refresh the page to try again."
+
+/** Shown beside a field standing down, whose stored amount can only be read through the currency's decimals */
+export const CURRENCY_LIST_FIELD_NOTICE = "We can't load the currency list right now, so this amount can't be shown or changed. Refresh the page to try again."

--- a/frontend/src/utils/currencyStatus.ts
+++ b/frontend/src/utils/currencyStatus.ts
@@ -1,5 +1,17 @@
-/** Shown when a form that creates something with an amount is refused, since it cannot work at all */
+/** Whether the currency list is in hand, on its way, or not coming without another page load */
+export type CurrencyListState = 'ready' | 'loading' | 'unavailable'
+
+/** Stands in for the currency in a field that cannot name it yet */
+export const CURRENCY_LIST_LOADING = 'Loading currencies...'
+
+/** Shown beside a currency field once the list has failed */
+export const CURRENCY_LIST_NOTICE = "We can't load the currency list right now. Refresh the page to try again."
+
+/** Shown beside an amount field standing down, which needs the currency's decimal places to say anything */
+export const CURRENCY_AMOUNT_NOTICE = "We can't load the currency list right now, so this amount can't be shown or changed. Refresh the page to try again."
+
+/** Shown when a form that creates something with an amount is refused because the list failed */
 export const CURRENCY_LIST_REFUSAL = "We can't load the currency list right now. Refresh the page to try again."
 
-/** Shown beside a field standing down, whose stored amount can only be read through the currency's decimals */
-export const CURRENCY_LIST_FIELD_NOTICE = "We can't load the currency list right now, so this amount can't be shown or changed. Refresh the page to try again."
+/** Shown when that same form is refused only because the list has not arrived yet */
+export const CURRENCY_LOADING_REFUSAL = 'The currency list is still loading. Try again in a moment.'

--- a/frontend/src/utils/moneyInput.ts
+++ b/frontend/src/utils/moneyInput.ts
@@ -59,8 +59,8 @@ export function readMoneyInputChange(value: string, typed: string, exponent: num
  * in the table
  *
  * The fallback cannot tell an unrecognized code from a table that has not loaded yet, so a field
- * whose text is frozen at mount must wait for the currencies query to resolve. A field that
- * recomputes its text every render corrects itself once the table arrives and needs no wait
+ * holding a stored amount should read its exponent through findCurrencyExponent below and stand down
+ * when there is none, rather than displaying an amount scaled by this guess
  */
 export function getCurrencyExponent(currencies: Currency[], code: string): number {
   return currencies.find((currency) => currency.id === code)?.minor_unit_exponent ?? DEFAULT_MINOR_UNIT_EXPONENT

--- a/frontend/src/utils/moneyInput.ts
+++ b/frontend/src/utils/moneyInput.ts
@@ -5,7 +5,7 @@ import type { Currency } from '@/api/currency'
 const CANONICAL_DECIMAL = '.'
 
 // Currencies missing from the table are treated as having two decimal places
-const DEFAULT_MINOR_UNIT_EXPONENT = 2
+export const DEFAULT_MINOR_UNIT_EXPONENT = 2
 
 // Whole digits, then at most one decimal point and its digits. Latin digits only, since a
 // character the field cannot read is a character it will not take
@@ -64,6 +64,17 @@ export function readMoneyInputChange(value: string, typed: string, exponent: num
  */
 export function getCurrencyExponent(currencies: Currency[], code: string): number {
   return currencies.find((currency) => currency.id === code)?.minor_unit_exponent ?? DEFAULT_MINOR_UNIT_EXPONENT
+}
+
+/**
+ * Returns the number of decimal places a currency uses, or null when the code is not in the table
+ *
+ * A form holding a stored amount needs the difference the fallback above hides: without the real
+ * exponent it can neither show that amount nor convert an edit to it, so the field has to stand down
+ * rather than display a number scaled by a guess
+ */
+export function findCurrencyExponent(currencies: Currency[], code: string): number | null {
+  return currencies.find((currency) => currency.id === code)?.minor_unit_exponent ?? null
 }
 
 /**

--- a/frontend/tests/accounts/accountDetailLogic.test.ts
+++ b/frontend/tests/accounts/accountDetailLogic.test.ts
@@ -150,6 +150,27 @@ describe('identity form helpers', () => {
     })
   })
 
+  it('withholds the credit limit rather than scaling it by a guess when the currency is not in the table', () => {
+    const account = createAccount({ account_kind: 'revolving', credit_limit: 500_000, currency: 'JPY' })
+    const form = createIdentityFormValues(account, [])
+
+    // Blank rather than 5000.00, which is what two assumed decimal places would have shown for ¥500,000
+    expect(form.credit_limit).toBe('')
+
+    // Left out of the payload entirely, since a blank converts to null and would clear the stored limit
+    expect(getIdentityUpdatePayload({
+      form,
+      isRevolving: true,
+      canLinkTaxAdvantagedCategory: false,
+      currencies: [],
+      accountCurrency: 'JPY',
+    })).toEqual({
+      name: 'Account',
+      institution_id: null,
+      is_archived: false,
+    })
+  })
+
   it('wraps edit account modal Tab focus through field controls only', () => {
     const fieldTabStops = [
       EDIT_ACCOUNT_IDENTITY_FIELD_IDS.name,

--- a/frontend/tests/api/currency.test.ts
+++ b/frontend/tests/api/currency.test.ts
@@ -30,7 +30,12 @@ describe('currency API functions', () => {
     });
 
     await expect(fetchCurrencies()).resolves.toEqual(currencies);
-    expect(fetchMock).toHaveBeenCalledWith(`${API_BASE}/currencies`);
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${API_BASE}/currencies`,
+      // Carries a timeout, so a request that hangs fails instead of leaving every form saying it is
+      // still loading forever
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
   });
 
   it('raises an error when currencies fail to load', async () => {

--- a/frontend/tests/budgets/budgetForm.test.ts
+++ b/frontend/tests/budgets/budgetForm.test.ts
@@ -52,6 +52,11 @@ describe('budget form helpers', () => {
     expect(toMinorUnits('0', currencies, 'CAD')).toBeNull()
   })
 
+  it('reads no amount from the blank limit a missing currency table leaves behind', () => {
+    // The edit form treats this null as no change, so a period keeps the limit the user was never shown
+    expect(toMinorUnits('', [], 'JPY')).toBeNull()
+  })
+
   it('validates create-budget fields before building an API payload', () => {
     expect(validateBudgetCreateForm(createForm(), currencies, categories)).toEqual({})
     expect(validateBudgetCreateForm(createForm({

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -223,6 +223,29 @@ describe('transaction modal helpers', () => {
     })
   })
 
+  it('withholds the amount rather than scaling it by a guess when the currency list is missing', () => {
+    const transaction = createTransaction({ amount: -500_000, currency: 'JPY' })
+    const form = buildInitialTransactionForm({
+      transaction,
+      categories: [createCategory({ id: 'groceries' })],
+      currencies: [],
+      selectableAccounts: [createAccount({ id: 'checking' })],
+      timeZone: undefined,
+    })
+
+    // Blank rather than 5000.00, which is what two assumed decimal places would have shown for ¥500,000
+    expect(form.amount).toBe('')
+
+    // A blank amount converts to zero, so leaving it out is what stops the save wiping the stored value
+    expect(buildUpdateTransactionPatch(form, transaction, null)).toBeNull()
+    expect(buildUpdateTransactionPatch({ ...form, notes: 'Checked' }, transaction, null))
+      .toEqual({ notes: 'Checked' })
+
+    // The rest of the form still has to pass, so the blank amount cannot block an edit to anything else
+    expect(validateTransactionForm(form, true)).toEqual({})
+    expect(validateTransactionForm(form)).toEqual({ amount: 'Enter an amount' })
+  })
+
   it('builds minimal edit patches and returns null when the transaction is unchanged', () => {
     const transaction = createTransaction({
       tag_ids: ['tax', 'business'],

--- a/frontend/tests/utils/moneyInput.test.ts
+++ b/frontend/tests/utils/moneyInput.test.ts
@@ -5,6 +5,7 @@
 import { describe, expect, it } from 'vitest'
 import type { Currency } from '@/api/currency'
 import {
+  findCurrencyExponent,
   fromMinorUnits,
   getCurrencyExponent,
   getMoneyPlaceholder,
@@ -152,6 +153,12 @@ describe('currency decimal places', () => {
     expect(getCurrencyExponent(currencies, 'CAD')).toBe(2)
     expect(getCurrencyExponent(currencies, 'JPY')).toBe(0)
     expect(getCurrencyExponent(currencies, 'XXX')).toBe(2)
+  })
+
+  it('reports an absent exponent instead of guessing one', () => {
+    expect(findCurrencyExponent(currencies, 'JPY')).toBe(0)
+    expect(findCurrencyExponent(currencies, 'XXX')).toBeNull()
+    expect(findCurrencyExponent([], 'CAD')).toBeNull()
   })
 })
 


### PR DESCRIPTION
A failed currency fetch used to leave three modals rendering nothing at all, so the account Edit button, the New Budget button and the budget cards took the click and did nothing visible. The currency list carries each currency's decimal places, and without them a stored amount can neither be shown nor converted. Each form now opens if it can still be useful, with the fields that need those decimals greyed out and empty, and the forms that cannot work without them do not open at all.
