### PR TITLE
Stop internal transfers counting against contribution limits

### DIFF
--- a/backend/alembic/versions/316916eab402_add_system_merchants.py
+++ b/backend/alembic/versions/316916eab402_add_system_merchants.py
@@ -1,0 +1,96 @@
+"""add system merchants
+
+Revision ID: 316916eab402
+Revises: cbf7ada87de3
+Create Date: 2026-07-31 18:30:47.330268
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "316916eab402"
+down_revision: str | Sequence[str] | None = "cbf7ada87de3"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_SYSTEM_MERCHANT_NAME = "Myself"
+
+
+def upgrade() -> None:
+    """Let a merchant ship with the app, and fold everyone's own Myself into the seeded one"""
+    op.add_column("merchants", sa.Column("is_system", sa.Boolean(), nullable=False, server_default="false"))
+
+    # A system merchant belongs to nobody, so the owner it has always required becomes optional
+    op.alter_column("merchants", "owner_id", existing_type=sa.UUID(), nullable=True)
+    op.create_check_constraint(
+        "ck_merchants_scope",
+        "merchants",
+        """
+        (
+            is_system = true
+            AND owner_id IS NULL
+            AND group_id IS NULL
+        )
+        OR (
+            is_system = false
+            AND owner_id IS NOT NULL
+        )
+        """,
+    )
+    op.create_index(
+        "uq_merchant_system_name", "merchants", ["name"],
+        unique=True, postgresql_where=sa.text("is_system = true"),
+    )
+
+    # Seeded here rather than left to the seed script, because the fold below needs it to exist and
+    # migrations run before seeding
+    op.execute(
+        sa.text(
+            "INSERT INTO merchants (id, owner_id, group_id, name, is_system) "
+            "VALUES (gen_random_uuid(), NULL, NULL, :name, true)",
+        ).bindparams(name=_SYSTEM_MERCHANT_NAME),
+    )
+
+    # Everyone who typed their own Myself keeps their transactions, now pointing at the shared one.
+    # Matched without regard to capitalisation, since "myself" and "MYSELF" are the same intent and
+    # would otherwise be left behind unable to be renamed onto the name this reserves
+    op.execute(
+        sa.text(
+            "UPDATE transactions SET merchant_id = ("
+            "  SELECT id FROM merchants WHERE is_system = true AND name = :name"
+            ") WHERE merchant_id IN ("
+            "  SELECT id FROM merchants WHERE is_system = false AND lower(name) = lower(:name)"
+            ")",
+        ).bindparams(name=_SYSTEM_MERCHANT_NAME),
+    )
+
+    # Any default category they had set on it goes with the row, since a shared merchant cannot
+    # carry one person's default
+    op.execute(
+        sa.text(
+            "DELETE FROM merchants WHERE is_system = false AND lower(name) = lower(:name)",
+        ).bindparams(name=_SYSTEM_MERCHANT_NAME),
+    )
+
+
+def downgrade() -> None:
+    """Remove system merchants, detaching the transactions that were folded onto them"""
+
+    # The merchants everyone had before are gone, so the transactions cannot be handed back and are
+    # left without a merchant rather than blocking the downgrade on the foreign key
+    op.execute(
+        sa.text(
+            "UPDATE transactions SET merchant_id = NULL WHERE merchant_id IN ("
+            "  SELECT id FROM merchants WHERE is_system = true"
+            ")",
+        ),
+    )
+    op.execute(sa.text("DELETE FROM merchants WHERE is_system = true"))
+
+    op.drop_index("uq_merchant_system_name", table_name="merchants", postgresql_where=sa.text("is_system = true"))
+    op.drop_constraint("ck_merchants_scope", "merchants", type_="check")
+    op.alter_column("merchants", "owner_id", existing_type=sa.UUID(), nullable=False)
+    op.drop_column("merchants", "is_system")

--- a/backend/alembic/versions/316916eab402_add_system_merchants.py
+++ b/backend/alembic/versions/316916eab402_add_system_merchants.py
@@ -93,4 +93,17 @@ def downgrade() -> None:
     op.drop_index("uq_merchant_system_name", table_name="merchants", postgresql_where=sa.text("is_system = true"))
     op.drop_constraint("ck_merchants_scope", "merchants", type_="check")
     op.alter_column("merchants", "owner_id", existing_type=sa.UUID(), nullable=False)
+
+    # PostgreSQL records a dependency from a policy to every column its expression reads, and
+    # refuses to drop one of those columns. A deployed database has the four is_system-aware
+    # policies, so they are replaced with the single ownership rule that preceded them before the
+    # column goes. The IF EXISTS covers a database still on that older rule
+    for policy in ("merchants_read", "merchants_insert", "merchants_update", "merchants_delete", "merchants_access"):
+        op.execute(sa.text(f"DROP POLICY IF EXISTS {policy} ON public.merchants"))
+    op.execute(sa.text(
+        "CREATE POLICY merchants_access ON public.merchants"
+        " USING (owner_id = public.current_user_id() OR public.can_access_group(group_id))"
+        " WITH CHECK (owner_id = public.current_user_id() OR public.can_access_group(group_id))",
+    ))
+
     op.drop_column("merchants", "is_system")

--- a/backend/alembic/versions/cbf7ada87de3_add_the_transfer_other_account_and_.py
+++ b/backend/alembic/versions/cbf7ada87de3_add_the_transfer_other_account_and_.py
@@ -1,0 +1,71 @@
+"""add the transfer other account and internal transfer counting
+
+Revision ID: cbf7ada87de3
+Revises: b60d4ea6d7e2
+Create Date: 2026-07-31 16:19:48.406792
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision: str = "cbf7ada87de3"
+down_revision: str | Sequence[str] | None = "b60d4ea6d7e2"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Record the other side of a transfer, and whether a category counts its own internal ones"""
+
+    # Existing categories take the new behaviour, which leaves internal transfers out of the totals
+    op.add_column(
+        "tax_advantaged_categories",
+        sa.Column("counts_internal_transfers", sa.Boolean(), nullable=False, server_default="false"),
+    )
+
+    # Created explicitly, since adding a column typed with an enum does not build the type
+    other_account_scope = postgresql.ENUM(
+        "TRACKED", "OUTSIDE", name="transferotheraccountscope", create_type=False,
+    )
+    other_account_scope.create(op.get_bind(), checkfirst=True)
+
+    # Both columns stay empty on every transaction predating them, which reads as unanswered
+    op.add_column("transactions", sa.Column("other_account_id", sa.Uuid(), nullable=True))
+    op.add_column("transactions", sa.Column("other_account_scope", other_account_scope, nullable=True))
+    op.create_index(op.f("ix_transactions_other_account_id"), "transactions", ["other_account_id"], unique=False)
+
+    # Restricting rather than cascading, since a transfer in another account keeps its own row
+    # when the account it records is deleted
+    op.create_foreign_key(
+        "fk_transactions_other_account_id_accounts",
+        "transactions",
+        "accounts",
+        ["other_account_id"],
+        ["id"],
+        ondelete="RESTRICT",
+    )
+
+    # Null-safe on both sides, so an account recorded without a scope is rejected rather than
+    # passing on an unknown comparison
+    op.create_check_constraint(
+        "ck_transactions_other_account_scope_matches_id",
+        "transactions",
+        "(other_account_id IS NOT NULL) = (other_account_scope IS NOT DISTINCT FROM 'TRACKED')",
+    )
+
+
+def downgrade() -> None:
+    """Drop both transfer columns, their constraints, and the internal transfer setting"""
+    op.drop_constraint("ck_transactions_other_account_scope_matches_id", "transactions", type_="check")
+    op.drop_constraint("fk_transactions_other_account_id_accounts", "transactions", type_="foreignkey")
+    op.drop_index(op.f("ix_transactions_other_account_id"), table_name="transactions")
+    op.drop_column("transactions", "other_account_scope")
+    op.drop_column("transactions", "other_account_id")
+    op.drop_column("tax_advantaged_categories", "counts_internal_transfers")
+
+    # Dropping the column leaves the enum type behind, so it goes explicitly
+    postgresql.ENUM(name="transferotheraccountscope").drop(op.get_bind(), checkfirst=True)

--- a/backend/alembic/versions/cbf7ada87de3_add_the_transfer_other_account_and_.py
+++ b/backend/alembic/versions/cbf7ada87de3_add_the_transfer_other_account_and_.py
@@ -38,15 +38,19 @@ def upgrade() -> None:
     op.add_column("transactions", sa.Column("other_account_scope", other_account_scope, nullable=True))
     op.create_index(op.f("ix_transactions_other_account_id"), "transactions", ["other_account_id"], unique=False)
 
-    # Restricting rather than cascading, since a transfer in another account keeps its own row
-    # when the account it records is deleted
+    # Refusing rather than cascading, since a transfer in another account keeps its own row when
+    # the account it records is deleted. Deferred to the commit, because deleting a group cascades
+    # into its accounts and their transactions in one statement and an immediate check fires or
+    # not depending on which physical row it reaches first
     op.create_foreign_key(
         "fk_transactions_other_account_id_accounts",
         "transactions",
         "accounts",
         ["other_account_id"],
         ["id"],
-        ondelete="RESTRICT",
+        ondelete="NO ACTION",
+        deferrable=True,
+        initially="DEFERRED",
     )
 
     # Null-safe on both sides, so an account recorded without a scope is rejected rather than

--- a/backend/app/db/rls/policies.py
+++ b/backend/app/db/rls/policies.py
@@ -202,8 +202,9 @@ def _secure_merchants(connection: Connection) -> None:
     """Enable RLS on merchants, keeping system rows readable but app-immutable"""
     owned = f"owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)"
 
-    # The bootstrap migration replays this against a database from before is_system existed, so
-    # the ownership-only rule stands in until the migration that adds the column re-applies these
+    # The bootstrap migration replays this against a database from before is_system existed, so the
+    # ownership-only rule stands in there. Nothing in the migration chain corrects it: the deploy
+    # re-applies these policies after migrating, which is when the system rows become readable
     if not _column_exists(connection, "merchants", "is_system"):
         _secure_table(connection, "merchants", owned, owned)
         return

--- a/backend/app/db/rls/policies.py
+++ b/backend/app/db/rls/policies.py
@@ -50,8 +50,6 @@ SECURED_TABLES = (
      f"user_id = {CURRENT_USER_ID}() AND {CAN_ACCESS_ACCOUNT}(account_id)"),
     ("saved_insights_ranges", f"user_id = {CURRENT_USER_ID}()", f"user_id = {CURRENT_USER_ID}()"),
     ("users", f"id = {CURRENT_USER_ID}()", f"id = {CURRENT_USER_ID}()"),
-    ("merchants", f"owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)",
-     f"owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)"),
     ("tags", f"owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)",
      f"owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)"),
     ("tax_advantaged_categories",
@@ -100,6 +98,7 @@ def apply_policies(connection: Connection) -> None:
             continue
         _secure_table(connection, table, using_expr, check_expr)
     _secure_categories(connection)
+    _secure_merchants(connection)
     _secure_groups(connection)
 
     for table in GLOBAL_READ_TABLES:
@@ -122,6 +121,17 @@ def _table_exists(connection: Connection, table: str) -> bool:
     """Whether a public table is already present in the database"""
     return connection.execute(
         text("SELECT to_regclass(:qualified)"), {"qualified": f"public.{table}"}
+    ).scalar() is not None
+
+
+def _column_exists(connection: Connection, table: str, column: str) -> bool:
+    """Whether a column is already present on a public table"""
+    return connection.execute(
+        text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = 'public' AND table_name = :table AND column_name = :column"
+        ),
+        {"table": table, "column": column},
     ).scalar() is not None
 
 
@@ -186,6 +196,30 @@ def _secure_categories(connection: Connection) -> None:
     connection.execute(text(f"CREATE POLICY categories_update ON public.categories FOR UPDATE USING ({scoped}) WITH CHECK ({scoped})"))
     connection.execute(text(f"CREATE POLICY categories_delete ON public.categories FOR DELETE USING ({scoped})"))
     connection.execute(text(f'GRANT {APP_TABLE_PRIVILEGES} ON public.categories TO "{APP_DB_USER}"'))
+
+
+def _secure_merchants(connection: Connection) -> None:
+    """Enable RLS on merchants, keeping system rows readable but app-immutable"""
+    owned = f"owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)"
+
+    # The bootstrap migration replays this against a database from before is_system existed, so
+    # the ownership-only rule stands in until the migration that adds the column re-applies these
+    if not _column_exists(connection, "merchants", "is_system"):
+        _secure_table(connection, "merchants", owned, owned)
+        return
+
+    connection.execute(text("ALTER TABLE public.merchants ENABLE ROW LEVEL SECURITY"))
+    connection.execute(text(
+        f"CREATE POLICY merchants_read ON public.merchants FOR SELECT USING (is_system OR {owned})"
+    ))
+
+    # System merchants are seeded by the migrator, so the app role can only write
+    # its own personal or group merchants
+    scoped = f"(owner_id = {CURRENT_USER_ID}() OR {CAN_ACCESS_GROUP}(group_id)) AND NOT is_system"
+    connection.execute(text(f"CREATE POLICY merchants_insert ON public.merchants FOR INSERT WITH CHECK ({scoped})"))
+    connection.execute(text(f"CREATE POLICY merchants_update ON public.merchants FOR UPDATE USING ({scoped}) WITH CHECK ({scoped})"))
+    connection.execute(text(f"CREATE POLICY merchants_delete ON public.merchants FOR DELETE USING ({scoped})"))
+    connection.execute(text(f'GRANT {APP_TABLE_PRIVILEGES} ON public.merchants TO "{APP_DB_USER}"'))
 
 
 def _secure_groups(connection: Connection) -> None:

--- a/backend/app/models/account.py
+++ b/backend/app/models/account.py
@@ -105,6 +105,15 @@ class TaxAdvantagedCategory(Base):
         default=0,
         server_default="0",
     )
+
+    # Whether a transfer with both sides on accounts linked to this category counts toward its
+    # contribution and withdrawal limits. False leaves it out of both totals
+    counts_internal_transfers: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+    )
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
 
 

--- a/backend/app/models/base.py
+++ b/backend/app/models/base.py
@@ -102,6 +102,19 @@ class CategoryKind(enum.StrEnum):
     TRANSFER = "transfer"
 
 
+class TransferOtherAccountScope(enum.StrEnum):
+    """Where the other side of a transfer sits
+
+    Recorded on the transfer transaction itself rather than derived from a
+    partner row, because the two sides of one movement are entered days apart
+    as the money actually arrives. A null column means nothing was recorded,
+    which is every transaction predating the column
+    """
+
+    TRACKED = "tracked"  # An account in the app, held in other_account_id
+    OUTSIDE = "outside"  # Money that left the tracked accounts
+
+
 class RecurrenceFreq(enum.StrEnum):
     """Budget recurrence frequency values"""
 

--- a/backend/app/models/merchant.py
+++ b/backend/app/models/merchant.py
@@ -3,17 +3,33 @@
 import uuid
 from datetime import datetime
 
-from sqlalchemy import VARCHAR, DateTime, ForeignKey, Index, UniqueConstraint, func, text
+from sqlalchemy import VARCHAR, Boolean, CheckConstraint, DateTime, ForeignKey, Index, UniqueConstraint, func, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
 
 
 class Merchant(Base):
-    """Merchant registry — stores, employers, people, or anything that sends/receives money."""
+    """Merchant registry: stores, employers, people, or anything that sends or receives money."""
 
     __tablename__ = "merchants"
     __table_args__ = (
+        # The same three scopes categories carry: owned by nobody when it ships with the app,
+        # otherwise by exactly one of a user or a group
+        CheckConstraint(
+            """
+            (
+                is_system = true
+                AND owner_id IS NULL
+                AND group_id IS NULL
+            )
+            OR (
+                is_system = false
+                AND owner_id IS NOT NULL
+            )
+            """,
+            name="ck_merchants_scope",
+        ),
         # Personal merchants: unique per user (only when not group-scoped)
         Index(
             "uq_merchant_owner_name", "owner_id", "name",
@@ -21,11 +37,20 @@ class Merchant(Base):
         ),
         # Group merchants: unique per group
         UniqueConstraint("group_id", "name", name="uq_merchant_group_name"),
+        # One merchant per name across the whole app, so a second Myself cannot be seeded
+        Index(
+            "uq_merchant_system_name", "name",
+            unique=True, postgresql_where=text("is_system = true"),
+        ),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
-    owner_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)
+    owner_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("users.id"))  # Null on system merchants
     group_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("groups.id", ondelete="CASCADE"))
     name: Mapped[str] = mapped_column(VARCHAR(256), nullable=False)
+
+    # Ships with the app and belongs to everyone, so it cannot be renamed, deleted, or given a
+    # default category, which lives on the merchant and would otherwise be shared by every user
+    is_system: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
     default_category_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("categories.id"))  # Auto-categorization hint
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -34,9 +34,16 @@ class Transaction(Base):
     notes: Mapped[str | None] = mapped_column(Text)
 
     # The account on the other side of a transfer. Recording it creates no transaction there and
-    # moves no balance, so deleting that account must leave this row alone rather than cascade
+    # moves no balance, so deleting that account has to be refused rather than cascade here.
+    #
+    # Deferred to the commit rather than checked per row, because deleting a group cascades into
+    # its accounts and their transactions in one statement, and an immediate check fires or not
+    # depending on which physical row the cascade reaches first. RESTRICT cannot be deferred at
+    # all, so the refusal comes from NO ACTION at the end of the transaction, by which point a
+    # cascade that removed both sides together leaves nothing to complain about
     other_account_id: Mapped[uuid.UUID | None] = mapped_column(
-        ForeignKey("accounts.id", ondelete="RESTRICT"), index=True,
+        ForeignKey("accounts.id", ondelete="NO ACTION", deferrable=True, initially="DEFERRED"),
+        index=True,
     )
     other_account_scope: Mapped[TransferOtherAccountScope | None] = mapped_column()
 

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -3,16 +3,24 @@
 import uuid
 from datetime import date, datetime
 
-from sqlalchemy import VARCHAR, BigInteger, Date, DateTime, ForeignKey, Numeric, Text, func
+from sqlalchemy import VARCHAR, BigInteger, CheckConstraint, Date, DateTime, ForeignKey, Numeric, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
-from app.models.base import Base
+from app.models.base import Base, TransferOtherAccountScope
 
 
 class Transaction(Base):
     """Core ledger: positive amount = inflow, negative = outflow. Transfers are two independent rows."""
 
     __tablename__ = "transactions"
+    __table_args__ = (
+        # Null-safe on both sides, so an account recorded without a scope is rejected rather
+        # than passing on an unknown comparison
+        CheckConstraint(
+            "(other_account_id IS NOT NULL) = (other_account_scope IS NOT DISTINCT FROM 'TRACKED')",
+            name="ck_transactions_other_account_scope_matches_id",
+        ),
+    )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
     created_by_user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)  # Audit trail
@@ -24,5 +32,13 @@ class Transaction(Base):
     currency: Mapped[str] = mapped_column(VARCHAR(3), ForeignKey("currencies.id"), nullable=False)
     fx_rate: Mapped[float | None] = mapped_column(Numeric)  # Exchange rate to account currency
     notes: Mapped[str | None] = mapped_column(Text)
+
+    # The account on the other side of a transfer. Recording it creates no transaction there and
+    # moves no balance, so deleting that account must leave this row alone rather than cascade
+    other_account_id: Mapped[uuid.UUID | None] = mapped_column(
+        ForeignKey("accounts.id", ondelete="RESTRICT"), index=True,
+    )
+    other_account_scope: Mapped[TransferOtherAccountScope | None] = mapped_column()
+
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -26,7 +26,8 @@ class Transaction(Base):
     created_by_user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)  # Audit trail
     account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False)
     dt: Mapped[date] = mapped_column(Date, nullable=False)
-    # Null only on a transfer recorded before every transaction was required to carry a merchant
+    # The create and edit routes require one, so this is null only on a transaction recorded before
+    # that rule or brought in by an import whose file named no payee
     merchant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("merchants.id"), index=True)
     category_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("categories.id"), nullable=False)
     amount: Mapped[int] = mapped_column(BigInteger, nullable=False)  # In currency base units

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -26,7 +26,8 @@ class Transaction(Base):
     created_by_user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), nullable=False)  # Audit trail
     account_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("accounts.id", ondelete="CASCADE"), nullable=False)
     dt: Mapped[date] = mapped_column(Date, nullable=False)
-    merchant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("merchants.id"), index=True)  # Null for transfers
+    # Null only on a transfer recorded before every transaction was required to carry a merchant
+    merchant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("merchants.id"), index=True)
     category_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("categories.id"), nullable=False)
     amount: Mapped[int] = mapped_column(BigInteger, nullable=False)  # In currency base units
     currency: Mapped[str] = mapped_column(VARCHAR(3), ForeignKey("currencies.id"), nullable=False)

--- a/backend/app/routes/accounts/balance_adjustment_helpers.py
+++ b/backend/app/routes/accounts/balance_adjustment_helpers.py
@@ -9,9 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.account import Account
 from app.models.base import CategoryKind
 from app.models.category import Category
+from app.models.merchant import Merchant
 from app.models.transaction import Transaction
 from app.models.user import User
 from app.services.accounts.snapshots import get_current_balances, recompute_snapshots_from
+from app.services.merchants.defaults import SELF_MERCHANT_NAME
 
 _BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
 _STARTING_BALANCE_NOTE = "Starting balance"
@@ -43,6 +45,7 @@ async def add_account_starting_balance_adjustment(
         account_id=account.id,
         dt=adjustment_date,
         category_id=await _get_system_balance_adjustment_category_id(db),
+        merchant_id=await _get_self_merchant_id(db),
         amount=amount,
         currency=account.currency,
         fx_rate=None,
@@ -78,6 +81,7 @@ async def zero_account_balance_for_archive(
         account_id=account.id,
         dt=archive_date,
         category_id=await _get_system_balance_adjustment_category_id(db),
+        merchant_id=await _get_self_merchant_id(db),
         amount=-current_balance,
         currency=account.currency,
         fx_rate=None,
@@ -85,6 +89,33 @@ async def zero_account_balance_for_archive(
     ))
     await db.flush()
     await recompute_snapshots_from(db, account.id, archive_date)
+
+
+async def _get_self_merchant_id(db: AsyncSession) -> uuid.UUID:
+    """Return the shared Myself merchant identifier
+
+    Args:
+        db: Active database session
+
+    Returns:
+        Myself merchant identifier
+
+    Raises:
+        HTTPException: Myself merchant is not configured
+    """
+    # Fetch the merchant the app attributes its own balance adjustments to
+    merchant_id = await db.scalar(
+        select(Merchant.id).where(
+            Merchant.is_system.is_(True),
+            Merchant.name == SELF_MERCHANT_NAME,
+        ),
+    )
+    if merchant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Myself merchant is not configured",
+        )
+    return merchant_id
 
 
 async def _get_system_balance_adjustment_category_id(db: AsyncSession) -> uuid.UUID:

--- a/backend/app/routes/accounts/balance_adjustment_helpers.py
+++ b/backend/app/routes/accounts/balance_adjustment_helpers.py
@@ -38,7 +38,7 @@ async def add_account_starting_balance_adjustment(
         adjustment_date: Date used for the adjustment transaction
 
     Raises:
-        HTTPException: Balance adjustment category is not configured
+        HTTPException: Balance adjustment category or the Myself merchant is not configured
     """
     db.add(Transaction(
         created_by_user_id=user_id,
@@ -70,7 +70,7 @@ async def zero_account_balance_for_archive(
         archive_date: Date used for the archive adjustment transaction
 
     Raises:
-        HTTPException: Balance adjustment category is not configured
+        HTTPException: Balance adjustment category or the Myself merchant is not configured
     """
     current_balance = (await get_current_balances(db, [account.id])).get(account.id, 0)
     if current_balance == 0:

--- a/backend/app/routes/accounts/deletion_helpers.py
+++ b/backend/app/routes/accounts/deletion_helpers.py
@@ -2,6 +2,8 @@
 
 import uuid
 
+from fastapi import HTTPException, status
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import PermissionLevel
@@ -22,11 +24,22 @@ async def delete_account_for_user(
         user_id: Authenticated user identifier
 
     Raises:
-        HTTPException: User does not have admin access
+        HTTPException: User does not have admin access, or transfers elsewhere record this account
     """
     account = await check_account_access(db, account_id, user_id, PermissionLevel.ADMIN)
 
     # Mark the account scope stale before deleting the account
     await mark_cache_changed_for_scope(db, user_id=account.owner_id, group_id=account.group_id)
     await db.delete(account)
-    await db.commit()
+
+    # Transfers in other accounts record this one as the other side, and the restricting foreign key
+    # rejects the delete rather than letting those rows lose what they recorded. Transactions inside
+    # this account cascade away with it and never reach here
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="This account is recorded as the other side of transfers in other accounts",
+        ) from e

--- a/backend/app/routes/categories/merge_helpers.py
+++ b/backend/app/routes/categories/merge_helpers.py
@@ -17,6 +17,7 @@ from app.routes.categories.access_helpers import (
 )
 from app.routes.categories.scope_filter_helpers import get_system_or_personal_category_filter
 from app.services.cache_state import mark_cache_changed_for_scope
+from app.services.transactions.validation import does_category_record_other_account
 
 
 async def get_merge_replacement_category(
@@ -72,15 +73,16 @@ async def get_merge_replacement_category(
 async def move_category_references(
     db: AsyncSession,
     source_category_id: uuid.UUID,
-    replacement_category_id: uuid.UUID,
+    replacement: Category,
 ) -> None:
     """Move category references from a source category to a replacement
 
     Args:
         db: Active database session
         source_category_id: Category being merged away
-        replacement_category_id: Category receiving the references
+        replacement: Category receiving the references
     """
+    replacement_category_id = replacement.id
     replacement_tracked_category = aliased(BudgetTrackedCategory)
 
     # Delete duplicate tracked-category rows before moving source references to the replacement
@@ -96,11 +98,18 @@ async def move_category_references(
         ),
     )
 
-    # Move source transactions to the replacement category
+    # Move source transactions to the replacement category. Merging into a category with no other
+    # side, which the matching-kind rule narrows to Balance Adjustment, drops the recorded account
+    # along the way, the same as editing one transaction onto that category does
+    transaction_values: dict[str, object] = {"category_id": replacement_category_id}
+    if not does_category_record_other_account(replacement):
+        transaction_values["other_account_id"] = None
+        transaction_values["other_account_scope"] = None
+
     await db.execute(
         sa.update(Transaction)
         .where(Transaction.category_id == source_category_id)
-        .values(category_id=replacement_category_id),
+        .values(**transaction_values),
     )
 
     # Move merchant default categories from the source category to the replacement
@@ -141,7 +150,7 @@ async def merge_category_into_replacement_for_user(
 
     await require_group_category_admin(db, category, user_id)
     replacement = await get_merge_replacement_category(db, category, replacement_category_id, user_id)
-    await move_category_references(db, category.id, replacement.id)
+    await move_category_references(db, category.id, replacement)
     await mark_cache_changed_for_scope(db, user_id=category.owner_id, group_id=category.group_id)
 
     # Delete the source category after all category references point to the replacement

--- a/backend/app/routes/categories/merge_helpers.py
+++ b/backend/app/routes/categories/merge_helpers.py
@@ -17,7 +17,7 @@ from app.routes.categories.access_helpers import (
 )
 from app.routes.categories.scope_filter_helpers import get_system_or_personal_category_filter
 from app.services.cache_state import mark_cache_changed_for_scope
-from app.services.transactions.validation import does_category_record_other_account
+from app.services.categories.transfer_rules import does_category_record_other_account
 
 
 async def get_merge_replacement_category(

--- a/backend/app/routes/groups/deletion_helpers.py
+++ b/backend/app/routes/groups/deletion_helpers.py
@@ -4,6 +4,7 @@ import uuid
 
 from fastapi import HTTPException, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.group import GroupMember
@@ -24,7 +25,7 @@ async def delete_group_for_owner(
         user_id: Authenticated user identifier
 
     Raises:
-        HTTPException: User is not a group member or group owner
+        HTTPException: User is not a group member or group owner, or a transfer records one of its accounts
     """
     await get_group_membership_or_404(db, group_id, user_id)
     group = await get_group_or_404(db, group_id)
@@ -42,4 +43,14 @@ async def delete_group_for_owner(
 
     # Delete the group after member cache invalidations are recorded
     await db.delete(group)
-    await db.commit()
+
+    # The group's accounts go with it, so a transfer elsewhere recording one of them reaches the
+    # same restricting foreign key that refuses deleting that account on its own
+    try:
+        await db.commit()
+    except IntegrityError as e:
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="An account in this group is recorded as the other side of transfers elsewhere",
+        ) from e

--- a/backend/app/routes/merchants/access_helpers.py
+++ b/backend/app/routes/merchants/access_helpers.py
@@ -96,6 +96,22 @@ async def require_group_merchant_admin(db: AsyncSession, merchant: Merchant, use
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Admin role required")
 
 
+def require_editable_merchant(merchant: Merchant) -> None:
+    """Raise when a merchant ships with the app and so belongs to nobody to change
+
+    Args:
+        merchant: Merchant being renamed or deleted
+
+    Raises:
+        HTTPException: Merchant is a system merchant
+    """
+    if merchant.is_system:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="System merchants cannot be changed or deleted",
+        )
+
+
 async def require_merchant_name_available(
     db: AsyncSession,
     name: str,
@@ -113,11 +129,14 @@ async def require_merchant_name_available(
     Raises:
         HTTPException: Merchant name already exists in the target scope
     """
-    duplicate_query = select(Merchant).where(Merchant.name == name)
+    # A system merchant is visible to everyone, so its name is taken in every scope. Without this a
+    # user could create their own Myself beside the seeded one and see two identical entries
+    scope_filter = Merchant.is_system.is_(True)
     if group_id:
-        duplicate_query = duplicate_query.where(Merchant.group_id == group_id)
+        scope_filter = scope_filter | (Merchant.group_id == group_id)
     else:
-        duplicate_query = duplicate_query.where(Merchant.owner_id == user_id, Merchant.group_id.is_(None))
+        scope_filter = scope_filter | ((Merchant.owner_id == user_id) & Merchant.group_id.is_(None))
+    duplicate_query = select(Merchant).where(Merchant.name == name, scope_filter)
 
     # Check whether the target scope already has a merchant with the requested name
     has_duplicate = (await db.execute(duplicate_query)).scalar_one_or_none() is not None

--- a/backend/app/routes/merchants/access_helpers.py
+++ b/backend/app/routes/merchants/access_helpers.py
@@ -2,7 +2,7 @@
 import uuid
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.category import Category
@@ -136,7 +136,10 @@ async def require_merchant_name_available(
         scope_filter = scope_filter | (Merchant.group_id == group_id)
     else:
         scope_filter = scope_filter | ((Merchant.owner_id == user_id) & Merchant.group_id.is_(None))
-    duplicate_query = select(Merchant).where(Merchant.name == name, scope_filter)
+
+    # Compared without regard to capitalisation, so "myself" cannot sit beside the seeded "Myself"
+    # and read as a second merchant. Matches how the migration folded the existing ones
+    duplicate_query = select(Merchant).where(func.lower(Merchant.name) == name.lower(), scope_filter)
 
     # Check whether the target scope already has a merchant with the requested name
     has_duplicate = (await db.execute(duplicate_query)).scalar_one_or_none() is not None

--- a/backend/app/routes/merchants/access_helpers.py
+++ b/backend/app/routes/merchants/access_helpers.py
@@ -117,6 +117,7 @@ async def require_merchant_name_available(
     name: str,
     user_id: uuid.UUID,
     group_id: uuid.UUID | None,
+    exclude_merchant_id: uuid.UUID | None = None,
 ) -> None:
     """Raise a conflict response when a merchant name is already used
 
@@ -125,6 +126,7 @@ async def require_merchant_name_available(
         name: Requested merchant name
         user_id: User identifier for personal merchant scope
         group_id: Optional group identifier for group merchant scope
+        exclude_merchant_id: Merchant being renamed, left out so it cannot clash with itself
 
     Raises:
         HTTPException: Merchant name already exists in the target scope
@@ -139,10 +141,17 @@ async def require_merchant_name_available(
 
     # Compared without regard to capitalisation, so "myself" cannot sit beside the seeded "Myself"
     # and read as a second merchant. Matches how the migration folded the existing ones
-    duplicate_query = select(Merchant).where(func.lower(Merchant.name) == name.lower(), scope_filter)
+    duplicate_query = select(Merchant.id).where(func.lower(Merchant.name) == name.lower(), scope_filter)
 
-    # Check whether the target scope already has a merchant with the requested name
-    has_duplicate = (await db.execute(duplicate_query)).scalar_one_or_none() is not None
+    # A rename measures the new name against everyone else, so changing only the capitalisation of a
+    # merchant's own name does not read as a clash with itself
+    if exclude_merchant_id is not None:
+        duplicate_query = duplicate_query.where(Merchant.id != exclude_merchant_id)
+
+    # Check whether the target scope already has a merchant with the requested name. A database
+    # written before capitalisation stopped counting here can hold several merchants that differ
+    # only in capitalisation, so one match settles it rather than being the only result allowed
+    has_duplicate = (await db.execute(duplicate_query.limit(1))).first() is not None
     if has_duplicate:
         raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail="Merchant with this name already exists")
 

--- a/backend/app/routes/merchants/deletion_helpers.py
+++ b/backend/app/routes/merchants/deletion_helpers.py
@@ -6,7 +6,11 @@ from fastapi import HTTPException, status
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.routes.merchants.access_helpers import get_accessible_merchant_or_404, require_group_merchant_admin
+from app.routes.merchants.access_helpers import (
+    get_accessible_merchant_or_404,
+    require_editable_merchant,
+    require_group_merchant_admin,
+)
 from app.services.cache_state import mark_cache_changed_for_scope
 
 
@@ -28,6 +32,7 @@ async def delete_merchant_for_user(
         HTTPException: Merchant is inaccessible, admin access is missing, or merchant is referenced
     """
     merchant = await get_accessible_merchant_or_404(db, merchant_id, user_id)
+    require_editable_merchant(merchant)
     await require_group_merchant_admin(db, merchant, user_id)
 
     # Delete the merchant and let the database reject existing transaction references

--- a/backend/app/routes/merchants/listing_helpers.py
+++ b/backend/app/routes/merchants/listing_helpers.py
@@ -7,10 +7,12 @@ from datetime import date, timedelta
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.category import Category
 from app.models.merchant import Merchant
 from app.models.transaction import Transaction
 from app.routes.merchants.access_helpers import require_group_member
 from app.routes.merchants.scope_filter_helpers import get_merchant_list_scope_filter
+from app.services.categories.transfer_rules import BALANCE_ADJUSTMENT_CATEGORY_NAME
 from app.utils.sql_search_helpers import escape_like_search_text
 
 # Recent-usage window that ranks the merchant dropdown so the merchants a user
@@ -46,13 +48,23 @@ async def get_merchants_for_user(
     recent_usage_cutoff = date.today() - timedelta(days=MERCHANT_FREQUENCY_WINDOW_DAYS)
     recent_usage_count = func.count(Transaction.id)
 
+    # Balance adjustments are written by the app rather than the user, and they carry the shared
+    # Myself merchant, so counting them would let opening a few accounts push that merchant to the
+    # top of a ranking meant to reflect who the user actually transacts with
+    balance_adjustment_category_ids = select(Category.id).where(
+        Category.is_system.is_(True),
+        Category.name == BALANCE_ADJUSTMENT_CATEGORY_NAME,
+    )
+
     # Count each merchant's transactions inside the recency window, the date lives
     # in the join condition so merchants with no recent activity are kept and ranked last
     merchant_query = (
         select(Merchant)
         .outerjoin(
             Transaction,
-            (Transaction.merchant_id == Merchant.id) & (Transaction.dt >= recent_usage_cutoff),
+            (Transaction.merchant_id == Merchant.id)
+            & (Transaction.dt >= recent_usage_cutoff)
+            & Transaction.category_id.notin_(balance_adjustment_category_ids),
         )
         .where(get_merchant_list_scope_filter(user_id, group_id))
         .group_by(Merchant.id)

--- a/backend/app/routes/merchants/merge_helpers.py
+++ b/backend/app/routes/merchants/merge_helpers.py
@@ -10,6 +10,7 @@ from app.models.merchant import Merchant
 from app.models.transaction import Transaction
 from app.routes.merchants.access_helpers import (
     get_accessible_merchant_or_404,
+    require_editable_merchant,
     require_group_merchant_admin,
 )
 from app.routes.merchants.scope_filter_helpers import get_personal_merchant_filter
@@ -34,6 +35,7 @@ async def merge_merchant_into_replacement_for_user(
         HTTPException: Merchant is inaccessible, replacement is invalid, or group admin access is missing
     """
     merchant = await get_accessible_merchant_or_404(db, merchant_id, user_id)
+    require_editable_merchant(merchant)
     await require_group_merchant_admin(db, merchant, user_id)
     replacement = await get_merge_replacement_merchant(db, merchant, replacement_merchant_id, user_id)
     await move_merchant_references(db, merchant.id, replacement.id)

--- a/backend/app/routes/merchants/merge_helpers.py
+++ b/backend/app/routes/merchants/merge_helpers.py
@@ -72,11 +72,15 @@ async def get_merge_replacement_merchant(
             detail="Replacement merchant must be different",
         )
 
-    replacement_filter = Merchant.id == replacement_merchant_id
+    # A merge restamps the source's transactions onto the replacement and deletes the source, so a
+    # merchant that ships with the app is a valid destination even though it is nobody's to edit
+    scope_filter = Merchant.is_system.is_(True)
     if source_merchant.group_id is None:
-        replacement_filter = replacement_filter & get_personal_merchant_filter(user_id)
+        scope_filter = scope_filter | get_personal_merchant_filter(user_id)
     else:
-        replacement_filter = replacement_filter & (Merchant.group_id == source_merchant.group_id)
+        scope_filter = scope_filter | (Merchant.group_id == source_merchant.group_id)
+
+    replacement_filter = (Merchant.id == replacement_merchant_id) & scope_filter
 
     # Fetch a replacement merchant from the same scope as the merchant being merged
     replacement_result = await db.execute(select(Merchant).where(replacement_filter))

--- a/backend/app/routes/merchants/scope_filter_helpers.py
+++ b/backend/app/routes/merchants/scope_filter_helpers.py
@@ -59,13 +59,18 @@ def get_merchant_list_scope_filter(user_id: uuid.UUID, group_id: uuid.UUID | Non
         group_id: Optional group identifier for group merchants
 
     Returns:
-        SQLAlchemy filter matching personal merchants and optional group merchants
+        SQLAlchemy filter matching system merchants, personal merchants and optional group merchants
     """
+    # System merchants ship with the app, so every list includes them whatever scope is asked for
     if group_id is None:
-        merchant_filter = get_personal_merchant_filter(user_id)
+        merchant_filter = Merchant.is_system.is_(True) | get_personal_merchant_filter(user_id)
         return merchant_filter
 
-    merchant_filter = get_personal_merchant_filter(user_id) | (Merchant.group_id == group_id)
+    merchant_filter = (
+        Merchant.is_system.is_(True)
+        | get_personal_merchant_filter(user_id)
+        | (Merchant.group_id == group_id)
+    )
     return merchant_filter
 
 
@@ -76,11 +81,17 @@ def get_accessible_merchant_filter(user_id: uuid.UUID):
         user_id: User identifier used for personal and group access
 
     Returns:
-        SQLAlchemy filter matching personal and group merchants
+        SQLAlchemy filter matching system, personal and group merchants
     """
     membership_filter = GroupMember.user_id == user_id
 
     # Build a subquery of group memberships so merchant access can include group-scoped merchants
     group_ids = select(GroupMember.group_id).where(membership_filter).scalar_subquery()
-    merchant_filter = get_personal_merchant_filter(user_id) | (Merchant.group_id.in_(group_ids))
+
+    # System merchants ship with the app and belong to everyone, the same way system categories do
+    merchant_filter = (
+        Merchant.is_system.is_(True)
+        | get_personal_merchant_filter(user_id)
+        | (Merchant.group_id.in_(group_ids))
+    )
     return merchant_filter

--- a/backend/app/routes/merchants/update_helpers.py
+++ b/backend/app/routes/merchants/update_helpers.py
@@ -10,6 +10,7 @@ from app.models.merchant import Merchant
 from app.routes.merchants.access_helpers import (
     get_accessible_merchant_or_404,
     require_default_category_available,
+    require_editable_merchant,
     require_group_merchant_admin,
 )
 from app.schemas.merchant import UpdateMerchantRequest
@@ -39,6 +40,7 @@ async def update_merchant_for_user(
         HTTPException: Merchant is inaccessible, group admin access is missing, or merchant name already exists
     """
     merchant = await get_accessible_merchant_or_404(db, merchant_id, user_id)
+    require_editable_merchant(merchant)
     await require_group_merchant_admin(db, merchant, user_id)
 
     updates = data.model_dump(exclude_unset=True)

--- a/backend/app/routes/merchants/update_helpers.py
+++ b/backend/app/routes/merchants/update_helpers.py
@@ -12,6 +12,7 @@ from app.routes.merchants.access_helpers import (
     require_default_category_available,
     require_editable_merchant,
     require_group_merchant_admin,
+    require_merchant_name_available,
 )
 from app.schemas.merchant import UpdateMerchantRequest
 from app.services.cache_state import mark_cache_changed_for_scope
@@ -46,6 +47,11 @@ async def update_merchant_for_user(
     updates = data.model_dump(exclude_unset=True)
     if not updates:
         return merchant
+
+    # Renaming goes through the same rule as creating, so nothing can be renamed onto a name that
+    # ships with the app, or onto one already used in the same scope
+    if "name" in updates and updates["name"] != merchant.name:
+        await require_merchant_name_available(db, updates["name"], user_id, merchant.group_id)
 
     if "default_category_id" in updates and updates["default_category_id"] is not None:
         await require_default_category_available(db, user_id, merchant.group_id, updates["default_category_id"])

--- a/backend/app/routes/merchants/update_helpers.py
+++ b/backend/app/routes/merchants/update_helpers.py
@@ -49,9 +49,12 @@ async def update_merchant_for_user(
         return merchant
 
     # Renaming goes through the same rule as creating, so nothing can be renamed onto a name that
-    # ships with the app, or onto one already used in the same scope
+    # ships with the app, or onto one already used in the same scope. The merchant itself is left
+    # out of that comparison, so recapitalising its own name is still a rename it can make
     if "name" in updates and updates["name"] != merchant.name:
-        await require_merchant_name_available(db, updates["name"], user_id, merchant.group_id)
+        await require_merchant_name_available(
+            db, updates["name"], user_id, merchant.group_id, exclude_merchant_id=merchant.id,
+        )
 
     if "default_category_id" in updates and updates["default_category_id"] is not None:
         await require_default_category_available(db, user_id, merchant.group_id, updates["default_category_id"])

--- a/backend/app/routes/tax_advantaged_categories/tac_category_helpers.py
+++ b/backend/app/routes/tax_advantaged_categories/tac_category_helpers.py
@@ -154,6 +154,7 @@ def build_tac_category(
         currency=data.currency,
         lifetime_contribution_limit=data.lifetime_contribution_limit,
         accrued_contributions=data.accrued_contributions,
+        counts_internal_transfers=data.counts_internal_transfers,
     )
     return tax_advantaged_category
 

--- a/backend/app/schemas/merchant.py
+++ b/backend/app/schemas/merchant.py
@@ -10,9 +10,12 @@ class MerchantResponse(BaseModel):
     """Merchant returned by list and detail endpoints."""
 
     id: uuid.UUID
-    owner_id: uuid.UUID
+    owner_id: uuid.UUID | None  # Null on a system merchant, which belongs to everyone
     group_id: uuid.UUID | None
     name: str
+
+    # System merchants ship with the app: they cannot be renamed, deleted, or given a default category
+    is_system: bool
     default_category_id: uuid.UUID | None
     created_at: datetime
 

--- a/backend/app/schemas/tax_advantaged_category.py
+++ b/backend/app/schemas/tax_advantaged_category.py
@@ -49,6 +49,9 @@ class TaxAdvantagedCategoryResponse(BaseModel):
     currency: str
     lifetime_contribution_limit: int | None
     accrued_contributions: int
+
+    # Whether transfers with both sides inside this category count toward its limits
+    counts_internal_transfers: bool
     accrued_lifetime_contribution_limit: int | None
     current_year_contribution_limit: int | None
     current_year_withdrawal_limit: int | None
@@ -69,6 +72,7 @@ class CreateTaxAdvantagedCategoryRequest(BaseModel):
     currency: str = Field(min_length=3, max_length=3)
     lifetime_contribution_limit: int | None = Field(default=None, ge=0)
     accrued_contributions: int = Field(default=0, ge=0)
+    counts_internal_transfers: bool = False
     group_id: uuid.UUID | None = None
 
 
@@ -79,4 +83,5 @@ class UpdateTaxAdvantagedCategoryRequest(BaseModel):
     tax_treatment: str | None = None
     lifetime_contribution_limit: int | None = Field(default=None, ge=0)
     accrued_contributions: int = Field(default=0, ge=0)
+    counts_internal_transfers: bool = False
     group_id: uuid.UUID | None = None

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -5,6 +5,7 @@ from datetime import date, datetime
 
 from pydantic import BaseModel, Field
 
+from app.models.base import TransferOtherAccountScope
 from app.schemas.fx import FxStatus
 
 
@@ -78,6 +79,10 @@ class TransactionResponse(BaseModel):
     currency: str
     fx_rate: float | None
     notes: str | None
+
+    # Where the other side of a transfer sits. Both null on anything recorded before the columns existed
+    other_account_id: uuid.UUID | None = None
+    other_account_scope: TransferOtherAccountScope | None = None
     created_at: datetime
     updated_at: datetime
     tag_ids: list[uuid.UUID] = []
@@ -98,6 +103,8 @@ class CreateTransactionRequest(BaseModel):
     fx_rate: float | None = Field(None, gt=0)
     notes: str | None = None
     tag_ids: list[uuid.UUID] = []
+    other_account_id: uuid.UUID | None = None
+    other_account_scope: TransferOtherAccountScope | None = None
 
 
 class UpdateTransactionRequest(BaseModel):
@@ -111,6 +118,8 @@ class UpdateTransactionRequest(BaseModel):
     fx_rate: float | None = Field(None, gt=0)
     notes: str | None = None
     tag_ids: list[uuid.UUID] | None = None
+    other_account_id: uuid.UUID | None = None
+    other_account_scope: TransferOtherAccountScope | None = None
 
 
 class TransactionImportCreateAccount(BaseModel):

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -99,7 +99,10 @@ class CreateTransactionRequest(BaseModel):
     category_id: uuid.UUID
     amount: int
     currency: str = Field(min_length=3, max_length=3)
-    merchant_id: uuid.UUID | None = None
+
+    # Required, unlike the stored column, which stays nullable for the transactions written before
+    # this rule and for the ones an import brings in without a payee
+    merchant_id: uuid.UUID
     fx_rate: float | None = Field(None, gt=0)
     notes: str | None = None
     tag_ids: list[uuid.UUID] = []

--- a/backend/app/services/categories/transfer_rules.py
+++ b/backend/app/services/categories/transfer_rules.py
@@ -1,0 +1,36 @@
+"""Which categories record the other side of a movement
+
+The write path and the tax-advantaged totals have to agree on this: a transaction that must answer
+the question is a transaction whose answer is then read when the limits are counted. Keeping the
+rule in one place is what stops a row validating under one definition and counting under another
+"""
+
+from sqlalchemy.sql.elements import ColumnElement
+
+from app.models.base import CategoryKind
+from app.models.category import Category
+
+# The one transfer-kind category with no other side, since it corrects a stale balance rather than
+# moving money anywhere
+BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
+
+
+def does_category_record_other_account(category: Category) -> bool:
+    """Return whether transactions in a category record the account on the other side
+
+    Args:
+        category: Category row the transaction uses
+
+    Returns:
+        True for every transfer-kind category except Balance Adjustment
+    """
+    return category.kind == CategoryKind.TRANSFER and category.name != BALANCE_ADJUSTMENT_CATEGORY_NAME
+
+
+def get_records_other_account_filter() -> ColumnElement[bool]:
+    """Return the same rule as a condition for queries joined against categories
+
+    Returns:
+        SQLAlchemy condition matching every transfer-kind category except Balance Adjustment
+    """
+    return (Category.kind == CategoryKind.TRANSFER) & (Category.name != BALANCE_ADJUSTMENT_CATEGORY_NAME)

--- a/backend/app/services/importers/firefly/row_resolution.py
+++ b/backend/app/services/importers/firefly/row_resolution.py
@@ -75,6 +75,7 @@ class FireflyLeg:
         merchant_name: Optional counterparty recorded as a merchant
         notes: Optional combined description and notes text
         tag_names: Tag names applied to the transaction
+        other_account: Account on the other side, set on transfer legs only
     """
 
     account: Account
@@ -84,6 +85,7 @@ class FireflyLeg:
     merchant_name: str | None
     notes: str | None
     tag_names: list[str]
+    other_account: Account | None = None
 
 
 def resolve_firefly_row(row: FireflyTransactionRow, context: FireflyResolutionContext) -> list[FireflyLeg]:
@@ -170,6 +172,8 @@ def _resolve_transfer_pair(
     Returns:
         Outgoing and incoming transfer legs
     """
+    # The imported row states both endpoints, so each leg records the opposite account and the
+    # pair comes out already answered rather than needing the question asked afterwards
     return [
         FireflyLeg(
             account=source_account,
@@ -179,6 +183,7 @@ def _resolve_transfer_pair(
             merchant_name=None,
             notes=notes,
             tag_names=row.tag_names,
+            other_account=destination_account,
         ),
         FireflyLeg(
             account=destination_account,
@@ -188,6 +193,7 @@ def _resolve_transfer_pair(
             merchant_name=None,
             notes=notes,
             tag_names=row.tag_names,
+            other_account=source_account,
         ),
     ]
 

--- a/backend/app/services/importers/firefly/row_resolution.py
+++ b/backend/app/services/importers/firefly/row_resolution.py
@@ -75,7 +75,6 @@ class FireflyLeg:
         merchant_name: Optional counterparty recorded as a merchant
         notes: Optional combined description and notes text
         tag_names: Tag names applied to the transaction
-        other_account: Account on the other side, set on transfer legs only
     """
 
     account: Account
@@ -85,7 +84,6 @@ class FireflyLeg:
     merchant_name: str | None
     notes: str | None
     tag_names: list[str]
-    other_account: Account | None = None
 
 
 def resolve_firefly_row(row: FireflyTransactionRow, context: FireflyResolutionContext) -> list[FireflyLeg]:
@@ -172,19 +170,6 @@ def _resolve_transfer_pair(
     Returns:
         Outgoing and incoming transfer legs
     """
-    # The imported row states both endpoints, so each leg records the opposite account and the
-    # pair comes out already answered rather than needing the question asked afterwards.
-    #
-    # Two imported names can be mapped onto one account, which would have each leg recording the
-    # account it already sits in. That is the one thing the field cannot mean, so those legs are
-    # left unanswered instead
-    if source_account.id == destination_account.id:
-        other_source_account = None
-        other_destination_account = None
-    else:
-        other_source_account = destination_account
-        other_destination_account = source_account
-
     return [
         FireflyLeg(
             account=source_account,
@@ -194,7 +179,6 @@ def _resolve_transfer_pair(
             merchant_name=None,
             notes=notes,
             tag_names=row.tag_names,
-            other_account=other_source_account,
         ),
         FireflyLeg(
             account=destination_account,
@@ -204,7 +188,6 @@ def _resolve_transfer_pair(
             merchant_name=None,
             notes=notes,
             tag_names=row.tag_names,
-            other_account=other_destination_account,
         ),
     ]
 

--- a/backend/app/services/importers/firefly/row_resolution.py
+++ b/backend/app/services/importers/firefly/row_resolution.py
@@ -173,7 +173,18 @@ def _resolve_transfer_pair(
         Outgoing and incoming transfer legs
     """
     # The imported row states both endpoints, so each leg records the opposite account and the
-    # pair comes out already answered rather than needing the question asked afterwards
+    # pair comes out already answered rather than needing the question asked afterwards.
+    #
+    # Two imported names can be mapped onto one account, which would have each leg recording the
+    # account it already sits in. That is the one thing the field cannot mean, so those legs are
+    # left unanswered instead
+    if source_account.id == destination_account.id:
+        other_source_account = None
+        other_destination_account = None
+    else:
+        other_source_account = destination_account
+        other_destination_account = source_account
+
     return [
         FireflyLeg(
             account=source_account,
@@ -183,7 +194,7 @@ def _resolve_transfer_pair(
             merchant_name=None,
             notes=notes,
             tag_names=row.tag_names,
-            other_account=destination_account,
+            other_account=other_source_account,
         ),
         FireflyLeg(
             account=destination_account,
@@ -193,7 +204,7 @@ def _resolve_transfer_pair(
             merchant_name=None,
             notes=notes,
             tag_names=row.tag_names,
-            other_account=source_account,
+            other_account=other_destination_account,
         ),
     ]
 

--- a/backend/app/services/importers/firefly/service.py
+++ b/backend/app/services/importers/firefly/service.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
+from app.models.base import TransferOtherAccountScope
 from app.models.tag import TransactionTag
 from app.models.transaction import Transaction
 from app.models.user import User
@@ -203,6 +204,10 @@ async def _write_legs(
                 currency=leg.account.currency,
                 fx_rate=None,
                 notes=leg.notes,
+                other_account_id=leg.other_account.id if leg.other_account else None,
+                other_account_scope=(
+                    TransferOtherAccountScope.TRACKED if leg.other_account else None
+                ),
             )
             pending.append((transaction, tags))
 

--- a/backend/app/services/importers/firefly/service.py
+++ b/backend/app/services/importers/firefly/service.py
@@ -8,7 +8,6 @@ from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
-from app.models.base import TransferOtherAccountScope
 from app.models.tag import TransactionTag
 from app.models.transaction import Transaction
 from app.models.user import User
@@ -204,10 +203,6 @@ async def _write_legs(
                 currency=leg.account.currency,
                 fx_rate=None,
                 notes=leg.notes,
-                other_account_id=leg.other_account.id if leg.other_account else None,
-                other_account_scope=(
-                    TransferOtherAccountScope.TRACKED if leg.other_account else None
-                ),
             )
             pending.append((transaction, tags))
 

--- a/backend/app/services/merchants/__init__.py
+++ b/backend/app/services/merchants/__init__.py
@@ -1,0 +1,5 @@
+"""Merchant service exports"""
+
+from app.services.merchants.defaults import seed_system_merchants
+
+__all__ = ["seed_system_merchants"]

--- a/backend/app/services/merchants/defaults.py
+++ b/backend/app/services/merchants/defaults.py
@@ -1,0 +1,38 @@
+"""System merchant defaults and seeding"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.merchant import Merchant
+
+# Merchants that ship with the app and belong to every user. "Myself" is what a transfer between
+# your own accounts is paid to, which otherwise leaves everyone typing their own spelling of it
+SYSTEM_MERCHANT_NAMES = ("Myself",)
+
+
+async def seed_system_merchants(db: AsyncSession) -> None:
+    """Create the global system merchants that are missing
+
+    Nothing is updated in place, since a system merchant carries only its name and that name is
+    what identifies it
+
+    Args:
+        db: Active database session
+    """
+    # Fetch the existing system merchants by name so seeding can run against a database that
+    # already has some of them
+    existing_result = await db.execute(
+        select(Merchant.name).where(Merchant.is_system.is_(True)),
+    )
+    existing_names = set(existing_result.scalars().all())
+
+    for name in SYSTEM_MERCHANT_NAMES:
+        if name in existing_names:
+            continue
+        db.add(Merchant(
+            owner_id=None,
+            group_id=None,
+            name=name,
+            is_system=True,
+            default_category_id=None,
+        ))

--- a/backend/app/services/merchants/defaults.py
+++ b/backend/app/services/merchants/defaults.py
@@ -5,9 +5,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.merchant import Merchant
 
-# Merchants that ship with the app and belong to every user. "Myself" is what a transfer between
-# your own accounts is paid to, which otherwise leaves everyone typing their own spelling of it
-SYSTEM_MERCHANT_NAMES = ("Myself",)
+# What a transfer between your own accounts is paid to, which otherwise leaves everyone typing
+# their own spelling of it. Also carried by the balance adjustments the app writes for itself,
+# since those are nobody's transaction but still have to name a merchant
+SELF_MERCHANT_NAME = "Myself"
+
+# Merchants that ship with the app and belong to every user
+SYSTEM_MERCHANT_NAMES = (SELF_MERCHANT_NAME,)
 
 
 async def seed_system_merchants(db: AsyncSession) -> None:

--- a/backend/app/services/tax_advantaged_categories/tac_transfer_metric_helpers.py
+++ b/backend/app/services/tax_advantaged_categories/tac_transfer_metric_helpers.py
@@ -6,14 +6,15 @@ from dataclasses import dataclass
 
 from sqlalchemy import case, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
 
 from app.models.account import Account, TaxAdvantagedCategory
-from app.models.base import CategoryKind
+from app.models.base import CategoryKind, TransferOtherAccountScope
 from app.models.category import Category
 from app.models.transaction import Transaction
 from app.services.tax_advantaged_categories.tac_limit_metric_helpers import TacLimitMetrics
 
-_TAC_TRANSFER_CATEGORY_NAME = "Transfer"
+_BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
 
 
 @dataclass
@@ -52,6 +53,23 @@ async def get_tac_transfer_totals(
     )
     positive_amount_filter = Transaction.amount > 0
     negative_amount_filter = Transaction.amount < 0
+    other_account = aliased(Account)
+
+    # Categories that treat their own accounts as one pot, where money moving between them is
+    # neither a contribution nor a withdrawal
+    category_ids_excluding_internal_transfers = [
+        tax_advantaged_category.id
+        for tax_advantaged_category in tax_advantaged_categories
+        if not tax_advantaged_category.counts_internal_transfers
+    ]
+
+    # A transfer whose recorded other side is another account of the same category the row is
+    # being counted for
+    is_uncounted_internal_transfer = (
+        (Transaction.other_account_scope == TransferOtherAccountScope.TRACKED)
+        & (other_account.tax_advantaged_category_id == Account.tax_advantaged_category_id)
+        & Account.tax_advantaged_category_id.in_(category_ids_excluding_internal_transfers)
+    )
 
     # Sum transfer-category activity for linked accounts by TAC category and transaction year
     transfer_total_result = await db.execute(
@@ -69,12 +87,22 @@ async def get_tac_transfer_totals(
         )
         .join(Account, Transaction.account_id == Account.id)
         .join(Category, Transaction.category_id == Category.id)
+
+        # The other side is read from a second join against the accounts table, made outer because
+        # most transfers record no account there and those rows still count
+        .outerjoin(other_account, Transaction.other_account_id == other_account.id)
         .where(
             Account.tax_advantaged_category_id.in_(tax_advantaged_category_ids),
 
             # Archived accounts remain linked to their tax-advantaged category history
             Category.kind == CategoryKind.TRANSFER,
-            Category.name == _TAC_TRANSFER_CATEGORY_NAME,
+
+            # A balance adjustment corrects a stale balance rather than moving money in or out
+            Category.name != _BALANCE_ADJUSTMENT_CATEGORY_NAME,
+
+            # Compared against true rather than negated, because a transfer with no recorded other
+            # account leaves the comparison unknown and would otherwise drop out of both totals
+            is_uncounted_internal_transfer.is_not(True),
         )
         .group_by(Account.tax_advantaged_category_id, "year"),
     )

--- a/backend/app/services/tax_advantaged_categories/tac_transfer_metric_helpers.py
+++ b/backend/app/services/tax_advantaged_categories/tac_transfer_metric_helpers.py
@@ -9,12 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import aliased
 
 from app.models.account import Account, TaxAdvantagedCategory
-from app.models.base import CategoryKind, TransferOtherAccountScope
+from app.models.base import TransferOtherAccountScope
 from app.models.category import Category
 from app.models.transaction import Transaction
+from app.services.categories.transfer_rules import get_records_other_account_filter
 from app.services.tax_advantaged_categories.tac_limit_metric_helpers import TacLimitMetrics
-
-_BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
 
 
 @dataclass
@@ -95,10 +94,8 @@ async def get_tac_transfer_totals(
             Account.tax_advantaged_category_id.in_(tax_advantaged_category_ids),
 
             # Archived accounts remain linked to their tax-advantaged category history
-            Category.kind == CategoryKind.TRANSFER,
-
-            # A balance adjustment corrects a stale balance rather than moving money in or out
-            Category.name != _BALANCE_ADJUSTMENT_CATEGORY_NAME,
+            # The same rule the write path enforces, so a row that had to answer is a row that counts
+            get_records_other_account_filter(),
 
             # Compared against true rather than negated, because a transfer with no recorded other
             # account leaves the comparison unknown and would otherwise drop out of both totals

--- a/backend/app/services/transactions/creation.py
+++ b/backend/app/services/transactions/creation.py
@@ -17,6 +17,7 @@ from app.services.transactions.validation import (
     validate_transaction_currency_exists,
     validate_transaction_fx_rate_for_account_currency,
     validate_transaction_merchant_access,
+    validate_transaction_other_account,
 )
 
 
@@ -54,7 +55,19 @@ async def create_transaction_and_get_response(
     validate_transaction_fx_rate_for_account_currency(data.currency, account.currency, data.fx_rate)
 
     # Confirm related records belong to the same accessible group as the account
-    await validate_transaction_category_access(db, data.category_id, user.id, account.group_id)
+    category = await validate_transaction_category_access(db, data.category_id, user.id, account.group_id)
+
+    # A transfer records where the money went as it is entered, since the receiving side is added
+    # days later and the two cannot be matched up afterwards
+    await validate_transaction_other_account(
+        db,
+        user.id,
+        category,
+        data.account_id,
+        data.other_account_id,
+        data.other_account_scope,
+        require_answer=True,
+    )
     if data.merchant_id:
         await validate_transaction_merchant_access(db, data.merchant_id, user.id, account.group_id)
     validated_tag_ids = []
@@ -72,6 +85,8 @@ async def create_transaction_and_get_response(
         currency=data.currency,
         fx_rate=data.fx_rate,
         notes=data.notes,
+        other_account_id=data.other_account_id,
+        other_account_scope=data.other_account_scope,
     )
     db.add(txn)
     await db.flush()

--- a/backend/app/services/transactions/creation.py
+++ b/backend/app/services/transactions/creation.py
@@ -66,7 +66,6 @@ async def create_transaction_and_get_response(
         data.account_id,
         data.other_account_id,
         data.other_account_scope,
-        require_answer=True,
     )
     await validate_transaction_merchant_access(db, data.merchant_id, user.id, account.group_id)
     validated_tag_ids = []

--- a/backend/app/services/transactions/creation.py
+++ b/backend/app/services/transactions/creation.py
@@ -68,8 +68,7 @@ async def create_transaction_and_get_response(
         data.other_account_scope,
         require_answer=True,
     )
-    if data.merchant_id:
-        await validate_transaction_merchant_access(db, data.merchant_id, user.id, account.group_id)
+    await validate_transaction_merchant_access(db, data.merchant_id, user.id, account.group_id)
     validated_tag_ids = []
     if data.tag_ids:
         validated_tag_ids = await get_valid_transaction_tag_ids(db, user.id, data.tag_ids, account.group_id)

--- a/backend/app/services/transactions/update.py
+++ b/backend/app/services/transactions/update.py
@@ -88,28 +88,23 @@ async def update_transaction_and_get_response(
         )
 
     # Confirm changed category and merchant records belong to the selected account group
-    # Both the category the transaction had and the one it ends up with matter: the answer is judged
-    # against the new one, and whether it is newly a transfer is judged against the old one
-    previous_category = await db.get(Category, txn.category_id)
     if "category_id" in changed_fields:
         category = await validate_transaction_category_access(
             db, changed_fields["category_id"], user.id, account_group_id,
         )
     else:
-        category = previous_category
+        # The answer is judged against the category the transaction ends up with, so an unchanged
+        # category is still loaded
+        category = await db.get(Category, txn.category_id)
     if "merchant_id" in changed_fields and changed_fields["merchant_id"] is not None:
         await validate_transaction_merchant_access(db, changed_fields["merchant_id"], user.id, account_group_id)
 
     if does_category_record_other_account(category):
-        # An edit that turns a transaction into a transfer is forming a new one, so it answers the
-        # question the same way creating one does. A transaction that was already a transfer keeps
-        # its exemption, which is what lets an old unanswered row have its notes or amount corrected
-        became_transfer = (
-            "category_id" in changed_fields
-            and not does_category_record_other_account(previous_category)
-        )
-
-        # Unsent fields keep their stored values, so an old transaction with no answer stays editable
+        # Editing a transfer answers the question, whatever else the edit changes. Transactions
+        # predating the field are the ones this reaches, and refusing the edit until they say where
+        # the money went is what moves that history onto the new footing rather than leaving it
+        # counting wrongly forever. Unsent fields keep their stored values, so a transfer that has
+        # already answered is untouched by this
         await validate_transaction_other_account(
             db,
             user.id,
@@ -117,7 +112,7 @@ async def update_transaction_and_get_response(
             changed_fields.get("account_id", txn.account_id),
             changed_fields.get("other_account_id", txn.other_account_id),
             changed_fields.get("other_account_scope", txn.other_account_scope),
-            require_answer=became_transfer,
+            require_answer=True,
         )
     else:
         if changed_fields.get("other_account_id") is not None or changed_fields.get("other_account_scope") is not None:

--- a/backend/app/services/transactions/update.py
+++ b/backend/app/services/transactions/update.py
@@ -1,9 +1,11 @@
 """Transaction update service"""
 import uuid
 
+from fastapi import HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.base import PermissionLevel
+from app.models.category import Category
 from app.models.user import User
 from app.permissions import check_account_access, check_transaction_access
 from app.schemas.transaction import TransactionResponse, UpdateTransactionRequest
@@ -16,10 +18,13 @@ from app.services.transactions.response_helpers import get_transaction_response
 from app.services.transactions.snapshots import recompute_snapshots_after_transaction_update
 from app.services.transactions.tags import replace_transaction_tag_assignments
 from app.services.transactions.validation import (
+    OTHER_ACCOUNT_NOT_ALLOWED_DETAIL,
+    does_category_record_other_account,
     get_valid_transaction_tag_ids,
     validate_transaction_category_access,
     validate_transaction_fx_rate_for_account_currency,
     validate_transaction_merchant_access,
+    validate_transaction_other_account,
 )
 
 
@@ -84,9 +89,37 @@ async def update_transaction_and_get_response(
 
     # Confirm changed category and merchant records belong to the selected account group
     if "category_id" in changed_fields:
-        await validate_transaction_category_access(db, changed_fields["category_id"], user.id, account_group_id)
+        category = await validate_transaction_category_access(
+            db, changed_fields["category_id"], user.id, account_group_id,
+        )
+    else:
+        # The other-account answer is judged against the category the transaction ends up with,
+        # so an unchanged category is still loaded
+        category = await db.get(Category, txn.category_id)
     if "merchant_id" in changed_fields and changed_fields["merchant_id"] is not None:
         await validate_transaction_merchant_access(db, changed_fields["merchant_id"], user.id, account_group_id)
+
+    if does_category_record_other_account(category):
+        # Unsent fields keep their stored values, so an old transaction with no answer stays editable
+        await validate_transaction_other_account(
+            db,
+            user.id,
+            category,
+            changed_fields.get("account_id", txn.account_id),
+            changed_fields.get("other_account_id", txn.other_account_id),
+            changed_fields.get("other_account_scope", txn.other_account_scope),
+            require_answer=False,
+        )
+    else:
+        if changed_fields.get("other_account_id") is not None or changed_fields.get("other_account_scope") is not None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=OTHER_ACCOUNT_NOT_ALLOWED_DETAIL,
+            )
+
+        # Moving to a category with no other side drops the answer recorded under the previous one
+        changed_fields["other_account_id"] = None
+        changed_fields["other_account_scope"] = None
 
     # Handle tags outside the model field loop because they live in a junction table
     new_tag_ids = changed_fields.pop("tag_ids", None)

--- a/backend/app/services/transactions/update.py
+++ b/backend/app/services/transactions/update.py
@@ -10,6 +10,7 @@ from app.models.user import User
 from app.permissions import check_account_access, check_transaction_access
 from app.schemas.transaction import TransactionResponse, UpdateTransactionRequest
 from app.services.cache_state import mark_cache_changed_for_scope
+from app.services.categories.transfer_rules import does_category_record_other_account
 from app.services.transactions.accounts import (
     get_parent_account_for_transaction,
     validate_transaction_account_is_not_archived,
@@ -17,7 +18,6 @@ from app.services.transactions.accounts import (
 from app.services.transactions.response_helpers import get_transaction_response
 from app.services.transactions.snapshots import recompute_snapshots_after_transaction_update
 from app.services.transactions.tags import replace_transaction_tag_assignments
-from app.services.categories.transfer_rules import does_category_record_other_account
 from app.services.transactions.validation import (
     OTHER_ACCOUNT_NOT_ALLOWED_DETAIL,
     get_valid_transaction_tag_ids,

--- a/backend/app/services/transactions/update.py
+++ b/backend/app/services/transactions/update.py
@@ -96,8 +96,18 @@ async def update_transaction_and_get_response(
         # The answer is judged against the category the transaction ends up with, so an unchanged
         # category is still loaded
         category = await db.get(Category, txn.category_id)
-    if "merchant_id" in changed_fields and changed_fields["merchant_id"] is not None:
-        await validate_transaction_merchant_access(db, changed_fields["merchant_id"], user.id, account_group_id)
+    # Editing brings the transaction onto the current rule, so one recorded before a merchant was
+    # required has to name one before any other change to it is accepted, and one that already has
+    # a merchant cannot have it taken away. Unsent fields keep their stored values, so an edit that
+    # leaves the merchant alone is untouched by this
+    resulting_merchant_id = changed_fields.get("merchant_id", txn.merchant_id)
+    if resulting_merchant_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="merchant_id is required",
+        )
+    if "merchant_id" in changed_fields:
+        await validate_transaction_merchant_access(db, resulting_merchant_id, user.id, account_group_id)
 
     if does_category_record_other_account(category):
         # Editing a transfer answers the question, whatever else the edit changes. Transactions

--- a/backend/app/services/transactions/update.py
+++ b/backend/app/services/transactions/update.py
@@ -17,9 +17,9 @@ from app.services.transactions.accounts import (
 from app.services.transactions.response_helpers import get_transaction_response
 from app.services.transactions.snapshots import recompute_snapshots_after_transaction_update
 from app.services.transactions.tags import replace_transaction_tag_assignments
+from app.services.categories.transfer_rules import does_category_record_other_account
 from app.services.transactions.validation import (
     OTHER_ACCOUNT_NOT_ALLOWED_DETAIL,
-    does_category_record_other_account,
     get_valid_transaction_tag_ids,
     validate_transaction_category_access,
     validate_transaction_fx_rate_for_account_currency,
@@ -88,18 +88,27 @@ async def update_transaction_and_get_response(
         )
 
     # Confirm changed category and merchant records belong to the selected account group
+    # Both the category the transaction had and the one it ends up with matter: the answer is judged
+    # against the new one, and whether it is newly a transfer is judged against the old one
+    previous_category = await db.get(Category, txn.category_id)
     if "category_id" in changed_fields:
         category = await validate_transaction_category_access(
             db, changed_fields["category_id"], user.id, account_group_id,
         )
     else:
-        # The other-account answer is judged against the category the transaction ends up with,
-        # so an unchanged category is still loaded
-        category = await db.get(Category, txn.category_id)
+        category = previous_category
     if "merchant_id" in changed_fields and changed_fields["merchant_id"] is not None:
         await validate_transaction_merchant_access(db, changed_fields["merchant_id"], user.id, account_group_id)
 
     if does_category_record_other_account(category):
+        # An edit that turns a transaction into a transfer is forming a new one, so it answers the
+        # question the same way creating one does. A transaction that was already a transfer keeps
+        # its exemption, which is what lets an old unanswered row have its notes or amount corrected
+        became_transfer = (
+            "category_id" in changed_fields
+            and not does_category_record_other_account(previous_category)
+        )
+
         # Unsent fields keep their stored values, so an old transaction with no answer stays editable
         await validate_transaction_other_account(
             db,
@@ -108,7 +117,7 @@ async def update_transaction_and_get_response(
             changed_fields.get("account_id", txn.account_id),
             changed_fields.get("other_account_id", txn.other_account_id),
             changed_fields.get("other_account_scope", txn.other_account_scope),
-            require_answer=False,
+            require_answer=became_transfer,
         )
     else:
         if changed_fields.get("other_account_id") is not None or changed_fields.get("other_account_scope") is not None:

--- a/backend/app/services/transactions/update.py
+++ b/backend/app/services/transactions/update.py
@@ -122,7 +122,6 @@ async def update_transaction_and_get_response(
             changed_fields.get("account_id", txn.account_id),
             changed_fields.get("other_account_id", txn.other_account_id),
             changed_fields.get("other_account_scope", txn.other_account_scope),
-            require_answer=True,
         )
     else:
         if changed_fields.get("other_account_id") is not None or changed_fields.get("other_account_scope") is not None:

--- a/backend/app/services/transactions/validation.py
+++ b/backend/app/services/transactions/validation.py
@@ -5,12 +5,19 @@ from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.base import CategoryKind, PermissionLevel, TransferOtherAccountScope
 from app.models.category import Category
 from app.models.currency import Currency
 from app.models.merchant import Merchant
 from app.models.tag import Tag
+from app.permissions import check_account_access
 
 _FX_RATE_REQUIRED_DETAIL = "fx_rate is required when transaction currency differs from account currency"
+
+# The one transfer-kind category with no other side, so it carries no other-account answer
+_BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
+
+OTHER_ACCOUNT_NOT_ALLOWED_DETAIL = "This category does not record another account"
 
 
 async def validate_transaction_currency_exists(db: AsyncSession, currency: str) -> None:
@@ -71,7 +78,7 @@ async def validate_transaction_category_access(
     category_id: uuid.UUID,
     user_id: uuid.UUID,
     group_id: uuid.UUID | None = None,
-) -> None:
+) -> Category:
     """Ensure a transaction can use the requested category
 
     Personal-account transactions may use system categories and the user's own
@@ -84,6 +91,9 @@ async def validate_transaction_category_access(
         category_id: Category identifier submitted on the transaction
         user_id: User identifier creating or updating the transaction
         group_id: Optional group identifier from the transaction account
+
+    Returns:
+        Category row the transaction may use, so callers can read its kind without a second lookup
 
     Raises:
         HTTPException: Category is missing or outside the transaction account scope
@@ -103,8 +113,10 @@ async def validate_transaction_category_access(
         )
 
     # Confirm the category exists inside the transaction account scope
-    if not (await db.execute(query)).scalar_one_or_none():
+    category = (await db.execute(query)).scalar_one_or_none()
+    if not category:
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Category not found")
+    return category
 
 
 async def validate_transaction_merchant_access(
@@ -182,3 +194,85 @@ async def get_valid_transaction_tag_ids(
     if found_tag_ids != set(unique_tag_ids):
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Tag not found")
     return unique_tag_ids
+
+
+def does_category_record_other_account(category: Category) -> bool:
+    """Return whether transactions in a category record the account on the other side
+
+    Args:
+        category: Category the transaction uses
+
+    Returns:
+        True for every transfer-kind category except Balance Adjustment, which has no other side
+    """
+    return category.kind == CategoryKind.TRANSFER and category.name != _BALANCE_ADJUSTMENT_CATEGORY_NAME
+
+
+async def validate_transaction_other_account(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    category: Category,
+    account_id: uuid.UUID,
+    other_account_id: uuid.UUID | None,
+    other_account_scope: TransferOtherAccountScope | None,
+    *,
+    require_answer: bool,
+) -> None:
+    """Ensure the recorded other side of a transfer agrees with its category
+
+    Args:
+        db: Active database session
+        user_id: User identifier creating or updating the transaction
+        category: Category the transaction ends up using
+        account_id: Account the transaction is recorded in
+        other_account_id: Account recorded as the other side, set only when the scope is tracked
+        other_account_scope: Where the other side sits, or None when nothing is recorded
+        require_answer: Whether a missing answer is rejected, true on create and false on update
+
+    Raises:
+        HTTPException: The answer is missing, contradicts itself, or points at an unusable account
+    """
+    if not does_category_record_other_account(category):
+        if other_account_scope is not None or other_account_id is not None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=OTHER_ACCOUNT_NOT_ALLOWED_DETAIL,
+            )
+        return
+
+    if other_account_scope is None:
+        # An old transaction can be corrected without answering the account question first
+        if require_answer:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="A transfer must record where the money went",
+            )
+        if other_account_id is not None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="other_account_scope is required when other_account_id is set",
+            )
+        return
+
+    if other_account_scope == TransferOtherAccountScope.OUTSIDE:
+        if other_account_id is not None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="other_account_id is not allowed when the money left the tracked accounts",
+            )
+        return
+
+    if other_account_id is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="other_account_id is required when the other side is a tracked account",
+        )
+    if other_account_id == account_id:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="A transfer cannot record its own account as the other side",
+        )
+
+    # Read access is enough, since recording an account writes nothing to it. Archived and closed
+    # accounts stay recordable, because archiving happens after the money moved
+    await check_account_access(db, other_account_id, user_id, PermissionLevel.READ)

--- a/backend/app/services/transactions/validation.py
+++ b/backend/app/services/transactions/validation.py
@@ -127,10 +127,11 @@ async def validate_transaction_merchant_access(
 ) -> None:
     """Ensure a transaction can use the requested merchant
 
-    Personal-account transactions may use only the user's personal merchants
-    Group-account transactions may also use merchants owned by the account's
-    group. Merchants from another user's personal scope or an unrelated group
-    are rejected
+    Every transaction may use a system merchant, since those ship with the app.
+    Personal-account transactions may otherwise use only the user's personal
+    merchants. Group-account transactions may also use merchants owned by the
+    account's group. Merchants from another user's personal scope or an
+    unrelated group are rejected
 
     Args:
         db: Active database session
@@ -145,10 +146,15 @@ async def validate_transaction_merchant_access(
     query = select(Merchant).where(Merchant.id == merchant_id)
     if group_id is not None:
         query = query.where(
-            ((Merchant.owner_id == user_id) & (Merchant.group_id.is_(None))) | (Merchant.group_id == group_id),
+            Merchant.is_system.is_(True)
+            | ((Merchant.owner_id == user_id) & (Merchant.group_id.is_(None)))
+            | (Merchant.group_id == group_id),
         )
     else:
-        query = query.where(Merchant.owner_id == user_id, Merchant.group_id.is_(None))
+        query = query.where(
+            Merchant.is_system.is_(True)
+            | ((Merchant.owner_id == user_id) & (Merchant.group_id.is_(None))),
+        )
 
     # Confirm the merchant exists inside the transaction account scope
     if not (await db.execute(query)).scalar_one_or_none():

--- a/backend/app/services/transactions/validation.py
+++ b/backend/app/services/transactions/validation.py
@@ -5,17 +5,15 @@ from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.base import CategoryKind, PermissionLevel, TransferOtherAccountScope
+from app.models.base import PermissionLevel, TransferOtherAccountScope
 from app.models.category import Category
 from app.models.currency import Currency
 from app.models.merchant import Merchant
 from app.models.tag import Tag
 from app.permissions import check_account_access
+from app.services.categories.transfer_rules import does_category_record_other_account
 
 _FX_RATE_REQUIRED_DETAIL = "fx_rate is required when transaction currency differs from account currency"
-
-# The one transfer-kind category with no other side, so it carries no other-account answer
-_BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
 
 OTHER_ACCOUNT_NOT_ALLOWED_DETAIL = "This category does not record another account"
 
@@ -200,18 +198,6 @@ async def get_valid_transaction_tag_ids(
     if found_tag_ids != set(unique_tag_ids):
         raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Tag not found")
     return unique_tag_ids
-
-
-def does_category_record_other_account(category: Category) -> bool:
-    """Return whether transactions in a category record the account on the other side
-
-    Args:
-        category: Category the transaction uses
-
-    Returns:
-        True for every transfer-kind category except Balance Adjustment, which has no other side
-    """
-    return category.kind == CategoryKind.TRANSFER and category.name != _BALANCE_ADJUSTMENT_CATEGORY_NAME
 
 
 async def validate_transaction_other_account(

--- a/backend/app/services/transactions/validation.py
+++ b/backend/app/services/transactions/validation.py
@@ -207,8 +207,6 @@ async def validate_transaction_other_account(
     account_id: uuid.UUID,
     other_account_id: uuid.UUID | None,
     other_account_scope: TransferOtherAccountScope | None,
-    *,
-    require_answer: bool,
 ) -> None:
     """Ensure the recorded other side of a transfer agrees with its category
 
@@ -219,7 +217,6 @@ async def validate_transaction_other_account(
         account_id: Account the transaction is recorded in
         other_account_id: Account recorded as the other side, set only when the scope is tracked
         other_account_scope: Where the other side sits, or None when nothing is recorded
-        require_answer: Whether a missing answer is rejected, true on create and false on update
 
     Raises:
         HTTPException: The answer is missing, contradicts itself, or points at an unusable account
@@ -232,19 +229,13 @@ async def validate_transaction_other_account(
             )
         return
 
+    # Editing answers the question as much as creating does, so a transfer recorded before the field
+    # existed has to say where the money went before any other change to it is accepted
     if other_account_scope is None:
-        # An old transaction can be corrected without answering the account question first
-        if require_answer:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="A transfer must record where the money went",
-            )
-        if other_account_id is not None:
-            raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                detail="other_account_scope is required when other_account_id is set",
-            )
-        return
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="A transfer must record where the money went",
+        )
 
     if other_account_scope == TransferOtherAccountScope.OUTSIDE:
         if other_account_id is not None:

--- a/backend/scripts/seed_merchants.py
+++ b/backend/scripts/seed_merchants.py
@@ -1,0 +1,22 @@
+"""Seed the merchants table with global system merchants"""
+
+import asyncio
+
+from app.database import create_migration_sessionmaker
+from app.models import category as _category  # noqa: F401
+from app.models import group as _group  # noqa: F401
+from app.models import user as _user  # noqa: F401
+from app.services.merchants.defaults import SYSTEM_MERCHANT_NAMES, seed_system_merchants
+
+
+async def seed_merchants() -> None:
+    """Insert every missing system merchant into the database"""
+    session_factory = create_migration_sessionmaker()
+    async with session_factory() as db:
+        await seed_system_merchants(db)
+        await db.commit()
+    print(f"Seeded {len(SYSTEM_MERCHANT_NAMES)} system merchants")
+
+
+if __name__ == "__main__":
+    asyncio.run(seed_merchants())

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -31,6 +31,7 @@ from app.models import (  # noqa: F401
 )
 from app.models.base import Base
 from app.services.categories.defaults import seed_system_categories
+from app.services.merchants.defaults import seed_system_merchants
 
 # Database credentials come from .env.test, which points at the isolated test database
 DB_HOST = require("DB_HOST")
@@ -112,5 +113,6 @@ async def clean_tables():
         ))
     async with TestSession() as session:
         await seed_system_categories(session)
+        await seed_system_merchants(session)
         await session.commit()
     yield

--- a/backend/tests/migrations/test_schema_parity.py
+++ b/backend/tests/migrations/test_schema_parity.py
@@ -26,6 +26,8 @@ _ALEMBIC_TEST_DB_NAME = f"{WORKER_DB_NAME}_alembic_schema"
 _ALEMBIC_ENUM_DB_NAME = f"{WORKER_DB_NAME}_alembic_enums"
 _ALEMBIC_AUTH_RESET_DB_NAME = f"{WORKER_DB_NAME}_alembic_auth_reset"
 _AUTH_SESSIONS_REVISION = "a4f8d1c2e7b3"
+_ALEMBIC_SYSTEM_MERCHANT_DB_NAME = f"{WORKER_DB_NAME}_alembic_system_merchant"
+_BEFORE_SYSTEM_MERCHANTS_REVISION = "cbf7ada87de3"
 
 
 async def test_alembic_schema_columns_match_model_metadata() -> None:
@@ -300,3 +302,104 @@ def _create_engine_for_database(database_name: str, *, isolation_level: str | No
     database_url = f"postgresql+asyncpg://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{database_name}"
     engine = create_async_engine(database_url, poolclass=NullPool, isolation_level=isolation_level)
     return engine
+
+
+async def test_system_merchant_migration_folds_everyones_own_myself() -> None:
+    """Verify the fold keeps transactions and removes the duplicates, whatever their capitalisation"""
+    await _recreate_database(_ALEMBIC_SYSTEM_MERCHANT_DB_NAME)
+    try:
+        _run_alembic_upgrade(_ALEMBIC_SYSTEM_MERCHANT_DB_NAME, revision=_BEFORE_SYSTEM_MERCHANTS_REVISION)
+        transaction_id = await _seed_own_myself_merchant(_ALEMBIC_SYSTEM_MERCHANT_DB_NAME)
+
+        _run_alembic_upgrade(_ALEMBIC_SYSTEM_MERCHANT_DB_NAME)
+
+        engine = _create_engine_for_database(_ALEMBIC_SYSTEM_MERCHANT_DB_NAME)
+        try:
+            async with engine.connect() as conn:
+                system_merchants = (await conn.execute(text(
+                    "SELECT id, name FROM merchants WHERE is_system = true",
+                ))).all()
+                remaining_own = (await conn.execute(text(
+                    "SELECT count(*) FROM merchants WHERE is_system = false",
+                ))).scalar_one()
+                merchant_on_transaction = (await conn.execute(
+                    text("SELECT merchant_id FROM transactions WHERE id = :id"),
+                    {"id": transaction_id},
+                )).scalar_one()
+        finally:
+            await engine.dispose()
+
+        assert [name for _, name in system_merchants] == ["Myself"]
+        assert remaining_own == 0
+        assert merchant_on_transaction == system_merchants[0][0]
+    finally:
+        await _drop_database(_ALEMBIC_SYSTEM_MERCHANT_DB_NAME)
+
+
+async def _seed_own_myself_merchant(database_name: str) -> UUID:
+    """Insert a user-owned merchant spelled MYSELF, carrying one transaction
+
+    Returns:
+        Identifier of the transaction that should survive the fold
+    """
+    user_id = UUID("44444444-4444-4444-8444-444444444444")
+    account_id = UUID("55555555-5555-4555-8555-555555555555")
+    category_id = UUID("66666666-6666-4666-8666-666666666666")
+    merchant_id = UUID("77777777-7777-4777-8777-777777777777")
+    transaction_id = UUID("88888888-8888-4888-8888-888888888888")
+
+    engine = _create_engine_for_database(database_name)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text(
+                "INSERT INTO currencies (id, name, symbol, minor_unit_exponent)"
+                " VALUES ('CAD', 'Canadian Dollar', '$', 2)",
+            ))
+            await conn.execute(
+                text(
+                    "INSERT INTO users (id, email, first_name, tz, base_currency)"
+                    " VALUES (:user_id, 'migration-merchant@example.com', 'Migration', 'America/Toronto', 'CAD')",
+                ),
+                {"user_id": user_id},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO accounts"
+                    " (id, owner_id, account_kind, account_type, name, currency, is_archived)"
+                    " VALUES (:account_id, :user_id, 'ASSET', 'CHECKING', 'Chequing', 'CAD', false)",
+                ),
+                {"account_id": account_id, "user_id": user_id},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO categories (id, owner_id, name, kind, is_system)"
+                    " VALUES (:category_id, :user_id, 'Moving money', 'TRANSFER', false)",
+                ),
+                {"category_id": category_id, "user_id": user_id},
+            )
+
+            # Spelled in capitals, which the fold has to catch as the same intent
+            await conn.execute(
+                text(
+                    "INSERT INTO merchants (id, owner_id, name) VALUES (:merchant_id, :user_id, 'MYSELF')",
+                ),
+                {"merchant_id": merchant_id, "user_id": user_id},
+            )
+            await conn.execute(
+                text(
+                    "INSERT INTO transactions"
+                    " (id, created_by_user_id, account_id, dt, merchant_id, category_id, amount, currency)"
+                    " VALUES (:transaction_id, :user_id, :account_id, '2026-03-15', :merchant_id,"
+                    " :category_id, -5000, 'CAD')",
+                ),
+                {
+                    "transaction_id": transaction_id,
+                    "user_id": user_id,
+                    "account_id": account_id,
+                    "merchant_id": merchant_id,
+                    "category_id": category_id,
+                },
+            )
+    finally:
+        await engine.dispose()
+    return transaction_id

--- a/backend/tests/routes/accounts/_balance_snapshot_helpers.py
+++ b/backend/tests/routes/accounts/_balance_snapshot_helpers.py
@@ -7,7 +7,7 @@ from sqlalchemy import select
 from app.models.account import AccountBalanceSnapshot
 from app.models.currency import Currency
 from tests.conftest import TestSession
-from tests.routes.support import _get_auth_header
+from tests.routes.support import _get_auth_header, _get_system_merchant_id
 
 
 def _creation_day(account_resp):
@@ -49,6 +49,10 @@ async def _create_transaction(client, headers, account_id, category_id, **overri
         "currency": "CAD",
         **overrides,
     }
+
+    # The route requires a merchant, so a test that does not care which one gets the shared Myself
+    if "merchant_id" not in payload:
+        payload["merchant_id"] = await _get_system_merchant_id(client, headers)
     return await client.post("/transactions", json=payload, headers=headers)
 
 NONEXISTENT_ID = "00000000-0000-0000-0000-000000000000"

--- a/backend/tests/routes/accounts/test_account_deletion.py
+++ b/backend/tests/routes/accounts/test_account_deletion.py
@@ -67,3 +67,51 @@ async def test_double_delete_returns_404_on_second(client):
 
     assert resp1.status_code == 204
     assert resp2.status_code == 404
+
+
+# --- Accounts recorded as the other side of a transfer ---
+
+
+async def _setup_recorded_transfer(client):
+    """Record a transfer in one account that points at a second account.
+
+    Returns:
+        Tuple of (auth_headers, account holding the transfer, account it records)
+    """
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    holder_id = (await _create_account(client, headers)).json()["id"]
+    recorded_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+
+    categories = await client.get("/categories", headers=headers)
+    transfer_id = next(cat["id"] for cat in categories.json() if cat["name"] == "Transfer")
+
+    created = await client.post("/transactions", json={
+        "account_id": holder_id,
+        "category_id": transfer_id,
+        "dt": "2026-03-15",
+        "amount": -5000,
+        "currency": "CAD",
+        "other_account_scope": "tracked",
+        "other_account_id": recorded_id,
+    }, headers=headers)
+    assert created.status_code == 201
+    return headers, holder_id, recorded_id
+
+
+async def test_delete_account_recorded_on_a_transfer_elsewhere_returns_409(client):
+    """Deleting it would strip what another account's transfer recorded, so it is refused."""
+    headers, _, recorded_id = await _setup_recorded_transfer(client)
+
+    resp = await client.delete(f"/accounts/{recorded_id}", headers=headers)
+
+    assert resp.status_code == 409
+
+
+async def test_delete_account_holding_the_transfer_returns_204(client):
+    """The transfer goes with the account it is recorded in, so that side is free to delete."""
+    headers, holder_id, _ = await _setup_recorded_transfer(client)
+
+    resp = await client.delete(f"/accounts/{holder_id}", headers=headers)
+
+    assert resp.status_code == 204

--- a/backend/tests/routes/accounts/test_account_deletion.py
+++ b/backend/tests/routes/accounts/test_account_deletion.py
@@ -4,7 +4,7 @@ from tests.routes.accounts._account_helpers import (
     NONEXISTENT_ID,
     _create_second_user,
 )
-from tests.routes.support import _create_account, _create_user, _get_auth_header
+from tests.routes.support import _create_account, _create_user, _get_auth_header, _get_system_merchant_id
 
 # --- DELETE /accounts/{account_id} ---
 
@@ -94,6 +94,7 @@ async def _setup_recorded_transfer(client):
         "currency": "CAD",
         "other_account_scope": "tracked",
         "other_account_id": recorded_id,
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
     assert created.status_code == 201
     return headers, holder_id, recorded_id

--- a/backend/tests/routes/accounts/test_account_listing.py
+++ b/backend/tests/routes/accounts/test_account_listing.py
@@ -17,7 +17,13 @@ from tests.routes.accounts._account_helpers import (
     _FixedClock,
     _signup_user,
 )
-from tests.routes.support import _create_account, _create_user, _get_auth_header, _seed_currency
+from tests.routes.support import (
+    _create_account,
+    _create_user,
+    _get_auth_header,
+    _get_system_merchant_id,
+    _seed_currency,
+)
 
 # --- GET /accounts ---
 
@@ -282,7 +288,8 @@ async def test_create_account_with_starting_balance_creates_adjustment(client):
     assert txn.created_by_user_id == user_id
     assert txn.account_id == account_id
     assert txn.dt == expected_dt
-    assert txn.merchant_id is None
+    # The app writes this transaction rather than the user, so it is attributed to the shared Myself
+    assert txn.merchant_id == UUID(await _get_system_merchant_id(client, headers))
     assert txn.fx_rate is None
     assert txn.amount == 123_45
     assert txn.currency == data["currency"]

--- a/backend/tests/routes/accounts/test_cash_flow.py
+++ b/backend/tests/routes/accounts/test_cash_flow.py
@@ -3,7 +3,7 @@ import importlib
 from datetime import UTC, date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from tests.routes.support import _create_account, _create_user, _get_auth_header
+from tests.routes.support import _create_account, _create_user, _get_auth_header, _get_system_merchant_id
 
 # --- Helpers ---
 
@@ -84,6 +84,10 @@ async def _create_transaction(client, headers, account_id, category_id, **overri
         "currency": "CAD",
         **overrides,
     }
+
+    # The route requires a merchant, so a test that does not care which one gets the shared Myself
+    if "merchant_id" not in payload:
+        payload["merchant_id"] = await _get_system_merchant_id(client, headers)
     return await client.post("/transactions", json=payload, headers=headers)
 
 

--- a/backend/tests/routes/accounts/test_cash_flow.py
+++ b/backend/tests/routes/accounts/test_cash_flow.py
@@ -293,7 +293,7 @@ async def test_income_expense_and_non_adjustment_transfers_contribute_to_cash_fl
     )
     await _create_transaction(
         client, headers, account_id, custom_transfer_cat["id"],
-        dt=today, amount=-5000,
+        dt=today, amount=-5000, other_account_scope="outside",
     )
     await _create_transaction(
         client, headers, account_id, balance_adjustment_id,
@@ -326,15 +326,15 @@ async def test_transfer_transactions_contribute_to_cash_flow_by_sign(client):
     )).json()
 
     today = _today_utc().isoformat()
-    # Transfer out — money leaving the account → expenses
+    # Transfer out, money leaving the account, counted in expenses
     await _create_transaction(
         client, headers, account_id, transfer_cat["id"],
-        dt=today, amount=-5000,
+        dt=today, amount=-5000, other_account_scope="outside",
     )
-    # Transfer in — money arriving at the account → income
+    # Transfer in, money arriving at the account, counted in income
     await _create_transaction(
         client, headers, account_id, transfer_cat["id"],
-        dt=today, amount=3000,
+        dt=today, amount=3000, other_account_scope="outside",
     )
     # Ordinary expense — also in expenses
     await _create_transaction(
@@ -413,15 +413,15 @@ async def test_other_accounts_of_the_same_user_do_not_leak_into_the_series(clien
     category_id = await _get_category_id(client, headers, "Transfer")
 
     today = _today_utc().isoformat()
-    # Queried account — should appear
+    # Queried account, should appear
     await _create_transaction(
         client, headers, account_id, category_id,
-        dt=today, amount=-1000,
+        dt=today, amount=-1000, other_account_scope="outside",
     )
-    # Other account — same user, same category, must NOT appear
+    # Other account, same user, same category, must NOT appear
     await _create_transaction(
         client, headers, other_account_id, category_id,
-        dt=today, amount=-9999,
+        dt=today, amount=-9999, other_account_scope="outside",
     )
 
     resp = await client.get(
@@ -447,12 +447,12 @@ async def test_prior_month_transaction_lands_in_second_to_last_entry(client):
     # Seed an expense on the 15th of last month (safe across month-length boundaries)
     await _create_transaction(
         client, headers, account_id, category_id,
-        dt=_mid_of_prior_month(today).isoformat(), amount=-3000,
+        dt=_mid_of_prior_month(today).isoformat(), amount=-3000, other_account_scope="outside",
     )
     # And a different expense in the current month — confirms both buckets compute independently
     await _create_transaction(
         client, headers, account_id, category_id,
-        dt=today.isoformat(), amount=-700,
+        dt=today.isoformat(), amount=-700, other_account_scope="outside",
     )
 
     resp = await client.get(
@@ -484,7 +484,7 @@ async def test_transaction_outside_the_window_does_not_contribute(client):
     out_of_window = _first_of_month_n_back(today, 5).replace(day=15)
     await _create_transaction(
         client, headers, account_id, category_id,
-        dt=out_of_window.isoformat(), amount=-9999,
+        dt=out_of_window.isoformat(), amount=-9999, other_account_scope="outside",
     )
 
     resp = await client.get(
@@ -514,7 +514,7 @@ async def test_transaction_on_window_start_is_included(client):
     window_start = _first_of_month_n_back(today, 5)
     await _create_transaction(
         client, headers, account_id, category_id,
-        dt=window_start.isoformat(), amount=-1000,
+        dt=window_start.isoformat(), amount=-1000, other_account_scope="outside",
     )
 
     resp = await client.get(
@@ -542,7 +542,7 @@ async def test_transaction_on_day_before_window_start_is_excluded(client):
     day_before = window_start - timedelta(days=1)
     await _create_transaction(
         client, headers, account_id, category_id,
-        dt=day_before.isoformat(), amount=-9999,
+        dt=day_before.isoformat(), amount=-9999, other_account_scope="outside",
     )
 
     resp = await client.get(
@@ -712,7 +712,7 @@ async def test_closed_account_still_returns_cash_flow(client):
 
     await _create_transaction(
         client, headers, account_id, category_id,
-        dt=_today_utc().isoformat(), amount=-1000,
+        dt=_today_utc().isoformat(), amount=-1000, other_account_scope="outside",
     )
 
     close_resp = await client.patch(

--- a/backend/tests/routes/accounts/test_spending_breakdown.py
+++ b/backend/tests/routes/accounts/test_spending_breakdown.py
@@ -1,9 +1,12 @@
 """Route tests for GET /accounts/{account_id}/spending-breakdown."""
 import importlib
+import uuid
 from datetime import UTC, date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
-from tests.routes.support import _create_account, _create_user, _get_auth_header
+from app.models.transaction import Transaction
+from tests.conftest import TestSession
+from tests.routes.support import _create_account, _create_user, _get_auth_header, _get_system_merchant_id
 
 # --- Helpers ---
 
@@ -59,6 +62,10 @@ async def _create_transaction(client, headers, account_id, category_id, **overri
         "currency": "CAD",
         **overrides,
     }
+
+    # The route requires a merchant, so a test that does not care which one gets the shared Myself
+    if "merchant_id" not in payload:
+        payload["merchant_id"] = await _get_system_merchant_id(client, headers)
     return await client.post("/transactions", json=payload, headers=headers)
 
 
@@ -324,16 +331,26 @@ async def test_expense_without_merchant_contributes_to_categories_and_total_only
     category = (await _create_category(client, headers)).json()
     merchant = (await _create_merchant(client, headers)).json()
 
-    today = _today_utc().isoformat()
+    today = _today_utc()
     # One expense with a merchant, one without
-    await _create_transaction(
+    with_merchant = await _create_transaction(
         client, headers, account_id, category["id"],
-        dt=today, amount=-1000, merchant_id=merchant["id"],
+        dt=today.isoformat(), amount=-1000, merchant_id=merchant["id"],
     )
-    await _create_transaction(
-        client, headers, account_id, category["id"],
-        dt=today, amount=-400,  # merchant_id omitted → None
-    )
+
+    # Inserted past the route, which now requires a merchant, since what is under test is how the
+    # breakdown reports the transactions recorded before that rule
+    async with TestSession() as session:
+        session.add(Transaction(
+            created_by_user_id=uuid.UUID(with_merchant.json()["created_by_user_id"]),
+            account_id=uuid.UUID(account_id),
+            dt=today,
+            category_id=uuid.UUID(category["id"]),
+            merchant_id=None,
+            amount=-400,
+            currency="CAD",
+        ))
+        await session.commit()
 
     resp = await client.get(
         f"/accounts/{account_id}/spending-breakdown",
@@ -358,15 +375,19 @@ async def test_expense_without_merchant_contributes_to_categories_and_total_only
 # --- Top-5 cap and other counts ---
 
 
-async def test_top_five_cap_with_seven_categories_and_eight_merchants(client):
-    """Top-5 cap: with 7 distinct categories and 8 distinct merchants, response has 5 of each plus other counts."""
+async def test_top_five_cap_with_seven_categories_and_nine_merchants(client):
+    """Top-5 cap: with 7 distinct categories and 9 distinct merchants, response has 5 of each plus other counts."""
     headers, account_id = await _setup_account(client)
 
     today = _today_utc().isoformat()
 
-    # 7 categories. Category 0 gets a large base spend so it remains the biggest
-    # category even after we pile the 8 merchant transactions onto one other
-    # category below — this keeps the category ordering deterministic
+    # Every transaction carries a merchant, so the base spends share one of their own rather than
+    # landing on whichever merchant the helper would otherwise pick
+    base_merchant = (await _create_merchant(client, headers, name="Base Spend")).json()
+
+    # 7 categories. Category 0 gets a large base spend so it remains the biggest category even
+    # after the 8 merchant transactions below pile onto another one, which keeps the category
+    # ordering deterministic
     categories = []
     for i in range(7):
         cat = (await _create_category(client, headers, name=f"Test Cat {i}")).json()
@@ -375,7 +396,7 @@ async def test_top_five_cap_with_seven_categories_and_eight_merchants(client):
         base = 100_000 if i == 0 else (70_000 - i * 10_000)
         await _create_transaction(
             client, headers, account_id, cat["id"],
-            dt=today, amount=-base,
+            dt=today, amount=-base, merchant_id=base_merchant["id"],
         )
 
     # 8 distinct merchants attached to the LAST of the 7 categories — that way
@@ -402,19 +423,20 @@ async def test_top_five_cap_with_seven_categories_and_eight_merchants(client):
     # Top-5 cap applied on both
     assert len(data["top_categories"]) == 5
     assert len(data["top_merchants"]) == 5
-    # 7 categories → 2 beyond the top 5; 8 merchants → 3 beyond
+    # 7 categories → 2 beyond the top 5; 9 merchants → 4 beyond
     assert data["other_categories_count"] == 2
-    assert data["other_merchants_count"] == 3
+    assert data["other_merchants_count"] == 4
 
     # Category 0 remains the largest category (-100_000 base, no merchant pile)
     assert data["top_categories"][0]["category_id"] == categories[0]["id"]
     assert data["top_categories"][0]["total"] == 100_000
 
-    # Top merchants: the five with the largest spend (i=0..4) in descending order
+    # The base merchant carries every category's base spend, so it leads, followed by the four
+    # largest of the eight
     merchant_ids_returned = [m["merchant_id"] for m in data["top_merchants"]]
-    assert merchant_ids_returned == [merchants[i]["id"] for i in range(5)]
+    assert merchant_ids_returned == [base_merchant["id"], *[merchants[i]["id"] for i in range(4)]]
     merchant_totals = [m["total"] for m in data["top_merchants"]]
-    assert merchant_totals == [8000 - i * 100 for i in range(5)]
+    assert merchant_totals == [310_000, *[8000 - i * 100 for i in range(4)]]
 
 
 async def test_exactly_five_entries_yields_zero_other_counts(client):

--- a/backend/tests/routes/budgets/_utilization_helpers.py
+++ b/backend/tests/routes/budgets/_utilization_helpers.py
@@ -7,7 +7,7 @@ import sqlalchemy as sa
 from app.models.budget import BudgetTrackedCategory
 from app.models.currency import Currency
 from tests.conftest import TestSession
-from tests.routes.support import _get_auth_header
+from tests.routes.support import _get_auth_header, _get_system_merchant_id
 
 NONEXISTENT_ID = "00000000-0000-0000-0000-000000000000"
 
@@ -138,6 +138,10 @@ async def _create_transaction(client, headers, account_id, category_id, **overri
         "currency": "CAD",
         **overrides,
     }
+
+    # The route requires a merchant, so a test that does not care which one gets the shared Myself
+    if "merchant_id" not in payload:
+        payload["merchant_id"] = await _get_system_merchant_id(client, headers)
     return await client.post("/transactions", json=payload, headers=headers)
 
 async def _grant_base_budget_permission(client, admin_headers, base_budget_id, user_id, level):

--- a/backend/tests/routes/categories/test_category_merges.py
+++ b/backend/tests/routes/categories/test_category_merges.py
@@ -135,3 +135,46 @@ async def test_merge_group_category_as_non_admin_returns_403(client):
 
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Admin role required"
+
+
+async def test_merge_into_balance_adjustment_clears_the_recorded_other_account(client):
+    """Balance Adjustment has no other side, so a recorded account cannot survive the move."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    source_id = (await _create_category(client, headers, name="Account Move", kind="transfer")).json()["id"]
+    categories = await client.get("/categories", headers=headers)
+    balance_adjustment_id = next(
+        category["id"] for category in categories.json() if category["name"] == "Balance Adjustment"
+    )
+
+    holder_id = (await client.post("/accounts", json={
+        "account_kind": "asset", "account_type": "checking", "name": "Chequing", "currency": "CAD",
+    }, headers=headers)).json()["id"]
+    recorded_id = (await client.post("/accounts", json={
+        "account_kind": "asset", "account_type": "savings", "name": "Savings", "currency": "CAD",
+    }, headers=headers)).json()["id"]
+
+    created = await client.post("/transactions", json={
+        "account_id": holder_id,
+        "category_id": source_id,
+        "dt": "2026-03-15",
+        "amount": -5000,
+        "currency": "CAD",
+        "other_account_scope": "tracked",
+        "other_account_id": recorded_id,
+    }, headers=headers)
+    assert created.status_code == 201
+    txn_id = created.json()["id"]
+
+    merge_resp = await client.post(
+        f"/categories/{source_id}/merge",
+        json={"replacement_category_id": balance_adjustment_id},
+        headers=headers,
+    )
+
+    assert merge_resp.status_code == 204
+    moved = await client.get(f"/transactions/{txn_id}", headers=headers)
+    assert moved.json()["category_id"] == balance_adjustment_id
+    assert moved.json()["other_account_id"] is None
+    assert moved.json()["other_account_scope"] is None

--- a/backend/tests/routes/categories/test_category_merges.py
+++ b/backend/tests/routes/categories/test_category_merges.py
@@ -2,7 +2,7 @@ from tests.routes.categories._helpers import (
     _create_category,
     _setup_group_with_member,
 )
-from tests.routes.support import _create_user, _get_auth_header
+from tests.routes.support import _create_user, _get_auth_header, _get_system_merchant_id
 
 # --- POST /categories/{category_id}/merge ---
 
@@ -28,6 +28,7 @@ async def test_merge_category_reassigns_references_and_deletes_source(client):
         "dt": "2026-03-15",
         "amount": -5000,
         "currency": "CAD",
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
     merchant_resp = await client.post("/merchants", json={
         "name": "Costco",
@@ -163,6 +164,7 @@ async def test_merge_into_balance_adjustment_clears_the_recorded_other_account(c
         "currency": "CAD",
         "other_account_scope": "tracked",
         "other_account_id": recorded_id,
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
     assert created.status_code == 201
     txn_id = created.json()["id"]

--- a/backend/tests/routes/categories/test_group_categories.py
+++ b/backend/tests/routes/categories/test_group_categories.py
@@ -4,7 +4,7 @@ from tests.routes.categories._helpers import (
     _create_group,
     _setup_group_with_member,
 )
-from tests.routes.support import _create_user, _get_auth_header
+from tests.routes.support import _create_user, _get_auth_header, _get_system_merchant_id
 
 # --- Group categories: POST /categories ---
 
@@ -343,6 +343,7 @@ async def test_delete_category_referenced_by_transaction_returns_409(client):
         "dt": "2026-03-15",
         "amount": -5000,
         "currency": "CAD",
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
 
     resp = await client.delete(f"/categories/{category_id}", headers=headers)

--- a/backend/tests/routes/dashboard/_helpers.py
+++ b/backend/tests/routes/dashboard/_helpers.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
+from tests.routes.support import _get_system_merchant_id
+
 
 class _FixedClock:
     """Fixed clock used to make dashboard ranges deterministic"""
@@ -41,4 +43,8 @@ async def _create_transaction(client, headers, account_id, category_id, **overri
         "currency": "CAD",
         **overrides,
     }
+
+    # The route requires a merchant, so a test that does not care which one gets the shared Myself
+    if "merchant_id" not in payload:
+        payload["merchant_id"] = await _get_system_merchant_id(client, headers)
     return await client.post("/transactions", json=payload, headers=headers)

--- a/backend/tests/routes/groups/test_groups.py
+++ b/backend/tests/routes/groups/test_groups.py
@@ -856,3 +856,36 @@ async def test_remove_member_without_auth_returns_401(client):
     """DELETE /groups/{id}/members/{id} without auth returns 401."""
     resp = await client.delete(f"/groups/{NONEXISTENT_ID}/members/{NONEXISTENT_ID}")
     assert resp.status_code == 401
+
+
+async def test_delete_group_whose_account_a_transfer_records_returns_409(client):
+    """The group's accounts go with it, so a transfer recording one of them blocks the delete."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    group_id = (await _create_group(client, headers)).json()["id"]
+
+    group_account_id = (await client.post("/accounts", json={
+        "account_kind": "asset", "account_type": "savings", "name": "Shared Savings",
+        "currency": "CAD", "group_id": group_id,
+    }, headers=headers)).json()["id"]
+    personal_account_id = (await client.post("/accounts", json={
+        "account_kind": "asset", "account_type": "checking", "name": "Chequing", "currency": "CAD",
+    }, headers=headers)).json()["id"]
+
+    categories = await client.get("/categories", headers=headers)
+    transfer_id = next(category["id"] for category in categories.json() if category["name"] == "Transfer")
+
+    created = await client.post("/transactions", json={
+        "account_id": personal_account_id,
+        "category_id": transfer_id,
+        "dt": "2026-03-15",
+        "amount": -5000,
+        "currency": "CAD",
+        "other_account_scope": "tracked",
+        "other_account_id": group_account_id,
+    }, headers=headers)
+    assert created.status_code == 201
+
+    resp = await client.delete(f"/groups/{group_id}", headers=headers)
+
+    assert resp.status_code == 409

--- a/backend/tests/routes/groups/test_groups.py
+++ b/backend/tests/routes/groups/test_groups.py
@@ -889,3 +889,39 @@ async def test_delete_group_whose_account_a_transfer_records_returns_409(client)
     resp = await client.delete(f"/groups/{group_id}", headers=headers)
 
     assert resp.status_code == 409
+
+
+async def test_delete_group_with_a_transfer_between_its_own_accounts_returns_204(client):
+    """Both sides go with the group, so nothing outside it is left recording a deleted account."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    group_id = (await _create_group(client, headers)).json()["id"]
+
+    # The recorded account is created first, so the cascade can reach it before the transaction
+    # recording it has been removed. The other order passes whatever the foreign key does
+    recorded_id = (await client.post("/accounts", json={
+        "account_kind": "asset", "account_type": "savings", "name": "Shared Savings",
+        "currency": "CAD", "group_id": group_id,
+    }, headers=headers)).json()["id"]
+    holder_id = (await client.post("/accounts", json={
+        "account_kind": "asset", "account_type": "checking", "name": "Shared Chequing",
+        "currency": "CAD", "group_id": group_id,
+    }, headers=headers)).json()["id"]
+
+    categories = await client.get("/categories", headers=headers)
+    transfer_id = next(category["id"] for category in categories.json() if category["name"] == "Transfer")
+
+    created = await client.post("/transactions", json={
+        "account_id": holder_id,
+        "category_id": transfer_id,
+        "dt": "2026-03-15",
+        "amount": -5000,
+        "currency": "CAD",
+        "other_account_scope": "tracked",
+        "other_account_id": recorded_id,
+    }, headers=headers)
+    assert created.status_code == 201
+
+    resp = await client.delete(f"/groups/{group_id}", headers=headers)
+
+    assert resp.status_code == 204

--- a/backend/tests/routes/groups/test_groups.py
+++ b/backend/tests/routes/groups/test_groups.py
@@ -1,4 +1,4 @@
-from tests.routes.support import _create_user, _get_auth_header
+from tests.routes.support import _create_user, _get_auth_header, _get_system_merchant_id
 
 # --- Helpers ---
 
@@ -883,6 +883,7 @@ async def test_delete_group_whose_account_a_transfer_records_returns_409(client)
         "currency": "CAD",
         "other_account_scope": "tracked",
         "other_account_id": group_account_id,
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
     assert created.status_code == 201
 
@@ -919,6 +920,7 @@ async def test_delete_group_with_a_transfer_between_its_own_accounts_returns_204
         "currency": "CAD",
         "other_account_scope": "tracked",
         "other_account_id": recorded_id,
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
     assert created.status_code == 201
 

--- a/backend/tests/routes/groups/test_transactions.py
+++ b/backend/tests/routes/groups/test_transactions.py
@@ -4,7 +4,7 @@ Verifies cross-user isolation holds even when users share a group,
 and documents current limitations around group account transactions
 """
 
-from tests.routes.support import _create_user, _get_auth_header
+from tests.routes.support import _create_user, _get_auth_header, _get_system_merchant_id
 
 # --- Helpers ---
 
@@ -72,6 +72,10 @@ async def _create_transaction(client, headers, account_id, category_id, **overri
         "currency": "CAD",
         **overrides,
     }
+
+    # The route requires a merchant, so a test that does not care which one gets the shared Myself
+    if "merchant_id" not in payload:
+        payload["merchant_id"] = await _get_system_merchant_id(client, headers)
     return await client.post("/transactions", json=payload, headers=headers)
 
 

--- a/backend/tests/routes/insights/test_period_glance.py
+++ b/backend/tests/routes/insights/test_period_glance.py
@@ -12,7 +12,7 @@ from app.models.category import Category
 from app.models.currency import Currency
 from app.models.transaction import Transaction
 from tests.conftest import TestSession
-from tests.routes.support import _create_account, _create_user, _get_auth_header
+from tests.routes.support import _create_account, _create_user, _get_auth_header, _get_system_merchant_id
 
 
 def _category(user_id: UUID, name: str, kind: CategoryKind) -> tuple[UUID, Category]:
@@ -59,6 +59,10 @@ async def _create_transaction_api(client, headers, account_id, category_id, **ov
         "currency": "CAD",
         **overrides,
     }
+
+    # The route requires a merchant, so a test that does not care which one gets the shared Myself
+    if "merchant_id" not in payload:
+        payload["merchant_id"] = await _get_system_merchant_id(client, headers)
     return await client.post("/transactions", json=payload, headers=headers)
 
 

--- a/backend/tests/routes/merchants/_helpers.py
+++ b/backend/tests/routes/merchants/_helpers.py
@@ -6,6 +6,21 @@ MERCHANT_PAYLOAD = {
     "name": "Costco",
 }
 
+
+def _own_merchant_names(response):
+    """Return the names of a merchant listing, without the ones that ship with the app
+
+    Every listing carries the system merchants, so a test about a user's own merchants filters
+    them out rather than repeating them in each expected list
+
+    Args:
+        response: API response from a merchant listing endpoint
+
+    Returns:
+        Names of the merchants the user or their group owns, in the order returned
+    """
+    return [merchant["name"] for merchant in response.json() if not merchant["is_system"]]
+
 async def _create_merchant(client, headers, **overrides):
     """Create a merchant via POST /merchants
 

--- a/backend/tests/routes/merchants/test_group_merchants.py
+++ b/backend/tests/routes/merchants/test_group_merchants.py
@@ -4,6 +4,7 @@ from tests.routes.merchants._helpers import (
     _create_group,
     _create_merchant,
     _get_system_category_id,
+    _own_merchant_names,
     _setup_group_with_member,
 )
 from tests.routes.support import _create_user, _get_auth_header
@@ -228,12 +229,7 @@ async def test_list_merchants_with_group_filter_excludes_other_groups(client):
     resp = await client.get(f"/merchants?group_id={group_b}", headers=headers)
 
     assert resp.status_code == 200
-    data = resp.json()
-    names = {m["name"] for m in data}
-    assert len(data) == 2
-    assert "Personal Store" in names
-    assert "Group B Store" in names
-    assert "Group A Store" not in names
+    assert set(_own_merchant_names(resp)) == {"Personal Store", "Group B Store"}
 
 
 async def test_list_merchants_group_filter_supports_search_and_pagination(client):

--- a/backend/tests/routes/merchants/test_merchant_merges.py
+++ b/backend/tests/routes/merchants/test_merchant_merges.py
@@ -4,9 +4,43 @@ from tests.routes.merchants._helpers import (
     _get_system_category_id,
     _setup_group_with_member,
 )
-from tests.routes.support import _create_user, _get_auth_header
+from tests.routes.support import _create_user, _get_auth_header, _get_system_merchant_id
 
 # --- POST /merchants/{merchant_id}/merge ---
+
+
+async def test_merge_merchant_into_a_system_merchant_restamps_its_transactions(client):
+    """Merging into Myself restamps the transactions onto it, which is what folding an own spelling means."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    category_id = await _get_system_category_id(client, headers)
+    source_id = (await _create_merchant(client, headers, name="Me")).json()["id"]
+    system_merchant_id = await _get_system_merchant_id(client, headers)
+
+    account_resp = await client.post("/accounts", json={
+        "account_kind": "asset", "account_type": "checking", "name": "Chequing", "currency": "CAD",
+    }, headers=headers)
+    await client.post("/transactions", json={
+        "account_id": account_resp.json()["id"],
+        "category_id": category_id,
+        "merchant_id": source_id,
+        "dt": "2026-03-15",
+        "amount": -5000,
+        "currency": "CAD",
+    }, headers=headers)
+
+    resp = await client.post(
+        f"/merchants/{source_id}/merge",
+        json={"replacement_merchant_id": system_merchant_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 204
+    assert (await client.get(f"/merchants/{source_id}", headers=headers)).status_code == 404
+
+    transactions_resp = await client.get("/transactions", headers=headers)
+    assert transactions_resp.json()[0]["merchant_id"] == system_merchant_id
 
 
 async def test_merge_merchant_reassigns_transactions_and_deletes_source(client):

--- a/backend/tests/routes/merchants/test_merchant_ranking.py
+++ b/backend/tests/routes/merchants/test_merchant_ranking.py
@@ -4,6 +4,7 @@ from app.routes.merchants.listing_helpers import MERCHANT_FREQUENCY_WINDOW_DAYS
 from tests.routes.merchants._helpers import (
     _create_merchant,
     _get_system_category_id,
+    _own_merchant_names,
 )
 from tests.routes.support import _create_user, _get_auth_header
 
@@ -70,7 +71,7 @@ async def test_list_merchants_ranks_more_used_merchant_first(client):
     resp = await client.get("/merchants", headers=headers)
 
     assert resp.status_code == 200
-    assert [merchant["name"] for merchant in resp.json()] == ["Zulu Store", "Mike Store", "Alpha Store"]
+    assert _own_merchant_names(resp) == ["Zulu Store", "Mike Store", "Alpha Store"]
 
 
 async def test_list_merchants_breaks_frequency_ties_by_name(client):
@@ -91,7 +92,7 @@ async def test_list_merchants_breaks_frequency_ties_by_name(client):
     resp = await client.get("/merchants", headers=headers)
 
     assert resp.status_code == 200
-    assert [merchant["name"] for merchant in resp.json()] == ["Bravo Market", "Charlie Market", "Alpha Market"]
+    assert _own_merchant_names(resp) == ["Bravo Market", "Charlie Market", "Alpha Market"]
 
 
 async def test_list_merchants_ignores_usage_outside_window(client):
@@ -110,7 +111,7 @@ async def test_list_merchants_ignores_usage_outside_window(client):
     resp = await client.get("/merchants", headers=headers)
 
     assert resp.status_code == 200
-    assert [merchant["name"] for merchant in resp.json()] == ["Fresh Store", "Stale Store"]
+    assert _own_merchant_names(resp) == ["Fresh Store", "Stale Store"]
 
 
 async def test_list_merchants_ranks_by_all_history_when_shorter_than_window(client):
@@ -129,4 +130,4 @@ async def test_list_merchants_ranks_by_all_history_when_shorter_than_window(clie
     resp = await client.get("/merchants", headers=headers)
 
     assert resp.status_code == 200
-    assert [merchant["name"] for merchant in resp.json()] == ["Busy Store", "Quiet Store"]
+    assert _own_merchant_names(resp) == ["Busy Store", "Quiet Store"]

--- a/backend/tests/routes/merchants/test_merchant_ranking.py
+++ b/backend/tests/routes/merchants/test_merchant_ranking.py
@@ -53,6 +53,31 @@ async def _record_merchant_transactions(client, headers, account_id, category_id
         }, headers=headers)
 
 
+async def test_list_merchants_ignores_the_balance_adjustments_the_app_writes(client):
+    """Opening accounts is not transacting, so the merchant those adjustments carry does not climb."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    # Each account written with a starting balance produces a balance adjustment carrying Myself
+    for name in ("Chequing", "Savings", "Vacation"):
+        await client.post("/accounts", json={
+            "account_kind": "asset",
+            "account_type": "checking",
+            "name": name,
+            "currency": "CAD",
+            "starting_balance": 100_00,
+        }, headers=headers)
+
+    account_id = await _create_checking_account(client, headers)
+    category_id = await _get_system_category_id(client, headers)
+    merchant_id = (await _create_merchant(client, headers, name="Corner Shop")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, merchant_id, 1, date.today())
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert [merchant["name"] for merchant in resp.json()][0] == "Corner Shop"
+
+
 async def test_list_merchants_ranks_more_used_merchant_first(client):
     """Merchants with more recent transactions rank above less used ones regardless of name."""
     headers = _get_auth_header(await _create_user(client))

--- a/backend/tests/routes/merchants/test_merchant_ranking.py
+++ b/backend/tests/routes/merchants/test_merchant_ranking.py
@@ -75,7 +75,7 @@ async def test_list_merchants_ignores_the_balance_adjustments_the_app_writes(cli
 
     resp = await client.get("/merchants", headers=headers)
 
-    assert [merchant["name"] for merchant in resp.json()][0] == "Corner Shop"
+    assert next(merchant["name"] for merchant in resp.json()) == "Corner Shop"
 
 
 async def test_list_merchants_ranks_more_used_merchant_first(client):

--- a/backend/tests/routes/merchants/test_personal_merchants.py
+++ b/backend/tests/routes/merchants/test_personal_merchants.py
@@ -1,3 +1,7 @@
+import uuid
+
+from app.models.merchant import Merchant
+from tests.conftest import TestSession
 from tests.routes.merchants._helpers import (
     MERCHANT_PAYLOAD,
     _own_merchant_names,
@@ -390,6 +394,36 @@ async def test_patch_merchant_rename_to_duplicate_returns_409(client):
     # Verify the merchant was not mutated
     get_resp = await client.get(f"/merchants/{merchant_id}", headers=headers)
     assert get_resp.json()["name"] == "Walmart"
+
+
+async def test_patch_merchant_recapitalises_its_own_name(client):
+    """The duplicate check leaves the merchant itself out, so correcting its capitalisation is a rename it can make."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    merchant_id = (await _create_merchant(client, headers, name="corner shop")).json()["id"]
+
+    resp = await client.patch(f"/merchants/{merchant_id}", json={"name": "Corner Shop"}, headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Corner Shop"
+
+
+async def test_creating_a_merchant_beside_two_stored_case_variants_returns_409(client):
+    """A database written before capitalisation stopped counting can hold both, and the check still answers cleanly."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    created = (await _create_merchant(client, headers, name="Corner Shop")).json()
+
+    # Inserted past the route, which now refuses the second variant, to stand in for the pair a
+    # database from before this rule already holds
+    async with TestSession() as session:
+        session.add(Merchant(owner_id=uuid.UUID(created["owner_id"]), name="corner shop"))
+        await session.commit()
+
+    resp = await _create_merchant(client, headers, name="CORNER SHOP")
+
+    assert resp.status_code == 409
+    assert "already exists" in resp.json()["detail"]
 
 
 async def test_patch_merchant_without_auth_returns_401(client):

--- a/backend/tests/routes/merchants/test_personal_merchants.py
+++ b/backend/tests/routes/merchants/test_personal_merchants.py
@@ -1,5 +1,6 @@
 from tests.routes.merchants._helpers import (
     MERCHANT_PAYLOAD,
+    _own_merchant_names,
     NONEXISTENT_ID,
     _create_category,
     _create_merchant,
@@ -19,7 +20,7 @@ async def test_list_merchants_returns_empty_list(client):
     resp = await client.get("/merchants", headers=headers)
 
     assert resp.status_code == 200
-    assert resp.json() == []
+    assert _own_merchant_names(resp) == []
 
 
 async def test_list_merchants_returns_user_merchants(client):
@@ -36,10 +37,7 @@ async def test_list_merchants_returns_user_merchants(client):
     resp = await client.get("/merchants", headers=headers)
 
     assert resp.status_code == 200
-    data = resp.json()
-    assert len(data) == 2
-    names = {m["name"] for m in data}
-    assert names == {"Costco", "Walmart"}
+    assert set(_own_merchant_names(resp)) == {"Costco", "Walmart"}
 
 
 async def test_list_merchants_supports_limit_and_offset(client):
@@ -54,10 +52,12 @@ async def test_list_merchants_supports_limit_and_offset(client):
     first_page = await client.get("/merchants?limit=2", headers=headers)
     second_page = await client.get("/merchants?limit=2&offset=2", headers=headers)
 
+    # Paging counts the system merchants too, since a page is what the endpoint returns rather than
+    # what the user owns, and an unused one sorts by name among the rest
     assert first_page.status_code == 200
     assert [merchant["name"] for merchant in first_page.json()] == ["Alpha Market", "Bravo Market"]
     assert second_page.status_code == 200
-    assert [merchant["name"] for merchant in second_page.json()] == ["Charlie Market"]
+    assert [merchant["name"] for merchant in second_page.json()] == ["Charlie Market", "Myself"]
 
 
 async def test_list_merchants_searches_names_case_insensitively(client):
@@ -74,7 +74,7 @@ async def test_list_merchants_searches_names_case_insensitively(client):
     resp = await client.get("/merchants?q=COF", headers=headers)
 
     assert resp.status_code == 200
-    assert [merchant["name"] for merchant in resp.json()] == ["Coffee Bar"]
+    assert _own_merchant_names(resp) == ["Coffee Bar"]
 
 
 async def test_list_merchants_rejects_invalid_pagination_params(client):
@@ -444,3 +444,58 @@ async def test_delete_merchant_without_auth_returns_401(client):
     """DELETE /merchants/{id} without an Authorization header returns 401."""
     resp = await client.delete(f"/merchants/{NONEXISTENT_ID}")
     assert resp.status_code == 401
+
+
+# --- System merchants ---
+
+
+async def _system_merchant(client, headers, name="Myself"):
+    """Return the system merchant with the given name from the listing."""
+    resp = await client.get("/merchants", headers=headers)
+    return next(merchant for merchant in resp.json() if merchant["name"] == name)
+
+
+async def test_system_merchant_is_listed_for_every_user(client):
+    """A merchant that ships with the app belongs to everyone rather than to one user."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    other_headers = _get_auth_header(await _create_second_user(client))
+
+    for user_headers in (headers, other_headers):
+        merchant = await _system_merchant(client, user_headers)
+        assert merchant["is_system"] is True
+        assert merchant["owner_id"] is None
+        assert merchant["default_category_id"] is None
+
+
+async def test_creating_a_merchant_with_a_system_name_returns_409(client):
+    """The seeded name is taken everywhere, so a second Myself cannot appear beside it."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    resp = await _create_merchant(client, headers, name="Myself")
+
+    assert resp.status_code == 409
+    assert "already exists" in resp.json()["detail"]
+
+
+async def test_renaming_a_system_merchant_returns_403(client):
+    """A merchant that ships with the app is not one user's to rename."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    merchant = await _system_merchant(client, headers)
+
+    resp = await client.patch(f"/merchants/{merchant['id']}", json={"name": "Me"}, headers=headers)
+
+    assert resp.status_code == 403
+
+
+async def test_deleting_a_system_merchant_returns_403(client):
+    """Nor is it one user's to delete out from under everyone else."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    merchant = await _system_merchant(client, headers)
+
+    resp = await client.delete(f"/merchants/{merchant['id']}", headers=headers)
+
+    assert resp.status_code == 403

--- a/backend/tests/routes/merchants/test_personal_merchants.py
+++ b/backend/tests/routes/merchants/test_personal_merchants.py
@@ -499,3 +499,40 @@ async def test_deleting_a_system_merchant_returns_403(client):
     resp = await client.delete(f"/merchants/{merchant['id']}", headers=headers)
 
     assert resp.status_code == 403
+
+
+async def test_creating_a_merchant_with_a_system_name_in_any_case_returns_409(client):
+    """A different capitalisation would read as a second copy of the same merchant."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    resp = await _create_merchant(client, headers, name="mYsElF")
+
+    assert resp.status_code == 409
+
+
+async def test_renaming_a_merchant_onto_a_system_name_returns_409(client):
+    """The reserved name holds on rename, not only on create."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    merchant_id = (await _create_merchant(client, headers, name="Corner Shop")).json()["id"]
+
+    resp = await client.patch(f"/merchants/{merchant_id}", json={"name": "Myself"}, headers=headers)
+
+    assert resp.status_code == 409
+
+
+async def test_merging_a_system_merchant_away_returns_403(client):
+    """Merging deletes the source, so it is refused for the merchant everyone shares."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    replacement_id = (await _create_merchant(client, headers, name="Corner Shop")).json()["id"]
+    system_merchant = await _system_merchant(client, headers)
+
+    resp = await client.post(
+        f"/merchants/{system_merchant['id']}/merge",
+        json={"replacement_merchant_id": replacement_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 403

--- a/backend/tests/routes/merchants/test_personal_merchants.py
+++ b/backend/tests/routes/merchants/test_personal_merchants.py
@@ -4,12 +4,12 @@ from app.models.merchant import Merchant
 from tests.conftest import TestSession
 from tests.routes.merchants._helpers import (
     MERCHANT_PAYLOAD,
-    _own_merchant_names,
     NONEXISTENT_ID,
     _create_category,
     _create_merchant,
     _create_second_user,
     _get_system_category_id,
+    _own_merchant_names,
 )
 from tests.routes.support import _create_user, _get_auth_header
 

--- a/backend/tests/routes/support/__init__.py
+++ b/backend/tests/routes/support/__init__.py
@@ -9,6 +9,7 @@ from tests.routes.support.auth_helpers import (
     _seed_currency,
     _seed_reset_token,
 )
+from tests.routes.support.merchant_helpers import _get_system_merchant_id
 
 __all__ = [
     "ACCOUNT_PAYLOAD",
@@ -17,6 +18,7 @@ __all__ = [
     "_create_user",
     "_fresh_totp_code",
     "_get_auth_header",
+    "_get_system_merchant_id",
     "_seed_currency",
     "_seed_reset_token",
 ]

--- a/backend/tests/routes/support/merchant_helpers.py
+++ b/backend/tests/routes/support/merchant_helpers.py
@@ -1,0 +1,19 @@
+"""Shared merchant route test helpers"""
+
+
+async def _get_system_merchant_id(client, headers, name="Myself"):
+    """Return the identifier of a merchant that ships with the app
+
+    The create and edit routes require a merchant, so a test that does not care which one uses this
+    rather than making its own
+
+    Args:
+        client: Async test client
+        headers: Auth headers for the requesting user
+        name: Merchant name to look up
+
+    Returns:
+        Identifier of the named system merchant
+    """
+    resp = await client.get("/merchants", headers=headers)
+    return next(merchant["id"] for merchant in resp.json() if merchant["name"] == name)

--- a/backend/tests/routes/tags/test_personal_tags.py
+++ b/backend/tests/routes/tags/test_personal_tags.py
@@ -1,4 +1,4 @@
-from tests.routes.support import _create_account, _create_user, _get_auth_header
+from tests.routes.support import _create_account, _create_user, _get_auth_header, _get_system_merchant_id
 from tests.routes.tags._helpers import (
     NONEXISTENT_ID,
     TAG_PAYLOAD,
@@ -351,6 +351,7 @@ async def test_delete_tag_referenced_by_transaction_returns_409(client):
         "amount": -5000,
         "currency": "CAD",
         "tag_ids": [tag_id],
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
     assert txn_resp.status_code == 201
 
@@ -384,6 +385,7 @@ async def test_merge_tag_moves_transaction_references_and_deletes_source(client)
         "amount": -5000,
         "currency": "CAD",
         "tag_ids": [source_id],
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
     transaction_id = transaction_resp.json()["id"]
 
@@ -424,6 +426,7 @@ async def test_merge_tag_deduplicates_existing_replacement_reference(client):
         "amount": -5000,
         "currency": "CAD",
         "tag_ids": [source_id, replacement_id],
+        "merchant_id": await _get_system_merchant_id(client, headers),
     }, headers=headers)
     transaction_id = transaction_resp.json()["id"]
 

--- a/backend/tests/routes/tax_advantaged_categories/test_tax_advantaged_categories.py
+++ b/backend/tests/routes/tax_advantaged_categories/test_tax_advantaged_categories.py
@@ -3,7 +3,7 @@ from datetime import UTC, date, datetime
 from sqlalchemy import select
 
 import app.services.tax_advantaged_categories as tax_advantaged_category_services
-from app.models.base import CategoryKind
+from app.models.base import CategoryKind, TransferOtherAccountScope
 from app.models.category import Category
 from app.models.transaction import Transaction
 from tests.conftest import TestSession
@@ -68,7 +68,15 @@ async def _get_system_category_id(name: str):
         return category_id
 
 
-async def _seed_transaction(account_id, category_id, created_by_user_id, amount: int, dt: date) -> None:
+async def _seed_transaction(
+    account_id,
+    category_id,
+    created_by_user_id,
+    amount: int,
+    dt: date,
+    other_account_id=None,
+    other_account_scope: TransferOtherAccountScope | None = None,
+) -> None:
     """Insert a transaction directly via DB
 
     Args:
@@ -77,6 +85,8 @@ async def _seed_transaction(account_id, category_id, created_by_user_id, amount:
         created_by_user_id: User that created the transaction
         amount: Signed transaction amount in minor units
         dt: Transaction date
+        other_account_id: Account recorded on the other side of a transfer, set only with a tracked scope
+        other_account_scope: Where the other side sits, or None for a transfer that recorded no answer
     """
     async with TestSession() as session:
         session.add(Transaction(
@@ -86,6 +96,8 @@ async def _seed_transaction(account_id, category_id, created_by_user_id, amount:
             dt=dt,
             amount=amount,
             currency="CAD",
+            other_account_id=other_account_id,
+            other_account_scope=other_account_scope,
         ))
         await session.commit()
 
@@ -433,8 +445,8 @@ async def test_tax_advantaged_category_detail_includes_archived_linked_account_a
     assert resp.json()["lifetime_withdrawals"] == 5_000
 
 
-async def test_tax_advantaged_category_metrics_only_count_transfer_category(client):
-    """Only the seeded Transfer category counts as TAC activity."""
+async def test_tax_advantaged_category_metrics_count_every_transfer_category_but_balance_adjustment(client):
+    """Credit card payments and user-made transfer categories count, balance adjustments do not."""
     signup_resp = await _create_user(client)
     headers = _get_auth_header(signup_resp)
     user_id = signup_resp.json()["user"]["id"]
@@ -443,20 +455,22 @@ async def test_tax_advantaged_category_metrics_only_count_transfer_category(clie
     transfer_id = await _get_system_category_id("Transfer")
     balance_adjustment_id = await _get_system_category_id("Balance Adjustment")
     credit_card_payment_id = await _get_system_category_id("Credit Card Payment")
+    user_transfer_id = await _seed_category(user_id, CategoryKind.TRANSFER, "Plan Rebalance")
     current_year = datetime.now(UTC).year
 
     await _seed_transaction(account_id, transfer_id, user_id, 50_000, date(current_year, 2, 1))
     await _seed_transaction(account_id, transfer_id, user_id, -10_000, date(current_year, 3, 1))
-    await _seed_transaction(account_id, balance_adjustment_id, user_id, 999_000, date(current_year, 4, 1))
-    await _seed_transaction(account_id, balance_adjustment_id, user_id, -888_000, date(current_year, 5, 1))
-    await _seed_transaction(account_id, credit_card_payment_id, user_id, 777_000, date(current_year - 1, 6, 1))
+    await _seed_transaction(account_id, user_transfer_id, user_id, 15_000, date(current_year, 4, 1))
+    await _seed_transaction(account_id, balance_adjustment_id, user_id, 999_000, date(current_year, 5, 1))
+    await _seed_transaction(account_id, balance_adjustment_id, user_id, -888_000, date(current_year, 6, 1))
+    await _seed_transaction(account_id, credit_card_payment_id, user_id, 777_000, date(current_year - 1, 7, 1))
 
     resp = await client.get(f"/tax-advantaged-categories/{tax_advantaged_category_id}", headers=headers)
 
     assert resp.status_code == 200
-    assert resp.json()["ytd_contributions"] == 50_000
+    assert resp.json()["ytd_contributions"] == 65_000
     assert resp.json()["ytd_withdrawals"] == 10_000
-    assert resp.json()["lifetime_contributions"] == 50_000
+    assert resp.json()["lifetime_contributions"] == 842_000
     assert resp.json()["lifetime_withdrawals"] == 10_000
 
 
@@ -547,3 +561,175 @@ async def test_update_without_the_setting_leaves_it_alone(client):
 
     assert resp.status_code == 200
     assert resp.json()["counts_internal_transfers"] is True
+
+
+async def _setup_category_with_two_accounts(client, headers, **overrides):
+    """Create a tax-advantaged category and two accounts linked to it
+
+    Args:
+        client: Async test client
+        headers: Auth headers for the requesting user
+        **overrides: Fields to override on the tax-advantaged category
+
+    Returns:
+        Tuple of category ID, first account ID and second account ID
+    """
+    category_id = (await _create_tax_advantaged_category(client, headers, **overrides)).json()["id"]
+    first_account_id = (
+        await _create_account(client, headers, name="TFSA Cash", tax_advantaged_category_id=category_id)
+    ).json()["id"]
+    second_account_id = (
+        await _create_account(client, headers, name="TFSA Investing", tax_advantaged_category_id=category_id)
+    ).json()["id"]
+    return category_id, first_account_id, second_account_id
+
+
+async def test_internal_transfer_is_left_out_of_both_totals(client):
+    """With the setting off, a move between the category's own accounts is neither side of the limits."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = signup_resp.json()["user"]["id"]
+    category_id, first_account_id, second_account_id = await _setup_category_with_two_accounts(client, headers)
+    transfer_id = await _get_system_category_id("Transfer")
+    current_year = datetime.now(UTC).year
+
+    await _seed_transaction(
+        first_account_id, transfer_id, user_id, -20_000, date(current_year, 2, 1),
+        other_account_id=second_account_id, other_account_scope=TransferOtherAccountScope.TRACKED,
+    )
+    await _seed_transaction(
+        second_account_id, transfer_id, user_id, 20_000, date(current_year, 2, 2),
+        other_account_id=first_account_id, other_account_scope=TransferOtherAccountScope.TRACKED,
+    )
+    await _seed_transaction(
+        first_account_id, transfer_id, user_id, 50_000, date(current_year, 3, 1),
+        other_account_scope=TransferOtherAccountScope.OUTSIDE,
+    )
+
+    resp = await client.get(f"/tax-advantaged-categories/{category_id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["ytd_contributions"] == 50_000
+    assert resp.json()["ytd_withdrawals"] == 0
+    assert resp.json()["lifetime_contributions"] == 50_000
+    assert resp.json()["lifetime_withdrawals"] == 0
+
+
+async def test_internal_transfer_counts_when_the_category_counts_them(client):
+    """With the setting on, both legs of an internal move count as they are recorded."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = signup_resp.json()["user"]["id"]
+    category_id, first_account_id, second_account_id = await _setup_category_with_two_accounts(
+        client, headers, counts_internal_transfers=True,
+    )
+    transfer_id = await _get_system_category_id("Transfer")
+    current_year = datetime.now(UTC).year
+
+    await _seed_transaction(
+        first_account_id, transfer_id, user_id, -20_000, date(current_year, 2, 1),
+        other_account_id=second_account_id, other_account_scope=TransferOtherAccountScope.TRACKED,
+    )
+    await _seed_transaction(
+        second_account_id, transfer_id, user_id, 20_000, date(current_year, 2, 2),
+        other_account_id=first_account_id, other_account_scope=TransferOtherAccountScope.TRACKED,
+    )
+    await _seed_transaction(
+        first_account_id, transfer_id, user_id, 50_000, date(current_year, 3, 1),
+        other_account_scope=TransferOtherAccountScope.OUTSIDE,
+    )
+
+    resp = await client.get(f"/tax-advantaged-categories/{category_id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["ytd_contributions"] == 70_000
+    assert resp.json()["ytd_withdrawals"] == 20_000
+    assert resp.json()["lifetime_contributions"] == 70_000
+    assert resp.json()["lifetime_withdrawals"] == 20_000
+
+
+async def test_transfer_between_two_tax_advantaged_categories_counts_on_both_sides(client):
+    """Money really does leave one category and enter the other, whatever either setting says."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = signup_resp.json()["user"]["id"]
+    excluding_category_id = (
+        await _create_tax_advantaged_category(client, headers, name="TFSA")
+    ).json()["id"]
+    counting_category_id = (
+        await _create_tax_advantaged_category(
+            client, headers, name="RRSP", tax_treatment="tax_deferred", counts_internal_transfers=True,
+        )
+    ).json()["id"]
+    excluding_account_id = (
+        await _create_account(client, headers, name="TFSA Cash", tax_advantaged_category_id=excluding_category_id)
+    ).json()["id"]
+    counting_account_id = (
+        await _create_account(client, headers, name="RRSP Cash", tax_advantaged_category_id=counting_category_id)
+    ).json()["id"]
+    transfer_id = await _get_system_category_id("Transfer")
+    current_year = datetime.now(UTC).year
+
+    await _seed_transaction(
+        excluding_account_id, transfer_id, user_id, -20_000, date(current_year, 2, 1),
+        other_account_id=counting_account_id, other_account_scope=TransferOtherAccountScope.TRACKED,
+    )
+    await _seed_transaction(
+        counting_account_id, transfer_id, user_id, 20_000, date(current_year, 2, 2),
+        other_account_id=excluding_account_id, other_account_scope=TransferOtherAccountScope.TRACKED,
+    )
+
+    resp = await client.get("/tax-advantaged-categories", headers=headers)
+
+    assert resp.status_code == 200
+    metrics_by_name = {row["name"]: row for row in resp.json()}
+    assert metrics_by_name["TFSA"]["ytd_withdrawals"] == 20_000
+    assert metrics_by_name["TFSA"]["ytd_contributions"] == 0
+    assert metrics_by_name["RRSP"]["ytd_contributions"] == 20_000
+    assert metrics_by_name["RRSP"]["ytd_withdrawals"] == 0
+
+
+async def test_transfer_recorded_as_leaving_the_tracked_accounts_counts(client):
+    """An answer of outside is money genuinely leaving the category."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = signup_resp.json()["user"]["id"]
+    category_id = (await _create_tax_advantaged_category(client, headers)).json()["id"]
+    account_id = (
+        await _create_account(client, headers, tax_advantaged_category_id=category_id)
+    ).json()["id"]
+    transfer_id = await _get_system_category_id("Transfer")
+    current_year = datetime.now(UTC).year
+
+    await _seed_transaction(
+        account_id, transfer_id, user_id, -20_000, date(current_year, 2, 1),
+        other_account_scope=TransferOtherAccountScope.OUTSIDE,
+    )
+
+    resp = await client.get(f"/tax-advantaged-categories/{category_id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["ytd_withdrawals"] == 20_000
+    assert resp.json()["lifetime_withdrawals"] == 20_000
+
+
+async def test_transfer_with_no_recorded_other_account_counts(client):
+    """A transfer predating the recorded answer keeps counting on both sides."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    user_id = signup_resp.json()["user"]["id"]
+    category_id = (await _create_tax_advantaged_category(client, headers)).json()["id"]
+    account_id = (
+        await _create_account(client, headers, tax_advantaged_category_id=category_id)
+    ).json()["id"]
+    transfer_id = await _get_system_category_id("Transfer")
+    current_year = datetime.now(UTC).year
+
+    await _seed_transaction(account_id, transfer_id, user_id, 30_000, date(current_year, 2, 1))
+    await _seed_transaction(account_id, transfer_id, user_id, -5_000, date(current_year, 3, 1))
+
+    resp = await client.get(f"/tax-advantaged-categories/{category_id}", headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["ytd_contributions"] == 30_000
+    assert resp.json()["ytd_withdrawals"] == 5_000

--- a/backend/tests/routes/tax_advantaged_categories/test_tax_advantaged_categories.py
+++ b/backend/tests/routes/tax_advantaged_categories/test_tax_advantaged_categories.py
@@ -488,3 +488,62 @@ async def test_group_tax_advantaged_category_counts_transaction_created_by_non_o
     assert resp.json()["lifetime_contributions"] == 123_000
     assert resp.json()["ytd_withdrawals"] == 0
     assert resp.json()["lifetime_withdrawals"] == 0
+
+
+# --- Transfers between the category's own accounts ---
+
+
+async def test_create_tax_advantaged_category_defaults_internal_transfers_off(client):
+    """Leaving the setting out excludes internal transfers from the limits."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    resp = await _create_tax_advantaged_category(client, headers)
+
+    assert resp.status_code == 201
+    assert resp.json()["counts_internal_transfers"] is False
+
+
+async def test_create_tax_advantaged_category_can_count_internal_transfers(client):
+    """A category whose accounts are one pot can count moves between them."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    resp = await _create_tax_advantaged_category(client, headers, counts_internal_transfers=True)
+
+    assert resp.status_code == 201
+    assert resp.json()["counts_internal_transfers"] is True
+
+
+async def test_update_tax_advantaged_category_toggles_internal_transfers(client):
+    """The setting is editable after the category exists."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    category_id = (await _create_tax_advantaged_category(client, headers)).json()["id"]
+
+    resp = await client.patch(
+        f"/tax-advantaged-categories/{category_id}",
+        json={"counts_internal_transfers": True},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["counts_internal_transfers"] is True
+
+
+async def test_update_without_the_setting_leaves_it_alone(client):
+    """An unsent flag keeps the stored value rather than resetting it to the default."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    category_id = (
+        await _create_tax_advantaged_category(client, headers, counts_internal_transfers=True)
+    ).json()["id"]
+
+    resp = await client.patch(
+        f"/tax-advantaged-categories/{category_id}",
+        json={"name": "Renamed"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["counts_internal_transfers"] is True

--- a/backend/tests/routes/transactions/_helpers.py
+++ b/backend/tests/routes/transactions/_helpers.py
@@ -4,7 +4,7 @@ from app.models.base import InstitutionStatus
 from app.models.currency import Currency
 from app.models.institution import Institution
 from tests.conftest import TestSession
-from tests.routes.support import _create_user, _get_auth_header
+from tests.routes.support import _create_user, _get_auth_header, _get_system_merchant_id
 
 NONEXISTENT_ID = "00000000-0000-0000-0000-000000000000"
 
@@ -129,7 +129,12 @@ async def _create_transaction(client, headers, account_id, category_id, **overri
         "currency": "CAD",
         **overrides,
     }
+
+    # The route requires a merchant, so a test that does not care which one gets the shared Myself
+    if "merchant_id" not in payload:
+        payload["merchant_id"] = await _get_system_merchant_id(client, headers)
     return await client.post("/transactions", json=payload, headers=headers)
+
 
 async def _get_system_category_id(client, headers, name="Groceries"):
     """Return the ID for a seeded system category"""

--- a/backend/tests/routes/transactions/test_creation.py
+++ b/backend/tests/routes/transactions/test_creation.py
@@ -60,9 +60,13 @@ async def test_create_transaction_accepts_debit_and_credit_for_all_category_kind
         category_resp = await _create_category(client, headers, name=f"Direction {kind}", kind=kind)
         categories[kind] = category_resp.json()["id"]
 
-    for category_id in categories.values():
+    for kind, category_id in categories.items():
+        # A transfer records where the money went, and the other kinds reject the field
+        other_account = {"other_account_scope": "outside"} if kind == "transfer" else {}
         for amount in (-1234, 5678):
-            resp = await _create_transaction(client, headers, account_id, category_id, amount=amount)
+            resp = await _create_transaction(
+                client, headers, account_id, category_id, amount=amount, **other_account,
+            )
 
             assert resp.status_code == 201
             data = resp.json()

--- a/backend/tests/routes/transactions/test_creation.py
+++ b/backend/tests/routes/transactions/test_creation.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from app.models.transaction import Transaction
 from tests.conftest import TestSession
-from tests.routes.support import _create_user, _get_auth_header
+from tests.routes.support import _create_user, _get_auth_header, _get_system_merchant_id
 from tests.routes.transactions._helpers import (
     NONEXISTENT_ID,
     _create_account,
@@ -39,7 +39,7 @@ async def test_create_transaction_returns_201(client):
     assert data["category_id"] == category_id
     assert data["amount"] == -5000
     assert data["currency"] == "CAD"
-    assert data["merchant_id"] is None
+    assert data["merchant_id"] == await _get_system_merchant_id(client, headers)
     assert data["fx_rate"] is None
     assert data["notes"] is None
     assert data["tag_ids"] == []
@@ -146,6 +146,21 @@ async def test_create_transaction_invalid_merchant_returns_422(client):
 
     assert resp.status_code == 422
     assert resp.json()["detail"] == "Merchant not found"
+
+
+async def test_create_transaction_without_a_merchant_returns_422(client):
+    """Every transaction created through the route has to carry a merchant."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+
+    resp = await client.post("/transactions", json={
+        "account_id": account_id,
+        "category_id": category_id,
+        "dt": "2026-03-15",
+        "amount": -5000,
+        "currency": "CAD",
+    }, headers=headers)
+
+    assert resp.status_code == 422
 
 
 async def test_create_transaction_invalid_tag_returns_422(client):

--- a/backend/tests/routes/transactions/test_firefly_imports.py
+++ b/backend/tests/routes/transactions/test_firefly_imports.py
@@ -148,6 +148,16 @@ async def test_firefly_import_converts_transfers_into_two_legs(client):
         transaction["category_id"] == transfer_category_id for transaction in transactions_resp.json()
     )
 
+    # The imported row states both endpoints, so each leg comes out recording the other account
+    recorded_by_account = {
+        transaction["account_id"]: (transaction["other_account_id"], transaction["other_account_scope"])
+        for transaction in transactions_resp.json()
+    }
+    assert recorded_by_account == {
+        chequing_id: (savings_id, "tracked"),
+        savings_id: (chequing_id, "tracked"),
+    }
+
 
 async def test_firefly_import_uses_foreign_amount_for_cross_currency_transfers(client):
     """Cross-currency transfer legs are written in each account's own currency."""

--- a/backend/tests/routes/transactions/test_firefly_imports.py
+++ b/backend/tests/routes/transactions/test_firefly_imports.py
@@ -432,3 +432,38 @@ async def test_firefly_import_skips_amounts_past_the_storable_range(client):
     assert data["rows_imported"] == 1
     assert data["rows_skipped"] == 1
     assert data["skipped"][0]["reason"] == 'Invalid amount "99999999999999999999.00"'
+
+
+async def test_firefly_transfer_between_two_sources_on_one_account_records_no_other_account(client):
+    """Both endpoints mapped onto one account cannot record that account as its own other side."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    account_id = (await client.post("/accounts", json={
+        "account_kind": "asset", "account_type": "checking", "name": "Everyday Chequing", "currency": "CAD",
+    }, headers=headers)).json()["id"]
+
+    resp = await client.post("/transactions/import/firefly", json={
+        "accounts": [
+            {"source": "Everyday Chequing", "account_id": account_id},
+            {"source": "Old Chequing", "account_id": account_id},
+        ],
+        "categories": [],
+        "rows": [_firefly_row(
+            type="Transfer",
+            amount="500.00",
+            description="Renamed account carried across",
+            destination_name="Old Chequing",
+            destination_type="Asset account",
+            category=None,
+        )],
+    }, headers=headers)
+
+    assert resp.status_code == 201
+    assert resp.json()["transactions_created"] == 2
+
+    transactions = await client.get("/transactions", headers=headers)
+    assert all(
+        transaction["other_account_id"] is None and transaction["other_account_scope"] is None
+        for transaction in transactions.json()
+    )

--- a/backend/tests/routes/transactions/test_firefly_imports.py
+++ b/backend/tests/routes/transactions/test_firefly_imports.py
@@ -148,16 +148,6 @@ async def test_firefly_import_converts_transfers_into_two_legs(client):
         transaction["category_id"] == transfer_category_id for transaction in transactions_resp.json()
     )
 
-    # The imported row states both endpoints, so each leg comes out recording the other account
-    recorded_by_account = {
-        transaction["account_id"]: (transaction["other_account_id"], transaction["other_account_scope"])
-        for transaction in transactions_resp.json()
-    }
-    assert recorded_by_account == {
-        chequing_id: (savings_id, "tracked"),
-        savings_id: (chequing_id, "tracked"),
-    }
-
 
 async def test_firefly_import_uses_foreign_amount_for_cross_currency_transfers(client):
     """Cross-currency transfer legs are written in each account's own currency."""
@@ -432,38 +422,3 @@ async def test_firefly_import_skips_amounts_past_the_storable_range(client):
     assert data["rows_imported"] == 1
     assert data["rows_skipped"] == 1
     assert data["skipped"][0]["reason"] == 'Invalid amount "99999999999999999999.00"'
-
-
-async def test_firefly_transfer_between_two_sources_on_one_account_records_no_other_account(client):
-    """Both endpoints mapped onto one account cannot record that account as its own other side."""
-    signup_resp = await _create_user(client)
-    headers = _get_auth_header(signup_resp)
-
-    account_id = (await client.post("/accounts", json={
-        "account_kind": "asset", "account_type": "checking", "name": "Everyday Chequing", "currency": "CAD",
-    }, headers=headers)).json()["id"]
-
-    resp = await client.post("/transactions/import/firefly", json={
-        "accounts": [
-            {"source": "Everyday Chequing", "account_id": account_id},
-            {"source": "Old Chequing", "account_id": account_id},
-        ],
-        "categories": [],
-        "rows": [_firefly_row(
-            type="Transfer",
-            amount="500.00",
-            description="Renamed account carried across",
-            destination_name="Old Chequing",
-            destination_type="Asset account",
-            category=None,
-        )],
-    }, headers=headers)
-
-    assert resp.status_code == 201
-    assert resp.json()["transactions_created"] == 2
-
-    transactions = await client.get("/transactions", headers=headers)
-    assert all(
-        transaction["other_account_id"] is None and transaction["other_account_scope"] is None
-        for transaction in transactions.json()
-    )

--- a/backend/tests/routes/transactions/test_other_account.py
+++ b/backend/tests/routes/transactions/test_other_account.py
@@ -250,3 +250,58 @@ async def test_setting_the_field_alongside_a_category_that_rejects_it_fails(clie
     )
 
     assert resp.status_code == 422
+
+
+async def test_editing_a_transaction_into_a_transfer_requires_an_answer(client):
+    """An edit that forms a new transfer answers the question the same way creating one does."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+    expense_id = (await _create_category(client, headers, name="Corner shop", kind="expense")).json()["id"]
+    created = await _create_transaction(client, headers, account_id, expense_id)
+    txn_id = created.json()["id"]
+
+    resp = await client.patch(
+        f"/transactions/{txn_id}", json={"category_id": transfer_id}, headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_editing_a_transaction_into_a_transfer_succeeds_with_an_answer(client):
+    """The same edit goes through once it says where the money went."""
+    headers, account_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    expense_id = (await _create_category(client, headers, name="Corner store", kind="expense")).json()["id"]
+    created = await _create_transaction(client, headers, account_id, expense_id)
+    txn_id = created.json()["id"]
+
+    resp = await client.patch(
+        f"/transactions/{txn_id}",
+        json={
+            "category_id": transfer_id,
+            "other_account_scope": "tracked",
+            "other_account_id": other_account_id,
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["other_account_id"] == other_account_id
+
+
+async def test_editing_an_unanswered_transfer_still_needs_no_answer(client):
+    """History stays correctable, which is why the requirement is on becoming a transfer only."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+    created = await _create_transaction(
+        client, headers, account_id, transfer_id, other_account_scope="outside",
+    )
+    txn_id = created.json()["id"]
+
+    async with TestSession() as session:
+        txn = await session.get(Transaction, uuid.UUID(txn_id))
+        txn.other_account_scope = None
+        txn.other_account_id = None
+        await session.commit()
+
+    resp = await client.patch(f"/transactions/{txn_id}", json={"amount": -777}, headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["other_account_scope"] is None

--- a/backend/tests/routes/transactions/test_other_account.py
+++ b/backend/tests/routes/transactions/test_other_account.py
@@ -1,0 +1,217 @@
+import uuid
+
+from app.models.transaction import Transaction
+from tests.conftest import TestSession
+from tests.routes.support import _create_user, _get_auth_header
+from tests.routes.transactions._helpers import (
+    _create_account,
+    _create_category,
+    _create_transaction,
+    _get_system_category_id,
+    _setup_user_with_deps,
+)
+
+# --- The other account recorded on a transfer ---
+
+
+async def _setup_transfer_user(client):
+    """Return auth headers, an account, a second account, and a transfer category."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    account_id = (await _create_account(client, headers)).json()["id"]
+    other_account_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+    transfer_id = await _get_system_category_id(client, headers, "Transfer")
+    return headers, account_id, other_account_id, transfer_id
+
+
+async def test_create_transfer_without_an_answer_is_rejected(client):
+    """A transfer has to record where the money went as it is entered."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+
+    resp = await _create_transaction(client, headers, account_id, transfer_id)
+
+    assert resp.status_code == 422
+
+
+async def test_create_transfer_recording_a_tracked_account(client):
+    """A transfer records another account without writing anything to it."""
+    headers, account_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+
+    resp = await _create_transaction(
+        client, headers, account_id, transfer_id,
+        other_account_scope="tracked", other_account_id=other_account_id,
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["other_account_id"] == other_account_id
+    assert resp.json()["other_account_scope"] == "tracked"
+
+    # Recording an account creates no transaction there, so the user still has exactly one row
+    listing = await client.get("/transactions", headers=headers)
+    assert [txn["account_id"] for txn in listing.json()] == [account_id]
+
+
+async def test_create_transfer_recording_money_leaving_the_tracked_accounts(client):
+    """An answer of outside carries no account and is stored as its own state."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+
+    resp = await _create_transaction(
+        client, headers, account_id, transfer_id, other_account_scope="outside",
+    )
+
+    assert resp.status_code == 201
+    assert resp.json()["other_account_scope"] == "outside"
+    assert resp.json()["other_account_id"] is None
+
+
+async def test_create_transfer_recording_its_own_account_is_rejected(client):
+    """Money cannot move from an account to itself."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+
+    resp = await _create_transaction(
+        client, headers, account_id, transfer_id,
+        other_account_scope="tracked", other_account_id=account_id,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_create_transfer_recording_an_unreachable_account_is_rejected(client):
+    """Another user's account cannot be recorded as the other side."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+    _, stranger_account_id, _ = await _setup_user_with_deps(
+        client, email="second@example.com", name_prefix="Other",
+    )
+
+    resp = await _create_transaction(
+        client, headers, account_id, transfer_id,
+        other_account_scope="tracked", other_account_id=stranger_account_id,
+    )
+
+    assert resp.status_code == 404
+
+
+async def test_create_transfer_with_a_tracked_answer_and_no_account_is_rejected(client):
+    """The two columns have to agree, which the database rule also enforces."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+
+    resp = await _create_transaction(
+        client, headers, account_id, transfer_id, other_account_scope="tracked",
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_balance_adjustment_rejects_the_field(client):
+    """A balance adjustment is a correction with no other side."""
+    headers, account_id, other_account_id, _ = await _setup_transfer_user(client)
+    balance_adjustment_id = await _get_system_category_id(client, headers, "Balance Adjustment")
+
+    resp = await _create_transaction(
+        client, headers, account_id, balance_adjustment_id,
+        other_account_scope="tracked", other_account_id=other_account_id,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_balance_adjustment_needs_no_answer(client):
+    """The requirement covers transfer categories with another side, which excludes this one."""
+    headers, account_id, _, _ = await _setup_transfer_user(client)
+    balance_adjustment_id = await _get_system_category_id(client, headers, "Balance Adjustment")
+
+    resp = await _create_transaction(client, headers, account_id, balance_adjustment_id)
+
+    assert resp.status_code == 201
+
+
+async def test_expense_rejects_the_field(client):
+    """Only transfers record another account."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+
+    resp = await _create_transaction(
+        client, headers, account_id, category_id, other_account_scope="outside",
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_update_leaves_an_unanswered_transfer_editable(client):
+    """Transactions recorded before the columns existed stay correctable."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+    created = await _create_transaction(
+        client, headers, account_id, transfer_id, other_account_scope="outside",
+    )
+    txn_id = created.json()["id"]
+
+    # Empty both columns to match a row predating them, which the API itself cannot produce
+    async with TestSession() as session:
+        txn = await session.get(Transaction, uuid.UUID(txn_id))
+        txn.other_account_scope = None
+        txn.other_account_id = None
+        await session.commit()
+
+    resp = await client.patch(f"/transactions/{txn_id}", json={"notes": "corrected"}, headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["notes"] == "corrected"
+    assert resp.json()["other_account_scope"] is None
+
+
+async def test_update_can_record_the_answer_later(client):
+    """The field is accepted on update so history can be filled in."""
+    headers, account_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    created = await _create_transaction(
+        client, headers, account_id, transfer_id, other_account_scope="outside",
+    )
+    txn_id = created.json()["id"]
+
+    resp = await client.patch(
+        f"/transactions/{txn_id}",
+        json={"other_account_scope": "tracked", "other_account_id": other_account_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["other_account_id"] == other_account_id
+
+
+async def test_moving_to_a_category_with_no_other_side_clears_the_answer(client):
+    """A category change drops an answer that no longer applies rather than refusing the edit."""
+    headers, account_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    expense_id = (await _create_category(client, headers, name="Groceries run", kind="expense")).json()["id"]
+    created = await _create_transaction(
+        client, headers, account_id, transfer_id,
+        other_account_scope="tracked", other_account_id=other_account_id,
+    )
+    txn_id = created.json()["id"]
+
+    resp = await client.patch(
+        f"/transactions/{txn_id}", json={"category_id": expense_id}, headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["other_account_id"] is None
+    assert resp.json()["other_account_scope"] is None
+
+
+async def test_setting_the_field_alongside_a_category_that_rejects_it_fails(client):
+    """An explicit answer on a category with no other side is a contradiction, not a clear."""
+    headers, account_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    expense_id = (await _create_category(client, headers, name="Groceries trip", kind="expense")).json()["id"]
+    created = await _create_transaction(
+        client, headers, account_id, transfer_id, other_account_scope="outside",
+    )
+    txn_id = created.json()["id"]
+
+    resp = await client.patch(
+        f"/transactions/{txn_id}",
+        json={
+            "category_id": expense_id,
+            "other_account_scope": "tracked",
+            "other_account_id": other_account_id,
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422

--- a/backend/tests/routes/transactions/test_other_account.py
+++ b/backend/tests/routes/transactions/test_other_account.py
@@ -171,8 +171,8 @@ async def test_expense_rejects_the_field(client):
     assert resp.status_code == 422
 
 
-async def test_update_leaves_an_unanswered_transfer_editable(client):
-    """Transactions recorded before the columns existed stay correctable."""
+async def test_editing_an_unanswered_transfer_is_refused_until_it_answers(client):
+    """Touching a transfer recorded before the field existed is what brings it onto the new footing."""
     headers, account_id, _, transfer_id = await _setup_transfer_user(client)
     created = await _create_transaction(
         client, headers, account_id, transfer_id, other_account_scope="outside",
@@ -188,9 +188,16 @@ async def test_update_leaves_an_unanswered_transfer_editable(client):
 
     resp = await client.patch(f"/transactions/{txn_id}", json={"notes": "corrected"}, headers=headers)
 
-    assert resp.status_code == 200
-    assert resp.json()["notes"] == "corrected"
-    assert resp.json()["other_account_scope"] is None
+    assert resp.status_code == 422
+
+    # Answering it in the same edit is what lets the correction through
+    answered = await client.patch(
+        f"/transactions/{txn_id}",
+        json={"notes": "corrected", "other_account_scope": "outside"},
+        headers=headers,
+    )
+    assert answered.status_code == 200
+    assert answered.json()["notes"] == "corrected"
 
 
 async def test_update_can_record_the_answer_later(client):
@@ -287,21 +294,15 @@ async def test_editing_a_transaction_into_a_transfer_succeeds_with_an_answer(cli
     assert resp.json()["other_account_id"] == other_account_id
 
 
-async def test_editing_an_unanswered_transfer_still_needs_no_answer(client):
-    """History stays correctable, which is why the requirement is on becoming a transfer only."""
+async def test_editing_an_answered_transfer_needs_nothing_resent(client):
+    """A transfer that already says where the money went is untouched by the requirement."""
     headers, account_id, _, transfer_id = await _setup_transfer_user(client)
     created = await _create_transaction(
         client, headers, account_id, transfer_id, other_account_scope="outside",
     )
     txn_id = created.json()["id"]
 
-    async with TestSession() as session:
-        txn = await session.get(Transaction, uuid.UUID(txn_id))
-        txn.other_account_scope = None
-        txn.other_account_id = None
-        await session.commit()
-
     resp = await client.patch(f"/transactions/{txn_id}", json={"amount": -777}, headers=headers)
 
     assert resp.status_code == 200
-    assert resp.json()["other_account_scope"] is None
+    assert resp.json()["other_account_scope"] == "outside"

--- a/backend/tests/routes/transactions/test_other_account.py
+++ b/backend/tests/routes/transactions/test_other_account.py
@@ -1,5 +1,9 @@
 import uuid
 
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.models.base import TransferOtherAccountScope
 from app.models.transaction import Transaction
 from tests.conftest import TestSession
 from tests.routes.support import _create_user, _get_auth_header
@@ -100,6 +104,37 @@ async def test_create_transfer_with_a_tracked_answer_and_no_account_is_rejected(
     )
 
     assert resp.status_code == 422
+
+
+async def test_the_database_refuses_an_account_recorded_without_a_scope(client):
+    """The check constraint holds on writes that do not come through the API."""
+    headers, account_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    created = await _create_transaction(
+        client, headers, account_id, transfer_id, other_account_scope="outside",
+    )
+    txn_id = created.json()["id"]
+
+    with pytest.raises(IntegrityError):
+        async with TestSession() as session:
+            txn = await session.get(Transaction, uuid.UUID(txn_id))
+            txn.other_account_id = uuid.UUID(other_account_id)
+            txn.other_account_scope = None
+            await session.commit()
+
+
+async def test_the_database_refuses_a_tracked_scope_with_no_account(client):
+    """The other half of the same rule, which the API rejects before the database sees it."""
+    headers, account_id, _, transfer_id = await _setup_transfer_user(client)
+    created = await _create_transaction(
+        client, headers, account_id, transfer_id, other_account_scope="outside",
+    )
+    txn_id = created.json()["id"]
+
+    with pytest.raises(IntegrityError):
+        async with TestSession() as session:
+            txn = await session.get(Transaction, uuid.UUID(txn_id))
+            txn.other_account_scope = TransferOtherAccountScope.TRACKED
+            await session.commit()
 
 
 async def test_balance_adjustment_rejects_the_field(client):

--- a/backend/tests/routes/transactions/test_overview.py
+++ b/backend/tests/routes/transactions/test_overview.py
@@ -44,8 +44,12 @@ async def test_transactions_overview_net_flow_excludes_balance_adjustments(clien
 
     await _create_transaction(client, headers, account_id, category_id, amount=10_000)
     await _create_transaction(client, headers, account_id, category_id, amount=-4_000)
-    await _create_transaction(client, headers, account_id, transfer_id, amount=2_500)
-    await _create_transaction(client, headers, account_id, transfer_id, amount=-1_500)
+    await _create_transaction(
+        client, headers, account_id, transfer_id, amount=2_500, other_account_scope="outside",
+    )
+    await _create_transaction(
+        client, headers, account_id, transfer_id, amount=-1_500, other_account_scope="outside",
+    )
     await _create_transaction(client, headers, account_id, balance_adjustment_id, amount=99_999)
     await _create_transaction(client, headers, account_id, balance_adjustment_id, amount=-88_888)
 

--- a/backend/tests/routes/transactions/test_updates.py
+++ b/backend/tests/routes/transactions/test_updates.py
@@ -1,5 +1,10 @@
 
 
+import uuid
+from datetime import date
+
+from app.models.transaction import Transaction
+from tests.conftest import TestSession
 from tests.routes.support import _create_user, _get_auth_header
 from tests.routes.transactions._helpers import (
     NONEXISTENT_ID,
@@ -228,6 +233,56 @@ async def test_patch_transaction_invalid_tag_returns_422(client):
 
     assert resp.status_code == 422
     assert resp.json()["detail"] == "Tag not found"
+
+
+async def _seed_transaction_without_a_merchant(client, headers, account_id, category_id):
+    """Insert a transaction with no merchant, which the route no longer creates
+
+    Returns:
+        Identifier of the seeded transaction
+    """
+    reference = (await _create_transaction(client, headers, account_id, category_id)).json()
+    async with TestSession() as session:
+        txn = Transaction(
+            created_by_user_id=uuid.UUID(reference["created_by_user_id"]),
+            account_id=uuid.UUID(account_id),
+            dt=date(2026, 3, 15),
+            category_id=uuid.UUID(category_id),
+            merchant_id=None,
+            amount=-5000,
+            currency="CAD",
+        )
+        session.add(txn)
+        await session.commit()
+        return str(txn.id)
+
+
+async def test_patch_transaction_recorded_without_a_merchant_is_refused(client):
+    """History predating the rule is what the rule is for, so any edit to it has to supply one."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn_id = await _seed_transaction_without_a_merchant(client, headers, account_id, category_id)
+
+    resp = await client.patch(f"/transactions/{txn_id}", json={"notes": "Corrected"}, headers=headers)
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "merchant_id is required"
+
+
+async def test_patch_transaction_recorded_without_a_merchant_succeeds_once_it_supplies_one(client):
+    """Supplying the merchant is what puts the transaction onto the current rule."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn_id = await _seed_transaction_without_a_merchant(client, headers, account_id, category_id)
+    merchant_id = (await _create_merchant(client, headers)).json()["id"]
+
+    resp = await client.patch(
+        f"/transactions/{txn_id}",
+        json={"notes": "Corrected", "merchant_id": merchant_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["merchant_id"] == merchant_id
+    assert resp.json()["notes"] == "Corrected"
 
 
 async def test_patch_transaction_cannot_clear_merchant(client):

--- a/backend/tests/routes/transactions/test_updates.py
+++ b/backend/tests/routes/transactions/test_updates.py
@@ -230,8 +230,8 @@ async def test_patch_transaction_invalid_tag_returns_422(client):
     assert resp.json()["detail"] == "Tag not found"
 
 
-async def test_patch_transaction_clears_merchant(client):
-    """PATCH with merchant_id=null clears the merchant."""
+async def test_patch_transaction_cannot_clear_merchant(client):
+    """Every edited transaction keeps a merchant, so sending null takes one away rather than correcting it."""
     headers, account_id, category_id = await _setup_user_with_deps(client)
     merchant_resp = await _create_merchant(client, headers)
 
@@ -240,9 +240,8 @@ async def test_patch_transaction_clears_merchant(client):
 
     resp = await client.patch(f"/transactions/{txn_id}", json={"merchant_id": None}, headers=headers)
 
-    assert resp.status_code == 200
-    assert resp.json()["merchant_id"] is None
-    assert resp.json()["merchant_name"] is None
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "merchant_id is required"
 
 
 async def test_patch_transaction_clears_notes(client):

--- a/backend/tests/routes/transactions/test_updates.py
+++ b/backend/tests/routes/transactions/test_updates.py
@@ -36,12 +36,15 @@ async def test_patch_transaction_accepts_sign_changes_for_all_category_kinds(cli
 
     for kind in ("expense", "income", "transfer"):
         category_resp = await _create_category(client, headers, name=f"Patch Direction {kind}", kind=kind)
+        # A transfer records where the money went, and the other kinds reject the field
+        other_account = {"other_account_scope": "outside"} if kind == "transfer" else {}
         create_resp = await _create_transaction(
             client,
             headers,
             account_id,
             category_resp.json()["id"],
             amount=-1000,
+            **other_account,
         )
         txn_id = create_resp.json()["id"]
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,6 +66,7 @@ python -m app.db.provision apply-rls
 
 python -m scripts.seed_currencies
 python -m scripts.seed_categories
+python -m scripts.seed_merchants
 
 # Caddy serves the frontend and proxies /api to this local Uvicorn process
 uvicorn app.main:app --host 127.0.0.1 --port 8000 &

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -60,8 +60,9 @@ python -m app.db.provision transfer-ownership
 alembic upgrade head
 
 # A restored backup arrives at migration head with its ACLs stripped so the bootstrap RLS
-# migration never re-runs, this re-applies the policies and app role grants from the app
-# source and is a no-op on a freshly migrated database
+# migration never re-runs, this re-applies the policies and app role grants from the app source.
+# It is also what installs any policy that reads a column added after the bootstrap, since the
+# bootstrap replays against a schema without it, so a freshly migrated database needs this too
 python -m app.db.provision apply-rls
 
 python -m scripts.seed_currencies

--- a/frontend/src/api/cache/updates/transactions.ts
+++ b/frontend/src/api/cache/updates/transactions.ts
@@ -30,6 +30,8 @@ const TRANSACTION_LIST_FIELDS = new Set<keyof UpdateTransactionPayload>([
   'merchant_id',
   'notes',
   'tag_ids',
+  'other_account_id',
+  'other_account_scope',
 ]);
 
 const TRANSACTION_OVERVIEW_FIELDS = new Set<keyof UpdateTransactionPayload>([
@@ -67,6 +69,18 @@ const INCOME_EXPENSE_FIELDS = new Set<keyof UpdateTransactionPayload>([
   'dt',
   'category_id',
   'amount',
+]);
+
+// Wider than the income and expense set, because a transfer between two accounts of one
+// tax-advantaged category counts toward its limits or not depending on the account recorded on it,
+// so editing only that account moves the contribution and withdrawal totals
+const TAX_ADVANTAGED_FIELDS = new Set<keyof UpdateTransactionPayload>([
+  'account_id',
+  'dt',
+  'category_id',
+  'amount',
+  'other_account_id',
+  'other_account_scope',
 ]);
 
 const CREDIT_ACTIVITY_FIELDS = new Set<keyof UpdateTransactionPayload>([
@@ -297,8 +311,8 @@ export function invalidatePatchedTransactionData(
     invalidateBudgets(queryClient);
     invalidateDashboardBudgets(queryClient);
     invalidateRunway(queryClient);
-    invalidateTaxAdvantagedActivity(queryClient, accountIds);
   }
+  if (patchTouches(patch, TAX_ADVANTAGED_FIELDS)) invalidateTaxAdvantagedActivity(queryClient, accountIds);
   if (patchTouches(patch, CREDIT_ACTIVITY_FIELDS)) invalidateCreditActivity(queryClient, accountIds);
   if (patchTouches(patch, MERCHANT_ACTIVITY_FIELDS)) invalidateInsightsMerchants(queryClient);
 }

--- a/frontend/src/api/merchants/types.ts
+++ b/frontend/src/api/merchants/types.ts
@@ -1,8 +1,13 @@
 export interface Merchant {
   id: string;
-  owner_id: string;
+
+  /** Null on a system merchant, which belongs to everyone rather than to one user */
+  owner_id: string | null;
   group_id: string | null;
   name: string;
+
+  /** Ships with the app: cannot be renamed, deleted, or given a default category */
+  is_system: boolean;
   default_category_id: string | null;
   created_at: string;
 }

--- a/frontend/src/api/tax-advantaged-categories/types.ts
+++ b/frontend/src/api/tax-advantaged-categories/types.ts
@@ -9,6 +9,9 @@ export interface TaxAdvantagedCategory {
   currency: string;
   lifetime_contribution_limit: number | null;
   accrued_contributions: number;
+
+  // Whether transfers with both sides inside this category count toward its limits
+  counts_internal_transfers: boolean;
   accrued_lifetime_contribution_limit: number | null;
   current_year_contribution_limit: number | null;
   current_year_withdrawal_limit: number | null;
@@ -34,6 +37,9 @@ export interface CreateTaxAdvantagedCategoryPayload {
   currency: string;
   lifetime_contribution_limit: number | null;
   accrued_contributions?: number;
+
+  // Defaults to false server-side when left out
+  counts_internal_transfers?: boolean;
   group_id?: string | null;
 }
 
@@ -42,6 +48,9 @@ export interface UpdateTaxAdvantagedCategoryPayload {
   tax_treatment?: TaxTreatment;
   lifetime_contribution_limit?: number | null;
   accrued_contributions?: number;
+
+  // Left out to leave the stored setting unchanged
+  counts_internal_transfers?: boolean;
   group_id?: string | null;
 }
 

--- a/frontend/src/api/transactions/index.ts
+++ b/frontend/src/api/transactions/index.ts
@@ -8,6 +8,7 @@ export type {
   TransactionFilters,
   TransactionTag,
   TransactionsOverview,
+  TransferOtherAccountScope,
   UpdateTransactionPayload,
 } from '@/api/transactions/types';
 

--- a/frontend/src/api/transactions/types.ts
+++ b/frontend/src/api/transactions/types.ts
@@ -1,5 +1,11 @@
 import type { FxStatus } from '@/api/shared/fx';
 
+/**
+ * Where the other side of a transfer sits: a tracked account elsewhere in the app, or money
+ * that left the tracked accounts entirely
+ */
+export type TransferOtherAccountScope = 'tracked' | 'outside';
+
 export interface Transaction {
   id: string;
   created_by_user_id: string;
@@ -18,6 +24,13 @@ export interface Transaction {
   currency: string;
   fx_rate: number | null;
   notes: string | null;
+
+  /**
+   * Where the other side of a transfer sits. Both null on anything recorded before the columns
+   * existed, and on every non-transfer transaction
+   */
+  other_account_id: string | null;
+  other_account_scope: TransferOtherAccountScope | null;
   created_at: string;
   updated_at: string;
   tag_ids: string[];
@@ -106,6 +119,13 @@ export interface CreateTransactionPayload {
   fx_rate?: number | null;
   notes?: string | null;
   tag_ids?: string[];
+
+  /**
+   * Where the other side of a transfer sits. Required for a transfer-kind category other than
+   * Balance Adjustment, and rejected outright for every other category
+   */
+  other_account_id?: string | null;
+  other_account_scope?: TransferOtherAccountScope | null;
 }
 
 export interface UpdateTransactionPayload {
@@ -117,4 +137,6 @@ export interface UpdateTransactionPayload {
   fx_rate?: number | null;
   notes?: string | null;
   tag_ids?: string[];
+  other_account_id?: string | null;
+  other_account_scope?: TransferOtherAccountScope | null;
 }

--- a/frontend/src/api/transactions/types.ts
+++ b/frontend/src/api/transactions/types.ts
@@ -115,7 +115,9 @@ export interface CreateTransactionPayload {
   category_id: string;
   amount: number;
   currency: string;
-  merchant_id?: string | null;
+
+  // Required, unlike on an update, where leaving it out keeps whatever the transaction already has
+  merchant_id: string;
   fx_rate?: number | null;
   notes?: string | null;
   tag_ids?: string[];

--- a/frontend/src/components/display/SlotMachineText.tsx
+++ b/frontend/src/components/display/SlotMachineText.tsx
@@ -81,11 +81,13 @@ export function AppSlotMachineText({
           {text.split('').map((char, i) => (
             <motion.span
               key={`${text}-${i}`}
-              className={char === ' ' ? 'inline-block w-1.5' : 'inline-block'}
+              className="inline-block"
               variants={charVariants}
               transition={shouldReduceMotion ? { duration: 0 } : slotTransition}
             >
-              {char}
+              {/* A space collapses inside an inline-block, so it is rendered as a non-breaking one
+                  to keep the font's own width rather than a fixed box that reads too wide */}
+              {char === ' ' ? ' ' : char}
             </motion.span>
           ))}
         </motion.span>

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -15,7 +15,7 @@ const ROW_EXIT_EASE = [0.25, 0.1, 0.25, 1] as const
  * Describes the other side of a transfer for the line that shows a merchant on other kinds
  *
  * Returns null when nothing was recorded, which is every transfer predating the field, so the row
- * falls back to its plain transfer label rather than claiming an answer it does not have
+ * falls back to the merchant rather than claiming an answer it does not have
  */
 function describeTransferOtherSide(
   transaction: Transaction,
@@ -154,11 +154,13 @@ export default function TransactionRow({
   const categoryIcon = category?.icon ?? DEFAULT_CATEGORY_ICON
   const fallbackTitle = category?.kind === 'transfer' ? 'Transfer' : 'Transaction'
 
-  // A transfer carries no merchant, so the line showing one on other kinds says where the money went
+  // A transfer's merchant is almost always the same stand-in, so where the money went takes the line
+  // that shows a merchant on other kinds, and the merchant fills in only for a transfer that
+  // recorded no other side
   const transferOtherSide = category?.kind === 'transfer'
     ? describeTransferOtherSide(transaction, otherAccountName)
     : null
-  const title = transaction.merchant_name ?? transferOtherSide ?? fallbackTitle
+  const title = transferOtherSide ?? transaction.merchant_name ?? fallbackTitle
   const hasNotes = Boolean(transaction.notes?.trim())
   const tags = [...(transaction.tags ?? [])].sort((a, b) => a.name.localeCompare(b.name))
   const visibleTags = tags.slice(0, MAX_VISIBLE_TAGS)

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -11,8 +11,27 @@ const MAX_VISIBLE_TAGS = 1
 const DEFAULT_CATEGORY_ICON = '🏷️'
 const ROW_EXIT_EASE = [0.25, 0.1, 0.25, 1] as const
 
+/**
+ * Describes the other side of a transfer for the line that shows a merchant on other kinds
+ *
+ * Returns null when nothing was recorded, which is every transfer predating the field, so the row
+ * falls back to its plain transfer label rather than claiming an answer it does not have
+ */
+function describeTransferOtherSide(
+  transaction: Transaction,
+  otherAccountName: string | undefined,
+): string | null {
+  if (transaction.other_account_scope === 'outside') return 'Outside this app'
+  if (transaction.other_account_scope !== 'tracked' || !otherAccountName) return null
+  return transaction.amount < 0 ? `To ${otherAccountName}` : `From ${otherAccountName}`
+}
+
 interface TransactionRowProps {
   accountName?: string
+
+  // The account a transfer recorded as its other side, looked up by the caller. Absent on every
+  // other kind, and on a transfer whose recorded account is not in the caller's list
+  otherAccountName?: string
   accountInstitution?: Institution | null
   category: Category | undefined
   currency: string
@@ -118,6 +137,7 @@ function TagTooltip({ tags }: { tags: Transaction['tags'] }) {
  */
 export default function TransactionRow({
   accountName,
+  otherAccountName,
   accountInstitution,
   category,
   currency,
@@ -133,7 +153,12 @@ export default function TransactionRow({
   const categoryName = category?.name ?? 'Uncategorized'
   const categoryIcon = category?.icon ?? DEFAULT_CATEGORY_ICON
   const fallbackTitle = category?.kind === 'transfer' ? 'Transfer' : 'Transaction'
-  const title = transaction.merchant_name ?? fallbackTitle
+
+  // A transfer carries no merchant, so the line showing one on other kinds says where the money went
+  const transferOtherSide = category?.kind === 'transfer'
+    ? describeTransferOtherSide(transaction, otherAccountName)
+    : null
+  const title = transaction.merchant_name ?? transferOtherSide ?? fallbackTitle
   const hasNotes = Boolean(transaction.notes?.trim())
   const tags = [...(transaction.tags ?? [])].sort((a, b) => a.name.localeCompare(b.name))
   const visibleTags = tags.slice(0, MAX_VISIBLE_TAGS)

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -21,9 +21,14 @@ function describeTransferOtherSide(
   transaction: Transaction,
   otherAccountName: string | undefined,
 ): string | null {
-  if (transaction.other_account_scope === 'outside') return 'Outside this app'
-  if (transaction.other_account_scope !== 'tracked' || !otherAccountName) return null
-  return transaction.amount < 0 ? `To ${otherAccountName}` : `From ${otherAccountName}`
+  const otherSide = transaction.other_account_scope === 'outside'
+    ? 'outside this app'
+    : transaction.other_account_scope === 'tracked' ? otherAccountName : undefined
+  if (!otherSide) return null
+
+  // Which way the money went reads the same whether the other side is an account or not, so money
+  // leaving the tracked accounts gets the same wording rather than standing on its own
+  return transaction.amount < 0 ? `To ${otherSide}` : `From ${otherSide}`
 }
 
 interface TransactionRowProps {

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { useNavigate, useParams } from 'react-router'
-import { useAccount, type Account } from '@/api/accounts'
+import { useAccount, useAccounts, type Account } from '@/api/accounts'
 import { useTaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import type { Transaction } from '@/api/transactions'
 import AccountIdentityCard from '@/pages/accounts/detail/components/identity/Card'
@@ -13,6 +13,7 @@ import { TopCategoriesBySpendingCard } from '@/pages/accounts/detail/components/
 import { TopMerchantsBySpendingCard } from '@/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard'
 import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
 import TransactionListSection from '@/pages/transactions/components/ListSection'
+import { toTransactionListAccount } from '@/pages/transactions/types/transactionList'
 import CreateTransactionModal from '@/pages/transactions/components/transaction-modal/Modal'
 import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 
@@ -30,6 +31,10 @@ export default function AccountDetailPage() {
   const navigate = useNavigate()
   const { accountId } = useParams<{ accountId: string }>()
   const { data: account, error } = useAccount(accountId)
+
+  // The whole list, not just the account in view, so a transfer's row can name the account on its
+  // other side. The transaction modal on this page loads it anyway, so it costs no extra request
+  const { data: accounts } = useAccounts()
   const requireCurrencies = useCurrencyGuard()
 
   const [showTxnModal, setShowTxnModal] = useState(false)
@@ -151,6 +156,7 @@ export default function AccountDetailPage() {
                 institution: visibleAccount.institution,
                 is_archived: visibleAccount.is_archived,
               }}
+              accounts={(accounts ?? []).map(toTransactionListAccount)}
               currency={visibleAccount.currency}
               onCreateTransaction={openCreateTransaction}
               onEditTransaction={openEditTransaction}

--- a/frontend/src/pages/imports/firefly/utils/preview.ts
+++ b/frontend/src/pages/imports/firefly/utils/preview.ts
@@ -75,6 +75,10 @@ function buildFireflyPreviewRow(
       currency: leg.account.currency,
       fx_rate: null,
       notes: notes || null,
+
+      // The preview shows what the import will write, and the importer fills these in itself
+      other_account_id: null,
+      other_account_scope: null,
       created_at: timestamp,
       updated_at: timestamp,
       tag_ids: tagIds,

--- a/frontend/src/pages/imports/firefly/utils/preview.ts
+++ b/frontend/src/pages/imports/firefly/utils/preview.ts
@@ -76,7 +76,8 @@ function buildFireflyPreviewRow(
       fx_rate: null,
       notes: notes || null,
 
-      // The preview shows what the import will write, and the importer fills these in itself
+      // The preview shows what the import will write, and neither importer answers this yet, so an
+      // imported transfer arrives unanswered and counts against a tax-advantaged limit until edited
       other_account_id: null,
       other_account_scope: null,
       created_at: timestamp,

--- a/frontend/src/pages/imports/utils/preview.ts
+++ b/frontend/src/pages/imports/utils/preview.ts
@@ -136,6 +136,10 @@ export function buildImportPreviewRows({
           currency,
           fx_rate: null,
           notes: notes || null,
+
+          // A CSV row carries one account, so there is no other side to show
+          other_account_id: null,
+          other_account_scope: null,
           created_at: timestamp,
           updated_at: timestamp,
           tag_ids: tagIds,

--- a/frontend/src/pages/settings/components/merchant-settings-section/hooks/useList.ts
+++ b/frontend/src/pages/settings/components/merchant-settings-section/hooks/useList.ts
@@ -56,6 +56,11 @@ export function useMerchantSettingsList(locallyDeletedMerchantIds: string[]) {
     showMerchantListEnd: showListEnd,
     showMerchantListMoreIndicator: showListMoreIndicator,
     merchantListRef: listRef,
-    visibleMerchants: visibleItems,
+
+    // Merchants that ship with the app cannot be renamed, deleted or merged, so settings leaves
+    // them out rather than showing rows whose every control is refused. They are still offered
+    // when picking one on a transaction, which is the only place they are meant to be used.
+    // Filtered here rather than in the query, so a page holding one comes back a row short
+    visibleMerchants: visibleItems.filter((merchant: Merchant) => !merchant.is_system),
   }
 }

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCategoryDetailsForm.ts
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCategoryDetailsForm.ts
@@ -40,6 +40,7 @@ export function useTaxAdvantagedCategoryDetailsForm({
     currency: plan.currency,
     lifetime_contribution_limit: fromMinorUnits(plan.lifetime_contribution_limit, currencies, plan.currency),
     accrued_contributions: fromMinorUnits(plan.accrued_contributions, currencies, plan.currency),
+    counts_internal_transfers: plan.counts_internal_transfers,
   }
   const [planOverrides, setPlanOverrides] = useState<Partial<TaxPlanFormState>>({})
   const planForm: TaxPlanFormState = { ...planBase, ...planOverrides }
@@ -95,6 +96,7 @@ export function useTaxAdvantagedCategoryDetailsForm({
           tax_treatment: planForm.tax_treatment,
           lifetime_contribution_limit: nextLifetimeLimit,
           accrued_contributions: nextAccruedContributions,
+          counts_internal_transfers: planForm.counts_internal_transfers,
         })
         setPlanOverrides({})
         setPlanError(null)
@@ -156,6 +158,7 @@ function getPlanUpdateState(
     || form.tax_treatment !== plan.tax_treatment
     || nextLifetimeLimit !== plan.lifetime_contribution_limit
     || nextAccruedContributions !== plan.accrued_contributions
+    || form.counts_internal_transfers !== plan.counts_internal_transfers
 
   return { dirty, nextAccruedContributions, nextLifetimeLimit }
 }

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCreateCategoryForm.ts
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCreateCategoryForm.ts
@@ -31,6 +31,7 @@ export function useCreateTaxAdvantagedCategoryForm({
     currency: userBaseCurrency ?? '',
     lifetime_contribution_limit: '',
     accrued_contributions: '',
+    counts_internal_transfers: false,
   })
   const [createError, setCreateError] = useState<string | null>(null)
   const [createInProgress, setCreateInProgress] = useState(false)
@@ -69,6 +70,7 @@ export function useCreateTaxAdvantagedCategoryForm({
         currency: selectedCurrency,
         lifetime_contribution_limit: toMinorUnits(form.lifetime_contribution_limit, currencies, selectedCurrency),
         accrued_contributions: toMinorUnits(form.accrued_contributions, currencies, selectedCurrency) ?? 0,
+        counts_internal_transfers: form.counts_internal_transfers,
         group_id: null,
       },
     ).then(async () => {

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modalFieldIds.ts
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modalFieldIds.ts
@@ -4,4 +4,5 @@ export const CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS = {
   currency: 'create-tac-currency',
   lifetimeContributionLimit: 'create-tac-lifetime-contribution-limit',
   accruedContributions: 'create-tac-accrued-contributions',
+  countsInternalTransfers: 'create-tac-counts-internal-transfers',
 } as const

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryDetailsModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryDetailsModal.tsx
@@ -1,4 +1,4 @@
-import { Pencil, X } from 'lucide-react'
+import { ArrowLeftRight, Pencil, X } from 'lucide-react'
 import { ModalShell } from '@/components/modal/Shell'
 import type { Currency } from '@/api/currency'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
@@ -11,6 +11,8 @@ import {
   TaxAdvantagedCurrencyWarning,
 } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/controls/FormControls'
 import TaxAdvantagedOpeningUsageLabel from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/controls/OpeningUsageLabel'
+
+const COUNTS_INTERNAL_TRANSFERS_FIELD_ID = 'tac-details-counts-internal-transfers'
 
 interface TaxAdvantagedCategoryDetailsModalProps {
   currencies: Currency[]
@@ -149,6 +151,45 @@ export default function TaxAdvantagedCategoryDetailsModal({
               </div>
             </div>
           </div>
+
+          <label
+            htmlFor={COUNTS_INTERNAL_TRANSFERS_FIELD_ID}
+            className="flex cursor-pointer items-center justify-between gap-4 rounded-xl p-4"
+            style={{
+              background: 'var(--app-input-bg)',
+              border: '1px solid var(--app-input-border)',
+            }}
+          >
+            <span className="min-w-0">
+              <span className="flex items-center gap-2 font-medium">
+                <ArrowLeftRight size={16} style={{ color: 'var(--app-text-muted)' }} aria-hidden />
+                Count transfers between this category's accounts
+              </span>
+              <span className="mt-0.5 block text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                Money moved between two accounts in the category counts toward its contribution and withdrawal limits.
+              </span>
+            </span>
+            <span className="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors">
+              <input
+                id={COUNTS_INTERNAL_TRANSFERS_FIELD_ID}
+                type="checkbox"
+                role="switch"
+                checked={planForm.counts_internal_transfers}
+                onChange={(event) => onPlanFieldChange('counts_internal_transfers', event.target.checked)}
+                className="peer sr-only"
+              />
+              <span
+                className="absolute inset-0 rounded-full transition-colors peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2"
+                style={{ background: planForm.counts_internal_transfers ? 'var(--app-accent)' : 'var(--app-border-strong)' }}
+                aria-hidden
+              />
+              <span
+                className="relative h-5 w-5 rounded-full bg-white shadow-sm transition-transform"
+                style={{ transform: planForm.counts_internal_transfers ? 'translateX(1.25rem)' : 'translateX(0)' }}
+                aria-hidden
+              />
+            </span>
+          </label>
 
           {planError && (
             <p className="text-sm" style={{ color: 'var(--app-negative)' }}>

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryModal.tsx
@@ -255,6 +255,10 @@ export default function TaxAdvantagedCategoryModal({
               />
               <TaxAdvantagedInfoItem label="Scope" value={plan.group_id ? 'Group' : 'Personal'} />
               <TaxAdvantagedInfoItem label="Linked Accounts" value={linkedAccountsSummary} />
+              <TaxAdvantagedInfoItem
+                label="Internal Transfers"
+                value={plan.counts_internal_transfers ? 'Counted' : 'Not counted'}
+              />
             </div>
 
             {planError && (

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CreateCategoryModal.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from 'motion/react'
-import { Landmark } from 'lucide-react'
+import { ArrowLeftRight, Landmark } from 'lucide-react'
 import type { Currency } from '@/api/currency'
 import type { TaxTreatment } from '@/api/tax-advantaged-categories'
 import Dropdown from '@/components/dropdown/Dropdown'
@@ -151,6 +151,61 @@ export default function CreateTaxAdvantagedCategoryModal({
                 />
               </div>
             </div>
+          </div>
+        </section>
+
+        <section className="grid grid-cols-[1rem_minmax(0,1fr)] gap-x-2 min-[1050px]:gap-x-3">
+          <div className="flex min-h-0 flex-col items-center">
+            <span className="flex h-4 shrink-0 items-center text-xs font-semibold leading-none" style={{ color: 'var(--app-accent)' }} aria-hidden>
+              03
+            </span>
+            <span
+              className="mt-1 w-px flex-1"
+              style={{ backgroundColor: 'var(--app-border-strong)' }}
+              aria-hidden
+            />
+          </div>
+
+          <div className="min-w-0 space-y-3">
+            <p className="flex h-4 items-center text-base font-bold leading-none" style={{ color: 'var(--app-accent)' }}>Transfers</p>
+            <label
+              htmlFor={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.countsInternalTransfers}
+              className="flex cursor-pointer items-center justify-between gap-4 rounded-xl p-4"
+              style={{
+                background: 'var(--app-input-bg)',
+                border: '1px solid var(--app-input-border)',
+              }}
+            >
+              <span className="min-w-0">
+                <span className="flex items-center gap-2 font-medium">
+                  <ArrowLeftRight size={16} style={{ color: 'var(--app-text-muted)' }} aria-hidden />
+                  Count transfers between this category's accounts
+                </span>
+                <span className="mt-0.5 block text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                  Money moved between two accounts in the category counts toward its contribution and withdrawal limits.
+                </span>
+              </span>
+              <span className="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full p-0.5 transition-colors">
+                <input
+                  id={CREATE_TAX_ADVANTAGED_CATEGORY_FIELD_IDS.countsInternalTransfers}
+                  type="checkbox"
+                  role="switch"
+                  checked={form.counts_internal_transfers}
+                  onChange={(event) => setField('counts_internal_transfers', event.target.checked)}
+                  className="peer sr-only"
+                />
+                <span
+                  className="absolute inset-0 rounded-full transition-colors peer-focus-visible:outline peer-focus-visible:outline-2 peer-focus-visible:outline-offset-2"
+                  style={{ background: form.counts_internal_transfers ? 'var(--app-accent)' : 'var(--app-border-strong)' }}
+                  aria-hidden
+                />
+                <span
+                  className="relative h-5 w-5 rounded-full bg-white shadow-sm transition-transform"
+                  style={{ transform: form.counts_internal_transfers ? 'translateX(1.25rem)' : 'translateX(0)' }}
+                  aria-hidden
+                />
+              </span>
+            </label>
           </div>
         </section>
 

--- a/frontend/src/pages/settings/components/tax-advantaged/types.ts
+++ b/frontend/src/pages/settings/components/tax-advantaged/types.ts
@@ -6,6 +6,7 @@ export interface TaxPlanFormState {
   currency: string
   lifetime_contribution_limit: string
   accrued_contributions: string
+  counts_internal_transfers: boolean
 }
 
 export interface TaxPlanLimitFormState {

--- a/frontend/src/pages/transactions/TransactionsPage.tsx
+++ b/frontend/src/pages/transactions/TransactionsPage.tsx
@@ -11,6 +11,7 @@ import TransactionListSection from '@/pages/transactions/components/ListSection'
 import CreateTransactionModal from '@/pages/transactions/components/transaction-modal/Modal'
 import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 import TransactionsTopBand from '@/pages/transactions/components/TopBand'
+import { toTransactionListAccount } from '@/pages/transactions/types/transactionList'
 import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
 import {
   formatOverviewRangeLabel,
@@ -108,13 +109,7 @@ export default function TransactionsPage() {
     overviewToDate,
   ].join('|')
   const transactionAccounts = useMemo(
-    () => (accounts ?? []).map((account) => ({
-      id: account.id,
-      name: account.name,
-      currency: account.currency,
-      institution: account.institution,
-      is_archived: account.is_archived,
-    })),
+    () => (accounts ?? []).map(toTransactionListAccount),
     [accounts],
   )
   const editingTransactionReadOnly = useMemo(() => {

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -87,12 +87,19 @@ export default function TransactionDateGroupList({
               {transactions.map((transaction) => {
                 const category = categoryMap.get(transaction.category_id)
                 const rowAccount = fixedAccount ?? accountMap.get(transaction.account_id)
+
+                // Always from the full account list, since the other side of a transfer is often
+                // an account the current view is not showing
+                const otherAccount = transaction.other_account_id
+                  ? accountMap.get(transaction.other_account_id)
+                  : undefined
                 const readOnlyReason = rowAccount?.is_archived ? 'Archived · Read-only' : undefined
                 return (
                   <TransactionRow
                     key={transaction.id}
                     accountInstitution={rowAccount?.institution}
                     accountName={rowAccount?.name}
+                    otherAccountName={otherAccount?.name}
                     category={category}
                     currency={transaction.currency}
                     readOnlyReason={readOnlyReason}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -9,6 +9,7 @@ import { KIND_LABELS } from '@/pages/transactions/components/transaction-modal/c
 import { buildInitialTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/initialForm'
 import { buildCurrencyOptions } from '@/pages/transactions/components/transaction-modal/utils/options'
 import { isSymmetricTransferForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
+import { orderAccountFields } from '@/pages/transactions/components/transaction-modal/utils/accountFields'
 import type {
   CreateTransactionModalProps,
   TransactionFormValues,
@@ -202,11 +203,8 @@ export default function CreateTransactionModal({
   const showRunningBalance = !editing && keepOpenAfterCreate && !!selectedAccount
   const isSymmetricTransfer = isSymmetricTransferForm(form)
 
-  // A ticked pair reads source first, so a credit shows the two accounts the other way round from
-  // how the form stores them. Swapping the whole field, its value, its error and its option list
-  // together keeps them in agreement, and means the direction toggle moves the accounts between the
-  // fields without anything having to be written back to the form
-  const isPairShownReversed = isSymmetricTransfer && form.direction === 'credit'
+  // The direction toggle moves the accounts between the two fields without anything being written
+  // back to the form, because the ordering is worked out here on every render
   const recordedAccountField = {
     options: accountField.accountOptions,
     selectedOption: accountField.selectedArchivedAccountOption,
@@ -221,9 +219,11 @@ export default function CreateTransactionModal({
     error: showError('other_account_id'),
     onChange: accountField.handleOtherAccountChange,
   }
-  const [topAccountField, secondAccountField] = isPairShownReversed
-    ? [otherAccountField, recordedAccountField]
-    : [recordedAccountField, otherAccountField]
+  const [topAccountField, secondAccountField] = orderAccountFields(
+    recordedAccountField,
+    otherAccountField,
+    { isSymmetricTransfer, direction: form.direction },
+  )
 
   return (
     <>

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -294,6 +294,7 @@ export default function CreateTransactionModal({
             // direction toggle was left on before the checkbox disabled it
             direction={isSymmetricTransfer ? 'debit' : form.direction}
             isSymmetricTransfer={form.symmetric_transfer}
+            isTransferPairOffered={!editing}
             otherAccountOptions={accountField.otherAccountOptions}
             otherAccountValue={form.other_account_id}
             otherAccountError={showError('other_account_id')}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -191,6 +191,7 @@ export default function CreateTransactionModal({
     selectedToAccount,
     selectedCurrencyExponent,
     isAmountLocked,
+    isBalanceAdjustmentCategory: categoryField.isBalanceAdjustmentCategory,
     deleteLoading,
     openRef,
     recordCreatedAccountId,
@@ -264,9 +265,13 @@ export default function CreateTransactionModal({
               ? { amount: runningBalance, currency: selectedAccount.currency }
               : undefined}
             kind={form.kind}
+            direction={form.direction}
             isSymmetricTransfer={form.symmetric_transfer}
             toAccountValue={form.to_account_id}
             toAccountError={showError('to_account_id')}
+            otherAccountOptions={accountField.otherAccountOptions}
+            otherAccountValue={form.other_account_id}
+            otherAccountError={showError('other_account_id')}
             merchantOptions={merchantField.merchantOptions}
             selectedMerchantOption={merchantField.selectedMerchantOption}
             merchantValue={form.merchant_id}
@@ -295,6 +300,7 @@ export default function CreateTransactionModal({
             onAccountChange={accountField.handleAccountChange}
             onSymmetricTransferChange={accountField.handleSymmetricTransferChange}
             onToAccountChange={accountField.handleToAccountChange}
+            onOtherAccountChange={accountField.handleOtherAccountChange}
             onMerchantChange={merchantField.handleMerchantChange}
             onMerchantSearchChange={merchantField.setSearch}
             onMerchantSearchCommit={merchantField.setActiveSearch}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -215,6 +215,30 @@ export default function CreateTransactionModal({
         : ''
   const directionValue = isSymmetricTransfer ? symmetricDisplayDirection : form.direction
 
+  // A pair always debits the account above and credits the recorded one, so its direction is
+  // really which side the account being viewed sits on. Flipping the toggle therefore swaps the
+  // two accounts rather than changing a sign. With no account in view there is nothing for the
+  // direction to be relative to, so the toggle stays disabled there as before
+  const canFlipSymmetricDirection = isSymmetricTransfer && symmetricDisplayDirection !== ''
+
+  const handleDirectionChange = (value: TransactionDirection) => {
+    if (!isSymmetricTransfer) {
+      handleField('direction', value)
+      return
+    }
+    if (!canFlipSymmetricDirection || value === symmetricDisplayDirection) return
+
+    setForm((previous) => ({
+      ...previous,
+      account_id: previous.other_account_id,
+      other_account_id: previous.account_id,
+      // The currency follows the account the transaction is recorded in, the same as choosing it
+      // from the dropdown does
+      currency: accounts.find((account) => account.id === previous.other_account_id)?.currency
+        ?? previous.currency,
+    }))
+  }
+
   return (
     <>
       <ModalTitledPanel
@@ -249,10 +273,10 @@ export default function CreateTransactionModal({
             direction={directionValue}
             editing={editing}
             readOnly={readOnly}
-            directionDisabled={isSymmetricTransfer}
+            directionDisabled={isSymmetricTransfer && !canFlipSymmetricDirection}
             directionHighlightKey={directionHighlightKey}
             onKindChange={applyKindChange}
-            onDirectionChange={(value) => handleField('direction', value)}
+            onDirectionChange={handleDirectionChange}
           />
 
           <TransactionReferencesSection

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -265,7 +265,10 @@ export default function CreateTransactionModal({
               ? { amount: runningBalance, currency: selectedAccount.currency }
               : undefined}
             kind={form.kind}
-            direction={form.direction}
+
+            // A pair always debits the account above and credits the receiving one, whatever the
+            // direction toggle was left on before the checkbox disabled it
+            direction={isSymmetricTransfer ? 'debit' : form.direction}
             isSymmetricTransfer={form.symmetric_transfer}
             toAccountValue={form.to_account_id}
             toAccountError={showError('to_account_id')}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -211,6 +211,12 @@ export default function CreateTransactionModal({
     value: form.account_id,
     error: showError('account_id'),
     onChange: accountField.handleAccountChange,
+
+    // The balance belongs to the account the transaction is recorded in, so it travels with that
+    // field rather than staying under whichever dropdown happens to be on top
+    runningBalance: showRunningBalance && selectedAccount
+      ? { amount: runningBalance, currency: selectedAccount.currency }
+      : undefined,
   }
   const otherAccountField = {
     options: accountField.otherAccountOptions,
@@ -218,6 +224,7 @@ export default function CreateTransactionModal({
     value: form.other_account_id,
     error: showError('other_account_id'),
     onChange: accountField.handleOtherAccountChange,
+    runningBalance: undefined,
   }
   const [topAccountField, secondAccountField] = orderAccountFields(
     recordedAccountField,
@@ -270,9 +277,7 @@ export default function CreateTransactionModal({
             accountValue={topAccountField.value}
             accountError={topAccountField.error}
             accountPlaceholder={accounts.length === 0 ? 'No accounts yet' : 'Select account...'}
-            runningBalance={showRunningBalance && selectedAccount
-              ? { amount: runningBalance, currency: selectedAccount.currency }
-              : undefined}
+            runningBalance={topAccountField.runningBalance}
             kind={form.kind}
 
             direction={form.direction}
@@ -282,6 +287,7 @@ export default function CreateTransactionModal({
             selectedArchivedOtherAccountOption={secondAccountField.selectedOption}
             otherAccountValue={secondAccountField.value}
             otherAccountError={secondAccountField.error}
+            otherAccountRunningBalance={secondAccountField.runningBalance}
             merchantOptions={merchantField.merchantOptions}
             selectedMerchantOption={merchantField.selectedMerchantOption}
             merchantValue={form.merchant_id}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -203,33 +203,18 @@ export default function CreateTransactionModal({
   const showRunningBalance = !editing && keepOpenAfterCreate && !!selectedAccount
   const isSymmetricTransfer = isSymmetricTransferForm(form)
 
-  // A symmetric transfer shows its direction relative to the account being viewed, so the toggle
-  // reflects whether that account is the source or destination instead of a user choice. It falls
-  // back to the unselected state when the viewed account is on neither leg or no account is in view
-  const symmetricDisplayDirection: TransactionDirection | '' = !defaultAccountId
-    ? ''
-    : form.account_id === defaultAccountId
-      ? 'debit'
-      : form.other_account_id === defaultAccountId
-        ? 'credit'
-        : ''
-  const directionValue = isSymmetricTransfer ? symmetricDisplayDirection : form.direction
-
-  // A pair always debits the account above and credits the recorded one, so its direction is
-  // really which side the account being viewed sits on. Flipping the toggle therefore swaps the
-  // two accounts rather than changing a sign. With no account in view there is nothing for the
-  // direction to be relative to, so the toggle stays disabled there as before
-  const canFlipSymmetricDirection = isSymmetricTransfer && symmetricDisplayDirection !== ''
-
   const handleDirectionChange = (value: TransactionDirection) => {
-    if (!isSymmetricTransfer) {
+    if (!isSymmetricTransfer || value === form.direction) {
       handleField('direction', value)
       return
     }
-    if (!canFlipSymmetricDirection || value === symmetricDisplayDirection) return
 
+    // The direction says what happens to the account above, so flipping it on a pair also exchanges
+    // the two accounts. The money keeps moving the same way and only the account shown first
+    // changes, which is what lets the form read correctly from either account's side
     setForm((previous) => ({
       ...previous,
+      direction: value,
       account_id: previous.other_account_id,
       other_account_id: previous.account_id,
       // The currency follows the account the transaction is recorded in, the same as choosing it
@@ -270,10 +255,9 @@ export default function CreateTransactionModal({
         <div className="space-y-5">
           <TransactionTypeDirectionSection
             kind={form.kind}
-            direction={directionValue}
+            direction={form.direction}
             editing={editing}
             readOnly={readOnly}
-            directionDisabled={isSymmetricTransfer && !canFlipSymmetricDirection}
             directionHighlightKey={directionHighlightKey}
             onKindChange={applyKindChange}
             onDirectionChange={handleDirectionChange}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -11,7 +11,6 @@ import { buildCurrencyOptions } from '@/pages/transactions/components/transactio
 import { isSymmetricTransferForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
 import type {
   CreateTransactionModalProps,
-  TransactionDirection,
   TransactionFormValues,
 } from '@/pages/transactions/components/transaction-modal/types'
 import TransactionDetailsSection from '@/pages/transactions/components/transaction-modal/sections/DetailsSection'
@@ -203,26 +202,28 @@ export default function CreateTransactionModal({
   const showRunningBalance = !editing && keepOpenAfterCreate && !!selectedAccount
   const isSymmetricTransfer = isSymmetricTransferForm(form)
 
-  const handleDirectionChange = (value: TransactionDirection) => {
-    if (!isSymmetricTransfer || value === form.direction) {
-      handleField('direction', value)
-      return
-    }
-
-    // The direction says what happens to the account above, so flipping it on a pair also exchanges
-    // the two accounts. The money keeps moving the same way and only the account shown first
-    // changes, which is what lets the form read correctly from either account's side
-    setForm((previous) => ({
-      ...previous,
-      direction: value,
-      account_id: previous.other_account_id,
-      other_account_id: previous.account_id,
-      // The currency follows the account the transaction is recorded in, the same as choosing it
-      // from the dropdown does
-      currency: accounts.find((account) => account.id === previous.other_account_id)?.currency
-        ?? previous.currency,
-    }))
+  // A ticked pair reads source first, so a credit shows the two accounts the other way round from
+  // how the form stores them. Swapping the whole field, its value, its error and its option list
+  // together keeps them in agreement, and means the direction toggle moves the accounts between the
+  // fields without anything having to be written back to the form
+  const isPairShownReversed = isSymmetricTransfer && form.direction === 'credit'
+  const recordedAccountField = {
+    options: accountField.accountOptions,
+    selectedOption: accountField.selectedArchivedAccountOption,
+    value: form.account_id,
+    error: showError('account_id'),
+    onChange: accountField.handleAccountChange,
   }
+  const otherAccountField = {
+    options: accountField.otherAccountOptions,
+    selectedOption: accountField.selectedArchivedOtherAccountOption,
+    value: form.other_account_id,
+    error: showError('other_account_id'),
+    onChange: accountField.handleOtherAccountChange,
+  }
+  const [topAccountField, secondAccountField] = isPairShownReversed
+    ? [otherAccountField, recordedAccountField]
+    : [recordedAccountField, otherAccountField]
 
   return (
     <>
@@ -260,29 +261,27 @@ export default function CreateTransactionModal({
             readOnly={readOnly}
             directionHighlightKey={directionHighlightKey}
             onKindChange={applyKindChange}
-            onDirectionChange={handleDirectionChange}
+            onDirectionChange={(value) => handleField('direction', value)}
           />
 
           <TransactionReferencesSection
-            accountOptions={accountField.accountOptions}
-            selectedArchivedAccountOption={accountField.selectedArchivedAccountOption}
-            accountValue={form.account_id}
-            accountError={showError('account_id')}
+            accountOptions={topAccountField.options}
+            selectedArchivedAccountOption={topAccountField.selectedOption}
+            accountValue={topAccountField.value}
+            accountError={topAccountField.error}
             accountPlaceholder={accounts.length === 0 ? 'No accounts yet' : 'Select account...'}
             runningBalance={showRunningBalance && selectedAccount
               ? { amount: runningBalance, currency: selectedAccount.currency }
               : undefined}
             kind={form.kind}
 
-            // A pair always debits the account above and credits the receiving one, whatever the
-            // direction toggle was left on before the checkbox disabled it
-            direction={isSymmetricTransfer ? 'debit' : form.direction}
+            direction={form.direction}
             isSymmetricTransfer={form.symmetric_transfer}
             isTransferPairOffered={!editing}
-            otherAccountOptions={accountField.otherAccountOptions}
-            selectedArchivedOtherAccountOption={accountField.selectedArchivedOtherAccountOption}
-            otherAccountValue={form.other_account_id}
-            otherAccountError={showError('other_account_id')}
+            otherAccountOptions={secondAccountField.options}
+            selectedArchivedOtherAccountOption={secondAccountField.selectedOption}
+            otherAccountValue={secondAccountField.value}
+            otherAccountError={secondAccountField.error}
             merchantOptions={merchantField.merchantOptions}
             selectedMerchantOption={merchantField.selectedMerchantOption}
             merchantValue={form.merchant_id}
@@ -308,9 +307,9 @@ export default function CreateTransactionModal({
             tagHasMore={tagField.hasMore}
             selectedTags={tagField.selectedTags}
             readOnly={readOnly}
-            onAccountChange={accountField.handleAccountChange}
+            onAccountChange={topAccountField.onChange}
             onSymmetricTransferChange={accountField.handleSymmetricTransferChange}
-            onOtherAccountChange={accountField.handleOtherAccountChange}
+            onOtherAccountChange={secondAccountField.onChange}
             onMerchantChange={merchantField.handleMerchantChange}
             onMerchantSearchChange={merchantField.setSearch}
             onMerchantSearchCommit={merchantField.setActiveSearch}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -95,9 +95,9 @@ export default function CreateTransactionModal({
     () => accounts.find((account) => account.id === form.account_id),
     [accounts, form.account_id],
   )
-  const selectedToAccount = useMemo(
-    () => accounts.find((account) => account.id === form.to_account_id),
-    [accounts, form.to_account_id],
+  const selectedOtherAccount = useMemo(
+    () => accounts.find((account) => account.id === form.other_account_id),
+    [accounts, form.other_account_id],
   )
   const readOnly = editing && (readOnlyProp || Boolean(selectedAccount?.is_archived))
 
@@ -188,7 +188,7 @@ export default function CreateTransactionModal({
     readOnly,
     accounts,
     selectedAccount,
-    selectedToAccount,
+    selectedOtherAccount,
     selectedCurrencyExponent,
     isAmountLocked,
     isBalanceAdjustmentCategory: categoryField.isBalanceAdjustmentCategory,
@@ -210,7 +210,7 @@ export default function CreateTransactionModal({
     ? ''
     : form.account_id === defaultAccountId
       ? 'debit'
-      : form.to_account_id === defaultAccountId
+      : form.other_account_id === defaultAccountId
         ? 'credit'
         : ''
   const directionValue = isSymmetricTransfer ? symmetricDisplayDirection : form.direction
@@ -270,8 +270,6 @@ export default function CreateTransactionModal({
             // direction toggle was left on before the checkbox disabled it
             direction={isSymmetricTransfer ? 'debit' : form.direction}
             isSymmetricTransfer={form.symmetric_transfer}
-            toAccountValue={form.to_account_id}
-            toAccountError={showError('to_account_id')}
             otherAccountOptions={accountField.otherAccountOptions}
             otherAccountValue={form.other_account_id}
             otherAccountError={showError('other_account_id')}
@@ -302,7 +300,6 @@ export default function CreateTransactionModal({
             readOnly={readOnly}
             onAccountChange={accountField.handleAccountChange}
             onSymmetricTransferChange={accountField.handleSymmetricTransferChange}
-            onToAccountChange={accountField.handleToAccountChange}
             onOtherAccountChange={accountField.handleOtherAccountChange}
             onMerchantChange={merchantField.handleMerchantChange}
             onMerchantSearchChange={merchantField.setSearch}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -296,6 +296,7 @@ export default function CreateTransactionModal({
             isSymmetricTransfer={form.symmetric_transfer}
             isTransferPairOffered={!editing}
             otherAccountOptions={accountField.otherAccountOptions}
+            selectedArchivedOtherAccountOption={accountField.selectedArchivedOtherAccountOption}
             otherAccountValue={form.other_account_id}
             otherAccountError={showError('other_account_id')}
             merchantOptions={merchantField.merchantOptions}

--- a/frontend/src/pages/transactions/components/transaction-modal/constants.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/constants.ts
@@ -8,6 +8,9 @@ export const EASE = [0.25, 0.1, 0.25, 1] as const
 
 // The backend tags synthetic balance adjustments with this system transfer category name and excludes them from cash flow
 export const BALANCE_ADJUSTMENT_CATEGORY_NAME = 'Balance Adjustment'
+
+// Sentinel dropdown value for money that left the tracked accounts, distinct from any real account id
+export const OUTSIDE_ACCOUNT_VALUE = '__outside__'
 export const SELECTOR_SPRING = { type: 'spring', stiffness: 420, damping: 36, mass: 0.8 } as const
 export const DEFAULT_CATEGORY_ICON = '🏷️'
 export const MIN_ADD_TRANSACTION_LOADING_MS = 800
@@ -65,4 +68,5 @@ export const INITIAL_TRANSACTION_FORM: TransactionFormValues = {
   tag_ids: [],
   symmetric_transfer: false,
   to_account_id: '',
+  other_account_id: '',
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/constants.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/constants.ts
@@ -67,6 +67,5 @@ export const INITIAL_TRANSACTION_FORM: TransactionFormValues = {
   date: '',
   tag_ids: [],
   symmetric_transfer: false,
-  to_account_id: '',
   other_account_id: '',
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
@@ -1,7 +1,10 @@
 import { useMemo, type Dispatch, type SetStateAction } from 'react'
 import type { AccountsOverview } from '@/api/accounts'
 import type { Tag } from '@/api/tags'
-import { buildAccountOptions } from '@/pages/transactions/components/transaction-modal/utils/options'
+import {
+  buildAccountOptions,
+  buildOtherAccountOptions,
+} from '@/pages/transactions/components/transaction-modal/utils/options'
 import type {
   TransactionFormFieldErrors,
   TransactionFormValues,
@@ -21,9 +24,11 @@ interface UseAccountFieldOptions {
 interface AccountFieldState {
   accountOptions: { value: string; label: string }[]
   selectedArchivedAccountOption: { value: string; label: string } | undefined
+  otherAccountOptions: { value: string; label: string }[]
   handleAccountChange: (accountId: string) => void
   handleToAccountChange: (accountId: string) => void
   handleSymmetricTransferChange: (value: boolean) => void
+  handleOtherAccountChange: (accountId: string) => void
 }
 
 /**
@@ -44,6 +49,7 @@ export function useAccountField({
     () => buildAccountOptions(selectableAccounts, editing, form.currency),
     [selectableAccounts, editing, form.currency],
   )
+  const otherAccountOptions = useMemo(() => buildOtherAccountOptions(accounts), [accounts])
   const selectedArchivedAccountOption = editing && selectedAccount?.is_archived
     ? { value: selectedAccount.id, label: selectedAccount.name }
     : undefined
@@ -57,6 +63,8 @@ export function useAccountField({
       currency: account?.currency || '',
       // The originating account wins, so empty the receiving field when it held the same account
       to_account_id: accountId === f.to_account_id ? '' : f.to_account_id,
+      // Same reasoning for the recorded-other-account field: it cannot point at its own transaction
+      other_account_id: accountId === f.other_account_id ? '' : f.other_account_id,
       tag_ids: f.tag_ids.filter((tagId) => {
         const tag = tagById.get(tagId)
         return !tag || tag.group_id === null || tag.group_id === accountGroupId
@@ -65,6 +73,7 @@ export function useAccountField({
     clearError('account_id')
     clearError('currency')
     clearError('to_account_id')
+    clearError('other_account_id')
   }
 
   const handleToAccountChange = (accountId: string) => {
@@ -79,14 +88,24 @@ export function useAccountField({
 
   const handleSymmetricTransferChange = (value: boolean) => {
     setForm((f) => ({ ...f, symmetric_transfer: value }))
-    if (!value) clearError('to_account_id')
+    // Ticking pairs the two accounts, which already answers the other-account question, and
+    // unticking brings the standalone field back rather than the receiving-account field
+    if (value) clearError('other_account_id')
+    else clearError('to_account_id')
+  }
+
+  const handleOtherAccountChange = (accountId: string) => {
+    setForm((f) => ({ ...f, other_account_id: accountId }))
+    clearError('other_account_id')
   }
 
   return {
     accountOptions,
     selectedArchivedAccountOption,
+    otherAccountOptions,
     handleAccountChange,
     handleToAccountChange,
     handleSymmetricTransferChange,
+    handleOtherAccountChange,
   }
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
@@ -1,7 +1,6 @@
 import { useMemo, type Dispatch, type SetStateAction } from 'react'
 import type { AccountsOverview } from '@/api/accounts'
 import type { Tag } from '@/api/tags'
-import { OUTSIDE_ACCOUNT_VALUE } from '@/pages/transactions/components/transaction-modal/constants'
 import {
   buildAccountOptions,
   buildOtherAccountOptions,
@@ -76,13 +75,18 @@ export function useAccountField({
     clearError('other_account_id')
   }
 
+  /** Reports whether an account can hold the matching transaction the ticked checkbox writes */
+  const canReceivePairedTransaction = (accountId: string) =>
+    accounts.some((account) => account.id === accountId && !account.is_archived)
+
   const handleSymmetricTransferChange = (value: boolean) => {
     setForm((f) => ({
       ...f,
       symmetric_transfer: value,
-      // Outside the app is no longer offered once ticked, so an answer of that is dropped rather
-      // than left selected against an option the list no longer holds
-      other_account_id: value && f.other_account_id === OUTSIDE_ACCOUNT_VALUE ? '' : f.other_account_id,
+      // Ticking narrows the list to accounts that can take a real transaction, dropping both
+      // outside the app and the archived ones, so an answer that is no longer on the list is
+      // cleared rather than left selected against a missing option
+      other_account_id: value && !canReceivePairedTransaction(f.other_account_id) ? '' : f.other_account_id,
     }))
   }
 

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
@@ -49,7 +49,10 @@ export function useAccountField({
     () => buildAccountOptions(selectableAccounts, editing, form.currency),
     [selectableAccounts, editing, form.currency],
   )
-  const otherAccountOptions = useMemo(() => buildOtherAccountOptions(accounts), [accounts])
+  const otherAccountOptions = useMemo(
+    () => buildOtherAccountOptions(accounts, form.account_id, editing),
+    [accounts, form.account_id, editing],
+  )
   const selectedArchivedAccountOption = editing && selectedAccount?.is_archived
     ? { value: selectedAccount.id, label: selectedAccount.name }
     : undefined

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
@@ -50,8 +50,8 @@ export function useAccountField({
     [selectableAccounts, editing, form.currency],
   )
   const otherAccountOptions = useMemo(
-    () => buildOtherAccountOptions(accounts, form.account_id, editing),
-    [accounts, form.account_id, editing],
+    () => buildOtherAccountOptions(accounts, form.account_id),
+    [accounts, form.account_id],
   )
   const selectedArchivedAccountOption = editing && selectedAccount?.is_archived
     ? { value: selectedAccount.id, label: selectedAccount.name }

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
@@ -24,6 +24,7 @@ interface UseAccountFieldOptions {
 interface AccountFieldState {
   accountOptions: { value: string; label: string }[]
   selectedArchivedAccountOption: { value: string; label: string } | undefined
+  selectedArchivedOtherAccountOption: { value: string; label: string } | undefined
   otherAccountOptions: { value: string; label: string }[]
   handleAccountChange: (accountId: string) => void
   handleSymmetricTransferChange: (value: boolean) => void
@@ -54,6 +55,15 @@ export function useAccountField({
   )
   const selectedArchivedAccountOption = editing && selectedAccount?.is_archived
     ? { value: selectedAccount.id, label: selectedAccount.name }
+    : undefined
+
+  // An account archived after the transfer was recorded is off the list above, so the stored answer
+  // is supplied as its own option. Without it the field would read as unanswered, and every edit
+  // now has to answer, so correcting anything else on the transaction would force the account to be
+  // changed to one that is not where the money went
+  const recordedOtherAccount = accounts.find((account) => account.id === form.other_account_id)
+  const selectedArchivedOtherAccountOption = editing && recordedOtherAccount?.is_archived
+    ? { value: recordedOtherAccount.id, label: recordedOtherAccount.name }
     : undefined
 
   const handleAccountChange = (accountId: string) => {
@@ -98,6 +108,7 @@ export function useAccountField({
   return {
     accountOptions,
     selectedArchivedAccountOption,
+    selectedArchivedOtherAccountOption,
     otherAccountOptions,
     handleAccountChange,
     handleSymmetricTransferChange,

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
@@ -82,16 +82,19 @@ export function useAccountField({
       to_account_id: accountId,
       // The receiving account wins, so empty the originating field when it held the same account
       account_id: accountId === f.account_id ? '' : f.account_id,
+      // Choosing a receiving account fills what this leg records too. The field stays editable
+      // afterward and is not forced back into agreement if it is then changed
+      other_account_id: accountId,
     }))
     clearError('to_account_id')
+    clearError('other_account_id')
   }
 
   const handleSymmetricTransferChange = (value: boolean) => {
     setForm((f) => ({ ...f, symmetric_transfer: value }))
-    // Ticking pairs the two accounts, which already answers the other-account question, and
-    // unticking brings the standalone field back rather than the receiving-account field
-    if (value) clearError('other_account_id')
-    else clearError('to_account_id')
+    // The receiving-account field disappears when unticked, so its error goes with it. The
+    // other-account field stays on screen either way, so ticking does not touch its error
+    if (!value) clearError('to_account_id')
   }
 
   const handleOtherAccountChange = (accountId: string) => {

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useAccountField.ts
@@ -1,6 +1,7 @@
 import { useMemo, type Dispatch, type SetStateAction } from 'react'
 import type { AccountsOverview } from '@/api/accounts'
 import type { Tag } from '@/api/tags'
+import { OUTSIDE_ACCOUNT_VALUE } from '@/pages/transactions/components/transaction-modal/constants'
 import {
   buildAccountOptions,
   buildOtherAccountOptions,
@@ -26,7 +27,6 @@ interface AccountFieldState {
   selectedArchivedAccountOption: { value: string; label: string } | undefined
   otherAccountOptions: { value: string; label: string }[]
   handleAccountChange: (accountId: string) => void
-  handleToAccountChange: (accountId: string) => void
   handleSymmetricTransferChange: (value: boolean) => void
   handleOtherAccountChange: (accountId: string) => void
 }
@@ -50,8 +50,8 @@ export function useAccountField({
     [selectableAccounts, editing, form.currency],
   )
   const otherAccountOptions = useMemo(
-    () => buildOtherAccountOptions(accounts, form.account_id),
-    [accounts, form.account_id],
+    () => buildOtherAccountOptions(accounts, form.account_id, form.symmetric_transfer),
+    [accounts, form.account_id, form.symmetric_transfer],
   )
   const selectedArchivedAccountOption = editing && selectedAccount?.is_archived
     ? { value: selectedAccount.id, label: selectedAccount.name }
@@ -64,9 +64,7 @@ export function useAccountField({
       ...f,
       account_id: accountId,
       currency: account?.currency || '',
-      // The originating account wins, so empty the receiving field when it held the same account
-      to_account_id: accountId === f.to_account_id ? '' : f.to_account_id,
-      // Same reasoning for the recorded-other-account field: it cannot point at its own transaction
+      // The originating account wins, so empty the other field when it held the same account
       other_account_id: accountId === f.other_account_id ? '' : f.other_account_id,
       tag_ids: f.tag_ids.filter((tagId) => {
         const tag = tagById.get(tagId)
@@ -75,29 +73,17 @@ export function useAccountField({
     }))
     clearError('account_id')
     clearError('currency')
-    clearError('to_account_id')
-    clearError('other_account_id')
-  }
-
-  const handleToAccountChange = (accountId: string) => {
-    setForm((f) => ({
-      ...f,
-      to_account_id: accountId,
-      // The receiving account wins, so empty the originating field when it held the same account
-      account_id: accountId === f.account_id ? '' : f.account_id,
-      // Choosing a receiving account fills what this leg records too. The field stays editable
-      // afterward and is not forced back into agreement if it is then changed
-      other_account_id: accountId,
-    }))
-    clearError('to_account_id')
     clearError('other_account_id')
   }
 
   const handleSymmetricTransferChange = (value: boolean) => {
-    setForm((f) => ({ ...f, symmetric_transfer: value }))
-    // The receiving-account field disappears when unticked, so its error goes with it. The
-    // other-account field stays on screen either way, so ticking does not touch its error
-    if (!value) clearError('to_account_id')
+    setForm((f) => ({
+      ...f,
+      symmetric_transfer: value,
+      // Outside the app is no longer offered once ticked, so an answer of that is dropped rather
+      // than left selected against an option the list no longer holds
+      other_account_id: value && f.other_account_id === OUTSIDE_ACCOUNT_VALUE ? '' : f.other_account_id,
+    }))
   }
 
   const handleOtherAccountChange = (accountId: string) => {
@@ -110,7 +96,6 @@ export function useAccountField({
     selectedArchivedAccountOption,
     otherAccountOptions,
     handleAccountChange,
-    handleToAccountChange,
     handleSymmetricTransferChange,
     handleOtherAccountChange,
   }

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useCategoryField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useCategoryField.ts
@@ -66,7 +66,7 @@ export function useCategoryField({
       category_id: categoryId,
       ...(doesTransferRecordOtherAccount(nextKind, nextIsBalanceAdjustment)
         ? {}
-        : { other_account_id: '', symmetric_transfer: false, to_account_id: '' }),
+        : { other_account_id: '', symmetric_transfer: false }),
     })
     clearError('category_id')
   }

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useCategoryField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useCategoryField.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import type { Category } from '@/api/categories'
 import { BALANCE_ADJUSTMENT_CATEGORY_NAME } from '@/pages/transactions/components/transaction-modal/constants'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
+import { doesTransferRecordOtherAccount } from '@/pages/transactions/components/transaction-modal/utils/validation'
 import type {
   TransactionFormFieldErrors,
   TransactionFormValues,
@@ -57,8 +58,16 @@ export function useCategoryField({
   const handleCategoryChange = (categoryId: string) => {
     const category = categoryById.get(categoryId)
     const nextKind = (category?.kind as TransactionModalKind | undefined) ?? form.kind
-    // Auto-switch the kind toggle to match the chosen category
-    applyKindChange(nextKind, { category_id: categoryId })
+    const nextIsBalanceAdjustment = !!(category?.is_system && category.name === BALANCE_ADJUSTMENT_CATEGORY_NAME)
+    // Auto-switch the kind toggle to match the chosen category. Balance Adjustment has no other
+    // side, so a pending other-account answer or a symmetric pair set up under a real transfer
+    // category no longer applies once the category switches to it
+    applyKindChange(nextKind, {
+      category_id: categoryId,
+      ...(doesTransferRecordOtherAccount(nextKind, nextIsBalanceAdjustment)
+        ? {}
+        : { other_account_id: '', symmetric_transfer: false, to_account_id: '' }),
+    })
     clearError('category_id')
   }
 

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useFormState.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useFormState.ts
@@ -55,6 +55,9 @@ export function useTransactionFormState(initialForm: TransactionFormValues): Tra
     const kindChanged = nextKind !== form.kind
     setForm((f) => ({
       ...f,
+      // A non-transfer kind has no other side to record, so a pending answer from a previous
+      // transfer selection is dropped rather than lingering unseen
+      ...(nextKind === 'transfer' ? {} : { other_account_id: '' }),
       ...fields,
       kind: nextKind,
       direction: nextKind === f.kind ? f.direction : getDefaultDirectionForKind(nextKind),

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useFormState.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useFormState.ts
@@ -56,8 +56,10 @@ export function useTransactionFormState(initialForm: TransactionFormValues): Tra
     setForm((f) => ({
       ...f,
       // A non-transfer kind has no other side to record, so a pending answer from a previous
-      // transfer selection is dropped rather than lingering unseen
-      ...(nextKind === 'transfer' ? {} : { other_account_id: '' }),
+      // transfer selection is dropped rather than lingering unseen. The checkbox goes with it,
+      // since leaving it set would arm a second transaction on the next transfer without the user
+      // ticking it again
+      ...(nextKind === 'transfer' ? {} : { other_account_id: '', symmetric_transfer: false }),
       ...fields,
       kind: nextKind,
       direction: nextKind === f.kind ? f.direction : getDefaultDirectionForKind(nextKind),

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useMerchantField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useMerchantField.ts
@@ -5,12 +5,14 @@ import { ApiError } from '@/api/auth'
 import type { Category } from '@/api/categories'
 import { useInfiniteMerchants, useMerchant, useUpdateMerchant, type Merchant } from '@/api/merchants'
 import {
+  BALANCE_ADJUSTMENT_CATEGORY_NAME,
   MERCHANT_DROPDOWN_PAGE_SIZE,
   MERCHANT_FETCHING_MORE_TEXT_MIN_MS,
   MERCHANT_SEARCH_DEBOUNCE_MS,
   MERCHANT_SEARCH_LOADING_TEXT_MIN_MS,
 } from '@/pages/transactions/components/transaction-modal/constants'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
+import { doesTransferRecordOtherAccount } from '@/pages/transactions/components/transaction-modal/utils/validation'
 import type {
   TransactionFormFieldErrors,
   TransactionFormValues,
@@ -142,7 +144,18 @@ export function useMerchantField({
 
     const defaultCategory = categoryById.get(defaultCategoryId)
     const nextKind = (defaultCategory?.kind as TransactionModalKind | undefined) ?? form.kind
-    applyKindChange(nextKind, { merchant_id: merchantId, category_id: defaultCategoryId })
+    const nextIsBalanceAdjustment = !!(
+      defaultCategory?.is_system && defaultCategory.name === BALANCE_ADJUSTMENT_CATEGORY_NAME
+    )
+    // Balance Adjustment has no other side, so a pending other-account answer or a symmetric pair
+    // set up under a real transfer category no longer applies once the default category lands on it
+    applyKindChange(nextKind, {
+      merchant_id: merchantId,
+      category_id: defaultCategoryId,
+      ...(doesTransferRecordOtherAccount(nextKind, nextIsBalanceAdjustment)
+        ? {}
+        : { other_account_id: '', symmetric_transfer: false, to_account_id: '' }),
+    })
     clearError('merchant_id')
     clearError('category_id')
   }

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useMerchantField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useMerchantField.ts
@@ -122,8 +122,11 @@ export function useMerchantField({
     [categoryOptions],
   )
 
+  // A system merchant is shared by everyone, and its default category would be too, so it is not
+  // offered one rather than letting one person's choice change what auto-fills for the rest
   const showMerchantDefaultCategoryAction = !!(
     selectedMerchant &&
+    !selectedMerchant.is_system &&
     selectedCategory &&
     selectedMerchant.default_category_id !== selectedCategory.id
   )

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useMerchantField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useMerchantField.ts
@@ -157,7 +157,7 @@ export function useMerchantField({
       category_id: defaultCategoryId,
       ...(doesTransferRecordOtherAccount(nextKind, nextIsBalanceAdjustment)
         ? {}
-        : { other_account_id: '', symmetric_transfer: false, to_account_id: '' }),
+        : { other_account_id: '', symmetric_transfer: false }),
     })
     clearError('merchant_id')
     clearError('category_id')

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
@@ -39,7 +39,7 @@ interface UseTransactionSubmitOptions {
   readOnly: boolean
   accounts: AccountsOverview[]
   selectedAccount: AccountsOverview | undefined
-  selectedToAccount: AccountsOverview | undefined
+  selectedOtherAccount: AccountsOverview | undefined
   selectedCurrencyExponent: number
   isAmountLocked: boolean
   isBalanceAdjustmentCategory: boolean
@@ -75,7 +75,7 @@ export function useTransactionSubmit({
   readOnly,
   accounts,
   selectedAccount,
-  selectedToAccount,
+  selectedOtherAccount,
   selectedCurrencyExponent,
   isAmountLocked,
   isBalanceAdjustmentCategory,
@@ -107,9 +107,8 @@ export function useTransactionSubmit({
   // create and a batch of them would otherwise have to answer it again on each row. Outside a
   // transfer the field is off-screen and empty, so keeping it changes nothing
   //
-  // A symmetric transfer additionally keeps symmetric_transfer and to_account_id, because a
-  // transfer's identity is the account pair and dropping either would force re-arming the
-  // checkbox and the receiving account before every row
+  // A symmetric transfer additionally keeps symmetric_transfer, because dropping it would force
+  // re-arming the checkbox before every row of a batch
   const resetFormAfterCreate = ({ keepTransferPair }: { keepTransferPair: boolean }) => {
     setForm({
       ...INITIAL_TRANSACTION_FORM,
@@ -121,12 +120,7 @@ export function useTransactionSubmit({
       currency: form.currency,
       date: form.date,
       other_account_id: form.other_account_id,
-      ...(keepTransferPair
-        ? {
-          symmetric_transfer: form.symmetric_transfer,
-          to_account_id: form.to_account_id,
-        }
-        : {}),
+      ...(keepTransferPair ? { symmetric_transfer: form.symmetric_transfer } : {}),
     })
     setFieldErrors({})
     setTouched({})
@@ -138,10 +132,11 @@ export function useTransactionSubmit({
     e.preventDefault()
     if (isPending || readOnly) return
     const errors = validateTransactionForm(form, { isAmountLocked, isBalanceAdjustmentCategory })
-    // The receiving account needs both accounts loaded to compare currency and group
-    if (!editing && isSymmetricTransferForm(form) && !errors.to_account_id) {
-      const accountError = getSymmetricTransferAccountError(selectedAccount, selectedToAccount)
-      if (accountError) errors.to_account_id = accountError
+    // Ticking the checkbox creates a real transaction in the recorded account, so that account has
+    // to be one the amount is valid in. Both accounts have to be loaded to compare them
+    if (!editing && isSymmetricTransferForm(form) && !errors.other_account_id) {
+      const accountError = getSymmetricTransferAccountError(selectedAccount, selectedOtherAccount)
+      if (accountError) errors.other_account_id = accountError
     }
     setFieldErrors(errors)
     setTouched({
@@ -151,7 +146,6 @@ export function useTransactionSubmit({
       amount: true,
       currency: true,
       date: true,
-      to_account_id: true,
       other_account_id: true,
     })
     if (Object.keys(errors).length > 0) return
@@ -184,7 +178,7 @@ export function useTransactionSubmit({
       const [fromPayload, toPayload] = buildSymmetricTransferPayloads(form, selectedCurrencyExponent)
       const legs = [
         { failedKind: 'debit', accountId: form.account_id, payload: fromPayload },
-        { failedKind: 'credit', accountId: form.to_account_id, payload: toPayload },
+        { failedKind: 'credit', accountId: form.other_account_id, payload: toPayload },
       ]
 
       setSubmitError('')

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
@@ -103,11 +103,13 @@ export function useTransactionSubmit({
   // Resets the form after a create so a keep-open batch starts its next row from the same
   // account, category, merchant, currency, and date instead of blank fields
   //
-  // A symmetric transfer additionally keeps symmetric_transfer, to_account_id, and
-  // other_account_id, because a transfer's identity is the account pair and the other-account
-  // field is required on every create: dropping any of them would force re-arming the checkbox,
-  // the receiving account, and the answer before every row in the batch. The single-transaction
-  // path always clears them, which is a no-op since all three are off-screen outside a transfer
+  // The recorded other account is kept on every path, because it is required on every transfer
+  // create and a batch of them would otherwise have to answer it again on each row. Outside a
+  // transfer the field is off-screen and empty, so keeping it changes nothing
+  //
+  // A symmetric transfer additionally keeps symmetric_transfer and to_account_id, because a
+  // transfer's identity is the account pair and dropping either would force re-arming the
+  // checkbox and the receiving account before every row
   const resetFormAfterCreate = ({ keepTransferPair }: { keepTransferPair: boolean }) => {
     setForm({
       ...INITIAL_TRANSACTION_FORM,
@@ -118,11 +120,11 @@ export function useTransactionSubmit({
       merchant_id: form.merchant_id,
       currency: form.currency,
       date: form.date,
+      other_account_id: form.other_account_id,
       ...(keepTransferPair
         ? {
           symmetric_transfer: form.symmetric_transfer,
           to_account_id: form.to_account_id,
-          other_account_id: form.other_account_id,
         }
         : {}),
     })

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
@@ -15,6 +15,7 @@ import {
 import {
   buildCreateTransactionPayload,
   buildSymmetricTransferPayloads,
+  getSymmetricTransferLegKinds,
   buildUpdateTransactionPatch,
 } from '@/pages/transactions/components/transaction-modal/utils/payloads'
 import {
@@ -176,16 +177,10 @@ export function useTransactionSubmit({
 
     if (isSymmetricTransferForm(form)) {
       const [fromPayload, toPayload] = buildSymmetricTransferPayloads(form, selectedCurrencyExponent)
-      // The direction says what happens to the recorded account, so it is that leg's kind and the
-      // other leg is the opposite. Naming them the wrong way round would tell someone re-entering a
-      // failed leg by hand to enter it backwards
+      const [recordedLegKind, otherLegKind] = getSymmetricTransferLegKinds(form.direction)
       const legs = [
-        { failedKind: form.direction, accountId: form.account_id, payload: fromPayload },
-        {
-          failedKind: form.direction === 'debit' ? 'credit' : 'debit',
-          accountId: form.other_account_id,
-          payload: toPayload,
-        },
+        { failedKind: recordedLegKind, accountId: form.account_id, payload: fromPayload },
+        { failedKind: otherLegKind, accountId: form.other_account_id, payload: toPayload },
       ]
 
       setSubmitError('')

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
@@ -176,9 +176,16 @@ export function useTransactionSubmit({
 
     if (isSymmetricTransferForm(form)) {
       const [fromPayload, toPayload] = buildSymmetricTransferPayloads(form, selectedCurrencyExponent)
+      // The direction says what happens to the recorded account, so it is that leg's kind and the
+      // other leg is the opposite. Naming them the wrong way round would tell someone re-entering a
+      // failed leg by hand to enter it backwards
       const legs = [
-        { failedKind: 'debit', accountId: form.account_id, payload: fromPayload },
-        { failedKind: 'credit', accountId: form.other_account_id, payload: toPayload },
+        { failedKind: form.direction, accountId: form.account_id, payload: fromPayload },
+        {
+          failedKind: form.direction === 'debit' ? 'credit' : 'debit',
+          accountId: form.other_account_id,
+          payload: toPayload,
+        },
       ]
 
       setSubmitError('')

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
@@ -103,10 +103,11 @@ export function useTransactionSubmit({
   // Resets the form after a create so a keep-open batch starts its next row from the same
   // account, category, merchant, currency, and date instead of blank fields
   //
-  // A symmetric transfer additionally keeps symmetric_transfer and to_account_id, because a
-  // transfer's identity is the account pair: dropping them would force re-arming the checkbox
-  // and receiving account before every row in the batch. The single-transaction path always
-  // clears them, which is a no-op since both are off-screen outside a transfer
+  // A symmetric transfer additionally keeps symmetric_transfer, to_account_id, and
+  // other_account_id, because a transfer's identity is the account pair and the other-account
+  // field is required on every create: dropping any of them would force re-arming the checkbox,
+  // the receiving account, and the answer before every row in the batch. The single-transaction
+  // path always clears them, which is a no-op since all three are off-screen outside a transfer
   const resetFormAfterCreate = ({ keepTransferPair }: { keepTransferPair: boolean }) => {
     setForm({
       ...INITIAL_TRANSACTION_FORM,
@@ -118,7 +119,11 @@ export function useTransactionSubmit({
       currency: form.currency,
       date: form.date,
       ...(keepTransferPair
-        ? { symmetric_transfer: form.symmetric_transfer, to_account_id: form.to_account_id }
+        ? {
+          symmetric_transfer: form.symmetric_transfer,
+          to_account_id: form.to_account_id,
+          other_account_id: form.other_account_id,
+        }
         : {}),
     })
     setFieldErrors({})

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
@@ -42,6 +42,7 @@ interface UseTransactionSubmitOptions {
   selectedToAccount: AccountsOverview | undefined
   selectedCurrencyExponent: number
   isAmountLocked: boolean
+  isBalanceAdjustmentCategory: boolean
   deleteLoading: boolean
   openRef: MutableRefObject<boolean>
   recordCreatedAccountId: (accountId: string) => void
@@ -77,6 +78,7 @@ export function useTransactionSubmit({
   selectedToAccount,
   selectedCurrencyExponent,
   isAmountLocked,
+  isBalanceAdjustmentCategory,
   deleteLoading,
   openRef,
   recordCreatedAccountId,
@@ -128,14 +130,29 @@ export function useTransactionSubmit({
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     if (isPending || readOnly) return
-    const errors = validateTransactionForm(form, isAmountLocked)
+    const errors = validateTransactionForm(form, {
+      isAmountLocked,
+      isBalanceAdjustmentCategory,
+      // Only a create requires an other-account answer, since an existing transaction can be
+      // corrected without answering the question first
+      requireOtherAccount: !editing,
+    })
     // The receiving account needs both accounts loaded to compare currency and group
     if (!editing && isSymmetricTransferForm(form) && !errors.to_account_id) {
       const accountError = getSymmetricTransferAccountError(selectedAccount, selectedToAccount)
       if (accountError) errors.to_account_id = accountError
     }
     setFieldErrors(errors)
-    setTouched({ account_id: true, category_id: true, merchant_id: true, amount: true, currency: true, date: true, to_account_id: true })
+    setTouched({
+      account_id: true,
+      category_id: true,
+      merchant_id: true,
+      amount: true,
+      currency: true,
+      date: true,
+      to_account_id: true,
+      other_account_id: true,
+    })
     if (Object.keys(errors).length > 0) return
 
     if (editing && transaction) {

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useSubmit.ts
@@ -137,13 +137,7 @@ export function useTransactionSubmit({
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault()
     if (isPending || readOnly) return
-    const errors = validateTransactionForm(form, {
-      isAmountLocked,
-      isBalanceAdjustmentCategory,
-      // Only a create requires an other-account answer, since an existing transaction can be
-      // corrected without answering the question first
-      requireOtherAccount: !editing,
-    })
+    const errors = validateTransactionForm(form, { isAmountLocked, isBalanceAdjustmentCategory })
     // The receiving account needs both accounts loaded to compare currency and group
     if (!editing && isSymmetricTransferForm(form) && !errors.to_account_id) {
       const accountError = getSymmetricTransferAccountError(selectedAccount, selectedToAccount)

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -213,10 +213,15 @@ export default function TransactionReferencesSection({
               <div className="pt-3">
                 <CreateModalFieldLabelRow
                   label={(
-                    <AppSlotMachineText
-                      text={direction === 'debit' ? 'Money went to' : 'Money came from'}
-                      reserveText="Money came from"
-                    />
+                    <>
+                      {/* Only the part that changes rolls, so "Money" stays put rather than
+                          re-animating every character on a direction switch */}
+                      Money{' '}
+                      <AppSlotMachineText
+                        text={direction === 'debit' ? 'went to' : 'came from'}
+                        reserveText="came from"
+                      />
+                    </>
                   )}
                   error={otherAccountError}
                 />

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -28,6 +28,9 @@ interface TransactionReferencesSectionProps {
   accountError?: string | false
   accountPlaceholder: string
   runningBalance?: { amount: number; currency: string }
+
+  // Set instead of the one above when a paired transfer puts the recorded account in the second slot
+  otherAccountRunningBalance?: { amount: number; currency: string }
   kind: TransactionModalKind
 
   // Whether the amount is leaving (debit) or entering (credit) the recorded account, used to
@@ -95,6 +98,37 @@ interface TransactionReferencesSectionProps {
 }
 
 /**
+ * Shows what the account's balance becomes once the transaction is added, under whichever of the
+ * two account dropdowns is currently holding that account
+ */
+function RunningBalanceRow({ runningBalance }: { runningBalance?: { amount: number; currency: string } }) {
+  return (
+    <AnimatePresence initial={false}>
+      {runningBalance && (
+        <motion.div
+          key="running-balance"
+          className="overflow-hidden"
+          initial={{ height: 0, opacity: 0, y: -3 }}
+          animate={{ height: 'auto', opacity: 1, y: 0 }}
+          exit={{ height: 0, opacity: 0, y: -3 }}
+          transition={{ duration: 0.2, ease: EASE }}
+          aria-live="polite"
+        >
+          <div className="flex items-center justify-between gap-3 px-0.5 pt-2 text-xs">
+            <span className="font-medium" style={{ color: 'var(--app-text-muted)' }}>
+              Running balance
+            </span>
+            <span className="font-financial text-sm font-semibold" style={{ color: 'var(--app-text)' }}>
+              {formatCurrency(runningBalance.amount, runningBalance.currency)}
+            </span>
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}
+
+/**
  * Renders account, merchant, category, and tag reference controls for the transaction form
  */
 export default function TransactionReferencesSection({
@@ -104,6 +138,7 @@ export default function TransactionReferencesSection({
   accountError,
   accountPlaceholder,
   runningBalance,
+  otherAccountRunningBalance,
   kind,
   direction,
   isSymmetricTransfer,
@@ -184,31 +219,7 @@ export default function TransactionReferencesSection({
           searchPlaceholder="Search accounts..."
           disabled={readOnly}
         />
-        <AnimatePresence initial={false}>
-          {runningBalance && (
-            <motion.div
-              key="running-balance"
-              className="overflow-hidden"
-              initial={{ height: 0, opacity: 0, y: -3 }}
-              animate={{ height: 'auto', opacity: 1, y: 0 }}
-              exit={{ height: 0, opacity: 0, y: -3 }}
-              transition={{ duration: 0.2, ease: EASE }}
-              aria-live="polite"
-            >
-              <div className="flex items-center justify-between gap-3 px-0.5 pt-2 text-xs">
-                <span className="font-medium" style={{ color: 'var(--app-text-muted)' }}>
-                  Running balance
-                </span>
-                <span
-                  className="font-financial text-sm font-semibold"
-                  style={{ color: 'var(--app-text)' }}
-                >
-                  {formatCurrency(runningBalance.amount, runningBalance.currency)}
-                </span>
-              </div>
-            </motion.div>
-          )}
-        </AnimatePresence>
+        <RunningBalanceRow runningBalance={runningBalance} />
 
         <AnimatePresence initial={false}>
           {recordsOtherAccount && (
@@ -249,6 +260,7 @@ export default function TransactionReferencesSection({
                   // answer somewhere it can never be put back
                   disabled={readOnly || Boolean(selectedArchivedOtherAccountOption)}
                 />
+                <RunningBalanceRow runningBalance={otherAccountRunningBalance} />
                 <AnimatePresence initial={false}>
                   {/* Ticking the checkbox below does create one there, and its own description says
                       so, so this would contradict it. The padding sits inside the collapsing element

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -216,36 +216,23 @@ export default function TransactionReferencesSection({
               transition={{ height: { duration: 0.2, ease: EASE }, opacity: { duration: 0.14, ease: 'linear' } }}
             >
               <div className="pt-3">
-                <AnimatePresence initial={false} mode="wait">
-                  {!isSymmetricTransfer && (
-                    <motion.div
-                      key="other-account"
-                      className="overflow-hidden"
-                      initial={{ height: 0, opacity: 0 }}
-                      animate={{ height: 'auto', opacity: 1 }}
-                      exit={{ height: 0, opacity: 0 }}
-                      transition={{ duration: 0.2, ease: EASE }}
-                    >
-                      <CreateModalFieldLabelRow
-                        label={direction === 'debit' ? 'Money went to' : 'Money came from'}
-                        error={otherAccountError}
-                      />
-                      <Dropdown
-                        options={otherAccountOptions}
-                        value={otherAccountValue}
-                        onChange={onOtherAccountChange}
-                        className={`app-input ${otherAccountError ? 'app-input-error' : ''}`}
-                        placeholder="Select account..."
-                        searchable
-                        searchPlaceholder="Search accounts..."
-                        disabled={readOnly}
-                      />
-                      <p className="mt-2 text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                        Records the fact only, creating no transaction in that account.
-                      </p>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
+                <CreateModalFieldLabelRow
+                  label={direction === 'debit' ? 'Money went to' : 'Money came from'}
+                  error={otherAccountError}
+                />
+                <Dropdown
+                  options={otherAccountOptions}
+                  value={otherAccountValue}
+                  onChange={onOtherAccountChange}
+                  className={`app-input ${otherAccountError ? 'app-input-error' : ''}`}
+                  placeholder="Select account..."
+                  searchable
+                  searchPlaceholder="Search accounts..."
+                  disabled={readOnly}
+                />
+                <p className="mt-2 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                  Records the fact only, creating no transaction in that account.
+                </p>
               </div>
 
               <div className="pt-3">

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -36,6 +36,10 @@ interface TransactionReferencesSectionProps {
 
   isSymmetricTransfer: boolean
 
+  // Whether to offer the checkbox at all. It asks for a second transaction to be created, which is
+  // only something a new transfer can do, so an existing one is not shown it
+  isTransferPairOffered: boolean
+
   // Every account plus the "outside this app" entry, for the field recording where a transfer's
   // other side sits
   otherAccountOptions: DropdownOption[]
@@ -100,6 +104,7 @@ export default function TransactionReferencesSection({
   kind,
   direction,
   isSymmetricTransfer,
+  isTransferPairOffered,
   otherAccountOptions,
   otherAccountValue,
   otherAccountError,
@@ -244,31 +249,32 @@ export default function TransactionReferencesSection({
                 )}
               </div>
 
-              <div className="pt-3">
-                <label
-                  htmlFor="txn-symmetric-transfer"
-                  className="flex cursor-pointer items-start gap-3 rounded-xl px-1 py-1"
-                >
-                  <input
-                    id="txn-symmetric-transfer"
-                    type="checkbox"
-                    checked={isSymmetricTransfer}
-                    onChange={(event) => onSymmetricTransferChange(event.target.checked)}
-                    disabled={readOnly}
-                    className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer disabled:cursor-not-allowed"
-                    style={{ accentColor: 'var(--app-accent)' }}
-                  />
-                  <span className="min-w-0">
-                    <span className="block text-sm font-medium" style={{ color: 'var(--app-text)' }}>
-                      Record in both accounts
+              {isTransferPairOffered && (
+                <div className="pt-3">
+                  <label
+                    htmlFor="txn-symmetric-transfer"
+                    className="flex cursor-pointer items-start gap-3 rounded-xl px-1 py-1"
+                  >
+                    <input
+                      id="txn-symmetric-transfer"
+                      type="checkbox"
+                      checked={isSymmetricTransfer}
+                      onChange={(event) => onSymmetricTransferChange(event.target.checked)}
+                      disabled={readOnly}
+                      className="mt-0.5 h-4 w-4 shrink-0 cursor-pointer disabled:cursor-not-allowed"
+                      style={{ accentColor: 'var(--app-accent)' }}
+                    />
+                    <span className="min-w-0">
+                      <span className="block text-sm font-medium" style={{ color: 'var(--app-text)' }}>
+                        Record in both accounts
+                      </span>
+                      <span className="block text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                        Also create the matching entry in the receiving account
+                      </span>
                     </span>
-                    <span className="block text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                      Also create the matching entry in the receiving account
-                    </span>
-                  </span>
-                </label>
-
-              </div>
+                  </label>
+                </div>
+              )}
             </motion.div>
           )}
         </AnimatePresence>

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -158,8 +158,9 @@ export default function TransactionReferencesSection({
   // Every transfer-kind category except Balance Adjustment records which other account the money touched
   const recordsOtherAccount = doesTransferRecordOtherAccount(kind, isBalanceAdjustmentCategory)
 
-  // Ticking the checkbox writes a transaction in both accounts, so neither one is the single
-  // account it was recorded in
+  // Ticking the checkbox writes a transaction in both accounts, so neither one is the single account
+  // it was recorded in. The two fields then read source first, which is why the one below says the
+  // money went to it whatever the direction toggle is set to
   const accountLabel = kind === 'transfer' && isSymmetricTransfer
     ? 'From account'
     : recordsOtherAccount ? 'Recorded in' : 'Account'
@@ -227,7 +228,7 @@ export default function TransactionReferencesSection({
                           re-animating every character on a direction switch */}
                       Money{' '}
                       <AppSlotMachineText
-                        text={direction === 'debit' ? 'went to' : 'came from'}
+                        text={isSymmetricTransfer || direction === 'debit' ? 'went to' : 'came from'}
                         reserveText="came from"
                       />
                     </>

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -3,6 +3,7 @@ import { Tag as TagIcon, X } from 'lucide-react'
 import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow'
 import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
+import { AppSlotMachineText } from '@/components/display/SlotMachineText'
 import {
   EASE,
   TRANSACTION_MODAL_FIELD_IDS,
@@ -34,8 +35,6 @@ interface TransactionReferencesSectionProps {
   direction: TransactionDirection
 
   isSymmetricTransfer: boolean
-  toAccountValue: string
-  toAccountError?: string | false
 
   // Every account plus the "outside this app" entry, for the field recording where a transfer's
   // other side sits
@@ -71,7 +70,6 @@ interface TransactionReferencesSectionProps {
   readOnly: boolean
   onAccountChange: (value: string) => void
   onSymmetricTransferChange: (value: boolean) => void
-  onToAccountChange: (value: string) => void
   onOtherAccountChange: (value: string) => void
   onMerchantChange: (value: string) => void
   onMerchantSearchChange: (value: string) => void
@@ -102,8 +100,6 @@ export default function TransactionReferencesSection({
   kind,
   direction,
   isSymmetricTransfer,
-  toAccountValue,
-  toAccountError,
   otherAccountOptions,
   otherAccountValue,
   otherAccountError,
@@ -134,7 +130,6 @@ export default function TransactionReferencesSection({
   readOnly,
   onAccountChange,
   onSymmetricTransferChange,
-  onToAccountChange,
   onOtherAccountChange,
   onMerchantChange,
   onMerchantSearchChange,
@@ -154,8 +149,8 @@ export default function TransactionReferencesSection({
   // Every transfer-kind category except Balance Adjustment records which other account the money touched
   const recordsOtherAccount = doesTransferRecordOtherAccount(kind, isBalanceAdjustmentCategory)
 
-  // Ticking the checkbox writes a transaction in both accounts, so neither one is the account it
-  // was recorded in and the pair keeps the from-and-to labels it has always had
+  // Ticking the checkbox writes a transaction in both accounts, so neither one is the single
+  // account it was recorded in
   const accountLabel = kind === 'transfer' && isSymmetricTransfer
     ? 'From account'
     : recordsOtherAccount ? 'Recorded in' : 'Account'
@@ -217,7 +212,12 @@ export default function TransactionReferencesSection({
             >
               <div className="pt-3">
                 <CreateModalFieldLabelRow
-                  label={direction === 'debit' ? 'Money went to' : 'Money came from'}
+                  label={(
+                    <AppSlotMachineText
+                      text={direction === 'debit' ? 'Money went to' : 'Money came from'}
+                      reserveText="Money came from"
+                    />
+                  )}
                   error={otherAccountError}
                 />
                 <Dropdown
@@ -259,32 +259,6 @@ export default function TransactionReferencesSection({
                   </span>
                 </label>
 
-                <AnimatePresence initial={false}>
-                  {isSymmetricTransfer && (
-                    <motion.div
-                      key="to-account"
-                      className="overflow-hidden"
-                      initial={{ height: 0, opacity: 0, y: -3 }}
-                      animate={{ height: 'auto', opacity: 1, y: 0 }}
-                      exit={{ height: 0, opacity: 0, y: -3 }}
-                      transition={{ duration: 0.2, ease: EASE }}
-                    >
-                      <div className="pt-3">
-                        <CreateModalFieldLabelRow label="To account" error={toAccountError} />
-                        <Dropdown
-                          options={accountOptions}
-                          value={toAccountValue}
-                          onChange={onToAccountChange}
-                          className={`app-input ${toAccountError ? 'app-input-error' : ''}`}
-                          placeholder={accountPlaceholder}
-                          searchable
-                          searchPlaceholder="Search accounts..."
-                          disabled={readOnly}
-                        />
-                      </div>
-                    </motion.div>
-                  )}
-                </AnimatePresence>
               </div>
             </motion.div>
           )}

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -246,13 +246,25 @@ export default function TransactionReferencesSection({
                   searchPlaceholder="Search accounts..."
                   disabled={readOnly}
                 />
-                {/* Ticking the checkbox below does create one there, and its own description says
-                    so, so this would contradict it */}
-                {!isSymmetricTransfer && (
-                  <p className="mt-2 text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                    Records the fact only, creating no transaction in that account.
-                  </p>
-                )}
+                <AnimatePresence initial={false}>
+                  {/* Ticking the checkbox below does create one there, and its own description says
+                      so, so this would contradict it. The padding sits inside the collapsing element
+                      so it goes with the text rather than holding the gap open after it leaves */}
+                  {!isSymmetricTransfer && (
+                    <motion.div
+                      key="other-account-note"
+                      className="overflow-hidden"
+                      initial={{ height: 0, opacity: 0, y: -3 }}
+                      animate={{ height: 'auto', opacity: 1, y: 0 }}
+                      exit={{ height: 0, opacity: 0, y: -3 }}
+                      transition={{ duration: 0.2, ease: EASE }}
+                    >
+                      <p className="pt-2 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                        Records the fact only, creating no transaction in that account
+                      </p>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
               </div>
 
               {isTransferPairOffered && (

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -8,7 +8,11 @@ import {
   TRANSACTION_MODAL_FIELD_IDS,
 } from '@/pages/transactions/components/transaction-modal/constants'
 import TransferCashFlowNotice from '@/pages/transactions/components/transaction-modal/controls/TransferCashFlowNotice'
-import type { TransactionModalKind } from '@/pages/transactions/components/transaction-modal/types'
+import { doesTransferRecordOtherAccount } from '@/pages/transactions/components/transaction-modal/utils/validation'
+import type {
+  TransactionDirection,
+  TransactionModalKind,
+} from '@/pages/transactions/components/transaction-modal/types'
 import { formatCurrency } from '@/utils/formatCurrency'
 
 type SelectedTransactionTag = {
@@ -25,9 +29,19 @@ interface TransactionReferencesSectionProps {
   runningBalance?: { amount: number; currency: string }
   kind: TransactionModalKind
 
+  // Whether the amount is leaving (debit) or entering (credit) the recorded account, used to
+  // label the other-account field as money going out or coming in
+  direction: TransactionDirection
+
   isSymmetricTransfer: boolean
   toAccountValue: string
   toAccountError?: string | false
+
+  // Every account plus the "outside this app" entry, for the field recording where a transfer's
+  // other side sits
+  otherAccountOptions: DropdownOption[]
+  otherAccountValue: string
+  otherAccountError?: string | false
   merchantOptions: DropdownOption[]
   selectedMerchantOption?: DropdownOption
   merchantValue: string
@@ -58,6 +72,7 @@ interface TransactionReferencesSectionProps {
   onAccountChange: (value: string) => void
   onSymmetricTransferChange: (value: boolean) => void
   onToAccountChange: (value: string) => void
+  onOtherAccountChange: (value: string) => void
   onMerchantChange: (value: string) => void
   onMerchantSearchChange: (value: string) => void
   onMerchantSearchCommit: (value: string) => void
@@ -85,9 +100,13 @@ export default function TransactionReferencesSection({
   accountPlaceholder,
   runningBalance,
   kind,
+  direction,
   isSymmetricTransfer,
   toAccountValue,
   toAccountError,
+  otherAccountOptions,
+  otherAccountValue,
+  otherAccountError,
   merchantOptions,
   selectedMerchantOption,
   merchantValue,
@@ -116,6 +135,7 @@ export default function TransactionReferencesSection({
   onAccountChange,
   onSymmetricTransferChange,
   onToAccountChange,
+  onOtherAccountChange,
   onMerchantChange,
   onMerchantSearchChange,
   onMerchantSearchCommit,
@@ -131,11 +151,20 @@ export default function TransactionReferencesSection({
   onCreateTag,
   onRemoveTag,
 }: TransactionReferencesSectionProps) {
+  // Every transfer-kind category except Balance Adjustment records which other account the money touched
+  const recordsOtherAccount = doesTransferRecordOtherAccount(kind, isBalanceAdjustmentCategory)
+
+  // Ticking the checkbox writes a transaction in both accounts, so neither one is the account it
+  // was recorded in and the pair keeps the from-and-to labels it has always had
+  const accountLabel = kind === 'transfer' && isSymmetricTransfer
+    ? 'From account'
+    : recordsOtherAccount ? 'Recorded in' : 'Account'
+
   return (
     <CreateModalSectionFrame step="02" title="Source/Destination">
       <div>
         <CreateModalFieldLabelRow
-          label={kind === 'transfer' && isSymmetricTransfer ? 'From account' : 'Account'}
+          label={accountLabel}
           error={accountError}
         />
         <Dropdown
@@ -177,7 +206,7 @@ export default function TransactionReferencesSection({
         </AnimatePresence>
 
         <AnimatePresence initial={false}>
-          {kind === 'transfer' && (
+          {recordsOtherAccount && (
             <motion.div
               key="symmetric-transfer"
               className="overflow-hidden"
@@ -186,6 +215,39 @@ export default function TransactionReferencesSection({
               exit={{ height: 0, opacity: 0 }}
               transition={{ height: { duration: 0.2, ease: EASE }, opacity: { duration: 0.14, ease: 'linear' } }}
             >
+              <div className="pt-3">
+                <AnimatePresence initial={false} mode="wait">
+                  {!isSymmetricTransfer && (
+                    <motion.div
+                      key="other-account"
+                      className="overflow-hidden"
+                      initial={{ height: 0, opacity: 0 }}
+                      animate={{ height: 'auto', opacity: 1 }}
+                      exit={{ height: 0, opacity: 0 }}
+                      transition={{ duration: 0.2, ease: EASE }}
+                    >
+                      <CreateModalFieldLabelRow
+                        label={direction === 'debit' ? 'Money went to' : 'Money came from'}
+                        error={otherAccountError}
+                      />
+                      <Dropdown
+                        options={otherAccountOptions}
+                        value={otherAccountValue}
+                        onChange={onOtherAccountChange}
+                        className={`app-input ${otherAccountError ? 'app-input-error' : ''}`}
+                        placeholder="Select account..."
+                        searchable
+                        searchPlaceholder="Search accounts..."
+                        disabled={readOnly}
+                      />
+                      <p className="mt-2 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                        Records the fact only, creating no transaction in that account.
+                      </p>
+                    </motion.div>
+                  )}
+                </AnimatePresence>
+              </div>
+
               <div className="pt-3">
                 <label
                   htmlFor="txn-symmetric-transfer"

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -244,7 +244,10 @@ export default function TransactionReferencesSection({
                   placeholder="Select account..."
                   searchable
                   searchPlaceholder="Search accounts..."
-                  disabled={readOnly}
+                  // An account archived since this transfer was recorded is off the list, so the
+                  // field is held at what it already says rather than letting one change strand the
+                  // answer somewhere it can never be put back
+                  disabled={readOnly || Boolean(selectedArchivedOtherAccountOption)}
                 />
                 <AnimatePresence initial={false}>
                   {/* Ticking the checkbox below does create one there, and its own description says

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -235,9 +235,13 @@ export default function TransactionReferencesSection({
                   searchPlaceholder="Search accounts..."
                   disabled={readOnly}
                 />
-                <p className="mt-2 text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                  Records the fact only, creating no transaction in that account.
-                </p>
+                {/* Ticking the checkbox below does create one there, and its own description says
+                    so, so this would contradict it */}
+                {!isSymmetricTransfer && (
+                  <p className="mt-2 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                    Records the fact only, creating no transaction in that account.
+                  </p>
+                )}
               </div>
 
               <div className="pt-3">

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -43,6 +43,9 @@ interface TransactionReferencesSectionProps {
   // Every account plus the "outside this app" entry, for the field recording where a transfer's
   // other side sits
   otherAccountOptions: DropdownOption[]
+
+  // The recorded account when it has since been archived, which keeps it off the list above
+  selectedArchivedOtherAccountOption?: DropdownOption
   otherAccountValue: string
   otherAccountError?: string | false
   merchantOptions: DropdownOption[]
@@ -106,6 +109,7 @@ export default function TransactionReferencesSection({
   isSymmetricTransfer,
   isTransferPairOffered,
   otherAccountOptions,
+  selectedArchivedOtherAccountOption,
   otherAccountValue,
   otherAccountError,
   merchantOptions,
@@ -232,6 +236,7 @@ export default function TransactionReferencesSection({
                 />
                 <Dropdown
                   options={otherAccountOptions}
+                  selectedOption={selectedArchivedOtherAccountOption}
                   value={otherAccountValue}
                   onChange={onOtherAccountChange}
                   className={`app-input ${otherAccountError ? 'app-input-error' : ''}`}

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/TypeDirectionSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/TypeDirectionSection.tsx
@@ -14,8 +14,7 @@ import TransactionModalPillSelector from '@/pages/transactions/components/transa
 interface TransactionTypeDirectionSectionProps {
   kind: TransactionModalKind
 
-  // An empty direction renders the unselected state, used when a symmetric transfer does not involve the viewed account
-  direction: TransactionDirection | ''
+  direction: TransactionDirection
   editing: boolean
   readOnly: boolean
   directionHighlightKey: number

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/TypeDirectionSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/TypeDirectionSection.tsx
@@ -18,9 +18,6 @@ interface TransactionTypeDirectionSectionProps {
   direction: TransactionDirection | ''
   editing: boolean
   readOnly: boolean
-
-  // A symmetric transfer derives its direction from the accounts, so the control is shown but not editable
-  directionDisabled: boolean
   directionHighlightKey: number
   onKindChange: (kind: TransactionModalKind) => void
   onDirectionChange: (direction: TransactionDirection) => void
@@ -34,7 +31,6 @@ export default function TransactionTypeDirectionSection({
   direction,
   editing,
   readOnly,
-  directionDisabled,
   directionHighlightKey,
   onKindChange,
   onDirectionChange,
@@ -68,7 +64,7 @@ export default function TransactionTypeDirectionSection({
             options={DIRECTION_OPTIONS}
             ariaLabel="Transaction direction"
             onChange={onDirectionChange}
-            disabled={readOnly || directionDisabled}
+            disabled={readOnly}
           />
         </div>
       </div>

--- a/frontend/src/pages/transactions/components/transaction-modal/types.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/types.ts
@@ -16,11 +16,9 @@ export interface TransactionFormValues {
   date: string
   tag_ids: string[]
 
-  // When set on a transfer, the same amount is recorded in both accounts as two independent rows
+  // When set on a transfer, the same amount is recorded in both accounts as two independent rows.
+  // The account it is recorded in is the one below, which doubles as the receiving account
   symmetric_transfer: boolean
-
-  // The receiving account for a symmetric transfer, debited from account_id and credited here
-  to_account_id: string
 
   // Where the other side of a transfer sits: an account id, the "outside this app" sentinel, or
   // empty when not yet answered. Ignored for every category except a transfer that is not
@@ -35,7 +33,6 @@ export interface TransactionFormFieldErrors {
   amount?: string
   currency?: string
   date?: string
-  to_account_id?: string
   other_account_id?: string
 }
 

--- a/frontend/src/pages/transactions/components/transaction-modal/types.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/types.ts
@@ -21,6 +21,11 @@ export interface TransactionFormValues {
 
   // The receiving account for a symmetric transfer, debited from account_id and credited here
   to_account_id: string
+
+  // Where the other side of a transfer sits: an account id, the "outside this app" sentinel, or
+  // empty when not yet answered. Ignored for every category except a transfer that is not
+  // Balance Adjustment
+  other_account_id: string
 }
 
 export interface TransactionFormFieldErrors {
@@ -31,6 +36,7 @@ export interface TransactionFormFieldErrors {
   currency?: string
   date?: string
   to_account_id?: string
+  other_account_id?: string
 }
 
 export interface CreateTransactionModalProps {

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/accountFields.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/accountFields.ts
@@ -1,0 +1,22 @@
+import type { TransactionDirection } from '@/pages/transactions/components/transaction-modal/types'
+
+/**
+ * Orders the modal's two account fields for display, source first
+ *
+ * An ordinary transfer is recorded in one account and states which other account the money touched,
+ * so the recorded one stays on top and the direction changes the label below it. A paired transfer
+ * writes a transaction in both, so its fields read as From and To instead. On a credit the money
+ * arrives in the recorded account, which makes the other one the source and puts it above.
+ *
+ * Each field is carried whole rather than field by field, so a field's value, error and option list
+ * cannot end up on opposite sides of the form
+ */
+export function orderAccountFields<T>(
+  recordedAccountField: T,
+  otherAccountField: T,
+  { isSymmetricTransfer, direction }: { isSymmetricTransfer: boolean; direction: TransactionDirection },
+): [T, T] {
+  return isSymmetricTransfer && direction === 'credit'
+    ? [otherAccountField, recordedAccountField]
+    : [recordedAccountField, otherAccountField]
+}

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
@@ -2,7 +2,10 @@ import type { AccountsOverview } from '@/api/accounts'
 import type { Category } from '@/api/categories'
 import type { Currency } from '@/api/currency'
 import type { Transaction } from '@/api/transactions'
-import { INITIAL_TRANSACTION_FORM } from '@/pages/transactions/components/transaction-modal/constants'
+import {
+  INITIAL_TRANSACTION_FORM,
+  OUTSIDE_ACCOUNT_VALUE,
+} from '@/pages/transactions/components/transaction-modal/constants'
 import { amountToInputString } from '@/pages/transactions/components/transaction-modal/utils/money'
 import { findCurrencyExponent } from '@/utils/moneyInput'
 import type {
@@ -66,5 +69,8 @@ export function buildInitialTransactionForm({
     tag_ids: transaction.tags?.map((tag) => tag.id) ?? transaction.tag_ids,
     symmetric_transfer: false,
     to_account_id: '',
+    other_account_id: transaction.other_account_scope === 'outside'
+      ? OUTSIDE_ACCOUNT_VALUE
+      : transaction.other_account_id ?? '',
   }
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/initialForm.ts
@@ -68,7 +68,6 @@ export function buildInitialTransactionForm({
     date: transaction.dt,
     tag_ids: transaction.tags?.map((tag) => tag.id) ?? transaction.tag_ids,
     symmetric_transfer: false,
-    to_account_id: '',
     other_account_id: transaction.other_account_scope === 'outside'
       ? OUTSIDE_ACCOUNT_VALUE
       : transaction.other_account_id ?? '',

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
@@ -1,5 +1,6 @@
 import type { AccountsOverview } from '@/api/accounts'
 import type { Currency } from '@/api/currency'
+import { OUTSIDE_ACCOUNT_VALUE } from '@/pages/transactions/components/transaction-modal/constants'
 
 /**
  * Builds account dropdown options, restricted to the transaction's own currency once editing
@@ -16,6 +17,21 @@ export function buildAccountOptions(
     ? selectableAccounts.filter((account) => account.currency === currency)
     : selectableAccounts
   return eligibleAccounts.map((account) => ({ value: account.id, label: account.name }))
+}
+
+/**
+ * Builds dropdown options for the other-account-recording field: every account the user holds,
+ * plus a fixed entry for money that left the tracked accounts entirely
+ *
+ * Unfiltered by currency or archived status, unlike the main account field: recording an account
+ * is a fact about where the money went rather than a second leg that must share a currency, and an
+ * archived or closed account still stays recordable since archiving happens after the money moved
+ */
+export function buildOtherAccountOptions(accounts: AccountsOverview[]) {
+  return [
+    ...accounts.map((account) => ({ value: account.id, label: account.name })),
+    { value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' },
+  ]
 }
 
 /**

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
@@ -27,12 +27,8 @@ export function buildAccountOptions(
  * is a fact about where the money went rather than a second leg that must share a currency, and an
  * archived or closed account still stays recordable since archiving happens after the money moved
  */
-export function buildOtherAccountOptions(
-  accounts: AccountsOverview[],
-  recordedAccountId: string,
-  editing: boolean,
-) {
-  const options = [
+export function buildOtherAccountOptions(accounts: AccountsOverview[], recordedAccountId: string) {
+  return [
     // Money cannot move from an account to itself, so the account holding the transfer is left out
     // rather than offered and then refused
     ...accounts
@@ -40,11 +36,6 @@ export function buildOtherAccountOptions(
       .map((account) => ({ value: account.id, label: account.name })),
     { value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' },
   ]
-
-  // Creating a transfer has to answer this, so the way back to unanswered is offered on an edit
-  // alone, which is also the only place a transaction can already be in that state
-  if (editing) options.unshift({ value: '', label: 'Not recorded' })
-  return options
 }
 
 /**

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
@@ -27,11 +27,24 @@ export function buildAccountOptions(
  * is a fact about where the money went rather than a second leg that must share a currency, and an
  * archived or closed account still stays recordable since archiving happens after the money moved
  */
-export function buildOtherAccountOptions(accounts: AccountsOverview[]) {
-  return [
-    ...accounts.map((account) => ({ value: account.id, label: account.name })),
+export function buildOtherAccountOptions(
+  accounts: AccountsOverview[],
+  recordedAccountId: string,
+  editing: boolean,
+) {
+  const options = [
+    // Money cannot move from an account to itself, so the account holding the transfer is left out
+    // rather than offered and then refused
+    ...accounts
+      .filter((account) => account.id !== recordedAccountId)
+      .map((account) => ({ value: account.id, label: account.name })),
     { value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' },
   ]
+
+  // Creating a transfer has to answer this, so the way back to unanswered is offered on an edit
+  // alone, which is also the only place a transaction can already be in that state
+  if (editing) options.unshift({ value: '', label: 'Not recorded' })
+  return options
 }
 
 /**

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
@@ -27,15 +27,23 @@ export function buildAccountOptions(
  * is a fact about where the money went rather than a second leg that must share a currency, and an
  * archived or closed account still stays recordable since archiving happens after the money moved
  */
-export function buildOtherAccountOptions(accounts: AccountsOverview[], recordedAccountId: string) {
-  return [
-    // Money cannot move from an account to itself, so the account holding the transfer is left out
-    // rather than offered and then refused
-    ...accounts
-      .filter((account) => account.id !== recordedAccountId)
-      .map((account) => ({ value: account.id, label: account.name })),
-    { value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' },
-  ]
+export function buildOtherAccountOptions(
+  accounts: AccountsOverview[],
+  recordedAccountId: string,
+  isSymmetricTransfer: boolean,
+) {
+  // Money cannot move from an account to itself, so the account holding the transfer is left out
+  // rather than offered and then refused
+  const accountOptions = accounts
+    .filter((account) => account.id !== recordedAccountId)
+    .map((account) => ({ value: account.id, label: account.name }))
+
+  // Ticking the checkbox makes this the account the matching transaction is written to, and there
+  // is nowhere outside the app to write one, so the entry is not offered there
+  if (isSymmetricTransfer) return accountOptions
+
+  // First, because it is the one answer that is not a search through the account list
+  return [{ value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' }, ...accountOptions]
 }
 
 /**

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
@@ -20,12 +20,13 @@ export function buildAccountOptions(
 }
 
 /**
- * Builds dropdown options for the other-account-recording field: every account the user holds,
- * plus a fixed entry for money that left the tracked accounts entirely
+ * Builds dropdown options for the other-account-recording field: the accounts the user holds, plus
+ * a fixed entry for money that left the tracked accounts entirely
  *
- * Unfiltered by currency or archived status, unlike the main account field: recording an account
- * is a fact about where the money went rather than a second leg that must share a currency, and an
- * archived or closed account still stays recordable since archiving happens after the money moved
+ * Unfiltered by currency, unlike the main account field, since recording an account is a fact about
+ * where the money went rather than a second leg that must share a currency. Archived accounts stay
+ * on the list for the same reason, until the checkbox turns the answer into a real transaction they
+ * can no longer accept
  */
 export function buildOtherAccountOptions(
   accounts: AccountsOverview[],
@@ -34,16 +35,18 @@ export function buildOtherAccountOptions(
 ) {
   // Money cannot move from an account to itself, so the account holding the transfer is left out
   // rather than offered and then refused
-  const accountOptions = accounts
-    .filter((account) => account.id !== recordedAccountId)
-    .map((account) => ({ value: account.id, label: account.name }))
+  const eligibleAccounts = accounts.filter((account) => account.id !== recordedAccountId)
+  const toOption = (account: AccountsOverview) => ({ value: account.id, label: account.name })
 
-  // Ticking the checkbox makes this the account the matching transaction is written to, and there
-  // is nowhere outside the app to write one, so the entry is not offered there
-  if (isSymmetricTransfer) return accountOptions
+  // Ticking the checkbox writes the matching transaction to this account, which an archived account
+  // refuses, so the list narrows to the accounts that can take one. There is also nowhere outside
+  // the app to write to, so that entry goes with them
+  if (isSymmetricTransfer) {
+    return eligibleAccounts.filter((account) => !account.is_archived).map(toOption)
+  }
 
   // First, because it is the one answer that is not a search through the account list
-  return [{ value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' }, ...accountOptions]
+  return [{ value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' }, ...eligibleAccounts.map(toOption)]
 }
 
 /**

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/options.ts
@@ -24,9 +24,9 @@ export function buildAccountOptions(
  * a fixed entry for money that left the tracked accounts entirely
  *
  * Unfiltered by currency, unlike the main account field, since recording an account is a fact about
- * where the money went rather than a second leg that must share a currency. Archived accounts stay
- * on the list for the same reason, until the checkbox turns the answer into a real transaction they
- * can no longer accept
+ * where the money went rather than a second leg that must share a currency. Archived accounts are
+ * left out, matching the main account field: an archived account takes no new transactions and its
+ * existing ones are read-only, so offering it here would be the one place it still accepted work
  */
 export function buildOtherAccountOptions(
   accounts: AccountsOverview[],
@@ -35,18 +35,16 @@ export function buildOtherAccountOptions(
 ) {
   // Money cannot move from an account to itself, so the account holding the transfer is left out
   // rather than offered and then refused
-  const eligibleAccounts = accounts.filter((account) => account.id !== recordedAccountId)
-  const toOption = (account: AccountsOverview) => ({ value: account.id, label: account.name })
+  const eligibleAccounts = accounts
+    .filter((account) => account.id !== recordedAccountId && !account.is_archived)
+    .map((account) => ({ value: account.id, label: account.name }))
 
-  // Ticking the checkbox writes the matching transaction to this account, which an archived account
-  // refuses, so the list narrows to the accounts that can take one. There is also nowhere outside
-  // the app to write to, so that entry goes with them
-  if (isSymmetricTransfer) {
-    return eligibleAccounts.filter((account) => !account.is_archived).map(toOption)
-  }
+  // Ticking the checkbox makes this the account the matching transaction is written to, and there
+  // is nowhere outside the app to write one, so the entry is not offered there
+  if (isSymmetricTransfer) return eligibleAccounts
 
   // First, because it is the one answer that is not a search through the account list
-  return [{ value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' }, ...eligibleAccounts.map(toOption)]
+  return [{ value: OUTSIDE_ACCOUNT_VALUE, label: 'Outside this app' }, ...eligibleAccounts]
 }
 
 /**

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
@@ -1,13 +1,30 @@
 import type {
   CreateTransactionPayload,
   Transaction,
+  TransferOtherAccountScope,
   UpdateTransactionPayload,
 } from '@/api/transactions'
+import { OUTSIDE_ACCOUNT_VALUE } from '@/pages/transactions/components/transaction-modal/constants'
 import {
   amountInputToMinorUnits,
   applyTransactionDirection,
 } from '@/pages/transactions/components/transaction-modal/utils/money'
 import type { TransactionFormValues } from '@/pages/transactions/components/transaction-modal/types'
+
+/**
+ * Splits the form's single other-account selection into the API's id-and-scope pair
+ *
+ * Empty means unanswered, so both come back null. The outside sentinel means the money left the
+ * tracked accounts, sent as a scope with no id. Anything else is a tracked account id
+ */
+function splitOtherAccountSelection(otherAccountId: string): {
+  other_account_id: string | null
+  other_account_scope: TransferOtherAccountScope | null
+} {
+  if (!otherAccountId) return { other_account_id: null, other_account_scope: null }
+  if (otherAccountId === OUTSIDE_ACCOUNT_VALUE) return { other_account_id: null, other_account_scope: 'outside' }
+  return { other_account_id: otherAccountId, other_account_scope: 'tracked' }
+}
 
 /**
  * Builds the create payload after the form has passed validation
@@ -27,6 +44,8 @@ export function buildCreateTransactionPayload(
     notes: form.notes.trim() || null,
   }
   if (form.tag_ids.length > 0) payload.tag_ids = form.tag_ids
+  // Every other category rejects the pair outright, so it is only ever sent for a transfer
+  if (form.kind === 'transfer') Object.assign(payload, splitOtherAccountSelection(form.other_account_id))
   return payload
 }
 
@@ -49,8 +68,21 @@ export function buildSymmetricTransferPayloads(
     currency: form.currency,
     notes: form.notes.trim() || null,
   }
-  const fromPayload: CreateTransactionPayload = { account_id: form.account_id, amount: -magnitude, ...shared }
-  const toPayload: CreateTransactionPayload = { account_id: form.to_account_id, amount: magnitude, ...shared }
+  // Each leg is a tracked account in the app, so it records the other leg's account as its other side
+  const fromPayload: CreateTransactionPayload = {
+    account_id: form.account_id,
+    amount: -magnitude,
+    other_account_id: form.to_account_id,
+    other_account_scope: 'tracked',
+    ...shared,
+  }
+  const toPayload: CreateTransactionPayload = {
+    account_id: form.to_account_id,
+    amount: magnitude,
+    other_account_id: form.account_id,
+    other_account_scope: 'tracked',
+    ...shared,
+  }
   if (form.tag_ids.length > 0) {
     fromPayload.tag_ids = form.tag_ids
     toPayload.tag_ids = form.tag_ids
@@ -82,6 +114,18 @@ export function buildUpdateTransactionPatch(
   if (form.date !== transaction.dt) patch.dt = form.date
   if (notes !== (transaction.notes ?? null)) patch.notes = notes
   if (!sameStringSet(form.tag_ids, transaction.tag_ids)) patch.tag_ids = form.tag_ids
+
+  // Left out entirely once the category leaves transfer, since the backend clears the stored
+  // answer itself when the category it ends up with no longer records another account
+  if (form.kind === 'transfer') {
+    const { other_account_id, other_account_scope } = splitOtherAccountSelection(form.other_account_id)
+    const storedScope = transaction.other_account_scope ?? null
+    const storedId = transaction.other_account_id ?? null
+    if (other_account_id !== storedId || other_account_scope !== storedScope) {
+      patch.other_account_id = other_account_id
+      patch.other_account_scope = other_account_scope
+    }
+  }
 
   return Object.keys(patch).length > 0 ? patch : null
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
@@ -9,7 +9,10 @@ import {
   amountInputToMinorUnits,
   applyTransactionDirection,
 } from '@/pages/transactions/components/transaction-modal/utils/money'
-import type { TransactionFormValues } from '@/pages/transactions/components/transaction-modal/types'
+import type {
+  TransactionDirection,
+  TransactionFormValues,
+} from '@/pages/transactions/components/transaction-modal/types'
 
 /**
  * Splits the form's single other-account selection into the API's id-and-scope pair
@@ -47,6 +50,19 @@ export function buildCreateTransactionPayload(
   // Every other category rejects the pair outright, so it is only ever sent for a transfer
   if (form.kind === 'transfer') Object.assign(payload, splitOtherAccountSelection(form.other_account_id))
   return payload
+}
+
+/**
+ * Returns what each leg of a symmetric transfer does, the recorded account's first
+ *
+ * The direction says what happens to the recorded account, so the other leg is always its opposite.
+ * A failed leg is reported to the user by this wording and they re-enter it by hand, so having the
+ * two the wrong way round would tell them to enter it backwards
+ */
+export function getSymmetricTransferLegKinds(
+  direction: TransactionDirection,
+): [TransactionDirection, TransactionDirection] {
+  return direction === 'debit' ? ['debit', 'credit'] : ['credit', 'debit']
 }
 
 /**

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
@@ -68,14 +68,16 @@ export function buildSymmetricTransferPayloads(
     currency: form.currency,
     notes: form.notes.trim() || null,
   }
-  // Each leg is a tracked account in the app, so it records the other leg's account as its other side
+  // The first leg records whatever the field holds rather than always the receiving account: it
+  // usually matches, since choosing a receiving account fills the field, but the field stays
+  // editable afterward and can be left pointed elsewhere, including at the outside sentinel
   const fromPayload: CreateTransactionPayload = {
     account_id: form.account_id,
     amount: -magnitude,
-    other_account_id: form.to_account_id,
-    other_account_scope: 'tracked',
     ...shared,
+    ...splitOtherAccountSelection(form.other_account_id),
   }
+  // The second leg's other side is not in question: it is always the originating account, a tracked account in the app
   const toPayload: CreateTransactionPayload = {
     account_id: form.to_account_id,
     amount: magnitude,

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
@@ -79,7 +79,7 @@ export function buildSymmetricTransferPayloads(
   }
   // The second leg's other side is not in question: it is always the originating account, a tracked account in the app
   const toPayload: CreateTransactionPayload = {
-    account_id: form.to_account_id,
+    account_id: form.other_account_id,
     amount: magnitude,
     other_account_id: form.account_id,
     other_account_scope: 'tracked',

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
@@ -68,9 +68,9 @@ export function buildSymmetricTransferPayloads(
     currency: form.currency,
     notes: form.notes.trim() || null,
   }
-  // The first leg records whatever the field holds rather than always the receiving account: it
-  // usually matches, since choosing a receiving account fills the field, but the field stays
-  // editable afterward and can be left pointed elsewhere, including at the outside sentinel
+  // One field serves as both the receiving account and the recorded one, so the two always agree
+  // here. Ticking the checkbox takes the outside entry off the list and clears it if it was chosen,
+  // so the split below only ever produces a tracked account
   const fromPayload: CreateTransactionPayload = {
     account_id: form.account_id,
     amount: -magnitude,

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/payloads.ts
@@ -50,11 +50,12 @@ export function buildCreateTransactionPayload(
 }
 
 /**
- * Builds the originating and receiving payloads for a symmetric transfer
+ * Builds the two payloads for a symmetric transfer
  *
- * The originating account is debited and the receiving account is credited the same magnitude
- * Both legs share every other field so they read as the same movement in two accounts. The two
- * rows stay independent on the backend, matching how the app already records transfers
+ * The direction decides which account loses the money and which gains it, and the magnitude is the
+ * same on both. Both legs share every other field so they read as the same movement in two
+ * accounts. The two rows stay independent on the backend, matching how the app already records
+ * transfers
  */
 export function buildSymmetricTransferPayloads(
   form: TransactionFormValues,
@@ -68,19 +69,23 @@ export function buildSymmetricTransferPayloads(
     currency: form.currency,
     notes: form.notes.trim() || null,
   }
+  // The direction says what happens to the account the transaction is recorded in, so it decides
+  // which of the two legs is the negative one rather than the recorded account always being it
+  const recordedAmount = form.direction === 'debit' ? -magnitude : magnitude
+
   // One field serves as both the receiving account and the recorded one, so the two always agree
   // here. Ticking the checkbox takes the outside entry off the list and clears it if it was chosen,
   // so the split below only ever produces a tracked account
   const fromPayload: CreateTransactionPayload = {
     account_id: form.account_id,
-    amount: -magnitude,
+    amount: recordedAmount,
     ...shared,
     ...splitOtherAccountSelection(form.other_account_id),
   }
   // The second leg's other side is not in question: it is always the originating account, a tracked account in the app
   const toPayload: CreateTransactionPayload = {
     account_id: form.other_account_id,
-    amount: magnitude,
+    amount: -recordedAmount,
     other_account_id: form.account_id,
     other_account_scope: 'tracked',
     ...shared,

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
@@ -63,8 +63,11 @@ export function validateTransactionForm(
   if (isSymmetricTransferForm(form)) {
     if (!form.to_account_id) errors.to_account_id = 'Select a receiving account'
     else if (form.to_account_id === form.account_id) errors.to_account_id = 'Choose a different receiving account'
-  } else if (doesTransferRecordOtherAccount(form.kind, isBalanceAdjustmentCategory)) {
-    // A symmetric transfer already answers this by pairing the account above with the receiving account
+  }
+
+  // The other-account field stays live whether or not the checkbox is ticked, since ticking only
+  // creates the matching transaction and does not by itself answer what this leg records
+  if (doesTransferRecordOtherAccount(form.kind, isBalanceAdjustmentCategory)) {
     if (!form.other_account_id) {
       if (requireOtherAccount) {
         errors.other_account_id = form.direction === 'debit'

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
@@ -2,6 +2,7 @@ import type { AccountsOverview } from '@/api/accounts'
 import type {
   TransactionFormFieldErrors,
   TransactionFormValues,
+  TransactionModalKind,
 } from '@/pages/transactions/components/transaction-modal/types'
 
 /**
@@ -12,12 +13,35 @@ export function isSymmetricTransferForm(form: TransactionFormValues): boolean {
 }
 
 /**
+ * Reports whether a transfer in the given kind and category records which other account the
+ * money touched
+ *
+ * True for every transfer-kind category except Balance Adjustment, which has no other side.
+ * Mirrors the backend's does_category_record_other_account
+ */
+export function doesTransferRecordOtherAccount(
+  kind: TransactionModalKind,
+  isBalanceAdjustmentCategory: boolean,
+): boolean {
+  return kind === 'transfer' && !isBalanceAdjustmentCategory
+}
+
+interface ValidateTransactionFormOptions {
+  isAmountLocked?: boolean
+  isBalanceAdjustmentCategory?: boolean
+
+  // Only a create requires an other-account answer, so an old transaction can be corrected without answering it first
+  requireOtherAccount?: boolean
+}
+
+/**
  * Validates fields required before a transaction can be sent to the API
  */
 export function validateTransactionForm(
   form: TransactionFormValues,
-  isAmountLocked = false,
+  options: ValidateTransactionFormOptions = {},
 ): TransactionFormFieldErrors {
+  const { isAmountLocked = false, isBalanceAdjustmentCategory = false, requireOtherAccount = false } = options
   const errors: TransactionFormFieldErrors = {}
   if (!form.account_id) errors.account_id = 'Select an account'
   if (!form.category_id) errors.category_id = 'Select a category'
@@ -39,6 +63,17 @@ export function validateTransactionForm(
   if (isSymmetricTransferForm(form)) {
     if (!form.to_account_id) errors.to_account_id = 'Select a receiving account'
     else if (form.to_account_id === form.account_id) errors.to_account_id = 'Choose a different receiving account'
+  } else if (doesTransferRecordOtherAccount(form.kind, isBalanceAdjustmentCategory)) {
+    // A symmetric transfer already answers this by pairing the account above with the receiving account
+    if (!form.other_account_id) {
+      if (requireOtherAccount) {
+        errors.other_account_id = form.direction === 'debit'
+          ? 'Select where the money went'
+          : 'Select where the money came from'
+      }
+    } else if (form.other_account_id === form.account_id) {
+      errors.other_account_id = 'Choose a different account'
+    }
   }
   return errors
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
@@ -29,9 +29,6 @@ export function doesTransferRecordOtherAccount(
 interface ValidateTransactionFormOptions {
   isAmountLocked?: boolean
   isBalanceAdjustmentCategory?: boolean
-
-  // Only a create requires an other-account answer, so an old transaction can be corrected without answering it first
-  requireOtherAccount?: boolean
 }
 
 /**
@@ -41,7 +38,7 @@ export function validateTransactionForm(
   form: TransactionFormValues,
   options: ValidateTransactionFormOptions = {},
 ): TransactionFormFieldErrors {
-  const { isAmountLocked = false, isBalanceAdjustmentCategory = false, requireOtherAccount = false } = options
+  const { isAmountLocked = false, isBalanceAdjustmentCategory = false } = options
   const errors: TransactionFormFieldErrors = {}
   if (!form.account_id) errors.account_id = 'Select an account'
   if (!form.category_id) errors.category_id = 'Select a category'
@@ -68,12 +65,12 @@ export function validateTransactionForm(
   // The other-account field stays live whether or not the checkbox is ticked, since ticking only
   // creates the matching transaction and does not by itself answer what this leg records
   if (doesTransferRecordOtherAccount(form.kind, isBalanceAdjustmentCategory)) {
+    // Editing answers this too, so a transfer recorded before the field existed says where the
+    // money went the next time it is touched at all
     if (!form.other_account_id) {
-      if (requireOtherAccount) {
-        errors.other_account_id = form.direction === 'debit'
-          ? 'Select where the money went'
-          : 'Select where the money came from'
-      }
+      errors.other_account_id = form.direction === 'debit'
+        ? 'Select where the money went'
+        : 'Select where the money came from'
     } else if (form.other_account_id === form.account_id) {
       errors.other_account_id = 'Choose a different account'
     }

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/validation.ts
@@ -56,14 +56,8 @@ export function validateTransactionForm(
   if (!form.currency) errors.currency = 'Select a currency'
   if (!form.date) errors.date = 'Select a date'
 
-  // A symmetric transfer needs a second account that differs from the originating one
-  if (isSymmetricTransferForm(form)) {
-    if (!form.to_account_id) errors.to_account_id = 'Select a receiving account'
-    else if (form.to_account_id === form.account_id) errors.to_account_id = 'Choose a different receiving account'
-  }
-
-  // The other-account field stays live whether or not the checkbox is ticked, since ticking only
-  // creates the matching transaction and does not by itself answer what this leg records
+  // The recorded account doubles as the receiving one when the checkbox is ticked, so there is a
+  // single account field either way and nothing to keep in agreement
   if (doesTransferRecordOtherAccount(form.kind, isBalanceAdjustmentCategory)) {
     // Editing answers this too, so a transfer recorded before the field existed says where the
     // money went the next time it is touched at all

--- a/frontend/src/pages/transactions/types/transactionList.ts
+++ b/frontend/src/pages/transactions/types/transactionList.ts
@@ -27,6 +27,22 @@ export interface TransactionListAccount {
   is_archived?: boolean
 }
 
+/**
+ * Narrows a loaded account to the fields the transaction list reads
+ *
+ * Both pages showing the list need the whole set, not only the accounts on screen, because a
+ * transfer's other side is often an account the current view is not showing
+ */
+export function toTransactionListAccount(account: AccountsOverview): TransactionListAccount {
+  return {
+    id: account.id,
+    name: account.name,
+    currency: account.currency,
+    institution: account.institution,
+    is_archived: account.is_archived,
+  }
+}
+
 export interface TransactionDateGroup {
   dateLabel: string
   transactions: Transaction[]

--- a/frontend/tests/accounts/accountsLogic.test.ts
+++ b/frontend/tests/accounts/accountsLogic.test.ts
@@ -89,6 +89,7 @@ function createTaxAdvantagedCategory(overrides: Partial<TaxAdvantagedCategory>):
     ytd_withdrawals: 0,
     lifetime_contributions: 0,
     lifetime_withdrawals: 0,
+    counts_internal_transfers: false,
     created_at: '2026-01-01T00:00:00Z',
     ...overrides,
   }

--- a/frontend/tests/accounts/createAccountModal.test.ts
+++ b/frontend/tests/accounts/createAccountModal.test.ts
@@ -51,6 +51,7 @@ const taxAdvantagedCategories: TaxAdvantagedCategory[] = [
     ytd_withdrawals: 0,
     lifetime_contributions: 0,
     lifetime_withdrawals: 0,
+    counts_internal_transfers: false,
     created_at: '2026-01-01T00:00:00Z',
   },
   {
@@ -69,6 +70,7 @@ const taxAdvantagedCategories: TaxAdvantagedCategory[] = [
     ytd_withdrawals: 0,
     lifetime_contributions: 0,
     lifetime_withdrawals: 0,
+    counts_internal_transfers: false,
     created_at: '2026-01-01T00:00:00Z',
   },
 ]

--- a/frontend/tests/dashboard/dashboardLogic.test.ts
+++ b/frontend/tests/dashboard/dashboardLogic.test.ts
@@ -81,6 +81,8 @@ function createTransaction(overrides: Partial<Transaction>): Transaction {
     currency: 'USD',
     fx_rate: null,
     notes: null,
+    other_account_id: null,
+    other_account_scope: null,
     created_at: '2026-01-05T12:00:00Z',
     updated_at: '2026-01-05T12:00:00Z',
     tag_ids: [],

--- a/frontend/tests/transactions/transactionDateGroups.test.ts
+++ b/frontend/tests/transactions/transactionDateGroups.test.ts
@@ -27,6 +27,8 @@ function createTransaction(overrides: Partial<Transaction>): Transaction {
     currency: 'USD',
     fx_rate: null,
     notes: null,
+    other_account_id: null,
+    other_account_scope: null,
     created_at: '2026-06-01T00:00:00Z',
     updated_at: '2026-06-01T00:00:00Z',
     tag_ids: [],

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -277,7 +277,7 @@ describe('transaction modal helpers', () => {
     })
   })
 
-  it('requires an other-account answer only when creating a transfer that is not Balance Adjustment', () => {
+  it('requires an other-account answer on every transfer that is not Balance Adjustment', () => {
     const transferForm = {
       kind: 'transfer' as const,
       direction: 'debit' as const,
@@ -294,36 +294,32 @@ describe('transaction modal helpers', () => {
       other_account_id: '',
     }
 
-    // A transfer with no answer fails validation when creating
-    expect(validateTransactionForm(transferForm, { requireOtherAccount: true }).other_account_id)
+    // A transfer with no answer fails validation, on an edit as much as on a create, which is what
+    // brings transactions recorded before the field existed onto the new footing
+    expect(validateTransactionForm(transferForm).other_account_id)
       .toBe('Select where the money went')
 
-    // An edit with the field left empty passes, since an old transaction can be corrected without answering first
-    expect(validateTransactionForm(transferForm, { requireOtherAccount: false }).other_account_id).toBeUndefined()
-
-    // Balance Adjustment has no other side, so it is never required even when creating
+    // Balance Adjustment has no other side, so it is never required
     expect(validateTransactionForm(
       transferForm,
-      { requireOtherAccount: true, isBalanceAdjustmentCategory: true },
+      { isBalanceAdjustmentCategory: true },
     ).other_account_id).toBeUndefined()
 
     // The field stays live once the checkbox is ticked, so a create requires it there too,
     // independently of the receiving-account requirement the checkbox already carries
     const symmetricForm = { ...transferForm, symmetric_transfer: true, to_account_id: 'savings' }
-    const symmetricErrors = validateTransactionForm(symmetricForm, { requireOtherAccount: true })
+    const symmetricErrors = validateTransactionForm(symmetricForm)
     expect(symmetricErrors.other_account_id).toBe('Select where the money went')
     expect(symmetricErrors.to_account_id).toBeUndefined()
 
     // Answering it once the checkbox is ticked clears the requirement, same as the standalone case
     expect(validateTransactionForm(
       { ...symmetricForm, other_account_id: 'savings' },
-      { requireOtherAccount: true },
     ).other_account_id).toBeUndefined()
 
     // Picking the transaction's own account as the other side is always rejected
     expect(validateTransactionForm(
       { ...transferForm, other_account_id: 'checking' },
-      { requireOtherAccount: true },
     ).other_account_id).toBe('Choose a different account')
   })
 
@@ -449,16 +445,14 @@ describe('other-account options', () => {
   ]
 
   it('leaves out the account holding the transfer and offers the outside entry', () => {
-    const options = buildOtherAccountOptions(accounts, 'checking', false)
+    const options = buildOtherAccountOptions(accounts, 'checking')
 
     expect(options.map((option) => option.value)).toEqual(['savings', OUTSIDE_ACCOUNT_VALUE])
   })
 
-  it('offers a way back to unanswered when editing, and none when creating', () => {
-    const editing = buildOtherAccountOptions(accounts, 'checking', true)
-    const creating = buildOtherAccountOptions(accounts, 'checking', false)
+  it('offers no way back to unanswered, since every edit has to answer', () => {
+    const options = buildOtherAccountOptions(accounts, 'checking')
 
-    expect(editing[0]).toEqual({ value: '', label: 'Not recorded' })
-    expect(creating.some((option) => option.value === '')).toBe(false)
+    expect(options.some((option) => option.value === '')).toBe(false)
   })
 })

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -439,4 +439,20 @@ describe('other-account options', () => {
 
     expect(options.some((option) => option.value === '')).toBe(false)
   })
+
+  it('still records an archived account, which is a fact about money that already moved', () => {
+    const withArchived = [...accounts, createAccount({ id: 'old-tfsa', name: 'Old TFSA', is_archived: true })]
+
+    const options = buildOtherAccountOptions(withArchived, 'checking', false)
+
+    expect(options.map((option) => option.value)).toContain('old-tfsa')
+  })
+
+  it('drops an archived account once the pair checkbox is ticked, since it refuses a transaction', () => {
+    const withArchived = [...accounts, createAccount({ id: 'old-tfsa', name: 'Old TFSA', is_archived: true })]
+
+    const options = buildOtherAccountOptions(withArchived, 'checking', true)
+
+    expect(options.map((option) => option.value)).toEqual(['savings'])
+  })
 })

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -20,6 +20,7 @@ import {
   buildCreateTransactionPayload,
   buildSymmetricTransferPayloads,
   buildUpdateTransactionPatch,
+  getSymmetricTransferLegKinds,
 } from '@/pages/transactions/components/transaction-modal/utils/payloads'
 import { validateTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
 import { orderAccountFields } from '@/pages/transactions/components/transaction-modal/utils/accountFields'
@@ -424,6 +425,36 @@ describe('transaction modal helpers', () => {
     )).toEqual({ category_id: 'groceries' })
   })
 
+})
+
+describe('symmetric transfer leg kinds', () => {
+  it('gives the recorded account the direction and the other leg its opposite', () => {
+    expect(getSymmetricTransferLegKinds('debit')).toEqual(['debit', 'credit'])
+    expect(getSymmetricTransferLegKinds('credit')).toEqual(['credit', 'debit'])
+  })
+
+  it('agrees with the signs the payloads carry, so a failed leg is described as it was built', () => {
+    const form = {
+      kind: 'transfer' as const,
+      direction: 'credit' as const,
+      account_id: 'checking',
+      category_id: 'transfer-out',
+      merchant_id: 'store',
+      amount: '50.00',
+      currency: 'CAD',
+      notes: '',
+      date: '2026-06-11',
+      tag_ids: [],
+      symmetric_transfer: true,
+      other_account_id: 'savings',
+    }
+
+    const [recordedKind, otherKind] = getSymmetricTransferLegKinds(form.direction)
+    const [recordedPayload, otherPayload] = buildSymmetricTransferPayloads(form, 2)
+
+    expect(recordedKind === 'debit').toBe(recordedPayload.amount < 0)
+    expect(otherKind === 'debit').toBe(otherPayload.amount < 0)
+  })
 })
 
 describe('account field ordering', () => {

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -6,6 +6,7 @@ import type { AccountsOverview } from '@/api/accounts'
 import type { Category } from '@/api/categories'
 import type { Currency } from '@/api/currency'
 import type { Transaction } from '@/api/transactions'
+import { OUTSIDE_ACCOUNT_VALUE } from '@/pages/transactions/components/transaction-modal/constants'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
 import { buildInitialTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/initialForm'
 import {
@@ -16,6 +17,7 @@ import {
 } from '@/pages/transactions/components/transaction-modal/utils/money'
 import {
   buildCreateTransactionPayload,
+  buildSymmetricTransferPayloads,
   buildUpdateTransactionPatch,
 } from '@/pages/transactions/components/transaction-modal/utils/payloads'
 import { validateTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
@@ -88,6 +90,8 @@ function createTransaction(overrides: Partial<Transaction> = {}): Transaction {
     currency: overrides.currency ?? 'CAD',
     fx_rate: null,
     notes: overrides.notes ?? null,
+    other_account_id: overrides.other_account_id ?? null,
+    other_account_scope: overrides.other_account_scope ?? null,
     created_at: '2026-06-11T12:00:00Z',
     updated_at: '2026-06-11T12:00:00Z',
     tag_ids: overrides.tag_ids ?? [],
@@ -185,6 +189,7 @@ describe('transaction modal helpers', () => {
       tag_ids: [],
       symmetric_transfer: false,
       to_account_id: '',
+      other_account_id: '',
     })).toEqual({
       account_id: 'Select an account',
       category_id: 'Select a category',
@@ -207,6 +212,7 @@ describe('transaction modal helpers', () => {
       tag_ids: ['tax'],
       symmetric_transfer: false,
       to_account_id: '',
+      other_account_id: '',
     }, 2)).toEqual({
       account_id: 'checking',
       dt: '2026-06-11',
@@ -238,7 +244,7 @@ describe('transaction modal helpers', () => {
       .toEqual({ notes: 'Checked' })
 
     // The rest of the form still has to pass, so the blank amount cannot block an edit to anything else
-    expect(validateTransactionForm(form, true)).toEqual({})
+    expect(validateTransactionForm(form, { isAmountLocked: true })).toEqual({})
     expect(validateTransactionForm(form)).toEqual({ amount: 'Enter an amount' })
   })
 
@@ -268,6 +274,143 @@ describe('transaction modal helpers', () => {
       amount: 20000,
       tag_ids: ['business'],
     })
+  })
+
+  it('requires an other-account answer only when creating a transfer that is not Balance Adjustment', () => {
+    const transferForm = {
+      kind: 'transfer' as const,
+      direction: 'debit' as const,
+      account_id: 'checking',
+      category_id: 'transfer-out',
+      merchant_id: 'store',
+      amount: '50.00',
+      currency: 'CAD',
+      notes: '',
+      date: '2026-06-11',
+      tag_ids: [],
+      symmetric_transfer: false,
+      to_account_id: '',
+      other_account_id: '',
+    }
+
+    // A transfer with no answer fails validation when creating
+    expect(validateTransactionForm(transferForm, { requireOtherAccount: true }).other_account_id)
+      .toBe('Select where the money went')
+
+    // An edit with the field left empty passes, since an old transaction can be corrected without answering first
+    expect(validateTransactionForm(transferForm, { requireOtherAccount: false }).other_account_id).toBeUndefined()
+
+    // Balance Adjustment has no other side, so it is never required even when creating
+    expect(validateTransactionForm(
+      transferForm,
+      { requireOtherAccount: true, isBalanceAdjustmentCategory: true },
+    ).other_account_id).toBeUndefined()
+
+    // A symmetric transfer already answers it by pairing the accounts, so the field itself is not required
+    expect(validateTransactionForm(
+      { ...transferForm, symmetric_transfer: true, to_account_id: 'savings' },
+      { requireOtherAccount: true },
+    ).other_account_id).toBeUndefined()
+
+    // Picking the transaction's own account as the other side is always rejected
+    expect(validateTransactionForm(
+      { ...transferForm, other_account_id: 'checking' },
+      { requireOtherAccount: true },
+    ).other_account_id).toBe('Choose a different account')
+  })
+
+  it('builds each leg of a symmetric transfer to record the other as a tracked account', () => {
+    const form = {
+      kind: 'transfer' as const,
+      direction: 'debit' as const,
+      account_id: 'checking',
+      category_id: 'transfer-out',
+      merchant_id: 'store',
+      amount: '50.00',
+      currency: 'CAD',
+      notes: '',
+      date: '2026-06-11',
+      tag_ids: [],
+      symmetric_transfer: true,
+      to_account_id: 'savings',
+      other_account_id: '',
+    }
+
+    const [fromPayload, toPayload] = buildSymmetricTransferPayloads(form, 2)
+    expect(fromPayload).toMatchObject({
+      account_id: 'checking',
+      other_account_id: 'savings',
+      other_account_scope: 'tracked',
+    })
+    expect(toPayload).toMatchObject({
+      account_id: 'savings',
+      other_account_id: 'checking',
+      other_account_scope: 'tracked',
+    })
+  })
+
+  it('splits the other-account selection into an id-and-scope pair for create and update payloads', () => {
+    const transferForm = {
+      kind: 'transfer' as const,
+      direction: 'debit' as const,
+      account_id: 'checking',
+      category_id: 'transfer-out',
+      merchant_id: 'store',
+      amount: '50.00',
+      currency: 'CAD',
+      notes: '',
+      date: '2026-06-11',
+      tag_ids: [],
+      symmetric_transfer: false,
+      to_account_id: '',
+      other_account_id: OUTSIDE_ACCOUNT_VALUE,
+    }
+
+    expect(buildCreateTransactionPayload(transferForm, 2)).toMatchObject({
+      other_account_id: null,
+      other_account_scope: 'outside',
+    })
+    expect(buildCreateTransactionPayload({ ...transferForm, other_account_id: 'savings' }, 2)).toMatchObject({
+      other_account_id: 'savings',
+      other_account_scope: 'tracked',
+    })
+
+    const transaction = createTransaction({
+      category_id: 'transfer-out',
+      other_account_id: 'savings',
+      other_account_scope: 'tracked',
+    })
+    const unchangedForm = buildInitialTransactionForm({
+      transaction,
+      categories: [createCategory({ id: 'transfer-out', kind: 'transfer' })],
+      currencies,
+      selectableAccounts: [createAccount({ id: 'checking' })],
+      timeZone: undefined,
+    })
+
+    // Untouched, so no patch at all
+    expect(buildUpdateTransactionPatch(unchangedForm, transaction, 2)).toBeNull()
+
+    // Recording a different account sends the new pair
+    expect(buildUpdateTransactionPatch(
+      { ...unchangedForm, other_account_id: 'joint-savings' },
+      transaction,
+      2,
+    )).toMatchObject({ other_account_id: 'joint-savings', other_account_scope: 'tracked' })
+
+    // Clearing the field back to unanswered sends nulls rather than omitting them
+    expect(buildUpdateTransactionPatch(
+      { ...unchangedForm, other_account_id: '' },
+      transaction,
+      2,
+    )).toMatchObject({ other_account_id: null, other_account_scope: null })
+
+    // Moving to a non-transfer category leaves the pair out entirely, since the backend clears it itself
+    expect(buildUpdateTransactionPatch(
+      { ...unchangedForm, kind: 'expense', category_id: 'groceries' },
+      transaction,
+      2,
+    )).toEqual({ category_id: 'groceries' })
   })
 
 })

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -349,6 +349,15 @@ describe('transaction modal helpers', () => {
       other_account_id: 'checking',
       other_account_scope: 'tracked',
     })
+
+    // The direction says what happens to the account above, so on a credit the money arrives there
+    // and leaves the other, rather than the recorded account always being the one debited
+    const [creditFrom, creditTo] = buildSymmetricTransferPayloads(
+      { ...baseForm, direction: 'credit' as const },
+      2,
+    )
+    expect(creditFrom).toMatchObject({ account_id: 'checking', amount: 5000 })
+    expect(creditTo).toMatchObject({ account_id: 'savings', amount: -5000 })
   })
 
   it('splits the other-account selection into an id-and-scope pair for create and update payloads', () => {

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -8,6 +8,7 @@ import type { Currency } from '@/api/currency'
 import type { Transaction } from '@/api/transactions'
 import { OUTSIDE_ACCOUNT_VALUE } from '@/pages/transactions/components/transaction-modal/constants'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
+import { buildOtherAccountOptions } from '@/pages/transactions/components/transaction-modal/utils/options'
 import { buildInitialTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/initialForm'
 import {
   amountInputToMinorUnits,
@@ -439,4 +440,25 @@ describe('transaction modal helpers', () => {
     )).toEqual({ category_id: 'groceries' })
   })
 
+})
+
+describe('other-account options', () => {
+  const accounts = [
+    createAccount({ id: 'checking', name: 'Chequing' }),
+    createAccount({ id: 'savings', name: 'Savings' }),
+  ]
+
+  it('leaves out the account holding the transfer and offers the outside entry', () => {
+    const options = buildOtherAccountOptions(accounts, 'checking', false)
+
+    expect(options.map((option) => option.value)).toEqual(['savings', OUTSIDE_ACCOUNT_VALUE])
+  })
+
+  it('offers a way back to unanswered when editing, and none when creating', () => {
+    const editing = buildOtherAccountOptions(accounts, 'checking', true)
+    const creating = buildOtherAccountOptions(accounts, 'checking', false)
+
+    expect(editing[0]).toEqual({ value: '', label: 'Not recorded' })
+    expect(creating.some((option) => option.value === '')).toBe(false)
+  })
 })

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -306,9 +306,16 @@ describe('transaction modal helpers', () => {
       { requireOtherAccount: true, isBalanceAdjustmentCategory: true },
     ).other_account_id).toBeUndefined()
 
-    // A symmetric transfer already answers it by pairing the accounts, so the field itself is not required
+    // The field stays live once the checkbox is ticked, so a create requires it there too,
+    // independently of the receiving-account requirement the checkbox already carries
+    const symmetricForm = { ...transferForm, symmetric_transfer: true, to_account_id: 'savings' }
+    const symmetricErrors = validateTransactionForm(symmetricForm, { requireOtherAccount: true })
+    expect(symmetricErrors.other_account_id).toBe('Select where the money went')
+    expect(symmetricErrors.to_account_id).toBeUndefined()
+
+    // Answering it once the checkbox is ticked clears the requirement, same as the standalone case
     expect(validateTransactionForm(
-      { ...transferForm, symmetric_transfer: true, to_account_id: 'savings' },
+      { ...symmetricForm, other_account_id: 'savings' },
       { requireOtherAccount: true },
     ).other_account_id).toBeUndefined()
 
@@ -319,8 +326,8 @@ describe('transaction modal helpers', () => {
     ).other_account_id).toBe('Choose a different account')
   })
 
-  it('builds each leg of a symmetric transfer to record the other as a tracked account', () => {
-    const form = {
+  it('builds the receiving leg to record the originating account, and the first leg to record whatever the field holds', () => {
+    const baseForm = {
       kind: 'transfer' as const,
       direction: 'debit' as const,
       account_id: 'checking',
@@ -333,20 +340,39 @@ describe('transaction modal helpers', () => {
       tag_ids: [],
       symmetric_transfer: true,
       to_account_id: 'savings',
-      other_account_id: '',
+      other_account_id: 'savings',
     }
 
-    const [fromPayload, toPayload] = buildSymmetricTransferPayloads(form, 2)
-    expect(fromPayload).toMatchObject({
+    // Choosing the receiving account fills the field, so the common case matches it
+    const [matchingFrom, matchingTo] = buildSymmetricTransferPayloads(baseForm, 2)
+    expect(matchingFrom).toMatchObject({
       account_id: 'checking',
       other_account_id: 'savings',
       other_account_scope: 'tracked',
     })
-    expect(toPayload).toMatchObject({
+    expect(matchingTo).toMatchObject({
       account_id: 'savings',
       other_account_id: 'checking',
       other_account_scope: 'tracked',
     })
+
+    // The field stays editable afterward, so it can be changed to a different account than the
+    // one actually receiving the second transaction, and that pairing is let through
+    const [divergedFrom, divergedTo] = buildSymmetricTransferPayloads(
+      { ...baseForm, other_account_id: 'joint-savings' },
+      2,
+    )
+    expect(divergedFrom).toMatchObject({ account_id: 'checking', other_account_id: 'joint-savings', other_account_scope: 'tracked' })
+    // The receiving leg's other side is not in question: it is always the originating account
+    expect(divergedTo).toMatchObject({ account_id: 'savings', other_account_id: 'checking', other_account_scope: 'tracked' })
+
+    // The field can also hold the outside sentinel while the second leg still exists
+    const [outsideFrom, outsideTo] = buildSymmetricTransferPayloads(
+      { ...baseForm, other_account_id: OUTSIDE_ACCOUNT_VALUE },
+      2,
+    )
+    expect(outsideFrom).toMatchObject({ account_id: 'checking', other_account_id: null, other_account_scope: 'outside' })
+    expect(outsideTo).toMatchObject({ account_id: 'savings', other_account_id: 'checking', other_account_scope: 'tracked' })
   })
 
   it('splits the other-account selection into an id-and-scope pair for create and update payloads', () => {

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -440,15 +440,15 @@ describe('other-account options', () => {
     expect(options.some((option) => option.value === '')).toBe(false)
   })
 
-  it('still records an archived account, which is a fact about money that already moved', () => {
+  it('leaves out an archived account, which takes no new transactions anywhere else either', () => {
     const withArchived = [...accounts, createAccount({ id: 'old-tfsa', name: 'Old TFSA', is_archived: true })]
 
     const options = buildOtherAccountOptions(withArchived, 'checking', false)
 
-    expect(options.map((option) => option.value)).toContain('old-tfsa')
+    expect(options.map((option) => option.value)).toEqual([OUTSIDE_ACCOUNT_VALUE, 'savings'])
   })
 
-  it('drops an archived account once the pair checkbox is ticked, since it refuses a transaction', () => {
+  it('leaves it out with the pair checkbox ticked as well', () => {
     const withArchived = [...accounts, createAccount({ id: 'old-tfsa', name: 'Old TFSA', is_archived: true })]
 
     const options = buildOtherAccountOptions(withArchived, 'checking', true)

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -22,6 +22,7 @@ import {
   buildUpdateTransactionPatch,
 } from '@/pages/transactions/components/transaction-modal/utils/payloads'
 import { validateTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/validation'
+import { orderAccountFields } from '@/pages/transactions/components/transaction-modal/utils/accountFields'
 
 const currencies: Currency[] = [
   { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
@@ -423,6 +424,38 @@ describe('transaction modal helpers', () => {
     )).toEqual({ category_id: 'groceries' })
   })
 
+})
+
+describe('account field ordering', () => {
+  const recorded = { name: 'recorded' }
+  const other = { name: 'other' }
+
+  it('keeps the recorded account on top for an ordinary transfer, whichever way the money goes', () => {
+    for (const direction of ['debit', 'credit'] as const) {
+      expect(orderAccountFields(recorded, other, { isSymmetricTransfer: false, direction }))
+        .toEqual([recorded, other])
+    }
+  })
+
+  it('keeps the recorded account on top for a pair going out of it', () => {
+    expect(orderAccountFields(recorded, other, { isSymmetricTransfer: true, direction: 'debit' }))
+      .toEqual([recorded, other])
+  })
+
+  it('puts the other account on top for a pair coming into the recorded one, since it is the source', () => {
+    expect(orderAccountFields(recorded, other, { isSymmetricTransfer: true, direction: 'credit' }))
+      .toEqual([other, recorded])
+  })
+
+  it('moves each field whole, so its value, error and options cannot land on opposite sides', () => {
+    const [top, second] = orderAccountFields(recorded, other, {
+      isSymmetricTransfer: true,
+      direction: 'credit',
+    })
+
+    expect(top).toBe(other)
+    expect(second).toBe(recorded)
+  })
 })
 
 describe('other-account options', () => {

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -189,7 +189,6 @@ describe('transaction modal helpers', () => {
       date: '',
       tag_ids: [],
       symmetric_transfer: false,
-      to_account_id: '',
       other_account_id: '',
     })).toEqual({
       account_id: 'Select an account',
@@ -212,7 +211,6 @@ describe('transaction modal helpers', () => {
       date: '2026-06-11',
       tag_ids: ['tax'],
       symmetric_transfer: false,
-      to_account_id: '',
       other_account_id: '',
     }, 2)).toEqual({
       account_id: 'checking',
@@ -290,7 +288,6 @@ describe('transaction modal helpers', () => {
       date: '2026-06-11',
       tag_ids: [],
       symmetric_transfer: false,
-      to_account_id: '',
       other_account_id: '',
     }
 
@@ -305,12 +302,10 @@ describe('transaction modal helpers', () => {
       { isBalanceAdjustmentCategory: true },
     ).other_account_id).toBeUndefined()
 
-    // The field stays live once the checkbox is ticked, so a create requires it there too,
-    // independently of the receiving-account requirement the checkbox already carries
-    const symmetricForm = { ...transferForm, symmetric_transfer: true, to_account_id: 'savings' }
-    const symmetricErrors = validateTransactionForm(symmetricForm)
-    expect(symmetricErrors.other_account_id).toBe('Select where the money went')
-    expect(symmetricErrors.to_account_id).toBeUndefined()
+    // Ticking the checkbox makes this field the receiving account, so it is the one field asked
+    // for either way rather than a second one appearing beside it
+    const symmetricForm = { ...transferForm, symmetric_transfer: true }
+    expect(validateTransactionForm(symmetricForm).other_account_id).toBe('Select where the money went')
 
     // Answering it once the checkbox is ticked clears the requirement, same as the standalone case
     expect(validateTransactionForm(
@@ -323,7 +318,7 @@ describe('transaction modal helpers', () => {
     ).other_account_id).toBe('Choose a different account')
   })
 
-  it('builds the receiving leg to record the originating account, and the first leg to record whatever the field holds', () => {
+  it('writes the pair into the one chosen account, each leg recording the other', () => {
     const baseForm = {
       kind: 'transfer' as const,
       direction: 'debit' as const,
@@ -336,40 +331,24 @@ describe('transaction modal helpers', () => {
       date: '2026-06-11',
       tag_ids: [],
       symmetric_transfer: true,
-      to_account_id: 'savings',
       other_account_id: 'savings',
     }
 
-    // Choosing the receiving account fills the field, so the common case matches it
-    const [matchingFrom, matchingTo] = buildSymmetricTransferPayloads(baseForm, 2)
-    expect(matchingFrom).toMatchObject({
+    // The one account field is both what the pair is written to and what each leg records, so the
+    // two can no longer disagree
+    const [fromPayload, toPayload] = buildSymmetricTransferPayloads(baseForm, 2)
+    expect(fromPayload).toMatchObject({
       account_id: 'checking',
+      amount: -5000,
       other_account_id: 'savings',
       other_account_scope: 'tracked',
     })
-    expect(matchingTo).toMatchObject({
+    expect(toPayload).toMatchObject({
       account_id: 'savings',
+      amount: 5000,
       other_account_id: 'checking',
       other_account_scope: 'tracked',
     })
-
-    // The field stays editable afterward, so it can be changed to a different account than the
-    // one actually receiving the second transaction, and that pairing is let through
-    const [divergedFrom, divergedTo] = buildSymmetricTransferPayloads(
-      { ...baseForm, other_account_id: 'joint-savings' },
-      2,
-    )
-    expect(divergedFrom).toMatchObject({ account_id: 'checking', other_account_id: 'joint-savings', other_account_scope: 'tracked' })
-    // The receiving leg's other side is not in question: it is always the originating account
-    expect(divergedTo).toMatchObject({ account_id: 'savings', other_account_id: 'checking', other_account_scope: 'tracked' })
-
-    // The field can also hold the outside sentinel while the second leg still exists
-    const [outsideFrom, outsideTo] = buildSymmetricTransferPayloads(
-      { ...baseForm, other_account_id: OUTSIDE_ACCOUNT_VALUE },
-      2,
-    )
-    expect(outsideFrom).toMatchObject({ account_id: 'checking', other_account_id: null, other_account_scope: 'outside' })
-    expect(outsideTo).toMatchObject({ account_id: 'savings', other_account_id: 'checking', other_account_scope: 'tracked' })
   })
 
   it('splits the other-account selection into an id-and-scope pair for create and update payloads', () => {
@@ -444,14 +423,20 @@ describe('other-account options', () => {
     createAccount({ id: 'savings', name: 'Savings' }),
   ]
 
-  it('leaves out the account holding the transfer and offers the outside entry', () => {
-    const options = buildOtherAccountOptions(accounts, 'checking')
+  it('offers the outside entry first and leaves out the account holding the transfer', () => {
+    const options = buildOtherAccountOptions(accounts, 'checking', false)
 
-    expect(options.map((option) => option.value)).toEqual(['savings', OUTSIDE_ACCOUNT_VALUE])
+    expect(options.map((option) => option.value)).toEqual([OUTSIDE_ACCOUNT_VALUE, 'savings'])
+  })
+
+  it('drops the outside entry once the pair checkbox is ticked, since a transaction is written there', () => {
+    const options = buildOtherAccountOptions(accounts, 'checking', true)
+
+    expect(options.map((option) => option.value)).toEqual(['savings'])
   })
 
   it('offers no way back to unanswered, since every edit has to answer', () => {
-    const options = buildOtherAccountOptions(accounts, 'checking')
+    const options = buildOtherAccountOptions(accounts, 'checking', false)
 
     expect(options.some((option) => option.value === '')).toBe(false)
   })

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -364,7 +364,6 @@ describe('transaction modal helpers', () => {
       date: '2026-06-11',
       tag_ids: [],
       symmetric_transfer: false,
-      to_account_id: '',
       other_account_id: OUTSIDE_ACCOUNT_VALUE,
     }
 


### PR DESCRIPTION
A transfer now records where its money went as it is entered, so moving money between two accounts inside the same tax-advantaged category stops counting as both a contribution and a withdrawal against that category's limit.

- Transfers gain a field for the other side, set either to another of your accounts or to outside the app, required when creating and when editing. Filling it in creates no transaction in that account and changes no balance
- Editing a transfer recorded before this refuses to save until that field is filled in, which is what brings existing history onto the new rule
- "Record in both accounts" writes the matching transaction in the receiving account, and is offered while creating only. With it ticked the two account fields read source first, and the direction toggle decides which of the two the money leaves
- Archived accounts are not offered as the other side. A transfer that already records one shows it and holds the field, so an edit cannot move it to something that can never be put back
- Each tax-advantaged category gains a setting for whether transfers between its own accounts count toward its limits, defaulting to off, so existing categories stop double counting on deploy
- The limit sums widen from the single system Transfer category to every transfer-kind category except Balance Adjustment, so credit card payments and categories a user made themselves count where they did not
- A shared "Myself" merchant ships with the app, and each user's own is folded into it whatever its capitalisation. It cannot be renamed or deleted, and other merchants can be merged into it
- Every transaction created or edited requires a merchant. Transactions already stored without one are left alone until someone edits them
- The starting balance and archive adjustments the app writes for itself carry the Myself merchant, and are left out of the merchant dropdown's usage ranking
- Transaction rows show where a transfer's money went in the place other kinds show the merchant, reading as the account's name or as outside this app
