### PR TITLE
Order dates and category kinds by value instead of as literal strings

### DIFF
--- a/frontend/src/pages/accounts/detail/utils/balanceChartSeries.ts
+++ b/frontend/src/pages/accounts/detail/utils/balanceChartSeries.ts
@@ -1,6 +1,6 @@
 import type { AccountBalanceSnapshot, SnapshotGranularity } from '@/api/accounts'
 import { calendarDateMs } from './calendarDate'
-import { DATE_FORMATS, formatDate, formatYmd } from '@/utils/date'
+import { DATE_FORMATS, formatDate, formatYmd, getYmdTime } from '@/utils/date'
 
 export interface BalanceChartPoint {
   date: string
@@ -77,20 +77,24 @@ export function buildChartSeries(
   const sampleDates = generateSampleDates(fromDate, toDate, granularity)
   if (sampleDates.length === 0) return []
 
-  const sorted = [...snapshots].sort((a, b) => a.dt.localeCompare(b.dt))
+  // Each snapshot date is read into a time value once, so the walk below advances in calendar order
+  // and every comparison it makes is arithmetic on those values
+  const sorted = snapshots
+    .map((snapshot) => ({ time: getYmdTime(snapshot.dt), balance: snapshot.balance }))
+    .sort((a, b) => a.time - b.time)
 
   // The pointer advances once through sorted snapshots so each sample uses the latest known balance
   let idx = 0
   let runningBalance = 0
   const points: BalanceChartPoint[] = []
   for (const sampleDate of sampleDates) {
-    const sampleDateStr = formatYmd(sampleDate)
-    while (idx < sorted.length && sorted[idx].dt <= sampleDateStr) {
+    const sampleTime = sampleDate.getTime()
+    while (idx < sorted.length && sorted[idx].time <= sampleTime) {
       runningBalance = sorted[idx].balance
       idx++
     }
     points.push({
-      date: sampleDateStr,
+      date: formatYmd(sampleDate),
       dateMs: calendarDateMs(sampleDate),
       dateLabel: formatDate(sampleDate, DATE_FORMATS.monthDay),
       tooltipLabel: formatDate(sampleDate, DATE_FORMATS.monthDayYear),

--- a/frontend/src/pages/budgets/hooks/useBudgetCards.ts
+++ b/frontend/src/pages/budgets/hooks/useBudgetCards.ts
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import type { BaseBudget, Budget } from '@/api/budgets'
 import type { BudgetCardViewModel } from '@/pages/budgets/types'
+import { getYmdTime } from '@/utils/date'
 
 /**
  * Builds stable budget card view models from base budgets and period instances
@@ -34,8 +35,9 @@ export function useBudgetCards({
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((baseBudget) => {
         const budgetPeriods = (periodsByBase.get(baseBudget.id) ?? [])
-          .slice()
-          .sort((a, b) => b.period_start.localeCompare(a.period_start))
+          .map((period) => ({ period, startTime: getYmdTime(period.period_start) }))
+          .sort((a, b) => b.startTime - a.startTime)
+          .map((entry) => entry.period)
         return {
           baseBudget,
           periods: budgetPeriods,

--- a/frontend/src/pages/budgets/utils/budgetDetails.ts
+++ b/frontend/src/pages/budgets/utils/budgetDetails.ts
@@ -4,7 +4,7 @@ import type { BudgetChartPoint } from '@/pages/budgets/components/budget-details
 import type { CalendarDate } from '@/pages/budgets/types'
 import { nextRecurringPeriodStart } from '@/pages/budgets/utils/budgetPeriods'
 import { formatCalendarDate, parseCalendarDate } from '@/pages/budgets/utils/date'
-import { DATE_FORMATS, formatDate } from '@/utils/date'
+import { DATE_FORMATS, formatDate, getYmdTime } from '@/utils/date'
 import { getBudgetUtilizationPercent } from '@/pages/budgets/utils/utilization'
 import { getCategoryColorMap } from '@/utils/chartColor'
 
@@ -40,7 +40,10 @@ export const BUDGET_CHART_LAYOUT = {
  * Sorts periods oldest-to-newest for chart rendering and newest-to-oldest derivations
  */
 export function getSortedBudgetPeriods(periods: Budget[]) {
-  return periods.slice().sort((a, b) => a.period_start.localeCompare(b.period_start))
+  return periods
+    .map((period) => ({ period, startTime: getYmdTime(period.period_start) }))
+    .sort((a, b) => a.startTime - b.startTime)
+    .map((entry) => entry.period)
 }
 
 /**

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -49,6 +49,16 @@ export const KIND_LABELS: Record<Category['kind'], string> = {
   transfer: 'Transfer',
 }
 
+// Kind decides which group a category falls under in the import dropdowns, and an explicit rank
+// fixes that group order rather than leaving it to the browser's language rules, which can differ
+// between a user's devices. The ranks run alphabetically, matching what the dropdown showed before,
+// so a kind added later has to be placed here for the order to stay alphabetical
+export const KIND_RANKS: Record<Category['kind'], number> = {
+  expense: 0,
+  income: 1,
+  transfer: 2,
+}
+
 export const DEFAULT_CATEGORY_ICON = '🏷️'
 export const CREATE_ACCOUNT_VALUE = '__create_account__'
 export const CREATE_CATEGORY_VALUE = '__create_category__'

--- a/frontend/src/pages/imports/firefly/utils/budgets.ts
+++ b/frontend/src/pages/imports/firefly/utils/budgets.ts
@@ -144,20 +144,36 @@ export function buildFireflyBudgetImportBudgets(
 }
 
 /**
+ * One deduplicated limit period, with its dates read into time values so the
+ * schedule can be ordered without comparing the strings
+ */
+interface FireflyLimitEntry {
+  limit: FireflyBudgetImportLimit
+  currencyCode: string
+  startTime: number
+  endTime: number
+}
+
+/**
  * Builds the sorted limit period schedule for one budget from its export rows
  *
  * Rows missing a date, amount, or currency cannot place a period in the
  * schedule and are dropped, and exact duplicate rows collapse to one entry
  * while conflicting rows over the same days pass through for the backend to
  * reject
+ *
+ * The latest period's currency comes back alongside the schedule because it is
+ * the one the drafts table displays, and ordering the rows a second time to
+ * find it would order rows this pass has already refused
  */
 function buildLimitSchedule(limitRows: FireflyLimitRow[]): {
   limits: FireflyBudgetImportLimit[]
   currencyCodes: string[]
+  latestCurrencyCode: string
   hasUnreadableDates: boolean
 } {
   const seen = new Set<string>()
-  const limits: FireflyBudgetImportLimit[] = []
+  const entries: FireflyLimitEntry[] = []
   const currencyCodes = new Set<string>()
   let hasUnreadableDates = false
 
@@ -171,7 +187,9 @@ function buildLimitSchedule(limitRows: FireflyLimitRow[]): {
     // A present date that names no real day marks the file as corrupted, so
     // the budget is refused loudly rather than the row quietly vanishing or
     // the backend failing the whole batch
-    if (!parseYmd(row.start) || !parseYmd(row.end)) {
+    const start = parseYmd(row.start)
+    const end = parseYmd(row.end)
+    if (!start || !end) {
       hasUnreadableDates = true
       continue
     }
@@ -180,12 +198,20 @@ function buildLimitSchedule(limitRows: FireflyLimitRow[]): {
     const key = `${row.start} ${row.end} ${row.amount} ${row.currencyCode}`
     if (seen.has(key)) continue
     seen.add(key)
-    limits.push({ start: row.start, end: row.end, amount: row.amount })
+    entries.push({
+      limit: { start: row.start, end: row.end, amount: row.amount },
+      currencyCode: row.currencyCode,
+      startTime: start.getTime(),
+      endTime: end.getTime(),
+    })
   }
 
+  entries.sort((a, b) => a.startTime - b.startTime || a.endTime - b.endTime)
+
   return {
-    limits: limits.sort((a, b) => a.start.localeCompare(b.start) || a.end.localeCompare(b.end)),
+    limits: entries.map((entry) => entry.limit),
     currencyCodes: [...currencyCodes].sort(),
+    latestCurrencyCode: entries[entries.length - 1]?.currencyCode ?? '',
     hasUnreadableDates,
   }
 }
@@ -200,15 +226,16 @@ function buildBudgetDraft(
   usage: FireflyBudgetUsage | undefined,
 ): FireflyBudgetDraft {
   const categoryNames = [...usage?.categoryNames ?? []].sort((a, b) => a.localeCompare(b))
-  const { limits, currencyCodes, hasUnreadableDates } = buildLimitSchedule(budget.limitRows)
-  const latest = limits.length > 0 ? limits[limits.length - 1] : null
+  const {
+    limits,
+    currencyCodes,
+    latestCurrencyCode,
+    hasUnreadableDates,
+  } = buildLimitSchedule(budget.limitRows)
 
   // The most recent period decides the amount and currency the drafts table
   // displays, while the full schedule travels to the backend
-  const latestCurrency = [...budget.limitRows]
-    .filter((row) => row.start && row.end && row.amount && row.currencyCode)
-    .sort((a, b) => a.start.localeCompare(b.start))
-    .pop()?.currencyCode ?? ''
+  const latest = limits.length > 0 ? limits[limits.length - 1] : null
 
   const disabledReason = !usage || !usage.earliestDate
     ? FIREFLY_BUDGET_NO_TRANSACTIONS_REASON
@@ -227,7 +254,7 @@ function buildBudgetDraft(
   return {
     name,
     amount: latest?.amount ?? '',
-    currencyCode: latestCurrency,
+    currencyCode: latestCurrencyCode,
     currencyCodes,
     isArchived: budget.isArchived,
     limits,

--- a/frontend/src/pages/imports/utils/workflowOptions.ts
+++ b/frontend/src/pages/imports/utils/workflowOptions.ts
@@ -10,6 +10,7 @@ import {
   CREATE_CATEGORY_VALUE,
   DEFAULT_CATEGORY_ICON,
   KIND_LABELS,
+  KIND_RANKS,
 } from '@/pages/imports/constants'
 import type { ColumnMap, ImportAccountSource, ImportFileDraft } from '@/pages/imports/types'
 import { getImportAccountName } from './accountMapping'
@@ -65,7 +66,7 @@ export function buildImportCategoryMatchOptions(categories: Category[] = []): Dr
     },
     ...categories
       .slice()
-      .sort((a, b) => a.kind.localeCompare(b.kind) || a.name.localeCompare(b.name))
+      .sort((a, b) => KIND_RANKS[a.kind] - KIND_RANKS[b.kind] || a.name.localeCompare(b.name))
       .map((category) => ({
         value: category.id,
         label: category.name,

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -169,6 +169,25 @@ export function parseYmd(ymd: string): Date | null {
 }
 
 /**
+ * Reads a "YYYY-MM-DD" string into a time value that can be ordered arithmetically
+ *
+ * Sorting reads each date once into a number rather than comparing the strings, which would follow
+ * the browser's language rules and could order the same dates differently on a user's other device
+ *
+ * A string that is not a real calendar day means whatever produced it broke the shape the API
+ * promises, so this stops rather than ordering an unreadable value to one end where it would go
+ * unnoticed
+ *
+ * @throws When the string is not a zero-padded ISO calendar date
+ */
+export function getYmdTime(ymd: string): number {
+  const parsed = parseYmd(ymd)
+  if (parsed === null) throw new Error(`Expected a YYYY-MM-DD date, received "${ymd}"`)
+
+  return parsed.getTime()
+}
+
+/**
  * Returns a new date the given number of days later, or earlier for a negative count, leaving the
  * date passed in unchanged
  */

--- a/frontend/tests/budgets/budgetDetails.test.ts
+++ b/frontend/tests/budgets/budgetDetails.test.ts
@@ -152,6 +152,24 @@ describe('budget details helpers', () => {
     expect(getBudgetUtilizationByBudgetId(seeded, [loaded]).get('budget')?.total_spent).toBe(2000)
   })
 
+  it('orders periods by calendar date and leaves the array passed in alone', () => {
+    const periods = [
+      createBudget({ id: 'october', period_start: '2026-10-01', period_end: '2026-10-31' }),
+      createBudget({ id: 'february', period_start: '2026-02-01', period_end: '2026-02-28' }),
+      createBudget({ id: 'september', period_start: '2026-09-01', period_end: '2026-09-30' }),
+    ]
+
+    expect(getSortedBudgetPeriods(periods).map((period) => period.id))
+      .toEqual(['february', 'september', 'october'])
+    expect(periods.map((period) => period.id)).toEqual(['october', 'february', 'september'])
+  })
+
+  it('refuses a period whose start date is not a real day', () => {
+    const periods = [createBudget({ period_start: '2026-02-31' })]
+
+    expect(() => getSortedBudgetPeriods(periods)).toThrow('2026-02-31')
+  })
+
   it('sorts periods and builds chart rows from the latest twelve periods', () => {
     const periods = Array.from({ length: 13 }, (_, index) => {
       const month = (index % 12) + 1

--- a/frontend/tests/imports/fireflyBudgets.test.ts
+++ b/frontend/tests/imports/fireflyBudgets.test.ts
@@ -301,6 +301,23 @@ describe('buildFireflyBudgetDrafts', () => {
     expect(draft.disabledReason).toBe(FIREFLY_BUDGET_UNREADABLE_DATES_REASON)
   })
 
+  // The displayed currency comes off the schedule the export rows were cleaned into, so a row the
+  // cleaning refused cannot decide it however late its unreadable date would have sorted
+  it('takes the displayed currency from the latest period in the schedule', () => {
+    const budgetsFile = createBudgetsFile([
+      createLimitRow({ start_date: '2024-01-01', end_date: '2024-01-31' }),
+      createLimitRow({ start_date: '2025-02-31', end_date: '2025-03-31', currency_code: 'USD' }),
+    ])
+
+    const [draft] = buildFireflyBudgetDrafts({
+      budgetsFile,
+      transactionRows: [createTransactionRow()],
+    })
+
+    expect(draft.currencyCode).toBe('CAD')
+    expect(draft.currencyCodes).toEqual(['CAD'])
+  })
+
   it('disables a budget whose export rows cannot form a limit schedule', () => {
     const budgetsFile = createBudgetsFile([
       createLimitRow({ start_date: '', amount: '' }),

--- a/frontend/tests/imports/importWorkflowOptions.test.ts
+++ b/frontend/tests/imports/importWorkflowOptions.test.ts
@@ -102,6 +102,7 @@ describe('import workflow option helpers', () => {
 
   it('sorts category match options by kind and name after the create action', () => {
     expect(buildImportCategoryMatchOptions([
+      createCategory({ id: 'transfer', name: 'Between accounts', kind: 'transfer' }),
       createCategory({ id: 'salary', name: 'Salary', kind: 'income', icon: '💵' }),
       createCategory({ id: 'food', name: 'Food', kind: 'expense' }),
       createCategory({ id: 'rent', name: 'Rent', kind: 'expense' }),
@@ -110,6 +111,7 @@ describe('import workflow option helpers', () => {
       { value: 'food', label: 'Food', group: 'Expense' },
       { value: 'rent', label: 'Rent', group: 'Expense' },
       { value: 'salary', label: 'Salary', group: 'Income' },
+      { value: 'transfer', label: 'Between accounts', group: 'Transfer' },
     ])
   })
 

--- a/frontend/tests/utils/date.test.ts
+++ b/frontend/tests/utils/date.test.ts
@@ -14,6 +14,7 @@ import {
   getTodayDate,
   getTodayYmd,
   getWeekdayIndex,
+  getYmdTime,
   parseYmd,
   resolveTimeZone,
 } from '@/utils/date'
@@ -113,6 +114,17 @@ describe('YYYY-MM-DD strings', () => {
     expect(parseYmd('2026-01-05T00:00:00Z')).toBeNull()
     expect(parseYmd('2026/01/05')).toBeNull()
     expect(parseYmd('')).toBeNull()
+  })
+
+  it('orders dates by their time value', () => {
+    expect(getYmdTime('2026-01-05')).toBe(new Date(2026, 0, 5).getTime())
+    expect(getYmdTime('2026-01-09')).toBeLessThan(getYmdTime('2026-01-10'))
+    expect(getYmdTime('2025-12-31')).toBeLessThan(getYmdTime('2026-01-01'))
+  })
+
+  it('throws rather than ordering a date it cannot read', () => {
+    expect(() => getYmdTime('2026-02-31')).toThrow('2026-02-31')
+    expect(() => getYmdTime('')).toThrow()
   })
 })
 


### PR DESCRIPTION
Dates and a category kind were ordered through the browser's language rules, which vary with the locale it is set to and with the collation data that ships in that browser version, so the order was not fixed across a user's devices. Each sort now reads its value into the type it represents and orders on that.

- Balance snapshots, budget periods and Firefly limit periods order by their parsed dates, and a date that is not a real calendar day fails loudly instead of being ordered to one end
- The import dropdown's category groups follow an explicit rank per kind, in the same order as before
- The Firefly skipped budgets table shows the amount and the currency from the same limit period, where an unreadable date could previously set the currency displayed beside a readable row's amount
- The Firefly limit schedule reports its latest period's currency, replacing a second ordering of the raw export rows that skipped the schedule's own date checks
