### PR TITLE
Open the filter panel upward when there is no room below the pill

### DIFF
--- a/frontend/src/components/list-controls/FilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/FilterGlassPanel.tsx
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react
 import type { ReactNode } from 'react'
 import { motion, useReducedMotion } from 'motion/react'
 import { ChevronDown, SlidersHorizontal, X } from 'lucide-react'
-import { FILTER_GLASS_SPRING, FILTER_PANEL_BODY_TRANSITION, FILTER_PILL_HEAD_STYLE } from '@/components/list-controls/toolbarStyles'
+import {
+  FILTER_GLASS_SPRING,
+  FILTER_PANEL_BODY_TRANSITION,
+  FILTER_PANEL_FLIP_TRANSITION,
+  FILTER_PILL_HEAD_STYLE,
+} from '@/components/list-controls/toolbarStyles'
 import {
   DEFAULT_FILTER_PANEL_PLACEMENT,
   getFilterPanelPlacement,
@@ -50,6 +55,12 @@ export function FilterGlassPanel({
 }: FilterGlassPanelProps) {
   const [collapsedSize, setCollapsedSize] = useState(COLLAPSED_FALLBACK)
   const [placement, setPlacement] = useState(DEFAULT_FILTER_PANEL_PLACEMENT)
+  // The side the body is drawn on, which lags a measured change of direction until the body has
+  // pulled back into the pill, so the anchoring never switches under content that is on screen
+  const [renderedDirection, setRenderedDirection] = useState(DEFAULT_FILTER_PANEL_PLACEMENT.direction)
+  // True for the second half of a flip, so coming back out runs at the flip's pace rather than the
+  // slower pace of an ordinary open
+  const [isFlipOpening, setIsFlipOpening] = useState(false)
   const wrapperRef = useRef<HTMLDivElement>(null)
   const headRef = useRef<HTMLButtonElement>(null)
   const headContentRef = useRef<HTMLSpanElement>(null)
@@ -108,6 +119,9 @@ export function FilterGlassPanel({
         currentDirection: openDirection,
         viewportHeight: window.innerHeight,
       })
+      // The first measurement of an open cycle lands before the panel has painted, so opening on
+      // the other side from last time is applied whole rather than played as a flip
+      if (openDirection === null) setRenderedDirection(next.direction)
       openDirection = next.direction
       // Scrolling calls this on every frame, so an unchanged placement keeps the object it already
       // has rather than re-rendering the panel
@@ -160,7 +174,23 @@ export function FilterGlassPanel({
   const showClearButton = activeFacetCount > 0 && !open
   // Opening upward pins the glass to the bottom of the collapsed footprint and reverses the stack,
   // so the head stays exactly where the pill was while the body grows over the page above it
-  const openUpward = placement.direction === 'up'
+  const openUpward = renderedDirection === 'up'
+  // A measured change of direction retracts the body first, and the pill is the fixed point of both
+  // sides, so the flip reads as the panel closing into it and reopening the other way
+  const isRetracting = open && renderedDirection !== placement.direction
+
+  /**
+   * Carries a flip from one half to the next: the anchoring switches once the body is fully
+   * retracted, and the second half ends the flip so an ordinary close animates at its own pace
+   */
+  function handleBodyAnimationComplete() {
+    if (isRetracting) {
+      setRenderedDirection(placement.direction)
+      setIsFlipOpening(true)
+      return
+    }
+    if (isFlipOpening) setIsFlipOpening(false)
+  }
 
   return (
     <div
@@ -234,8 +264,16 @@ export function FilterGlassPanel({
         <motion.div
           style={{ overflow: 'hidden' }}
           initial={false}
-          animate={{ height: open ? placement.height : 0, opacity: open ? 1 : 0 }}
-          transition={shouldReduceMotion ? { duration: 0 } : FILTER_PANEL_BODY_TRANSITION}
+          animate={{
+            height: open && !isRetracting ? placement.height : 0,
+            opacity: open && !isRetracting ? 1 : 0,
+          }}
+          transition={
+            shouldReduceMotion
+              ? { duration: 0 }
+              : isRetracting || isFlipOpening ? FILTER_PANEL_FLIP_TRANSITION : FILTER_PANEL_BODY_TRANSITION
+          }
+          onAnimationComplete={handleBodyAnimationComplete}
         >
           {/* Scrolls only on a window too short to hold the controls that sit outside the option
               list, where the list has already given up all of its own height */}

--- a/frontend/src/components/list-controls/FilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/FilterGlassPanel.tsx
@@ -3,6 +3,12 @@ import type { ReactNode } from 'react'
 import { motion, useReducedMotion } from 'motion/react'
 import { ChevronDown, SlidersHorizontal, X } from 'lucide-react'
 import { FILTER_GLASS_SPRING, FILTER_PANEL_BODY_TRANSITION, FILTER_PILL_HEAD_STYLE } from '@/components/list-controls/toolbarStyles'
+import {
+  DEFAULT_FILTER_PANEL_PLACEMENT,
+  getFilterPanelPlacement,
+  type FilterPanelDirection,
+} from '@/components/list-controls/filterPanelPlacement'
+import { joinClassNames } from '@/utils/classNames'
 import { isFloatingLayerOpen, isInsideFloatingLayer } from '@/utils/floatingLayer'
 
 // Collapsed footprint used before the head is measured, so the toolbar slot does not jump on mount
@@ -12,17 +18,6 @@ const COLLAPSED_FALLBACK = { width: 140, height: 34 }
 // chevron, the chevron itself, and the borders, plus a couple of pixels so sub-pixel rounding never
 // clips the label. Added to the content width to size the pill
 const COLLAPSED_HEAD_CHROME = 64
-
-// The open panel fills to a consistent height with its option list growing to take the space, rather
-// than hugging each facet. This caps that height
-const OPEN_CONTENT_MAX = 440
-
-// Kept clear below the open panel so it never runs to the bottom edge of the viewport on a short
-// window, where the fill height shrinks to whatever space is left
-const OPEN_CONTENT_VIEWPORT_MARGIN = 24
-
-// Floor so a very short window still leaves the list usable rather than collapsing the panel
-const OPEN_CONTENT_MIN = 220
 
 type FilterGlassPanelProps = {
   // Accessible name for the collapsed pill button, naming the domain being filtered
@@ -40,8 +35,8 @@ type FilterGlassPanelProps = {
 /**
  * Renders the collapsing glass filter pill shared by the account and transaction desktop toolbars:
  * a pill that measures its own collapsed size, opens into an overlay anchored to its right edge so
- * it never shifts the toolbar height or the list below it, and caps its open height to the viewport.
- * The facet body is supplied as children so this component owns only the chrome
+ * it never shifts the toolbar height or the list below it, and opens upward when the space below it
+ * cannot hold the panel. The body is supplied as children so this component owns only the pill
  */
 export function FilterGlassPanel({
   ariaLabel,
@@ -54,7 +49,7 @@ export function FilterGlassPanel({
   children,
 }: FilterGlassPanelProps) {
   const [collapsedSize, setCollapsedSize] = useState(COLLAPSED_FALLBACK)
-  const [openContentHeight, setOpenContentHeight] = useState(OPEN_CONTENT_MAX)
+  const [placement, setPlacement] = useState(DEFAULT_FILTER_PANEL_PLACEMENT)
   const wrapperRef = useRef<HTMLDivElement>(null)
   const headRef = useRef<HTMLButtonElement>(null)
   const headContentRef = useRef<HTMLSpanElement>(null)
@@ -94,22 +89,40 @@ export function FilterGlassPanel({
     })
   }, [open, activeFacetCount])
 
-  // The open panel fills to a fixed height so the option list takes the available space instead of
-  // the panel hugging each facet. The height is capped at the viewport less a bottom margin, so a
-  // short window still leaves the panel clear of the bottom edge, and is remeasured on resize
+  // The open panel is one height whichever window it opens in, growing upward when the space under
+  // the pill cannot hold it. The toolbar is sticky, so scrolling moves the pill and changes which
+  // side has the room, and the panel is re-placed on both scroll and resize while it is open
   useLayoutEffect(() => {
     if (!open) return undefined
 
-    function measureOpenHeight() {
+    // Scoped to this open cycle so reopening picks a direction fresh, while a scroll partway
+    // through keeps the direction the panel is already open in
+    let openDirection: FilterPanelDirection | null = null
+
+    function measurePlacement() {
       const head = headRef.current
       if (!head) return
-      const available = window.innerHeight - head.getBoundingClientRect().bottom - OPEN_CONTENT_VIEWPORT_MARGIN
-      setOpenContentHeight(Math.round(Math.max(OPEN_CONTENT_MIN, Math.min(OPEN_CONTENT_MAX, available))))
+      const rect = head.getBoundingClientRect()
+      const next = getFilterPanelPlacement({
+        anchorRect: { bottom: rect.bottom, top: rect.top },
+        currentDirection: openDirection,
+        viewportHeight: window.innerHeight,
+      })
+      openDirection = next.direction
+      // Scrolling calls this on every frame, so an unchanged placement keeps the object it already
+      // has rather than re-rendering the panel
+      setPlacement((current) => (
+        current.direction === next.direction && current.height === next.height ? current : next
+      ))
     }
 
-    measureOpenHeight()
-    window.addEventListener('resize', measureOpenHeight)
-    return () => window.removeEventListener('resize', measureOpenHeight)
+    measurePlacement()
+    window.addEventListener('resize', measurePlacement)
+    window.addEventListener('scroll', measurePlacement, { passive: true })
+    return () => {
+      window.removeEventListener('resize', measurePlacement)
+      window.removeEventListener('scroll', measurePlacement)
+    }
   }, [open])
 
   // An outside press or Escape dismisses the panel and discards the draft
@@ -145,6 +158,9 @@ export function FilterGlassPanel({
   // The collapsed pill swaps the chevron for a clear control once filters are applied, so the user
   // can reset without opening the panel while the rest of the pill still opens it
   const showClearButton = activeFacetCount > 0 && !open
+  // Opening upward pins the glass to the bottom of the collapsed footprint and reverses the stack,
+  // so the head stays exactly where the pill was while the body grows over the page above it
+  const openUpward = placement.direction === 'up'
 
   return (
     <div
@@ -152,8 +168,16 @@ export function FilterGlassPanel({
       style={{ position: 'relative', marginLeft: 'auto', width: collapsedSize.width, height: collapsedSize.height }}
     >
       <motion.div
-        className="app-range-glass"
-        style={{ position: 'absolute', top: 0, right: 0, maxWidth: '90vw', zIndex: 50, marginLeft: 0 }}
+        className={joinClassNames('app-range-glass', openUpward && 'app-range-glass-up')}
+        style={{
+          position: 'absolute',
+          top: openUpward ? undefined : 0,
+          bottom: openUpward ? 0 : undefined,
+          right: 0,
+          maxWidth: '90vw',
+          zIndex: 50,
+          marginLeft: 0,
+        }}
         initial={false}
         animate={{ width: open ? openWidth : collapsedSize.width }}
         transition={transition}
@@ -210,10 +234,15 @@ export function FilterGlassPanel({
         <motion.div
           style={{ overflow: 'hidden' }}
           initial={false}
-          animate={{ height: open ? openContentHeight : 0, opacity: open ? 1 : 0 }}
+          animate={{ height: open ? placement.height : 0, opacity: open ? 1 : 0 }}
           transition={shouldReduceMotion ? { duration: 0 } : FILTER_PANEL_BODY_TRANSITION}
         >
-          <div className="flex flex-col" style={{ height: openContentHeight, padding: '0 12px 12px' }}>
+          {/* Scrolls only on a window too short to hold the controls that sit outside the option
+              list, where the list has already given up all of its own height */}
+          <div
+            className="flex flex-col overflow-y-auto"
+            style={{ height: placement.height, padding: '0 12px 12px' }}
+          >
             {children}
           </div>
         </motion.div>

--- a/frontend/src/components/list-controls/FilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/FilterGlassPanel.tsx
@@ -5,7 +5,7 @@ import { ChevronDown, SlidersHorizontal, X } from 'lucide-react'
 import {
   FILTER_GLASS_SPRING,
   FILTER_PANEL_BODY_TRANSITION,
-  FILTER_PANEL_FLIP_TRANSITION,
+  FILTER_PANEL_RETRACT_TRANSITION,
   FILTER_PILL_HEAD_STYLE,
 } from '@/components/list-controls/toolbarStyles'
 import {
@@ -58,9 +58,6 @@ export function FilterGlassPanel({
   // The side the body is drawn on, which lags a measured change of direction until the body has
   // pulled back into the pill, so the anchoring never switches under content that is on screen
   const [renderedDirection, setRenderedDirection] = useState(DEFAULT_FILTER_PANEL_PLACEMENT.direction)
-  // True for the second half of a flip, so coming back out runs at the flip's pace rather than the
-  // slower pace of an ordinary open
-  const [isFlipOpening, setIsFlipOpening] = useState(false)
   const wrapperRef = useRef<HTMLDivElement>(null)
   const headRef = useRef<HTMLButtonElement>(null)
   const headContentRef = useRef<HTMLSpanElement>(null)
@@ -180,16 +177,11 @@ export function FilterGlassPanel({
   const isRetracting = open && renderedDirection !== placement.direction
 
   /**
-   * Carries a flip from one half to the next: the anchoring switches once the body is fully
-   * retracted, and the second half ends the flip so an ordinary close animates at its own pace
+   * Switches the anchoring once the body has finished retracting, which is what turns the second
+   * half of a flip into an ordinary open on the other side
    */
   function handleBodyAnimationComplete() {
-    if (isRetracting) {
-      setRenderedDirection(placement.direction)
-      setIsFlipOpening(true)
-      return
-    }
-    if (isFlipOpening) setIsFlipOpening(false)
+    if (isRetracting) setRenderedDirection(placement.direction)
   }
 
   return (
@@ -271,7 +263,7 @@ export function FilterGlassPanel({
           transition={
             shouldReduceMotion
               ? { duration: 0 }
-              : isRetracting || isFlipOpening ? FILTER_PANEL_FLIP_TRANSITION : FILTER_PANEL_BODY_TRANSITION
+              : isRetracting ? FILTER_PANEL_RETRACT_TRANSITION : FILTER_PANEL_BODY_TRANSITION
           }
           onAnimationComplete={handleBodyAnimationComplete}
         >

--- a/frontend/src/components/list-controls/filterPanelPlacement.ts
+++ b/frontend/src/components/list-controls/filterPanelPlacement.ts
@@ -1,0 +1,61 @@
+export type FilterPanelDirection = 'down' | 'up'
+
+export interface FilterPanelAnchorRect {
+  // Viewport offset of the collapsed pill's bottom edge
+  bottom: number
+  // Viewport offset of the collapsed pill's top edge
+  top: number
+}
+
+export interface FilterPanelPlacement {
+  direction: FilterPanelDirection
+  height: number
+}
+
+interface FilterPanelPlacementParams {
+  anchorRect: FilterPanelAnchorRect
+  // Direction the panel is already open in, or null when it is being opened
+  currentDirection: FilterPanelDirection | null
+  viewportHeight: number
+}
+
+// The open panel is one height on every window, with the option list taking whatever the open tab's
+// own controls leave, rather than being sized to the space that happens to sit below the pill
+const OPEN_HEIGHT = 440
+
+// Kept clear beyond the open panel so it never runs to the top or bottom edge of the viewport
+const VIEWPORT_MARGIN = 24
+
+export const DEFAULT_FILTER_PANEL_PLACEMENT: FilterPanelPlacement = { direction: 'down', height: OPEN_HEIGHT }
+
+/**
+ * Chooses which way the open filter panel grows and how tall it is: downward wherever the full
+ * height fits below the pill, upward when only the space above it can hold it, and into whichever
+ * side is roomier when neither can
+ */
+export function getFilterPanelPlacement({
+  anchorRect,
+  currentDirection,
+  viewportHeight,
+}: FilterPanelPlacementParams): FilterPanelPlacement {
+  const spaceBelow = viewportHeight - anchorRect.bottom - VIEWPORT_MARGIN
+  const spaceAbove = anchorRect.top - VIEWPORT_MARGIN
+  const fitsBelow = spaceBelow >= OPEN_HEIGHT
+  const fitsAbove = spaceAbove >= OPEN_HEIGHT
+
+  // With no room either way the panel gives up its height rather than running off the window, so
+  // the side with more of it wins
+  if (!fitsBelow && !fitsAbove) {
+    return spaceAbove > spaceBelow
+      ? { direction: 'up', height: Math.max(0, Math.round(spaceAbove)) }
+      : { direction: 'down', height: Math.max(0, Math.round(spaceBelow)) }
+  }
+
+  // The toolbar is sticky, so scrolling moves the pill under an open panel. Keeping the direction
+  // it opened in for as long as that side still fits stops it flipping the moment the other side
+  // becomes the roomier one
+  if (currentDirection === 'up' && fitsAbove) return { direction: 'up', height: OPEN_HEIGHT }
+  if (currentDirection === 'down' && fitsBelow) return { direction: 'down', height: OPEN_HEIGHT }
+
+  return { direction: fitsBelow ? 'down' : 'up', height: OPEN_HEIGHT }
+}

--- a/frontend/src/components/list-controls/toolbarStyles.ts
+++ b/frontend/src/components/list-controls/toolbarStyles.ts
@@ -18,6 +18,14 @@ export const FILTER_PANEL_BODY_TRANSITION: Transition = {
   opacity: { duration: 0.26, delay: 0.05 },
 }
 
+// One half of a direction flip, played as the body pulls back into the pill and again as it comes
+// out the other side. Faster than opening, since replaying that timing twice would leave the panel
+// off screen for most of a second while the scroll that forced the flip carries on
+export const FILTER_PANEL_FLIP_TRANSITION: Transition = {
+  height: { duration: 0.2, ease: [0.22, 1, 0.36, 1] },
+  opacity: { duration: 0.14 },
+}
+
 // Lightly damped spring shared by the account and transaction filter glass panels so both settle
 // with the same feel
 export const FILTER_GLASS_SPRING = { type: 'spring', stiffness: 420, damping: 34, mass: 0.9 } as const

--- a/frontend/src/components/list-controls/toolbarStyles.ts
+++ b/frontend/src/components/list-controls/toolbarStyles.ts
@@ -18,12 +18,13 @@ export const FILTER_PANEL_BODY_TRANSITION: Transition = {
   opacity: { duration: 0.26, delay: 0.05 },
 }
 
-// One half of a direction flip, played as the body pulls back into the pill and again as it comes
-// out the other side. Faster than opening, since replaying that timing twice would leave the panel
-// off screen for most of a second while the scroll that forced the flip carries on
-export const FILTER_PANEL_FLIP_TRANSITION: Transition = {
-  height: { duration: 0.2, ease: [0.22, 1, 0.36, 1] },
-  opacity: { duration: 0.14 },
+// The body pulling back into the pill before a flip switches sides. It mirrors the expansion: the
+// curve is that one reversed, and the content leaves ahead of the box rather than settling after
+// it. Quick, because the weight of a flip belongs in the panel arriving on the other side, which
+// runs the expansion itself
+export const FILTER_PANEL_RETRACT_TRANSITION: Transition = {
+  height: { duration: 0.2, ease: [0.64, 0, 0.78, 0] },
+  opacity: { duration: 0.12 },
 }
 
 // Lightly damped spring shared by the account and transaction filter glass panels so both settle

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -578,8 +578,9 @@
     margin-left: 0;
   }
 
-  /* The mobile control floats at the bottom, so it stacks the panel above the pill and grows
-     upward while the panel content keeps its normal top-to-bottom order */
+  /* Stacks the panel above the pill and grows upward while the panel content keeps its normal
+     top-to-bottom order, for the mobile control that floats at the bottom of the screen and for a
+     filter panel opening on a window with no room beneath its pill */
   .app-range-glass-up {
     flex-direction: column-reverse;
   }

--- a/frontend/tests/components/list-controls/filterPanelPlacement.test.ts
+++ b/frontend/tests/components/list-controls/filterPanelPlacement.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Tests the placement the open filter panel takes, so refactors catch it opening into a side with
+ * no room, shrinking on a window that could hold it, or flipping direction under a scroll
+ */
+import { describe, expect, it } from 'vitest'
+import { getFilterPanelPlacement } from '@/components/list-controls/filterPanelPlacement'
+
+describe('filter panel placement', () => {
+  it('opens downward when the space below the pill holds the full height', () => {
+    expect(getFilterPanelPlacement({
+      anchorRect: { bottom: 100, top: 60 },
+      currentDirection: null,
+      viewportHeight: 900,
+    })).toEqual({ direction: 'down', height: 440 })
+  })
+
+  it('opens upward when only the space above the pill holds the full height', () => {
+    expect(getFilterPanelPlacement({
+      anchorRect: { bottom: 560, top: 520 },
+      currentDirection: null,
+      viewportHeight: 700,
+    })).toEqual({ direction: 'up', height: 440 })
+  })
+
+  it('keeps the direction it is already open in while that side still fits', () => {
+    // Both sides hold the panel here, so a scroll that makes below the roomier side must not flip
+    // an already-open upward panel
+    expect(getFilterPanelPlacement({
+      anchorRect: { bottom: 640, top: 600 },
+      currentDirection: 'up',
+      viewportHeight: 1200,
+    })).toEqual({ direction: 'up', height: 440 })
+  })
+
+  it('flips once the side it is open in stops fitting', () => {
+    expect(getFilterPanelPlacement({
+      anchorRect: { bottom: 140, top: 100 },
+      currentDirection: 'up',
+      viewportHeight: 900,
+    })).toEqual({ direction: 'down', height: 440 })
+  })
+
+  it('shrinks into the roomier side when neither holds the full height', () => {
+    expect(getFilterPanelPlacement({
+      anchorRect: { bottom: 440, top: 400 },
+      currentDirection: null,
+      viewportHeight: 600,
+    })).toEqual({ direction: 'up', height: 376 })
+
+    expect(getFilterPanelPlacement({
+      anchorRect: { bottom: 140, top: 100 },
+      currentDirection: null,
+      viewportHeight: 600,
+    })).toEqual({ direction: 'down', height: 436 })
+  })
+
+  it('reports no height rather than a negative one when neither side has any room', () => {
+    expect(getFilterPanelPlacement({
+      anchorRect: { bottom: 45, top: 10 },
+      currentDirection: null,
+      viewportHeight: 50,
+    })).toEqual({ direction: 'up', height: 0 })
+  })
+})


### PR DESCRIPTION
The desktop filter panel sized itself to whatever space was left below the pill, so its height changed with the window and with the scroll position. On a short window it shrank past the height of its own controls and cut off the Apply button. It now holds one height and chooses a side instead.