### PR TITLE
revert: undo window overlay stretch over the gutter

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -168,7 +168,7 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
           </AnimatePresence>
           <main
             id="app-page-content"
-            className={`min-w-0 flex-1 ${isFocusedPage ? 'app-window-overlay z-[60]' : `relative px-4 pb-8 pt-6 ${navOffsetClass} min-[1050px]:px-6 ${desktopBottomPadding} min-[1050px]:pt-10 transition-[margin] duration-[450ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`}`}
+            className={`min-w-0 flex-1 ${isFocusedPage ? 'fixed inset-0 z-[60] p-0' : `relative px-4 pb-8 pt-6 ${navOffsetClass} min-[1050px]:px-6 ${desktopBottomPadding} min-[1050px]:pt-10 transition-[margin] duration-[450ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`}`}
             aria-busy={pageTransitioning}
           >
             <motion.div

--- a/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
@@ -61,7 +61,7 @@ export function MobileFilterGlassPanel({
           role="dialog"
           aria-modal="true"
           aria-label={ariaLabel}
-          className="app-window-overlay z-[100] flex flex-col min-[750px]:hidden"
+          className="fixed inset-x-0 top-0 z-[100] flex flex-col min-[750px]:hidden"
           style={{
             // 100dvh tracks the dynamic viewport so the modal covers the screen even as the mobile
             // browser chrome shows or hides, leaving no strip of the list peeking below it

--- a/frontend/src/components/loading/Screen.tsx
+++ b/frontend/src/components/loading/Screen.tsx
@@ -1,5 +1,4 @@
 import { motion } from 'motion/react';
-import type { CSSProperties } from 'react';
 
 type LoadingScreenProps = {
   variant?: 'screen' | 'main';
@@ -10,18 +9,14 @@ type LoadingScreenProps = {
 // time it is mounted, otherwise its exit fade keeps swallowing taps on the menu and
 // in-page buttons for the length of the fade after the content is already interactive
 const loadingScreenClassNames = {
-  screen: 'app-window-overlay pointer-events-none z-50 flex flex-col items-center justify-center gap-5 text-center min-[730px]:gap-6',
-  main: 'app-window-overlay pointer-events-none z-30 flex flex-col items-center justify-center gap-5 text-center min-[730px]:gap-6 min-[1050px]:left-[260px]',
+  screen: 'pointer-events-none fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6',
+  main: 'pointer-events-none fixed inset-0 z-30 flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6 min-[1050px]:left-[260px]',
 };
-
-// The overlay's own inset from the left and right window edges. It is set here rather than with a padding
-// utility, so app-window-overlay can add the width reserved for the scrollbar on top of it
-const OVERLAY_INSET_X = '1.5rem';
 
 const LoadingScreen = ({ variant = 'screen', message = 'Your financial future awaits' }: LoadingScreenProps) => (
   <motion.div
     className={loadingScreenClassNames[variant]}
-    style={{ backgroundColor: 'var(--app-bg)', '--app-window-overlay-inset-x': OVERLAY_INSET_X } as CSSProperties}
+    style={{ backgroundColor: 'var(--app-bg)' }}
     role="status"
     aria-live="polite"
     initial={{ opacity: 0 }}

--- a/frontend/src/components/modal/Shell.tsx
+++ b/frontend/src/components/modal/Shell.tsx
@@ -166,7 +166,7 @@ export function ModalShell({
     <AnimatePresence onExitComplete={onExitComplete}>
       {open && (
         <motion.div
-          className={`app-window-overlay app-modal-backdrop ${appearance.className}`}
+          className={`app-modal-backdrop ${appearance.className}`}
           style={appearance.style}
           onClick={closeDisabled ? undefined : onClose}
           initial={{ opacity: 0 }}

--- a/frontend/src/pages/imports/components/ProgressOverlay.tsx
+++ b/frontend/src/pages/imports/components/ProgressOverlay.tsx
@@ -1,6 +1,5 @@
 import { AlertCircle, CheckCircle2, LoaderCircle } from 'lucide-react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
-import type { CSSProperties } from 'react'
 import type { Variants } from 'motion/react'
 import type { ImportOverlayPhase, ImportProgressStep, ImportProgressStepStatus } from '@/pages/imports/types'
 
@@ -10,9 +9,6 @@ const OVERLAY_MUTED_TEXT = 'var(--app-text-muted)'
 const OVERLAY_ACCENT = 'var(--app-accent)'
 const OVERLAY_SUCCESS = 'var(--app-positive)'
 const OVERLAY_ERROR = 'var(--app-negative)'
-// The overlay's own inset from the left and right window edges. It is set here rather than with a padding
-// utility, so app-window-overlay can add the width reserved for the scrollbar on top of it
-const OVERLAY_INSET_X = '1.25rem'
 const OVERLAY_EASE: [number, number, number, number] = [0.25, 0.1, 0.25, 1]
 const OVERLAY_SPRING_EASE: [number, number, number, number] = [0.16, 1, 0.3, 1]
 const overlayButtonClass = 'h-10 w-full box-border whitespace-nowrap leading-none sm:w-auto'
@@ -168,8 +164,8 @@ export function ImportProgressOverlay({
       {open && (
         <motion.div
           key="import-progress-overlay"
-          className="app-window-overlay z-[90] flex items-center justify-center py-8"
-          style={{ background: OVERLAY_BACKGROUND, color: OVERLAY_TEXT, '--app-window-overlay-inset-x': OVERLAY_INSET_X } as CSSProperties}
+          className="fixed inset-0 z-[90] flex items-center justify-center px-5 py-8"
+          style={{ background: OVERLAY_BACKGROUND, color: OVERLAY_TEXT }}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -1609,24 +1609,8 @@
     border: 1px solid var(--app-border-strong);
   }
 
-  /* Covers the window edge to edge, including the width html reserves for the scrollbar, while keeping
-     its contents inside the visible area so anything centred lines up with the page behind it. The
-     reserved width is the difference between the window and this element's containing block, which is
-     zero wherever the scrollbar is drawn over the content instead of beside it. An overlay's horizontal
-     inset goes in --app-window-overlay-inset-x, not a padding utility: a utility overrides the right
-     padding on its own, which leaves the fill reaching the edge but shifts everything centred inside it
-     right by half the reserved width */
-  .app-window-overlay {
-    @apply fixed inset-0;
-    --app-window-overlay-inset-x: 0px;
-    margin-right: calc(100% - 100vw);
-    padding-left: var(--app-window-overlay-inset-x);
-    padding-right: calc(var(--app-window-overlay-inset-x) + 100vw - 100%);
-  }
-
   .app-modal-backdrop {
-    @apply flex items-center justify-center py-4;
-    --app-window-overlay-inset-x: 1rem;
+    @apply fixed inset-0 flex items-center justify-center p-4;
     background: #0f0e0c8f;
   }
 


### PR DESCRIPTION
That was not the root cause and was instead caused by a browser misconfiguration.