### PR TITLE
fix: accept legacy IANA timezone identifiers

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,13 @@
+"""Backend application package"""
+
+import zoneinfo
+
+# Resolve every named timezone from the tzdata dependency rather than the operating system's
+# zone files. Python searches the system path first and falls back to the package, so the two
+# would otherwise be read from different releases of the IANA database, and which release a
+# given zone came from would depend on whether the base image happened to carry it.
+#
+# This runs here because importing any app module imports this package first, which is before
+# the accepted timezone set is built in app.schemas.auth and before anything constructs a zone.
+# A missing dependency now resolves nothing at all rather than silently narrowing the set
+zoneinfo.reset_tzpath(to=[])

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,6 +20,8 @@ dependencies = [
     "pyotp>=2.10.0",
     "python-dotenv>=1.2.2",
     "sqlalchemy>=2.0.51",
+    # DO NOT REMOVE: required for timezone (see app/__init__.py)
+    "tzdata>=2026.3",
     "uvicorn>=0.51.0",
     "webauthn>=3.0.0",
 ]

--- a/backend/tests/schemas/test_timezone_validation.py
+++ b/backend/tests/schemas/test_timezone_validation.py
@@ -1,0 +1,55 @@
+"""Timezone identifier validation tests"""
+
+import zoneinfo
+from datetime import datetime
+from importlib.util import find_spec
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from app.schemas.auth import validate_iana_timezone
+
+# Compatibility identifiers IANA keeps for places it has renamed. Debian 13 ships these in a
+# tzdata-legacy package the runtime image does not install, so in the container they exist only
+# because the tzdata dependency supplies them
+LEGACY_IDENTIFIERS = (
+    "America/Indianapolis",
+    "US/Eastern",
+    "Asia/Calcutta",
+    "Europe/Kiev",
+)
+
+# Any fixed instant will do, since the assertion is that the zone carries usable rules at all
+_WINTER_INSTANT = datetime(2026, 1, 15, 12, 0)
+
+
+def test_the_tzdata_package_is_installed():
+    """The zone database has to come from the dependency rather than the base image"""
+    assert find_spec("tzdata") is not None
+
+
+def test_zone_lookups_ignore_the_operating_system():
+    """One release of the IANA database is in play, whatever zone files the host carries
+
+    Importing anything from app empties the search path, so a zone present both in the package
+    and on the host cannot resolve to the host's older version of it
+    """
+    assert zoneinfo.TZPATH == ()
+
+
+@pytest.mark.parametrize("identifier", LEGACY_IDENTIFIERS)
+def test_a_legacy_identifier_is_accepted(identifier):
+    """A timezone picker offering a compatibility identifier does not produce a rejected signup"""
+    assert validate_iana_timezone(identifier) == identifier
+
+
+@pytest.mark.parametrize("identifier", LEGACY_IDENTIFIERS)
+def test_a_legacy_identifier_constructs_a_zone(identifier):
+    """Accepting an identifier the routes cannot then construct would move the failure to a 500"""
+    assert ZoneInfo(identifier).utcoffset(_WINTER_INSTANT) is not None
+
+
+def test_an_unrecognized_identifier_is_rejected():
+    """Widening the accepted set must not stop it rejecting a value that is not a timezone"""
+    with pytest.raises(ValueError, match="Invalid IANA timezone"):
+        validate_iana_timezone("Mars/Olympus_Mons")

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -563,6 +563,7 @@ dependencies = [
     { name = "pyotp" },
     { name = "python-dotenv" },
     { name = "sqlalchemy" },
+    { name = "tzdata" },
     { name = "uvicorn" },
     { name = "webauthn" },
 ]
@@ -597,6 +598,7 @@ requires-dist = [
     { name = "pyotp", specifier = ">=2.10.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "sqlalchemy", specifier = ">=2.0.51" },
+    { name = "tzdata", specifier = ">=2026.3" },
     { name = "uvicorn", specifier = ">=0.51.0" },
     { name = "webauthn", specifier = ">=3.0.0" },
 ]
@@ -1010,6 +1012,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The frontend relies on the browser to provide it with a list of timezones, and the backend relied on the system to tell it which timezone is currently accepted without considering any aliases to old names. This resulted in mismatches where the browser's list of timezones differed from that in the backend, causing some user to experience a 422 error on sign up. This PR fixes this issue by adding the `tzdata` package and pinning the backend to only source timezone information from the `tzdata` package, which now properly accepts aliases of IANA timezone identifiers.

Resolves #162 