### PR TITLE
Fix chart tooltips in modals and the cost of the backdrop blur

### DIFF
--- a/frontend/src/components/charts/CursorTooltipPortal.tsx
+++ b/frontend/src/components/charts/CursorTooltipPortal.tsx
@@ -5,6 +5,7 @@ import {
   type TransitionEvent as ReactTransitionEvent,
 } from 'react'
 import { createPortal } from 'react-dom'
+import { CURSOR_TOOLTIP_Z_INDEX } from '@/utils/tooltipPosition'
 
 type CursorTooltipPortalProps = {
   children: ReactNode
@@ -14,6 +15,7 @@ type CursorTooltipPortalProps = {
 }
 
 const defaultTooltipStyle: CSSProperties = {
+  zIndex: CURSOR_TOOLTIP_Z_INDEX,
   transition: 'opacity 150ms ease-out, transform 160ms cubic-bezier(0.22, 1, 0.36, 1)',
   willChange: 'opacity, transform',
 }
@@ -27,7 +29,7 @@ const CursorTooltipPortal = forwardRef<HTMLDivElement, CursorTooltipPortalProps>
   const tooltip = (
     <div
       ref={ref}
-      className="pointer-events-none fixed left-0 top-0 z-[60]"
+      className="pointer-events-none fixed left-0 top-0"
       onTransitionEnd={onTransitionEnd}
       style={{
         ...defaultTooltipStyle,

--- a/frontend/src/components/modal/Shell.tsx
+++ b/frontend/src/components/modal/Shell.tsx
@@ -12,23 +12,21 @@ const EASE = [0.25, 0.1, 0.25, 1] as const
 const LAYOUT_TRANSITION = { duration: 0.22, ease: EASE } as const
 
 // A modal opened from the page and a modal opened from another modal. The stacked level sits above every
-// page-level modal, blurs harder so the two panels stay visually separate, and settles a little faster so
-// the second one never feels slower to arrive than the first
+// page-level modal and settles a little faster so the second one never feels slower to arrive than the first
 //
-// Both blurs are kept small deliberately. The backdrop covers the viewport, and a backdrop filter over that
-// area is recomputed for every frame in which anything above it moves, so the cost lands on whatever the
-// modal holds: a chart tracking the pointer took the GPU to saturation at 4px in every browser tried
+// Neither level filters its own backdrop. The frosting comes from blurring whatever the dialog covers, the
+// page in app-behind-modal and the panel underneath in app-modal-panel-covered, both of which are inert and
+// still while the modal is open. A filter laid over them instead has to run again for every frame in which
+// anything above it moves, which took the GPU to saturation whenever a chart in a modal tracked the pointer
 const LEVELS = {
   page: {
     className: 'z-[60]',
-    style: { backdropFilter: 'blur(2px)' },
     backdropDuration: 0.2,
     panelOffset: { opacity: 0, scale: 0.96, y: 12 },
     panelTransition: { duration: 0.25, ease: EASE },
   },
   stacked: {
     className: 'z-[100]',
-    style: { backdropFilter: 'blur(4px)' },
     backdropDuration: 0.15,
     panelOffset: { opacity: 0, scale: 0.94, y: 16 },
     panelTransition: { duration: 0.22, ease: EASE },
@@ -171,7 +169,6 @@ export function ModalShell({
       {open && (
         <motion.div
           className={`app-modal-backdrop ${appearance.className}`}
-          style={appearance.style}
           onClick={closeDisabled ? undefined : onClose}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
@@ -186,7 +183,7 @@ export function ModalShell({
             tabIndex={-1}
             inert={covered}
             data-tooltip-bounds={boundsTooltips ? true : undefined}
-            className={`app-modal-panel ${panelClassName}`}
+            className={`app-modal-panel ${covered ? 'app-modal-panel-covered' : ''} ${panelClassName}`}
             onClick={(event) => event.stopPropagation()}
             layout={animateHeight}
             initial={appearance.panelOffset}

--- a/frontend/src/components/modal/Shell.tsx
+++ b/frontend/src/components/modal/Shell.tsx
@@ -14,17 +14,21 @@ const LAYOUT_TRANSITION = { duration: 0.22, ease: EASE } as const
 // A modal opened from the page and a modal opened from another modal. The stacked level sits above every
 // page-level modal, blurs harder so the two panels stay visually separate, and settles a little faster so
 // the second one never feels slower to arrive than the first
+//
+// Both blurs are kept small deliberately. The backdrop covers the viewport, and a backdrop filter over that
+// area is recomputed for every frame in which anything above it moves, so the cost lands on whatever the
+// modal holds: a chart tracking the pointer took the GPU to saturation at 4px in every browser tried
 const LEVELS = {
   page: {
     className: 'z-[60]',
-    style: { backdropFilter: 'blur(4px)' },
+    style: { backdropFilter: 'blur(2px)' },
     backdropDuration: 0.2,
     panelOffset: { opacity: 0, scale: 0.96, y: 12 },
     panelTransition: { duration: 0.25, ease: EASE },
   },
   stacked: {
     className: 'z-[100]',
-    style: { backdropFilter: 'blur(10px)' },
+    style: { backdropFilter: 'blur(4px)' },
     backdropDuration: 0.15,
     panelOffset: { opacity: 0, scale: 0.94, y: 16 },
     panelTransition: { duration: 0.22, ease: EASE },

--- a/frontend/src/components/modal/stack.ts
+++ b/frontend/src/components/modal/stack.ts
@@ -3,6 +3,12 @@
 // from screen readers without touching the dialog itself
 const APP_ROOT_ID = 'root'
 
+// Marks the page while any modal is open, so the stylesheet can blur what sits behind the dialog. The
+// blur belongs on the page rather than on a filter laid over it: the page is inert and scroll locked
+// for as long as a modal is open, so the browser rasterizes it once, where a filter over it has to run
+// again for every frame in which anything above it moves
+const PAGE_BEHIND_MODAL_CLASS = 'app-behind-modal'
+
 // Tokens for the modals currently open, the top-most last. One stack drives everything that depends on
 // that order: which modal Escape closes, and which panels below it stop taking input
 const openModalTokens: string[] = []
@@ -14,7 +20,7 @@ const stackListeners = new Set<() => void>()
  */
 export function registerOpenModal(token: string) {
   openModalTokens.push(token)
-  syncAppRootInert()
+  syncPageBehindModals()
   notifyStackListeners()
 }
 
@@ -25,7 +31,7 @@ export function unregisterOpenModal(token: string) {
   const index = openModalTokens.indexOf(token)
   if (index !== -1) openModalTokens.splice(index, 1)
 
-  syncAppRootInert()
+  syncPageBehindModals()
   notifyStackListeners()
 }
 
@@ -58,14 +64,15 @@ export function subscribeToModalStack(listener: () => void) {
 }
 
 /**
- * Marks the app root inert while any modal is open
+ * Marks the app root inert and blurred while any modal is open
  */
-function syncAppRootInert() {
+function syncPageBehindModals() {
   const appRoot = document.getElementById(APP_ROOT_ID)
   if (!appRoot) return
 
-  if (openModalTokens.length > 0) appRoot.setAttribute('inert', '')
-  else appRoot.removeAttribute('inert')
+  const anyModalOpen = openModalTokens.length > 0
+  appRoot.toggleAttribute('inert', anyModalOpen)
+  appRoot.classList.toggle(PAGE_BEHIND_MODAL_CLASS, anyModalOpen)
 }
 
 /**

--- a/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
@@ -99,6 +99,14 @@ export default function BudgetHistoryChart({
   const currentPeriodKey = chartData.find((point) => point.isCurrent)?.periodKey
   const [isMobile, setIsMobile] = useState(() => window.matchMedia(BUDGET_CHART_MOBILE_QUERY).matches)
 
+  // Recharts keys a bar's animation off the identity of the rectangles it computes, and that identity
+  // changes on every render, so an animated bar replays its entrance whenever anything re-renders the
+  // chart. Pointer movement re-renders it on every event, which leaves the plot repainting frame by
+  // frame for as long as the pointer keeps moving. Animation is therefore switched off as soon as the
+  // entrance has played, leaving the bars static for the rest of the chart's life
+  const [barsAnimating, setBarsAnimating] = useState(true)
+  const stopBarAnimation = () => setBarsAnimating(false)
+
   useEffect(() => {
     const mobileQuery = window.matchMedia(BUDGET_CHART_MOBILE_QUERY)
     const updateIsMobile = () => setIsMobile(mobileQuery.matches)
@@ -233,7 +241,9 @@ export default function BudgetHistoryChart({
                     />
                   )}
                   barSize={barSize}
+                  isAnimationActive={barsAnimating}
                   animationBegin={MODAL_SURFACE_TRANSITION_MS}
+                  onAnimationEnd={stopBarAnimation}
                 />
               )) : (
                 <Bar
@@ -249,7 +259,9 @@ export default function BudgetHistoryChart({
                     />
                   )}
                   barSize={barSize}
+                  isAnimationActive={barsAnimating}
                   animationBegin={MODAL_SURFACE_TRANSITION_MS}
+                  onAnimationEnd={stopBarAnimation}
                 />
               )}
               <ReferenceLine

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -1614,6 +1614,20 @@
     background: #0f0e0c8f;
   }
 
+  /* The frosting behind a dialog. Both of these blur something that is inert and still for as long as the
+     dialog is open, so each is rasterized once, where a filter laid over them runs again for every frame in
+     which anything above it moves. The navigation and the page are filtered separately rather than through
+     a shared ancestor, because a filter on an ancestor would re-anchor the fixed navigation to it */
+  .app-behind-modal #app-page-content,
+  .app-behind-modal .app-desktop-nav,
+  .app-behind-modal #app-mobile-navigation-toggle {
+    filter: blur(4px);
+  }
+
+  .app-modal-panel-covered {
+    filter: blur(10px);
+  }
+
   .app-modal-panel {
     @apply rounded-2xl;
     background: var(--app-bg);

--- a/frontend/src/utils/tooltipPosition.ts
+++ b/frontend/src/utils/tooltipPosition.ts
@@ -16,6 +16,12 @@ type ApplyCursorTooltipPositionOptions = CursorTooltipPositionOptions & {
   yProperty: string
 }
 
+// Above every modal level the modal shell uses, which reaches 100 for a modal opened from another
+// modal. A tooltip belonging to a chart inside a modal is portalled into the body beside the modal
+// rather than into the panel, so at an equal level whichever of the two React appended last would
+// paint on top, and the tooltip could end up underneath the panel it belongs to
+export const CURSOR_TOOLTIP_Z_INDEX = 110
+
 const DEFAULT_CURSOR_TOOLTIP_OFFSET = 10
 const DEFAULT_CURSOR_TOOLTIP_MARGIN = 8
 const DEFAULT_CURSOR_TOOLTIP_STRATEGY: CursorTooltipPositionStrategy = 'fixed'
@@ -94,7 +100,7 @@ export function applyCursorTooltipPosition({
 }: ApplyCursorTooltipPositionOptions) {
   const position = getCursorTooltipPosition({ tooltip, ...options })
   tooltip.style.position = options.strategy ?? DEFAULT_CURSOR_TOOLTIP_STRATEGY
-  tooltip.style.zIndex = '60'
+  tooltip.style.zIndex = String(CURSOR_TOOLTIP_Z_INDEX)
   tooltip.style.setProperty('--app-cursor-tooltip-max-width', `${position.maxWidth}px`)
   tooltip.style.setProperty(xProperty, `${position.x}px`)
   tooltip.style.setProperty(yProperty, `${position.y}px`)


### PR DESCRIPTION
Opening the budget details modal showed the utilization tooltip on the first visit and then disappears forever, likely due to a regression introduced in previous fixes. Additionally, sweeping the pointer across the vertical bars caused a significant jump in GPU utilization, which is abnormal for a simple graph. This was caused by the backdrop filter on modals being in the same layer as the modal and thus was repeatedly rendered whenever the cursor moved.

This PR fixes these two issues.