### PR TITLE
Order the budget chart by spending and tracked categories by name

### DIFF
--- a/backend/app/services/budgets/response_helpers.py
+++ b/backend/app/services/budgets/response_helpers.py
@@ -6,6 +6,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.budget import BaseBudget, Budget, BudgetTrackedCategory
+from app.models.category import Category
 from app.schemas.budget import BaseBudgetResponse, BudgetResponse
 
 
@@ -19,18 +20,23 @@ async def load_tracked_categories(
         base_budget_ids: Base budget identifiers to inspect
 
     Returns:
-        Active tracked category identifiers keyed by base budget identifier
+        Active tracked category identifiers keyed by base budget identifier, each list ordered by
+        category name
     """
     if not base_budget_ids:
         return {}
 
-    # Fetch active tracked category links for the requested base budgets in one batch
+    # Fetch active tracked category links for the requested base budgets in one batch, ordered by
+    # category name so every consumer of the list reads the same order between requests
     rows = (
         await db.execute(
-            select(BudgetTrackedCategory.base_budget_id, BudgetTrackedCategory.category_id).where(
+            select(BudgetTrackedCategory.base_budget_id, BudgetTrackedCategory.category_id)
+            .join(Category, Category.id == BudgetTrackedCategory.category_id)
+            .where(
                 BudgetTrackedCategory.base_budget_id.in_(base_budget_ids),
                 BudgetTrackedCategory.removed_at.is_(None),
-            ),
+            )
+            .order_by(Category.name, BudgetTrackedCategory.category_id),
         )
     ).all()
     result: dict[uuid.UUID, list[uuid.UUID]] = {}

--- a/backend/tests/routes/base_budgets/test_retrieval.py
+++ b/backend/tests/routes/base_budgets/test_retrieval.py
@@ -187,6 +187,25 @@ async def test_get_base_budget_excludes_soft_deleted_categories(client):
     assert resp.json()["category_ids"] == [cat_keep]
 
 
+async def test_get_base_budget_orders_categories_by_name(client):
+    """GET returns tracked categories ordered by category name, not by the order they were sent."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    cat_water = await _create_category(client, headers, name="Test Water")
+    cat_electricity = await _create_category(client, headers, name="Test Electricity")
+    cat_gas = await _create_category(client, headers, name="Test Gas")
+    create_resp = await _create_base_budget(
+        client, headers, category_ids=[cat_water, cat_gas, cat_electricity],
+    )
+    base_budget_id = create_resp.json()["id"]
+
+    resp = await client.get(f"/base-budgets/{base_budget_id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["category_ids"] == [cat_electricity, cat_gas, cat_water]
+
+
 async def test_get_base_budget_unauthenticated_returns_401(client):
     """Getting a base budget without auth returns 401."""
     resp = await client.get(f"/base-budgets/{NONEXISTENT_ID}")

--- a/frontend/src/pages/budgets/components/budget-details-modal/Modal.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/Modal.tsx
@@ -64,14 +64,6 @@ export default function BudgetDetailsModal({
     () => new Map(categories.map((category) => [category.id, category])),
     [categories],
   )
-  const chartCategories = useMemo(
-    () => getBudgetChartCategories({ baseBudget, categoryById, categoryDetailsById }),
-    [baseBudget, categoryById, categoryDetailsById],
-  )
-  const categoryColorById = useMemo(
-    () => new Map(chartCategories.map((category) => [category.id, category.color])),
-    [chartCategories],
-  )
   const sortedPeriods = useMemo(() => getSortedBudgetPeriods(periods), [periods])
   const latestPeriod = sortedPeriods[sortedPeriods.length - 1]
   const utilizationQuery = useBaseBudgetUtilizations(baseBudget.id)
@@ -82,6 +74,16 @@ export default function BudgetDetailsModal({
   const utilizationHistoryLoading = utilizationQuery.isLoading
   const utilizationHistoryError = utilizationQuery.isError
   const latestUtilization = latestPeriod ? utilizationByBudgetId.get(latestPeriod.id) : undefined
+
+  // Declared after the latest utilization because the chart's stack order ranks on that period's spending
+  const chartCategories = useMemo(
+    () => getBudgetChartCategories({ baseBudget, categoryById, categoryDetailsById, latestUtilization }),
+    [baseBudget, categoryById, categoryDetailsById, latestUtilization],
+  )
+  const categoryColorById = useMemo(
+    () => new Map(chartCategories.map((category) => [category.id, category.color])),
+    [chartCategories],
+  )
   const utilizationHistoryFxStatus = combineFxStatuses(
     sortedPeriods.map((period) => utilizationByBudgetId.get(period.id)?.fx_status),
   )

--- a/frontend/src/pages/budgets/utils/budgetDetails.ts
+++ b/frontend/src/pages/budgets/utils/budgetDetails.ts
@@ -69,17 +69,32 @@ export function getBudgetUtilizationByBudgetId(
 }
 
 /**
- * Builds category metadata and deterministic colours for the budget details utilization chart
+ * Builds category metadata and deterministic colours for the budget details utilization chart,
+ * ordered by the latest period's spending from highest to lowest
+ *
+ * This one order serves the whole chart: recharts stacks the categories in the order they are
+ * declared, bottom first, so the biggest current spender sits at the base of every bar, and the
+ * tooltip walks the same array, so it lists that category first. A period whose ranking differs
+ * from the latest one still draws in this order, since a category cannot change stack position
+ * from bar to bar
+ *
+ * The tracked categories of a budget with no spending yet are all tied at zero, so name and then
+ * ID break ties and keep the order from drifting between loads
  */
 export function getBudgetChartCategories({
   baseBudget,
   categoryById,
   categoryDetailsById,
+  latestUtilization,
 }: {
   baseBudget: BaseBudget
   categoryById: Map<string, string>
   categoryDetailsById: Map<string, Category>
+  latestUtilization: BudgetUtilization | undefined
 }): BudgetChartCategory[] {
+  const latestSpentByCategoryId = new Map(
+    (latestUtilization?.categories ?? []).map((category) => [category.category_id, category.spent]),
+  )
   const trackedCategories = baseBudget.category_ids.map((categoryId) => {
     const category = categoryDetailsById.get(categoryId)
 
@@ -88,6 +103,12 @@ export function getBudgetChartCategories({
       name: category?.name ?? categoryById.get(categoryId) ?? 'Uncategorized',
       kind: category?.kind ?? 'expense',
     }
+  }).sort((a, b) => {
+    // A category the latest period never spent against ranks alongside one that spent nothing
+    const spendDifference = (latestSpentByCategoryId.get(b.id) ?? 0) - (latestSpentByCategoryId.get(a.id) ?? 0)
+    if (spendDifference !== 0) return spendDifference
+
+    return a.name.localeCompare(b.name) || a.id.localeCompare(b.id)
   })
   const categoryColors = getCategoryColorMap(trackedCategories)
 

--- a/frontend/tests/budgets/budgetDetails.test.ts
+++ b/frontend/tests/budgets/budgetDetails.test.ts
@@ -128,7 +128,12 @@ describe('budget details helpers', () => {
       ['groceries', createCategory({ id: 'groceries', name: 'Groceries' })],
     ])
 
-    expect(getBudgetChartCategories({ baseBudget, categoryById, categoryDetailsById: categories })).toMatchObject([
+    expect(getBudgetChartCategories({
+      baseBudget,
+      categoryById,
+      categoryDetailsById: categories,
+      latestUtilization: undefined,
+    })).toMatchObject([
       {
         id: 'groceries',
         name: 'Groceries',
@@ -142,6 +147,81 @@ describe('budget details helpers', () => {
         dataKey: 'categoryPct1',
       },
     ])
+  })
+
+  it('orders chart categories by the latest period spending, highest first', () => {
+    const baseBudget = createBaseBudget({ category_ids: ['water', 'electricity', 'gas'] })
+    const categories = new Map([
+      ['water', createCategory({ id: 'water', name: 'Water' })],
+      ['electricity', createCategory({ id: 'electricity', name: 'Electricity' })],
+      ['gas', createCategory({ id: 'gas', name: 'Gas' })],
+    ])
+    const latestUtilization = createUtilization({
+      categories: [
+        { category_id: 'water', spent: 6000 },
+        { category_id: 'electricity', spent: 20000 },
+      ],
+    })
+
+    const chartCategories = getBudgetChartCategories({
+      baseBudget,
+      categoryById: new Map(),
+      categoryDetailsById: categories,
+      latestUtilization,
+    })
+
+    // Gas has no spending row at all, so it ranks with the zero spenders rather than being dropped
+    expect(chartCategories.map((category) => category.id)).toEqual(['electricity', 'water', 'gas'])
+    expect(chartCategories.map((category) => category.dataKey)).toEqual(['categoryPct0', 'categoryPct1', 'categoryPct2'])
+  })
+
+  it('orders equally spending chart categories by name and then ID', () => {
+    const baseBudget = createBaseBudget({ category_ids: ['water-b', 'transit', 'water-a'] })
+    const categories = new Map([
+      ['water-b', createCategory({ id: 'water-b', name: 'Water' })],
+      ['transit', createCategory({ id: 'transit', name: 'Transit' })],
+      ['water-a', createCategory({ id: 'water-a', name: 'Water' })],
+    ])
+    const latestUtilization = createUtilization({
+      categories: [
+        { category_id: 'water-b', spent: 4000 },
+        { category_id: 'transit', spent: 4000 },
+        { category_id: 'water-a', spent: 4000 },
+      ],
+    })
+
+    const chartCategories = getBudgetChartCategories({
+      baseBudget,
+      categoryById: new Map(),
+      categoryDetailsById: categories,
+      latestUtilization,
+    })
+
+    expect(chartCategories.map((category) => category.id)).toEqual(['transit', 'water-a', 'water-b'])
+  })
+
+  it('keeps a budget with no spending in a stable order whatever order the API returns', () => {
+    const categories = new Map([
+      ['water', createCategory({ id: 'water', name: 'Water' })],
+      ['electricity', createCategory({ id: 'electricity', name: 'Electricity' })],
+    ])
+    const latestUtilization = createUtilization({ total_spent: 0, categories: [] })
+
+    const firstLoad = getBudgetChartCategories({
+      baseBudget: createBaseBudget({ category_ids: ['water', 'electricity'] }),
+      categoryById: new Map(),
+      categoryDetailsById: categories,
+      latestUtilization,
+    })
+    const secondLoad = getBudgetChartCategories({
+      baseBudget: createBaseBudget({ category_ids: ['electricity', 'water'] }),
+      categoryById: new Map(),
+      categoryDetailsById: categories,
+      latestUtilization,
+    })
+
+    expect(firstLoad.map((category) => category.id)).toEqual(['electricity', 'water'])
+    expect(secondLoad.map((category) => category.id)).toEqual(['electricity', 'water'])
   })
 
   it('seeds latest utilization before historical query results override by budget ID', () => {


### PR DESCRIPTION
The budget chart's stacked segments and its tooltip could come back in a different order on every load, because the tracked categories arrived in whatever order Postgres returned them. They now follow the order the chart was designed around, biggest current spender at the bottom of the bar.

- The chart orders its categories by the latest period's spending, highest first, so the biggest spender sits at the bottom of every bar and is listed first in the tooltip
- Categories that spent the same amount, which on a budget with no spending yet means all of them, fall back to category name and then ID, so the order holds between loads
- The API returns tracked categories ordered by category name, so the budget card shows the same categories in the same order on every load
