### PR TITLE
Fix how the importer reads currencies and validates amounts

### DIFF
--- a/backend/app/services/importers/firefly/row_resolution.py
+++ b/backend/app/services/importers/firefly/row_resolution.py
@@ -23,6 +23,7 @@ from app.services.importers.shared.row_mappings import (
     validate_import_category_can_be_used_for_account,
 )
 from app.utils.money import (
+    MAX_MINOR_UNITS,
     DecimalAmountParseError,
     DecimalAmountPrecisionError,
     parse_decimal_amount_to_minor_units,
@@ -323,7 +324,8 @@ def _get_amount_in_account_currency(
         Absolute amount in account-currency minor units
 
     Raises:
-        FireflyRowSkipError: Raised when no amount is available in the account currency
+        FireflyRowSkipError: Raised when no amount is available in the account currency,
+            when the raw amount cannot be parsed, or when its magnitude cannot be stored
     """
     if row.currency_code.upper() == account.currency:
         raw_amount = row.amount
@@ -343,7 +345,14 @@ def _get_amount_in_account_currency(
         )
     except (DecimalAmountParseError, DecimalAmountPrecisionError) as exc:
         raise FireflyRowSkipError(f'Invalid amount "{raw_amount}"') from exc
-    return abs(amount)
+
+    # This path stores the magnitude rather than the parsed value, and the signed range
+    # holds one more value below zero than above it, so negating the smallest amount the
+    # parser accepts produces one the column cannot take
+    absolute_amount = abs(amount)
+    if absolute_amount > MAX_MINOR_UNITS:
+        raise FireflyRowSkipError(f'Amount is too large: "{raw_amount}"')
+    return absolute_amount
 
 
 def _build_leg_notes(row: FireflyTransactionRow) -> str | None:

--- a/backend/app/services/importers/generic/amounts.py
+++ b/backend/app/services/importers/generic/amounts.py
@@ -21,7 +21,8 @@ def parse_import_amount_to_minor_units(raw_amount: str, currency: Currency) -> i
         Parsed amount in the currency's minor units
 
     Raises:
-        HTTPException: Raised with 422 when the amount is malformed or too precise
+        HTTPException: Raised with 422 when the amount is malformed, when it carries more decimal
+            places than the currency holds, or when it falls outside the range the column holds
     """
     try:
         return parse_decimal_amount_to_minor_units(

--- a/backend/app/utils/money.py
+++ b/backend/app/utils/money.py
@@ -1,13 +1,16 @@
 """Money amount utilities"""
 import re
-from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation, localcontext
 
 _RAW_DECIMAL_AMOUNT_RE = re.compile(r"^[+-]?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?$")
 
-# Amounts are stored as signed 64-bit integers, so a parsed value past this
-# magnitude would only fail later at database flush instead of being rejected
-# where the string is validated
-MAX_MINOR_UNITS_MAGNITUDE = 2**63 - 1
+# Amounts are stored as signed 64-bit integers, so a parsed value outside this
+# range would only fail later at database flush instead of being rejected where
+# the string is validated. The range is not symmetric: two's complement gives one
+# more value below zero than above it, so a caller that negates a parsed amount
+# has to bound its own result rather than trusting this one
+MIN_MINOR_UNITS = -(2**63)
+MAX_MINOR_UNITS = 2**63 - 1
 
 
 class DecimalAmountParseError(ValueError):
@@ -35,7 +38,8 @@ def parse_decimal_amount_to_minor_units(
         Parsed amount in the currency's minor units
 
     Raises:
-        DecimalAmountParseError: Raised when the amount string is malformed
+        DecimalAmountParseError: Raised when the amount string is malformed, or when the
+            amount falls outside the signed 64-bit range the column holds
         DecimalAmountPrecisionError: Raised when the amount has too many decimal places
     """
     normalized_amount = raw_amount.strip()
@@ -47,12 +51,17 @@ def parse_decimal_amount_to_minor_units(
     except InvalidOperation as exc:
         raise DecimalAmountParseError(f"Invalid amount: {raw_amount}") from exc
 
-    multiplier = Decimal(10) ** minor_unit_exponent
-    minor_units = decimal_amount * multiplier
-    if minor_units != minor_units.to_integral_value():
-        raise DecimalAmountPrecisionError(f"Amount has too many decimal places for {currency_code}: {raw_amount}")
+    # Shifting the decimal point keeps the operand's own digits, so the context has to be
+    # wide enough to hold all of them. Under the default 28 the value is rounded to fit
+    # first, and an amount carrying more precision than the currency holds then passes the
+    # integral check below instead of failing it
+    with localcontext() as context:
+        context.prec = len(decimal_amount.as_tuple().digits) + minor_unit_exponent + 1
+        minor_units = decimal_amount.scaleb(minor_unit_exponent)
+        if minor_units != minor_units.to_integral_value():
+            raise DecimalAmountPrecisionError(f"Amount has too many decimal places for {currency_code}: {raw_amount}")
 
-    if abs(minor_units) > MAX_MINOR_UNITS_MAGNITUDE:
+    if not MIN_MINOR_UNITS <= minor_units <= MAX_MINOR_UNITS:
         raise DecimalAmountParseError(f"Amount is too large: {raw_amount}")
 
     return int(minor_units)

--- a/backend/tests/routes/transactions/test_firefly_imports.py
+++ b/backend/tests/routes/transactions/test_firefly_imports.py
@@ -597,3 +597,28 @@ async def test_firefly_import_skips_amounts_past_the_storable_range(client):
     assert data["rows_imported"] == 1
     assert data["rows_skipped"] == 1
     assert data["skipped"][0]["reason"] == 'Invalid amount "99999999999999999999.00"'
+
+
+async def test_firefly_import_skips_the_amount_whose_magnitude_cannot_be_stored(client):
+    """The one amount that parses but cannot be stored once negated skips the row
+
+    This path writes the magnitude rather than the parsed value, and the signed range holds
+    one more value below zero than above it, so this amount parses and its magnitude does not
+    """
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+
+    resp = await client.post("/transactions/import/firefly", json={
+        "accounts": [_chequing_mapping()],
+        "categories": [{"source": "Groceries", "create": {"name": "Groceries", "kind": "expense"}}],
+        "rows": [
+            _firefly_row(),
+            _firefly_row(journal_id="2", amount="-92233720368547758.08"),
+        ],
+    }, headers=headers)
+
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["rows_imported"] == 1
+    assert data["rows_skipped"] == 1
+    assert data["skipped"][0]["reason"] == 'Amount is too large: "-92233720368547758.08"'

--- a/backend/tests/utils/test_money.py
+++ b/backend/tests/utils/test_money.py
@@ -1,0 +1,94 @@
+"""Decimal amount parsing tests"""
+
+import pytest
+
+from app.utils.money import (
+    MAX_MINOR_UNITS,
+    MIN_MINOR_UNITS,
+    DecimalAmountParseError,
+    DecimalAmountPrecisionError,
+    parse_decimal_amount_to_minor_units,
+)
+
+# The largest and smallest amounts a two-decimal currency can hold, written as the decimal
+# text a file would carry. Their minor-unit values are the bounds of a signed 64-bit column
+LARGEST_STORABLE_TEXT = "92233720368547758.07"
+SMALLEST_STORABLE_TEXT = "-92233720368547758.08"
+
+
+def _parse(raw_amount, minor_unit_exponent=2):
+    """Parse an amount against a currency with the given number of decimal places"""
+    return parse_decimal_amount_to_minor_units(
+        raw_amount,
+        currency_code="TST",
+        minor_unit_exponent=minor_unit_exponent,
+    )
+
+
+@pytest.mark.parametrize(
+    ("raw_amount", "minor_unit_exponent", "expected_minor_units"),
+    [
+        ("12.34", 2, 1234),
+        ("-12.34", 2, -1234),
+        ("1,234.56", 2, 123456),
+        # Trailing zeros past the currency's places carry no precision, so they are not
+        # the same thing as a digit the currency cannot hold
+        ("12.3400", 2, 1234),
+        ("1234", 0, 1234),
+        ("1.234", 3, 1234),
+    ],
+)
+def test_parses_amounts_the_currency_can_hold(raw_amount, minor_unit_exponent, expected_minor_units):
+    """An amount within the currency's decimal places parses to its minor units"""
+    assert _parse(raw_amount, minor_unit_exponent) == expected_minor_units
+
+
+@pytest.mark.parametrize(
+    ("raw_amount", "minor_unit_exponent"),
+    [
+        ("12.345", 2),
+        ("1.005", 2),
+        ("12.34", 0),
+        ("1.2345", 3),
+    ],
+)
+def test_refuses_an_amount_carrying_more_decimal_places_than_the_currency(raw_amount, minor_unit_exponent):
+    """An amount with more decimal places than the currency holds is refused, not rounded"""
+    with pytest.raises(DecimalAmountPrecisionError):
+        _parse(raw_amount, minor_unit_exponent)
+
+
+def test_refuses_excess_precision_past_the_default_decimal_context():
+    """Precision beyond 28 significant digits is refused rather than rounded away first
+
+    Scaling inside the default context rounds the value to fit before the integral check
+    runs, which let an amount like this one parse as a whole 100 minor units
+    """
+    with pytest.raises(DecimalAmountPrecisionError):
+        _parse("1.0000000000000000000000000005")
+
+
+def test_refuses_excess_precision_that_rounds_onto_the_largest_storable_amount():
+    """An over-precise amount is refused even where rounding it would land exactly in range"""
+    with pytest.raises(DecimalAmountPrecisionError):
+        _parse("92233720368547758.070000000001")
+
+
+def test_parses_the_bounds_of_the_signed_range_the_column_holds():
+    """Both ends of the signed 64-bit range parse, including the asymmetric negative end"""
+    assert _parse(LARGEST_STORABLE_TEXT) == MAX_MINOR_UNITS
+    assert _parse(SMALLEST_STORABLE_TEXT) == MIN_MINOR_UNITS
+
+
+@pytest.mark.parametrize("raw_amount", ["92233720368547758.08", "-92233720368547758.09"])
+def test_refuses_an_amount_past_the_range_the_column_holds(raw_amount):
+    """An amount one minor unit outside the signed 64-bit range is refused"""
+    with pytest.raises(DecimalAmountParseError):
+        _parse(raw_amount)
+
+
+@pytest.mark.parametrize("raw_amount", ["$12.34", "12,34", "1.234.567", "", "twelve"])
+def test_refuses_malformed_amount_text(raw_amount):
+    """Text that is not a plain signed decimal number is refused"""
+    with pytest.raises(DecimalAmountParseError):
+        _parse(raw_amount)

--- a/frontend/src/pages/imports/components/FileUpload.tsx
+++ b/frontend/src/pages/imports/components/FileUpload.tsx
@@ -11,6 +11,10 @@ import { formatBytes } from '@/pages/imports/utils'
  * A rejection keeps the card in place and reports why the file was refused,
  * so the user can pick another one without losing the prompt or any guidance
  * sitting beside it
+ *
+ * A block reason is the other kind of refusal: no file can be taken at all yet,
+ * so it is shown without telling the user to choose a different one, and it
+ * leads when both are set
  */
 export function ImportUploadCard({
   title,
@@ -18,6 +22,7 @@ export function ImportUploadCard({
   processing,
   disabled,
   rejection,
+  blockReason,
   onClick,
 }: {
   title: string
@@ -25,6 +30,7 @@ export function ImportUploadCard({
   processing: boolean
   disabled: boolean
   rejection?: string | null
+  blockReason?: string | null
   onClick: () => void
 }) {
   const shouldReduceMotion = useReducedMotion()
@@ -78,7 +84,7 @@ export function ImportUploadCard({
                 <span className="h-1.5 w-6 animate-pulse [animation-delay:240ms]" style={{ background: 'var(--app-accent)' }} />
               </span>
             </motion.span>
-          ) : rejection ? (
+          ) : (blockReason ?? rejection) ? (
             <motion.span
               key="rejected"
               className="flex flex-col items-center"
@@ -92,11 +98,13 @@ export function ImportUploadCard({
                 <TriangleAlert size={20} strokeWidth={2.25} aria-hidden />
               </span>
               <span className="block text-sm font-semibold" style={{ color: 'var(--app-negative)' }}>
-                {rejection}
+                {blockReason ?? rejection}
               </span>
-              <span className="mt-1 block text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-                Choose another file to try again.
-              </span>
+              {!blockReason && (
+                <span className="mt-1 block text-xs" style={{ color: 'var(--app-text-subtle)' }}>
+                  Choose another file to try again.
+                </span>
+              )}
             </motion.span>
           ) : (
             <motion.span

--- a/frontend/src/pages/imports/components/FileUpload.tsx
+++ b/frontend/src/pages/imports/components/FileUpload.tsx
@@ -14,7 +14,8 @@ import { formatBytes } from '@/pages/imports/utils'
  *
  * A block reason is the other kind of refusal: no file can be taken at all yet,
  * so it is shown without telling the user to choose a different one, and it
- * leads when both are set
+ * leads when both are set. Only a block the user has to act on is dressed as an
+ * error, since a page that is still loading its reference data is not one
  */
 export function ImportUploadCard({
   title,
@@ -30,9 +31,11 @@ export function ImportUploadCard({
   processing: boolean
   disabled: boolean
   rejection?: string | null
-  blockReason?: string | null
+  blockReason?: { message: string; isFailure: boolean } | null
   onClick: () => void
 }) {
+  const isBlockedWithoutFailure = blockReason !== null && blockReason !== undefined && !blockReason.isFailure
+  const message = blockReason?.message ?? rejection ?? null
   const shouldReduceMotion = useReducedMotion()
   const uploadStateMotion = shouldReduceMotion
     ? {
@@ -51,11 +54,11 @@ export function ImportUploadCard({
   return (
     <button
       type="button"
-      className="group grid min-h-32 w-full place-items-center px-5 py-6 text-center transition-colors duration-150 hover:bg-[var(--app-surface-soft)] disabled:cursor-wait disabled:opacity-100"
+      className={`group grid min-h-32 w-full place-items-center px-5 py-6 text-center transition-colors duration-150 hover:bg-[var(--app-surface-soft)] disabled:opacity-100 ${blockReason?.isFailure ? 'disabled:cursor-not-allowed' : 'disabled:cursor-wait'}`}
       style={{
         ...IMPORT_INSET_STYLE,
         color: 'var(--app-text-muted)',
-        border: rejection ? '1px solid var(--app-negative-border)' : undefined,
+        border: (rejection ?? blockReason?.isFailure) ? '1px solid var(--app-negative-border)' : undefined,
       }}
       onClick={onClick}
       disabled={disabled}
@@ -84,21 +87,28 @@ export function ImportUploadCard({
                 <span className="h-1.5 w-6 animate-pulse [animation-delay:240ms]" style={{ background: 'var(--app-accent)' }} />
               </span>
             </motion.span>
-          ) : (blockReason ?? rejection) ? (
+          ) : message ? (
             <motion.span
               key="rejected"
               className="flex flex-col items-center"
-              role="alert"
+              role={isBlockedWithoutFailure ? 'status' : 'alert'}
               {...uploadStateMotion}
             >
               <span
                 className="mb-3 flex h-11 w-11 items-center justify-center"
-                style={{ background: 'var(--app-negative-soft)', color: 'var(--app-negative)' }}
+                style={isBlockedWithoutFailure
+                  ? { background: 'var(--app-surface-soft)', color: 'var(--app-accent)' }
+                  : { background: 'var(--app-negative-soft)', color: 'var(--app-negative)' }}
               >
-                <TriangleAlert size={20} strokeWidth={2.25} aria-hidden />
+                {isBlockedWithoutFailure
+                  ? <LoaderCircle size={21} strokeWidth={2.4} className="animate-spin motion-reduce:animate-none" aria-hidden />
+                  : <TriangleAlert size={20} strokeWidth={2.25} aria-hidden />}
               </span>
-              <span className="block text-sm font-semibold" style={{ color: 'var(--app-negative)' }}>
-                {blockReason ?? rejection}
+              <span
+                className="block text-sm font-semibold"
+                style={{ color: isBlockedWithoutFailure ? 'var(--app-text-muted)' : 'var(--app-negative)' }}
+              >
+                {message}
               </span>
               {!blockReason && (
                 <span className="mt-1 block text-xs" style={{ color: 'var(--app-text-subtle)' }}>

--- a/frontend/src/pages/imports/components/FileUpload.tsx
+++ b/frontend/src/pages/imports/components/FileUpload.tsx
@@ -1,7 +1,7 @@
 import { FileText, LoaderCircle, TriangleAlert, Upload, X } from 'lucide-react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { IMPORT_INSET_STYLE } from '@/pages/imports/constants'
-import type { ImportFileDraft } from '@/pages/imports/types'
+import type { ImportFileDraft, ImportUploadBlock } from '@/pages/imports/types'
 import { formatBytes } from '@/pages/imports/utils'
 
 /**
@@ -31,11 +31,13 @@ export function ImportUploadCard({
   processing: boolean
   disabled: boolean
   rejection?: string | null
-  blockReason?: { message: string; isFailure: boolean } | null
+  blockReason?: ImportUploadBlock | null
   onClick: () => void
 }) {
-  const isBlockedWithoutFailure = blockReason !== null && blockReason !== undefined && !blockReason.isFailure
+  // A block leads over a file's own refusal, since nothing can be uploaded while one stands
+  const isBlockedWithoutFailure = Boolean(blockReason) && !blockReason?.isFailure
   const message = blockReason?.message ?? rejection ?? null
+  const isRefusal = message !== null && !isBlockedWithoutFailure
   const shouldReduceMotion = useReducedMotion()
   const uploadStateMotion = shouldReduceMotion
     ? {
@@ -58,7 +60,7 @@ export function ImportUploadCard({
       style={{
         ...IMPORT_INSET_STYLE,
         color: 'var(--app-text-muted)',
-        border: (rejection ?? blockReason?.isFailure) ? '1px solid var(--app-negative-border)' : undefined,
+        border: isRefusal ? '1px solid var(--app-negative-border)' : undefined,
       }}
       onClick={onClick}
       disabled={disabled}
@@ -89,7 +91,11 @@ export function ImportUploadCard({
             </motion.span>
           ) : message ? (
             <motion.span
-              key="rejected"
+              // Waiting and refusing are separate keys so a fetch that fails after the waiting
+              // message is on screen animates between the two rather than swapping the icon in
+              // place, and so the polite live region is replaced by an assertive one rather than
+              // having its politeness changed under a screen reader, which is not reliably honoured
+              key={isBlockedWithoutFailure ? 'waiting' : 'rejected'}
               className="flex flex-col items-center"
               role={isBlockedWithoutFailure ? 'status' : 'alert'}
               {...uploadStateMotion}

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -41,9 +41,9 @@ export const COLUMN_TARGETS: Array<{
   { id: 'tag_ids', label: 'Tags', hint: 'Resolved from imported tag text.' },
 ]
 
-// Shown over the upload control while the currency list is not in hand. Reading a file needs it
-// twice over, to tell a cell holding a currency from a header word shaped like one, and to know how
-// many decimal places an amount may carry, so a file read without it would be read wrongly
+// Shown over the upload control while the currency list is not in hand. Reading a file uses it to
+// tell a cell holding a currency from a header word shaped like one, and that decision is kept on
+// the staged file, so a file read without the list stays wrongly read once it arrives
 export const CURRENCIES_LOADING_UPLOAD_BLOCK = 'Loading currencies, which the file is read against.'
 export const CURRENCIES_FAILED_UPLOAD_BLOCK = 'Currencies could not be loaded, and a file cannot be read without them. Reload the page to try again.'
 
@@ -66,10 +66,10 @@ export const ROW_AMOUNT_TOO_LARGE_REASON = 'The amount is larger than this app c
 /**
  * Says an amount carries decimal places its currency does not have
  *
- * How many are allowed is the currency's answer rather than the importer's, so the message names
- * it. It also says how a period is read, because a file written with periods grouping the
- * thousands fails here, and without that sentence the reason reads as a complaint about a number
- * the user considers whole
+ * How many are allowed is the currency's answer rather than the importer's, so the message states
+ * it. It also says how a period is read, because an amount like 1.234 written with a period
+ * grouping the thousands fails here, and without that sentence the reason reads as a complaint
+ * about a number the user considers whole
  */
 export function getRowAmountTooPreciseReason(currency: string) {
   return `The amount has more decimal places than ${currency} has. A period is read as a decimal point, never as a separator between thousands.`

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -44,7 +44,7 @@ export const COLUMN_TARGETS: Array<{
 // Shown over the upload control while the currency list is not in hand. Reading a file uses it to
 // tell a cell holding a currency from a header word shaped like one, and that decision is kept on
 // the staged file, so a file read without the list stays wrongly read once it arrives
-export const CURRENCIES_LOADING_UPLOAD_BLOCK = 'Loading currencies, which the file is read against.'
+export const CURRENCIES_LOADING_UPLOAD_BLOCK = 'Loading currencies...'
 export const CURRENCIES_FAILED_UPLOAD_BLOCK = 'Currencies could not be loaded, and a file cannot be read without them. Reload the page to try again.'
 
 // How many entries the skipped table lists before summarizing the remainder, shared by every table

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -30,7 +30,7 @@ export const COLUMN_TARGETS: Array<{
   {
     id: 'counterparty_account_id',
     label: 'Counterparty account',
-    hint: 'Says which account a transfer\'s money went to, or came from, without writing a transaction into that account. Only rows whose category records one can use it, and a blank cell records the transfer as going outside this app.',
+    hint: 'Says which account a transfer\'s money went to, or came from, without writing a transaction into that account. Only transfer rows can use it, and a blank cell records the transfer as going outside this app.',
   },
   { id: 'dt', label: 'Date', hint: 'Transaction date.', required: true },
   { id: 'category_id', label: 'Category', hint: 'Resolved from imported category text.', required: true },
@@ -40,6 +40,12 @@ export const COLUMN_TARGETS: Array<{
   { id: 'notes', label: 'Notes', hint: 'Optional transaction notes.' },
   { id: 'tag_ids', label: 'Tags', hint: 'Resolved from imported tag text.' },
 ]
+
+// Shown over the upload control while the currency list is not in hand. Reading a file needs it
+// twice over, to tell a cell holding a currency from a header word shaped like one, and to know how
+// many decimal places an amount may carry, so a file read without it would be read wrongly
+export const CURRENCIES_LOADING_UPLOAD_BLOCK = 'Loading currencies, which the file is read against.'
+export const CURRENCIES_FAILED_UPLOAD_BLOCK = 'Currencies could not be loaded, and a file cannot be read without them. Reload the page to try again.'
 
 // How many entries the skipped table lists before summarizing the remainder, shared by every table
 // built on it: refused rows in both import flows, and the Firefly budgets it cannot bring in
@@ -55,6 +61,19 @@ export const ROW_DATE_BLANK_REASON = 'The date cell is blank.'
 export const ROW_DATE_UNREADABLE_REASON = 'The date does not match the chosen format.'
 export const ROW_AMOUNT_BLANK_REASON = 'The amount cell is blank.'
 export const ROW_AMOUNT_UNREADABLE_REASON = 'The amount is not a number.'
+export const ROW_AMOUNT_TOO_LARGE_REASON = 'The amount is larger than this app can store.'
+
+/**
+ * Says an amount carries decimal places its currency does not have
+ *
+ * How many are allowed is the currency's answer rather than the importer's, so the message names
+ * it. It also says how a period is read, because a file written with periods grouping the
+ * thousands fails here, and without that sentence the reason reads as a complaint about a number
+ * the user considers whole
+ */
+export function getRowAmountTooPreciseReason(currency: string) {
+  return `The amount has more decimal places than ${currency} has. A period is read as a decimal point, never as a separator between thousands.`
+}
 export const ROW_COUNTERPARTY_NOT_A_TRANSFER_REASON = 'A non-transfer transaction should not have a counterparty account recorded.'
 export const ROW_COUNTERPARTY_IS_OWN_ACCOUNT_REASON = 'A transfer cannot record its own account as its counterparty.'
 

--- a/frontend/src/pages/imports/firefly/hooks/useFireflyImportWorkflow.ts
+++ b/frontend/src/pages/imports/firefly/hooks/useFireflyImportWorkflow.ts
@@ -16,6 +16,8 @@ import type {
 } from '@/pages/imports/types'
 import {
   getErrorMessage,
+  getImportUploadBlockReason,
+  getSupportedCurrencyCodes,
   groupPreviewRowsByDate,
   inferAccountMappings,
 } from '@/pages/imports/utils'
@@ -100,8 +102,10 @@ export function useFireflyImportWorkflow() {
   const importFireflyBudgets = useImportFireflyBudgets()
   const {
     categories,
+    currencies,
     accountsLoading,
     currenciesLoading,
+    currenciesError,
     institutionsLoading,
     categoriesLoading,
     selectableAccounts,
@@ -247,11 +251,13 @@ export function useFireflyImportWorkflow() {
       categoryCreateKinds: resolvedCategoryKinds,
       transferCategory,
       balanceAdjustmentCategory,
+      currencies,
     }),
     [
       accountById,
       balanceAdjustmentCategory,
       categoryById,
+      currencies,
       fireflyRows,
       institutionById,
       resolvedAccountCreateDetails,
@@ -281,11 +287,13 @@ export function useFireflyImportWorkflow() {
       categoryCreateKinds: resolvedCategoryKinds,
       transferCategory,
       balanceAdjustmentCategory,
+      currencies,
     }),
     [
       accountById,
       balanceAdjustmentCategory,
       categoryById,
+      currencies,
       fireflyRows,
       institutionById,
       resolvedAccountCreateDetails,
@@ -444,7 +452,7 @@ export function useFireflyImportWorkflow() {
 
     try {
       const [draft] = await Promise.all([
-        readFireflyCsvFile(selected, kind),
+        readFireflyCsvFile(selected, kind, getSupportedCurrencyCodes(currencies)),
         waitForMilliseconds(FIREFLY_CSV_PROCESSING_MIN_MS),
       ])
       assignFireflyFile(kind, draft)
@@ -654,6 +662,7 @@ export function useFireflyImportWorkflow() {
     isImportingBudgets,
     accountsLoading,
     currenciesLoading,
+    uploadBlockReason: getImportUploadBlockReason(currenciesLoading, currenciesError),
     institutionsLoading,
     categoriesLoading,
     accountOptions,

--- a/frontend/src/pages/imports/firefly/hooks/useFireflyImportWorkflow.ts
+++ b/frontend/src/pages/imports/firefly/hooks/useFireflyImportWorkflow.ts
@@ -662,7 +662,7 @@ export function useFireflyImportWorkflow() {
     isImportingBudgets,
     accountsLoading,
     currenciesLoading,
-    uploadBlockReason: getImportUploadBlockReason(currenciesLoading, currenciesError),
+    uploadBlockReason: getImportUploadBlockReason(currencies, currenciesError),
     institutionsLoading,
     categoriesLoading,
     accountOptions,

--- a/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
@@ -8,7 +8,7 @@ import {
   ImportStep,
   ImportUploadCard,
 } from '@/pages/imports/components'
-import type { ImportFileDraft } from '@/pages/imports/types'
+import type { ImportFileDraft, ImportUploadBlock } from '@/pages/imports/types'
 import type { FireflyImportWorkflow } from '@/pages/imports/firefly/hooks'
 import type { FireflyFileKind } from '@/pages/imports/firefly/types'
 
@@ -62,7 +62,7 @@ export function FireflyFilesStep({
       className="xl:h-full"
       contentClassName="flex min-h-0 flex-col gap-3"
     >
-      {FILE_SLOTS.map((slot) => (
+      {FILE_SLOTS.map((slot, slotIndex) => (
         <FireflyFileSlot
           key={slot.kind}
           kind={slot.kind}
@@ -72,7 +72,11 @@ export function FireflyFilesStep({
           file={filesByKind[slot.kind]}
           processing={processingFileKind === slot.kind}
           disabled={processingFileKind !== null}
-          blockReason={uploadBlockReason}
+          // A block is about the step rather than any one slot, so it is stated on the slot the
+          // user reaches first and the other is only disabled. Repeating it would read as two
+          // separate problems, and each slot's message is a live region a screen reader announces
+          blockReason={slotIndex === 0 ? uploadBlockReason : null}
+          isBlocked={uploadBlockReason !== null}
           onFileChange={handleFireflyFileChange}
           onRemove={removeFireflyFile}
           note={slot.kind === 'budgets' ? (
@@ -105,6 +109,7 @@ function FireflyFileSlot({
   processing,
   disabled,
   blockReason,
+  isBlocked,
   onFileChange,
   onRemove,
   note,
@@ -116,7 +121,10 @@ function FireflyFileSlot({
   file: ImportFileDraft | null
   processing: boolean
   disabled: boolean
-  blockReason: { message: string; isFailure: boolean } | null
+  blockReason: ImportUploadBlock | null
+
+  /** Whether no file can be staged, which every slot answers to even where only one states why */
+  isBlocked: boolean
   onFileChange: (kind: FireflyFileKind, event: ChangeEvent<HTMLInputElement>) => void
   onRemove: (kind: FireflyFileKind) => void
   note?: ReactNode
@@ -127,7 +135,7 @@ function FireflyFileSlot({
   // card and any guidance beside it and reports the refusal in place
   const stagedFile = file && !file.error ? file : null
   const rejection = file?.error ?? null
-  const isUploadBlocked = disabled || blockReason !== null
+  const isUploadBlocked = disabled || isBlocked
 
   return (
     <div className="space-y-2">

--- a/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
@@ -22,6 +22,7 @@ type FireflyFilesStepProps = Pick<
   | 'importedCategories'
   | 'handleFireflyFileChange'
   | 'removeFireflyFile'
+  | 'uploadBlockReason'
 >
 
 // Matches the ease the transaction list uses for row growth and collapse
@@ -46,6 +47,7 @@ export function FireflyFilesStep({
   importedCategories,
   handleFireflyFileChange,
   removeFireflyFile,
+  uploadBlockReason,
 }: FireflyFilesStepProps) {
   const filesByKind: Record<FireflyFileKind, ImportFileDraft | null> = {
     transactions: transactionsFile,
@@ -70,6 +72,7 @@ export function FireflyFilesStep({
           file={filesByKind[slot.kind]}
           processing={processingFileKind === slot.kind}
           disabled={processingFileKind !== null}
+          blockReason={uploadBlockReason}
           onFileChange={handleFireflyFileChange}
           onRemove={removeFireflyFile}
           note={slot.kind === 'budgets' ? (
@@ -101,6 +104,7 @@ function FireflyFileSlot({
   file,
   processing,
   disabled,
+  blockReason,
   onFileChange,
   onRemove,
   note,
@@ -112,6 +116,7 @@ function FireflyFileSlot({
   file: ImportFileDraft | null
   processing: boolean
   disabled: boolean
+  blockReason: string | null
   onFileChange: (kind: FireflyFileKind, event: ChangeEvent<HTMLInputElement>) => void
   onRemove: (kind: FireflyFileKind) => void
   note?: ReactNode
@@ -119,9 +124,11 @@ function FireflyFileSlot({
   const inputRef = useRef<HTMLInputElement>(null)
 
   // A rejected file never becomes a staged file, so the slot keeps its upload
-  // card and any guidance beside it and reports the refusal in place
+  // card and any guidance beside it and reports the refusal in place. A reason
+  // no file can be taken at all leads, since it is the one to act on first
   const stagedFile = file && !file.error ? file : null
-  const rejection = file?.error ?? null
+  const rejection = blockReason ?? file?.error ?? null
+  const isUploadBlocked = disabled || blockReason !== null
 
   return (
     <div className="space-y-2">
@@ -137,7 +144,7 @@ function FireflyFileSlot({
         className="hidden"
         accept=".csv,text/csv"
         onChange={(event) => onFileChange(kind, event)}
-        disabled={disabled}
+        disabled={isUploadBlocked}
       />
 
       {/* Each slot takes exactly one file, so the upload card and its note
@@ -167,7 +174,7 @@ function FireflyFileSlot({
               title={`Upload ${label.toLowerCase()}`}
               hint={hint}
               processing={processing}
-              disabled={disabled}
+              disabled={isUploadBlocked}
               rejection={rejection}
               onClick={() => inputRef.current?.click()}
             />

--- a/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
@@ -124,10 +124,9 @@ function FireflyFileSlot({
   const inputRef = useRef<HTMLInputElement>(null)
 
   // A rejected file never becomes a staged file, so the slot keeps its upload
-  // card and any guidance beside it and reports the refusal in place. A reason
-  // no file can be taken at all leads, since it is the one to act on first
+  // card and any guidance beside it and reports the refusal in place
   const stagedFile = file && !file.error ? file : null
-  const rejection = blockReason ?? file?.error ?? null
+  const rejection = file?.error ?? null
   const isUploadBlocked = disabled || blockReason !== null
 
   return (
@@ -176,6 +175,7 @@ function FireflyFileSlot({
               processing={processing}
               disabled={isUploadBlocked}
               rejection={rejection}
+              blockReason={blockReason}
               onClick={() => inputRef.current?.click()}
             />
             <EmptyState

--- a/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
@@ -116,7 +116,7 @@ function FireflyFileSlot({
   file: ImportFileDraft | null
   processing: boolean
   disabled: boolean
-  blockReason: string | null
+  blockReason: { message: string; isFailure: boolean } | null
   onFileChange: (kind: FireflyFileKind, event: ChangeEvent<HTMLInputElement>) => void
   onRemove: (kind: FireflyFileKind) => void
   note?: ReactNode

--- a/frontend/src/pages/imports/firefly/utils/files.ts
+++ b/frontend/src/pages/imports/firefly/utils/files.ts
@@ -13,9 +13,17 @@ const REQUIRED_HEADERS_BY_KIND: Record<FireflyFileKind, string[]> = {
 
 /**
  * Reads one Firefly III export file and flags missing required columns
+ *
+ * @param file - The uploaded file
+ * @param kind - Which Firefly III export this file is meant to be
+ * @param supportedCurrencyCodes - Upper-case codes from the currency list the API served
  */
-export async function readFireflyCsvFile(file: File, kind: FireflyFileKind): Promise<ImportFileDraft> {
-  const draft = await readCsvFile(file)
+export async function readFireflyCsvFile(
+  file: File,
+  kind: FireflyFileKind,
+  supportedCurrencyCodes: Set<string>,
+): Promise<ImportFileDraft> {
+  const draft = await readCsvFile(file, supportedCurrencyCodes)
   if (draft.error) return draft
 
   const headers = new Set(draft.headers)

--- a/frontend/src/pages/imports/firefly/utils/rowResolution.ts
+++ b/frontend/src/pages/imports/firefly/utils/rowResolution.ts
@@ -243,12 +243,10 @@ function getFireflyAmountInAccountCurrency(row: CsvRow, accountCurrency: string,
   const exponent = findCurrencyExponent(currencies, accountCurrency)
   if (exponent === null) throw new Error(`No currency metadata for ${accountCurrency}`)
 
+  // The backend catches its parser's malformed, over-precise and out-of-range errors together and
+  // reports all three as an invalid amount, so all three read the same way here
   const minorUnits = toImportMinorUnits(rawAmount, exponent)
-  if (typeof minorUnits !== 'bigint') {
-    throw new FireflyRowSkipError(
-      minorUnits === 'tooLarge' ? `Amount is too large: "${rawAmount}"` : `Invalid amount "${rawAmount}"`,
-    )
-  }
+  if (typeof minorUnits !== 'bigint') throw new FireflyRowSkipError(`Invalid amount "${rawAmount}"`)
 
   // The import writes the magnitude rather than the parsed value, and the signed range holds one
   // more value below zero than above it, so the smallest amount the parser accepts negates into

--- a/frontend/src/pages/imports/firefly/utils/rowResolution.ts
+++ b/frontend/src/pages/imports/firefly/utils/rowResolution.ts
@@ -3,8 +3,10 @@ import type { Category } from '@/api/categories'
 import { FIREFLY_NO_CATEGORY_SOURCE, isFireflyTrackedAccountType } from '@/api/firefly-imports'
 import type { Institution } from '@/api/institutions'
 import { CREATE_ACCOUNT_VALUE, CREATE_CATEGORY_VALUE, DEFAULT_CATEGORY_ICON } from '@/pages/imports/constants'
+import type { Currency } from '@/api/currency'
 import type { CsvRow, ImportCategoryKind } from '@/pages/imports/types'
-import { parseImportNumber, toMinorUnits } from '@/pages/imports/utils'
+import { MAX_IMPORT_MINOR_UNITS, toImportMinorUnits } from '@/pages/imports/utils'
+import { findCurrencyExponent } from '@/utils/moneyInput'
 import {
   FIREFLY_GENERIC_SKIP_REASON,
   FIREFLY_TYPE_DEPOSIT,
@@ -28,6 +30,9 @@ export interface FireflyRowResolutionOptions {
   categoryCreateKinds: Record<string, ImportCategoryKind>
   transferCategory: Category | undefined
   balanceAdjustmentCategory: Category | undefined
+
+  /** Currency metadata, read for the decimal places each account's currency holds */
+  currencies: Currency[]
 }
 
 /**
@@ -108,7 +113,7 @@ function buildFireflyRowLegs(row: CsvRow, options: FireflyRowResolutionOptions):
     const account = destination ?? source
     if (!account) throw new FireflyRowSkipError('Opening balance or reconciliation row is not attached to an imported account')
 
-    const amount = getFireflyAmountInAccountCurrency(row, account.currency)
+    const amount = getFireflyAmountInAccountCurrency(row, account.currency, options.currencies)
     return [{
       account,
       amount: destination ? amount : -amount,
@@ -134,14 +139,14 @@ function buildFireflyRowLegs(row: CsvRow, options: FireflyRowResolutionOptions):
     return [
       {
         account: source,
-        amount: -getFireflyAmountInAccountCurrency(row, source.currency),
+        amount: -getFireflyAmountInAccountCurrency(row, source.currency, options.currencies),
         category: options.transferCategory,
         merchantName: null,
         counterpartyAccount: destination,
       },
       {
         account: destination,
-        amount: getFireflyAmountInAccountCurrency(row, destination.currency),
+        amount: getFireflyAmountInAccountCurrency(row, destination.currency, options.currencies),
         category: options.transferCategory,
         merchantName: null,
         counterpartyAccount: source,
@@ -154,7 +159,7 @@ function buildFireflyRowLegs(row: CsvRow, options: FireflyRowResolutionOptions):
 
     return [{
       account: source,
-      amount: -getFireflyAmountInAccountCurrency(row, source.currency),
+      amount: -getFireflyAmountInAccountCurrency(row, source.currency, options.currencies),
       category: getFireflyMappedCategory(row, options),
       merchantName: row.destination_name?.trim() || null,
       counterpartyAccount: null,
@@ -166,7 +171,7 @@ function buildFireflyRowLegs(row: CsvRow, options: FireflyRowResolutionOptions):
 
     return [{
       account: destination,
-      amount: getFireflyAmountInAccountCurrency(row, destination.currency),
+      amount: getFireflyAmountInAccountCurrency(row, destination.currency, options.currencies),
       category: getFireflyMappedCategory(row, options),
       merchantName: row.source_name?.trim() || null,
       counterpartyAccount: null,
@@ -213,10 +218,10 @@ function resolveFireflyMappedAccount(
 
 /**
  * Gets the row's absolute amount in account-currency minor units, throwing
- * the backend-worded skip error when no amount exists in that currency or
- * the matching raw amount is unparseable
+ * the backend-worded skip error when no amount exists in that currency, the
+ * matching raw amount is unparseable, or its magnitude cannot be stored
  */
-function getFireflyAmountInAccountCurrency(row: CsvRow, accountCurrency: string): number {
+function getFireflyAmountInAccountCurrency(row: CsvRow, accountCurrency: string, currencies: Currency[]): number {
   // Firefly III writes the journal amount in the transaction currency and
   // carries a foreign amount when a second currency is involved, so the
   // account-side value is whichever of the two matches the account currency
@@ -233,9 +238,25 @@ function getFireflyAmountInAccountCurrency(row: CsvRow, accountCurrency: string)
     throw new FireflyRowSkipError(`Neither the amount nor the foreign amount is in the account's currency (${accountCurrency})`)
   }
 
-  const parsed = parseImportNumber(rawAmount)
-  if (parsed === null) throw new FireflyRowSkipError(`Invalid amount "${rawAmount}"`)
-  return Math.abs(toMinorUnits(parsed, accountCurrency))
+  // Every account's currency is one the API served, so a missing exponent is unreachable. An
+  // unanticipated failure is reported with the generic reason rather than a skip rule of its own
+  const exponent = findCurrencyExponent(currencies, accountCurrency)
+  if (exponent === null) throw new Error(`No currency metadata for ${accountCurrency}`)
+
+  const minorUnits = toImportMinorUnits(rawAmount, exponent)
+  if (typeof minorUnits !== 'bigint') {
+    throw new FireflyRowSkipError(
+      minorUnits === 'tooLarge' ? `Amount is too large: "${rawAmount}"` : `Invalid amount "${rawAmount}"`,
+    )
+  }
+
+  // The import writes the magnitude rather than the parsed value, and the signed range holds one
+  // more value below zero than above it, so the smallest amount the parser accepts negates into
+  // one the column cannot take. The backend bounds its own result the same way
+  const absoluteMinorUnits = minorUnits < 0n ? -minorUnits : minorUnits
+  if (absoluteMinorUnits > MAX_IMPORT_MINOR_UNITS) throw new FireflyRowSkipError(`Amount is too large: "${rawAmount}"`)
+
+  return Number(absoluteMinorUnits)
 }
 
 /**

--- a/frontend/src/pages/imports/hooks/useImportReferenceData.ts
+++ b/frontend/src/pages/imports/hooks/useImportReferenceData.ts
@@ -26,9 +26,9 @@ export interface ImportReferenceData {
   /**
    * Whether the currency list could not be fetched
    *
-   * Told apart from an empty list, because reading a file needs the real list: which codes are
-   * currencies and how many decimal places each has are both answered from it, and a failed fetch
-   * would otherwise read as every code being unsupported
+   * Reading a file needs the real list, since a code absent from it counts as no currency at all,
+   * so both flows block their upload until the list arrives. This says which of the two things
+   * happened, so the user is told to reload rather than to wait
    */
   currenciesError: boolean
   selectableAccounts: AccountsOverview[]

--- a/frontend/src/pages/imports/hooks/useImportReferenceData.ts
+++ b/frontend/src/pages/imports/hooks/useImportReferenceData.ts
@@ -22,6 +22,15 @@ export interface ImportReferenceData {
   currenciesLoading: boolean
   institutionsLoading: boolean
   categoriesLoading: boolean
+
+  /**
+   * Whether the currency list could not be fetched
+   *
+   * Told apart from an empty list, because reading a file needs the real list: which codes are
+   * currencies and how many decimal places each has are both answered from it, and a failed fetch
+   * would otherwise read as every code being unsupported
+   */
+  currenciesError: boolean
   selectableAccounts: AccountsOverview[]
   allAccounts: AccountsOverview[]
   accountOptions: DropdownOption[]
@@ -39,7 +48,7 @@ export interface ImportReferenceData {
  */
 export function useImportReferenceData(): ImportReferenceData {
   const { data: accounts = [], isLoading: accountsLoading } = useAccounts()
-  const { data: currencies = [], isLoading: currenciesLoading } = useCurrencies()
+  const { data: currencies = [], isLoading: currenciesLoading, isError: currenciesError } = useCurrencies()
   const { data: institutions = [], isLoading: institutionsLoading } = useInstitutions()
   const { data: categories, isLoading: categoriesLoading } = useCategories()
 
@@ -93,6 +102,7 @@ export function useImportReferenceData(): ImportReferenceData {
     categories,
     accountsLoading,
     currenciesLoading,
+    currenciesError,
     institutionsLoading,
     categoriesLoading,
     selectableAccounts,

--- a/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
@@ -21,7 +21,9 @@ import {
   getMissingRequiredColumnLabels,
   getNextAutoFilledColumnHeaders,
   getNextColumnMap,
+  getImportUploadBlockReason,
   getNextColumnValidationErrors,
+  getSupportedCurrencyCodes,
   inferAccountMappings,
   inferCategoryMappings,
   isColumnMappingComplete,
@@ -99,6 +101,7 @@ export function useTransactionImportWorkflow() {
     categories,
     accountsLoading,
     currenciesLoading,
+    currenciesError,
     institutionsLoading,
     categoriesLoading,
     selectableAccounts,
@@ -111,6 +114,11 @@ export function useTransactionImportWorkflow() {
     categoryById,
     institutionById,
   } = useImportReferenceData()
+
+  const supportedCurrencyCodes = useMemo(
+    () => getSupportedCurrencyCodes(currencies),
+    [currencies],
+  )
 
   const headers = useMemo(
     () => getImportHeaders(files),
@@ -146,8 +154,8 @@ export function useTransactionImportWorkflow() {
   // The date column answers to a choice made outside the mapping table, so its error is worked out
   // on every render rather than kept in the stored map, which only refreshes when a mapping changes
   const dateColumnValidation = useMemo(
-    () => (columnMap.dt ? validateColumnValues(files, columnMap.dt, 'dt', dateFormat) : null),
-    [columnMap.dt, dateFormat, files],
+    () => (columnMap.dt ? validateColumnValues(files, columnMap.dt, 'dt', supportedCurrencyCodes, dateFormat) : null),
+    [columnMap.dt, dateFormat, files, supportedCurrencyCodes],
   )
 
   const resolvedColumnValidationErrors = useMemo(() => {
@@ -276,6 +284,7 @@ export function useTransactionImportWorkflow() {
       categoryTypesBySource,
       columnMap,
       columnValidationErrors: resolvedColumnValidationErrors,
+      currencies,
       dateFormat,
       files,
       importedCategories,
@@ -289,6 +298,7 @@ export function useTransactionImportWorkflow() {
       categoryById,
       categoryCreateKinds,
       categoryTypesBySource,
+      currencies,
       columnMap,
       dateFormat,
       files,
@@ -357,14 +367,14 @@ export function useTransactionImportWorkflow() {
 
     try {
       const [drafts] = await Promise.all([
-        Promise.all(selectedFiles.map(readCsvFile)),
+        Promise.all(selectedFiles.map((selectedFile) => readCsvFile(selectedFile, supportedCurrencyCodes))),
         waitForMilliseconds(CSV_PROCESSING_MIN_MS),
       ])
       const next = drafts.slice(0, 1)
 
       setFiles(next)
       setColumnMap((previous) => {
-        const result = inferColumnMap(previous, next)
+        const result = inferColumnMap(previous, next, supportedCurrencyCodes)
         setColumnValidationErrors(result.errors)
         setAutoFilledColumnHeaders((current) => getNextAutoFilledColumnHeaders(current, previous, result.map))
         syncAutoMatchKeys(result.map, result.errors, next)
@@ -380,7 +390,7 @@ export function useTransactionImportWorkflow() {
     setFiles((current) => {
       const next = current.filter((file) => file.id !== fileId)
       setColumnMap((previous) => {
-        const result = inferColumnMap(previous, next)
+        const result = inferColumnMap(previous, next, supportedCurrencyCodes)
         setColumnValidationErrors(result.errors)
         setAutoFilledColumnHeaders((current) => getNextAutoFilledColumnHeaders(current, previous, result.map))
         syncAutoMatchKeys(result.map, result.errors, next)
@@ -392,7 +402,7 @@ export function useTransactionImportWorkflow() {
 
   const updateColumnTarget = (header: string, targetValue: string) => {
     const validation = targetValue
-      ? validateColumnValues(files, header, targetValue as ColumnTarget)
+      ? validateColumnValues(files, header, targetValue as ColumnTarget, supportedCurrencyCodes)
       : { valid: true, message: '' }
     const previousAccountHeader = columnMap.account_id
     const previousCategoryHeader = columnMap.category_id
@@ -518,6 +528,7 @@ export function useTransactionImportWorkflow() {
     importOverlayOpen,
     accountsLoading,
     currenciesLoading,
+    uploadBlockReason: getImportUploadBlockReason(currenciesLoading, currenciesError),
     institutionsLoading,
     categoriesLoading,
     accountOptions,

--- a/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
@@ -528,7 +528,7 @@ export function useTransactionImportWorkflow() {
     importOverlayOpen,
     accountsLoading,
     currenciesLoading,
-    uploadBlockReason: getImportUploadBlockReason(currenciesLoading, currenciesError),
+    uploadBlockReason: getImportUploadBlockReason(currencies, currenciesError),
     institutionsLoading,
     categoriesLoading,
     accountOptions,

--- a/frontend/src/pages/imports/sections/ImportFilesStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportFilesStep.tsx
@@ -52,7 +52,7 @@ export function ImportFilesStep({
         hint="One file accepted."
         processing={isProcessingFiles}
         disabled={isUploadBlocked}
-        rejection={uploadBlockReason}
+        blockReason={uploadBlockReason}
         onClick={() => inputRef.current?.click()}
       />
 

--- a/frontend/src/pages/imports/sections/ImportFilesStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportFilesStep.tsx
@@ -10,6 +10,7 @@ type ImportFilesStepProps = Pick<
   | 'mappedFieldCount'
   | 'handleFileChange'
   | 'removeFile'
+  | 'uploadBlockReason'
 >
 
 /**
@@ -24,7 +25,12 @@ export function ImportFilesStep({
   mappedFieldCount,
   handleFileChange,
   removeFile,
+  uploadBlockReason,
 }: ImportFilesStepProps) {
+  // A file is read against the currency list, so uploading one before it is in hand would read the
+  // file wrongly rather than merely leave a later step waiting
+  const isUploadBlocked = isProcessingFiles || uploadBlockReason !== null
+
   return (
     <ImportStep
       index="01"
@@ -39,13 +45,14 @@ export function ImportFilesStep({
         className="hidden"
         accept=".csv,text/csv"
         onChange={handleFileChange}
-        disabled={isProcessingFiles}
+        disabled={isUploadBlocked}
       />
       <ImportUploadCard
         title="Upload CSV file"
         hint="One file accepted."
         processing={isProcessingFiles}
-        disabled={isProcessingFiles}
+        disabled={isUploadBlocked}
+        rejection={uploadBlockReason}
         onClick={() => inputRef.current?.click()}
       />
 

--- a/frontend/src/pages/imports/types.ts
+++ b/frontend/src/pages/imports/types.ts
@@ -84,3 +84,14 @@ export interface ImportBuildResult {
   rowProblems: ImportRowProblem[]
   payload: TransactionImportPayload | null
 }
+
+/**
+ * Why no file can be staged yet, shown over the upload control
+ *
+ * A block the user has to act on is told apart from one that clears itself, so waiting on an
+ * ordinary page load is not dressed as an error
+ */
+export interface ImportUploadBlock {
+  message: string
+  isFailure: boolean
+}

--- a/frontend/src/pages/imports/utils/autoColumnMapping.ts
+++ b/frontend/src/pages/imports/utils/autoColumnMapping.ts
@@ -155,8 +155,12 @@ const EXCLUDED_HEADER_PARTS: Partial<Record<ColumnTarget, string[]>> = {
  * can only be claimed by the single best-scoring target so two fields never end up pointing at the
  * same header
  */
-export function inferColumnMap(columnMap: ColumnMap, files: ImportFileDraft[]) {
-  const result = validateColumnMap(columnMap, files)
+export function inferColumnMap(
+  columnMap: ColumnMap,
+  files: ImportFileDraft[],
+  supportedCurrencyCodes: Set<string>,
+) {
+  const result = validateColumnMap(columnMap, files, supportedCurrencyCodes)
   if (files.length === 0) return result
 
   const headers = unique(files.flatMap((file) => file.headers))
@@ -167,14 +171,14 @@ export function inferColumnMap(columnMap: ColumnMap, files: ImportFileDraft[]) {
   for (const target of COLUMN_TARGETS) {
     if (inferredMap[target.id]) continue
 
-    const header = getBestHeaderMatch(files, headers, usedHeaders, target.id)
+    const header = getBestHeaderMatch(files, headers, usedHeaders, target.id, supportedCurrencyCodes)
     if (!header) continue
 
     inferredMap[target.id] = header
     usedHeaders.add(header)
   }
 
-  return validateColumnMap(inferredMap, files)
+  return validateColumnMap(inferredMap, files, supportedCurrencyCodes)
 }
 
 function getBestHeaderMatch(
@@ -182,6 +186,7 @@ function getBestHeaderMatch(
   headers: string[],
   usedHeaders: Set<string>,
   target: ColumnTarget,
+  supportedCurrencyCodes: Set<string>,
 ) {
   let bestMatch: { header: string; score: number } | null = null
 
@@ -194,11 +199,11 @@ function getBestHeaderMatch(
 
     const score = Math.max(
       scoreHeaderForTarget(header, target),
-      scoreValuesForTarget(files, header, target),
+      scoreValuesForTarget(files, header, target, supportedCurrencyCodes),
     )
     if (score <= 0) continue
 
-    const validation = validateColumnValues(files, header, target)
+    const validation = validateColumnValues(files, header, target, supportedCurrencyCodes)
     if (!validation.valid) continue
 
     if (!bestMatch || score > bestMatch.score) {
@@ -226,14 +231,19 @@ function scoreHeaderForTarget(header: string, target: ColumnTarget) {
   return containsScore ?? 0
 }
 
-function scoreValuesForTarget(files: ImportFileDraft[], header: string, target: ColumnTarget) {
+function scoreValuesForTarget(
+  files: ImportFileDraft[],
+  header: string,
+  target: ColumnTarget,
+  supportedCurrencyCodes: Set<string>,
+) {
   const values = getColumnValues(files, header).filter(Boolean)
   if (values.length === 0) return 0
 
   const validDateRatio = getRatio(values, isValidDateValue)
   const validAmountRatio = getRatio(values, isValidAmountValue)
-  const validCurrencyRatio = getRatio(values, isSupportedCurrency)
-  const textValues = values.filter(isPlainTextData)
+  const validCurrencyRatio = getRatio(values, (value) => isSupportedCurrency(value, supportedCurrencyCodes))
+  const textValues = values.filter((value) => isPlainTextData(value, supportedCurrencyCodes))
   const textRatio = textValues.length / values.length
   const uniqueRatio = unique(textValues.map(normalizeValue)).length / Math.max(textValues.length, 1)
   const dominantRatio = getDominantRatio(textValues)
@@ -292,11 +302,11 @@ function getAverageLength(values: string[]) {
   return values.reduce((sum, value) => sum + value.length, 0) / values.length
 }
 
-function isPlainTextData(value: string) {
+function isPlainTextData(value: string, supportedCurrencyCodes: Set<string>) {
   return Boolean(value.trim())
     && !isValidDateValue(value)
     && !isValidAmountValue(value)
-    && !isSupportedCurrency(value)
+    && !isSupportedCurrency(value, supportedCurrencyCodes)
 }
 
 function isAccountLikeValue(value: string) {

--- a/frontend/src/pages/imports/utils/columnMapping.ts
+++ b/frontend/src/pages/imports/utils/columnMapping.ts
@@ -3,8 +3,8 @@ import type { ColumnMap, ColumnTarget, ColumnValidationErrors, CsvRow, ImportFil
 import { unique } from './common'
 import {
   type ImportDateFormat,
+  isSupportedCurrency,
   isValidAmountValue,
-  isValidCurrencyCode,
   isValidDateValue,
   readImportDate,
   truncateValue,
@@ -13,7 +13,7 @@ import {
 const COLUMN_VALIDATION_RULES: Record<ColumnTarget, {
   expected: string
   requiredValues?: boolean
-  accepts: (value: string) => boolean
+  accepts: (value: string, supportedCurrencyCodes: Set<string>) => boolean
 }> = {
   account_id: {
     expected: 'account names or source account labels; every row must have a value',
@@ -36,8 +36,8 @@ const COLUMN_VALIDATION_RULES: Record<ColumnTarget, {
     accepts: isValidAmountValue,
   },
   currency: {
-    expected: '3-letter ISO currency codes such as CAD or USD',
-    accepts: isValidCurrencyCode,
+    expected: 'ISO currency codes this app supports, such as CAD or USD',
+    accepts: isSupportedCurrency,
   },
   merchant_id: {
     expected: 'merchant or payee names as plain text',
@@ -64,7 +64,11 @@ const COLUMN_VALIDATION_RULES: Record<ColumnTarget, {
  * records a validation error for any mapped column whose values do not match what the target field
  * expects
  */
-export function validateColumnMap(columnMap: ColumnMap, files: ImportFileDraft[]) {
+export function validateColumnMap(
+  columnMap: ColumnMap,
+  files: ImportFileDraft[],
+  supportedCurrencyCodes: Set<string>,
+) {
   if (files.length === 0) return { map: EMPTY_COLUMN_MAP, errors: {} }
 
   const availableHeaders = new Set(files.flatMap((file) => file.headers))
@@ -77,7 +81,7 @@ export function validateColumnMap(columnMap: ColumnMap, files: ImportFileDraft[]
 
     // No format is passed, because this runs while inferring which column is which, before anyone
     // has chosen one. The hook holds the date column to the chosen format on its own path
-    const validation = validateColumnValues(files, header, target.id)
+    const validation = validateColumnValues(files, header, target.id, supportedCurrencyCodes)
     map[target.id] = header
     if (!validation.valid) errors[header] = validation.message
   }
@@ -94,6 +98,7 @@ export function validateColumnValues(
   files: ImportFileDraft[],
   header: string,
   target: ColumnTarget,
+  supportedCurrencyCodes: Set<string>,
   dateFormat: ImportDateFormat | null = null,
 ) {
   const rule = COLUMN_VALIDATION_RULES[target]
@@ -104,7 +109,7 @@ export function validateColumnValues(
   const expected = isDateColumnInChosenFormat ? getDateFormatExpectation(dateFormat) : rule.expected
   const accepts = isDateColumnInChosenFormat
     ? (value: string) => Boolean(readImportDate(value, dateFormat))
-    : rule.accepts
+    : (value: string) => rule.accepts(value, supportedCurrencyCodes)
 
   if (values.length === 0) {
     return {

--- a/frontend/src/pages/imports/utils/csv.ts
+++ b/frontend/src/pages/imports/utils/csv.ts
@@ -55,12 +55,16 @@ const HEADER_ALIASES = new Set([
 /**
  * Parses an uploaded CSV file into a staged import draft, detecting whether the first row is a
  * header row and recording a readable error on the draft instead of throwing when parsing fails
+ *
+ * @param file - The uploaded file
+ * @param supportedCurrencyCodes - Upper-case codes from the currency list the API served, used to
+ * tell a cell holding a currency from a header word that merely looks like one
  */
-export async function readCsvFile(file: File): Promise<ImportFileDraft> {
+export async function readCsvFile(file: File, supportedCurrencyCodes: Set<string>): Promise<ImportFileDraft> {
   const id = createFileId(file)
 
   try {
-    const { headers, hasHeaderRow, rows } = await parseCsvFile(file)
+    const { headers, hasHeaderRow, rows } = await parseCsvFile(file, supportedCurrencyCodes)
     return {
       id,
       name: file.name,
@@ -87,7 +91,10 @@ function createFileId(file: File) {
   return `${file.name}-${file.lastModified}-${file.size}-${Math.random().toString(36).slice(2)}`
 }
 
-async function parseCsvFile(file: File): Promise<{ headers: string[]; hasHeaderRow: boolean; rows: CsvRow[] }> {
+async function parseCsvFile(
+  file: File,
+  supportedCurrencyCodes: Set<string>,
+): Promise<{ headers: string[]; hasHeaderRow: boolean; rows: CsvRow[] }> {
   // Pull the CSV parser on demand so papaparse only ships with the import flow
   const { parse } = await import('papaparse')
 
@@ -106,7 +113,7 @@ async function parseCsvFile(file: File): Promise<{ headers: string[]; hasHeaderR
         }
       },
       complete: () => {
-        resolve(buildParsedCsv(records))
+        resolve(buildParsedCsv(records, supportedCurrencyCodes))
       },
       error: (error) => {
         reject(error)
@@ -115,10 +122,19 @@ async function parseCsvFile(file: File): Promise<{ headers: string[]; hasHeaderR
   })
 }
 
-function buildParsedCsv(records: string[][]) {
+/**
+ * Turns parsed CSV records into the headers and rows a staged file carries, deciding whether the
+ * first record holds headings or is itself a transaction
+ *
+ * Kept apart from reading the file so the decision can be exercised without one
+ *
+ * @param records - Every non-blank record, in file order
+ * @param supportedCurrencyCodes - Upper-case codes from the currency list the API served
+ */
+export function buildParsedCsv(records: string[][], supportedCurrencyCodes: Set<string>) {
   if (records.length === 0) return { headers: [], hasHeaderRow: false, rows: [] }
 
-  const hasHeaderRow = detectHeaderRow(records)
+  const hasHeaderRow = detectHeaderRow(records, supportedCurrencyCodes)
   const headers = dedupeHeaders(hasHeaderRow ? records[0] : makeGeneratedHeaders(getMaxColumnCount(records)))
   const rows = (hasHeaderRow ? records.slice(1) : records).map((record) => {
     const row: CsvRow = {}
@@ -151,13 +167,13 @@ function dedupeHeaders(rawHeaders: string[]) {
   })
 }
 
-function detectHeaderRow(records: string[][]) {
+function detectHeaderRow(records: string[][], supportedCurrencyCodes: Set<string>) {
   const first = records[0] ?? []
   const nonBlank = first.filter(Boolean)
   if (nonBlank.length === 0) return false
 
   const headerAliasCount = nonBlank.filter(isKnownHeaderCell).length
-  const dataLikeCount = nonBlank.filter(isDataLikeCell).length
+  const dataLikeCount = nonBlank.filter((cell) => isDataLikeCell(cell, supportedCurrencyCodes)).length
   if (dataLikeCount > 0 && dataLikeCount >= headerAliasCount) return false
   if (headerAliasCount >= 2) return true
   if (headerAliasCount === nonBlank.length) return true
@@ -175,7 +191,8 @@ function detectHeaderRow(records: string[][]) {
   if (headerAliasCount > 0 && knownHeaderShiftCount === headerAliasCount) return true
 
   const dataShiftCount = first.filter((cell, index) => (
-    isHeaderTextCell(cell) && following.some((record) => isDataLikeCell(record[index] ?? ''))
+    isHeaderTextCell(cell, supportedCurrencyCodes)
+    && following.some((record) => isDataLikeCell(record[index] ?? '', supportedCurrencyCodes))
   )).length
 
   return dataShiftCount >= 2
@@ -196,16 +213,18 @@ function isKnownHeaderCell(value: string) {
   return HEADER_ALIASES.has(compact)
 }
 
-function isHeaderTextCell(value: string) {
+function isHeaderTextCell(value: string, supportedCurrencyCodes: Set<string>) {
   const trimmed = value.trim()
   return Boolean(trimmed)
     && /[a-z]/i.test(trimmed)
-    && !isDataLikeCell(trimmed)
+    && !isDataLikeCell(trimmed, supportedCurrencyCodes)
     && trimmed.length <= 48
 }
 
-function isDataLikeCell(value: string) {
-  return isValidDateValue(value) || isValidAmountValue(value) || isSupportedCurrency(value)
+function isDataLikeCell(value: string, supportedCurrencyCodes: Set<string>) {
+  return isValidDateValue(value)
+    || isValidAmountValue(value)
+    || isSupportedCurrency(value, supportedCurrencyCodes)
 }
 
 function normalizeHeaderCell(value: string) {

--- a/frontend/src/pages/imports/utils/payload.ts
+++ b/frontend/src/pages/imports/utils/payload.ts
@@ -176,15 +176,18 @@ export function buildTransactionImportPayload({
 
   // A row is stored in the currency of the account it is written to, which is what decides how
   // many decimal places its amount may carry, so the answer each source resolved to is settled
-  // once here and read back per row. Every source reaching this point has an answer, because an
-  // unmapped or unanswered one added an error above and returned before any row was judged
+  // once here and read back per row. A source answered as money outside the tracked accounts has
+  // no currency of its own and is left out, and no row is written to such a source anyway
+  //
+  // The code is upper-cased to match what the payload sends for a new account, so the exponent is
+  // looked up under the same spelling the API will be given
   const currencyByAccountSource: Record<string, string> = {}
   for (const source of accountSources) {
     const choice = accountMappings[source.id] ?? ''
     const code = choice === CREATE_ACCOUNT_VALUE
       ? accountCreateCurrencies[source.id] ?? ''
       : accountById.get(choice)?.currency ?? ''
-    if (code) currencyByAccountSource[source.id] = code
+    if (code) currencyByAccountSource[source.id] = code.trim().toUpperCase()
   }
 
   const rows: TransactionImportPayload['rows'] = []

--- a/frontend/src/pages/imports/utils/payload.ts
+++ b/frontend/src/pages/imports/utils/payload.ts
@@ -6,8 +6,10 @@ import {
   CREATE_ACCOUNT_VALUE,
   CREATE_CATEGORY_VALUE,
   DEFAULT_CATEGORY_ICON,
+  getRowAmountTooPreciseReason,
   ROW_ACCOUNT_BLANK_REASON,
   ROW_AMOUNT_BLANK_REASON,
+  ROW_AMOUNT_TOO_LARGE_REASON,
   ROW_AMOUNT_UNREADABLE_REASON,
   ROW_CATEGORY_BLANK_REASON,
   ROW_COUNTERPARTY_IS_OWN_ACCOUNT_REASON,
@@ -26,10 +28,12 @@ import type {
   ImportRowProblem,
 } from '@/pages/imports/types'
 import { isImportAccountType } from '@/pages/imports/accountTypeGuard'
+import { findCurrencyExponent } from '@/utils/moneyInput'
+import type { Currency } from '@/api/currency'
 import { getCategoryMatchKind, splitImportedValues } from './categoryMatching'
 import { getImportRowId } from './common'
 import { getMappedValue } from './columnMapping'
-import { type ImportDateFormat, parseImportNumber, readImportDate } from './valueParsers'
+import { type ImportDateFormat, parseImportNumber, readImportDate, toImportMinorUnits } from './valueParsers'
 
 /**
  * Builds the commit payload for the generic CSV import flow from the staged files and every mapping
@@ -52,6 +56,7 @@ export function buildTransactionImportPayload({
   categoryTypesBySource,
   columnMap,
   columnValidationErrors,
+  currencies,
   dateFormat,
   files,
   importedCategories,
@@ -68,6 +73,7 @@ export function buildTransactionImportPayload({
   categoryTypesBySource: Record<string, string>
   columnMap: ColumnMap
   columnValidationErrors: ColumnValidationErrors
+  currencies: Currency[]
   dateFormat: ImportDateFormat | null
   files: ImportFileDraft[]
   importedCategories: string[]
@@ -168,6 +174,19 @@ export function buildTransactionImportPayload({
   // no date format settled, every row reads as one whose date does not fit
   if (errors.length > 0) return { errors: [...columnErrors, ...errors], rowProblems: [], payload: null }
 
+  // A row is stored in the currency of the account it is written to, which is what decides how
+  // many decimal places its amount may carry, so the answer each source resolved to is settled
+  // once here and read back per row. Every source reaching this point has an answer, because an
+  // unmapped or unanswered one added an error above and returned before any row was judged
+  const currencyByAccountSource: Record<string, string> = {}
+  for (const source of accountSources) {
+    const choice = accountMappings[source.id] ?? ''
+    const code = choice === CREATE_ACCOUNT_VALUE
+      ? accountCreateCurrencies[source.id] ?? ''
+      : accountById.get(choice)?.currency ?? ''
+    if (code) currencyByAccountSource[source.id] = code
+  }
+
   const rows: TransactionImportPayload['rows'] = []
   const rowProblems: ImportRowProblem[] = []
   for (const file of files) {
@@ -188,6 +207,8 @@ export function buildTransactionImportPayload({
         amount,
         categorySource,
         counterpartySource,
+        currencies,
+        currencyByAccountSource,
         dt,
         importedDate,
         recordsCounterpartyBySource,
@@ -238,6 +259,8 @@ function getImportRowProblem({
   amount,
   categorySource,
   counterpartySource,
+  currencies,
+  currencyByAccountSource,
   dt,
   importedDate,
   recordsCounterpartyBySource,
@@ -247,6 +270,8 @@ function getImportRowProblem({
   amount: string
   categorySource: string
   counterpartySource: string | null
+  currencies: Currency[]
+  currencyByAccountSource: Record<string, string>
   dt: string
   importedDate: string
   recordsCounterpartyBySource: Record<string, boolean>
@@ -260,11 +285,34 @@ function getImportRowProblem({
   if (!dt) return ROW_DATE_UNREADABLE_REASON
   if (!amount) return ROW_AMOUNT_BLANK_REASON
   if (parseImportNumber(amount) === null) return ROW_AMOUNT_UNREADABLE_REASON
+
+  const amountProblem = getImportRowAmountProblem(amount, currencyByAccountSource[accountSource], currencies)
+  if (amountProblem) return amountProblem
+
   if (!counterpartySource) return null
 
   if (!recordsCounterpartyBySource[categorySource]) return ROW_COUNTERPARTY_NOT_A_TRANSFER_REASON
   if (isSameMappedAccount(accountMappings, accountSource, counterpartySource)) return ROW_COUNTERPARTY_IS_OWN_ACCOUNT_REASON
   return null
+}
+
+/**
+ * Reports why an amount cannot be stored in its row's currency, or null when it can
+ *
+ * This is the same judgement the API makes when it converts the cell, made here so an over-precise
+ * or oversized amount is named against its row before the commit rather than failing the request
+ */
+function getImportRowAmountProblem(amount: string, currencyCode: string | undefined, currencies: Currency[]) {
+  const exponent = currencyCode ? findCurrencyExponent(currencies, currencyCode) : null
+  if (exponent === null || currencyCode === undefined) return null
+
+  const minorUnits = toImportMinorUnits(amount, exponent)
+  if (typeof minorUnits === 'bigint') return null
+  if (minorUnits === 'tooPrecise') return getRowAmountTooPreciseReason(currencyCode)
+
+  // An unreadable cell was already refused above, so the only reading left is a magnitude the
+  // storage cannot take
+  return ROW_AMOUNT_TOO_LARGE_REASON
 }
 
 function appendAccountMapping(

--- a/frontend/src/pages/imports/utils/preview.ts
+++ b/frontend/src/pages/imports/utils/preview.ts
@@ -120,12 +120,13 @@ export function buildImportPreviewRows({
 
       // A row whose amount this currency cannot hold is one the commit will refuse, so it is left
       // out rather than previewed with a rounded number. It is usually already excluded as a
-      // problem row, and reaches here only where an unanswered mapping question stopped the
-      // payload build before it judged any row
+      // problem row, and reaches here either where an unanswered mapping question stopped the
+      // payload build before it judged any row, or where the currency is missing from the loaded
+      // table and there are no decimal places to convert against
       if (typeof minorUnits !== 'bigint') continue
 
-      // Past the range a number holds exactly this loses digits, which is a display artifact on
-      // an amount of about ninety trillion units. The commit sends the cell's own text
+      // Past the range a number holds exactly this loses digits, which is a display artifact on an
+      // amount around ninety trillion in a two-decimal currency. The commit sends the cell's text
       const amount = Number(minorUnits)
       const importedCategory = getMappedValue(row, columnMap.category_id)
       const importedTagValues = splitImportedValues(getMappedValue(row, columnMap.tag_ids))

--- a/frontend/src/pages/imports/utils/preview.ts
+++ b/frontend/src/pages/imports/utils/preview.ts
@@ -9,13 +9,15 @@ import { getImportAccountName } from './accountMapping'
 import { getImportRowId } from './common'
 import { splitImportedValues } from './categoryMatching'
 import { getMappedValue } from './columnMapping'
+import { findCurrencyExponent } from '@/utils/moneyInput'
+import { getSupportedCurrencyCodes } from './workflowOptions'
 import {
   type ImportDateFormat,
   getPreviewDateLabel,
   isSupportedCurrency,
   parseImportNumber,
   readImportDate,
-  toMinorUnits,
+  toImportMinorUnits,
 } from './valueParsers'
 
 interface BuildImportPreviewRowsOptions {
@@ -82,6 +84,7 @@ export function buildImportPreviewRows({
   const problemRowIds = new Set(rowProblems.map((problem) => problem.id))
   const rows: PreviewTransactionRow[] = []
   const fallbackCurrency = currencies.some((currency) => currency.id === 'CAD') ? 'CAD' : currencies[0]?.id ?? 'CAD'
+  const supportedCurrencyCodes = getSupportedCurrencyCodes(currencies)
   const timestamp = new Date().toISOString()
 
   // Preview generation walks files in row order and stops early because the UI only renders a small sample
@@ -105,13 +108,25 @@ export function buildImportPreviewRows({
       const merchant = getMappedValue(row, columnMap.merchant_id)
       const notes = getMappedValue(row, columnMap.notes)
       const currency = getPreviewCurrency(
-        getMappedValue(row, columnMap.currency),
         account?.currency,
         createAccountCurrency,
         fallbackCurrency,
+        supportedCurrencyCodes,
       )
-      const amountValue = parseImportNumber(getMappedValue(row, columnMap.amount)) ?? 0
-      const amount = toMinorUnits(amountValue, currency)
+      const rawAmount = getMappedValue(row, columnMap.amount)
+      const amountValue = parseImportNumber(rawAmount) ?? 0
+      const exponent = findCurrencyExponent(currencies, currency)
+      const minorUnits = exponent === null ? 'unreadable' : toImportMinorUnits(rawAmount, exponent)
+
+      // A row whose amount this currency cannot hold is one the commit will refuse, so it is left
+      // out rather than previewed with a rounded number. It is usually already excluded as a
+      // problem row, and reaches here only where an unanswered mapping question stopped the
+      // payload build before it judged any row
+      if (typeof minorUnits !== 'bigint') continue
+
+      // Past the range a number holds exactly this loses digits, which is a display artifact on
+      // an amount of about ninety trillion units. The commit sends the cell's own text
+      const amount = Number(minorUnits)
       const importedCategory = getMappedValue(row, columnMap.category_id)
       const importedTagValues = splitImportedValues(getMappedValue(row, columnMap.tag_ids))
       const category = getPreviewCategory(
@@ -208,19 +223,23 @@ function getPreviewCounterpartyScope(recordsCounterparty: boolean, counterpartyC
 }
 
 /**
- * Picks the currency a previewed transaction will use, preferring the imported value over the
- * mapped account's currency, the currency chosen for a new account, and finally the caller's
- * fallback, and falling back to CAD when none of those is a supported currency
+ * Picks the currency a previewed transaction will use, preferring the mapped account's currency
+ * over the currency chosen for a new account and then the caller's fallback, and falling back to
+ * CAD when none of those is a supported currency
+ *
+ * The row's own currency column is deliberately not consulted. A row is stored in its account's
+ * currency, so previewing it in the imported one would show an amount scaled by decimal places
+ * the import will not use
  */
 export function getPreviewCurrency(
-  importedCurrency: string,
   accountCurrency: string | undefined,
   createAccountCurrency: string,
   fallbackCurrency: string,
+  supportedCurrencyCodes: Set<string>,
 ) {
-  for (const currency of [importedCurrency, accountCurrency, createAccountCurrency, fallbackCurrency]) {
+  for (const currency of [accountCurrency, createAccountCurrency, fallbackCurrency]) {
     const normalized = currency?.trim().toUpperCase()
-    if (normalized && isSupportedCurrency(normalized)) return normalized
+    if (normalized && isSupportedCurrency(normalized, supportedCurrencyCodes)) return normalized
   }
 
   return 'CAD'

--- a/frontend/src/pages/imports/utils/valueParsers.ts
+++ b/frontend/src/pages/imports/utils/valueParsers.ts
@@ -155,7 +155,7 @@ const IMPORT_NUMBER_PATTERN = /^([+-]?)(\d+|\d{1,3}(?:,\d{3})+)(?:\.(\d+))?$/
 // reaches one further than the positive, which is what two's complement holds, so a caller that
 // negates an amount has to bound its own result. The same two values are written out again in
 // backend/app/utils/money.py, and the two have to agree
-export const MIN_IMPORT_MINOR_UNITS = -(2n ** 63n)
+const MIN_IMPORT_MINOR_UNITS = -(2n ** 63n)
 export const MAX_IMPORT_MINOR_UNITS = 2n ** 63n - 1n
 
 /**

--- a/frontend/src/pages/imports/utils/valueParsers.ts
+++ b/frontend/src/pages/imports/utils/valueParsers.ts
@@ -145,36 +145,65 @@ function getMonthNumber(name: string) {
   return index === -1 ? null : index + 1
 }
 
-/**
- * Converts an amount into the whole minor units the backend stores, using the number of decimal
- * places the currency itself uses so a zero-decimal currency is not scaled by a hundred
- */
-export function toMinorUnits(value: number, currency: string) {
-  return Math.round(value * 10 ** getCurrencyExponent(currency))
-}
+// An optional sign, then either plain digits or digits grouped in threes by commas, then an
+// optional decimal part. Currency symbols, spaces between digits and brackets around negatives
+// are all refused rather than cleaned up, because guessing at them risks importing an amount the
+// file never stated. The groups are the sign, the whole part and the decimal digits
+const IMPORT_NUMBER_PATTERN = /^([+-]?)(\d+|\d{1,3}(?:,\d{3})+)(?:\.(\d+))?$/
 
-function getCurrencyExponent(currency: string) {
-  try {
-    const formatter = new Intl.NumberFormat(undefined, { style: 'currency', currency })
-    return formatter.resolvedOptions().maximumFractionDigits ?? 2
-  } catch {
-    return 2
-  }
-}
+// The bounds of the signed 64-bit column the backend stores an amount in. The negative side
+// reaches one further than the positive, which is what two's complement holds, so a caller that
+// negates an amount has to bound its own result. The same two values are written out again in
+// backend/app/utils/money.py, and the two have to agree
+export const MIN_IMPORT_MINOR_UNITS = -(2n ** 63n)
+export const MAX_IMPORT_MINOR_UNITS = 2n ** 63n - 1n
 
 /**
- * Reports whether a currency code can actually be formatted by the browser, which rules out
- * three-letter values that look like codes but name no currency
+ * Why an amount cell could not be converted, so the caller can say which rule it broke rather
+ * than only that it failed
  */
-export function isSupportedCurrency(currency: string) {
-  if (!isValidCurrencyCode(currency)) return false
+export type ImportAmountRefusal = 'unreadable' | 'tooPrecise' | 'tooLarge'
 
-  try {
-    new Intl.NumberFormat(undefined, { style: 'currency', currency })
-    return true
-  } catch {
-    return false
-  }
+/**
+ * Converts an amount cell into the whole minor units the backend stores
+ *
+ * The decimal point is moved through the digits rather than the value being multiplied, so an
+ * amount binary floating point cannot hold exactly still converts to the digits the file states.
+ * The result is a bigint because the largest storable amount is past the range a number holds
+ * exactly, and agreeing with the backend at that boundary is the point of the conversion
+ *
+ * @param rawValue - The raw cell value, which may carry a sign and commas grouping the thousands
+ * @param exponent - Decimal places of the currency the row will be stored in
+ * @returns The amount in minor units, or which of the three rules the cell broke
+ */
+export function toImportMinorUnits(rawValue: string, exponent: number): bigint | ImportAmountRefusal {
+  const match = IMPORT_NUMBER_PATTERN.exec(rawValue.trim())
+  if (!match) return 'unreadable'
+
+  const [, sign, whole, fraction = ''] = match
+
+  // Digits past the currency's places can only be dropped when they are zeros, since anything
+  // else is a value the currency cannot express, which the backend refuses outright
+  const kept = fraction.slice(0, exponent)
+  if (/[^0]/.test(fraction.slice(exponent))) return 'tooPrecise'
+
+  const scaled = BigInt(`${whole.replace(/,/g, '')}${kept.padEnd(exponent, '0')}`)
+  const minorUnits = sign === '-' ? -scaled : scaled
+
+  return minorUnits >= MIN_IMPORT_MINOR_UNITS && minorUnits <= MAX_IMPORT_MINOR_UNITS ? minorUnits : 'tooLarge'
+}
+
+/**
+ * Reports whether a code is a currency the app supports, meaning one the API served
+ *
+ * The browser cannot answer this. Its number formatter checks that a code is three letters and
+ * accepts any that are, so ZZZ, CUR and AMT all pass it
+ *
+ * @param currency - The raw cell value
+ * @param supportedCodes - Upper-case codes taken from the currency list the API served
+ */
+export function isSupportedCurrency(currency: string, supportedCodes: Set<string>) {
+  return supportedCodes.has(currency.trim().toUpperCase())
 }
 
 /**
@@ -196,28 +225,18 @@ export function isValidAmountValue(value: string) {
 }
 
 /**
- * Reads an amount from an imported cell, accepting an optional sign, commas grouping the thousands
- * and a decimal part, and returning null for anything else
+ * Reads an amount from an imported cell as a plain number, or null when the cell is not one
  *
- * Currency symbols, spaces between digits and brackets around negatives are all refused rather than
- * cleaned up, because guessing at them risks importing an amount the file never stated
+ * This answers whether a cell is an amount at all, and its sign, which is all the callers that
+ * classify a column or guess a category kind need. Converting an amount for storage is
+ * toImportMinorUnits above, which is exact where this is not
  */
 export function parseImportNumber(value: string) {
   const normalized = value.trim()
-  if (!normalized) return null
-
-  if (!/^[+-]?(?:\d+|\d{1,3}(?:,\d{3})+)(?:\.\d+)?$/.test(normalized)) return null
+  if (!IMPORT_NUMBER_PATTERN.test(normalized)) return null
 
   const parsed = Number(normalized.replace(/,/g, ''))
   return Number.isFinite(parsed) ? parsed : null
-}
-
-/**
- * Reports whether a value has the shape of a currency code, meaning exactly three letters in either
- * case, without checking that the code names a real currency
- */
-export function isValidCurrencyCode(value: string) {
-  return /^[A-Z]{3}$/i.test(value.trim())
 }
 
 /**

--- a/frontend/src/pages/imports/utils/workflowOptions.ts
+++ b/frontend/src/pages/imports/utils/workflowOptions.ts
@@ -58,15 +58,19 @@ export function getSupportedCurrencyCodes(currencies: Currency[]) {
 /**
  * Says why a file cannot be uploaded yet, or null when it can
  *
- * Both flows read a file against the currency list, so staging one before that list is in hand
- * would detect its header row and judge its amounts against nothing
+ * Both flows read a file against the currency list, and which cells hold a currency is decided
+ * once and kept on the staged file, so a file read before that list arrives stays wrong afterwards
  *
- * @param currenciesLoading - Whether the currency list is still being fetched
+ * The list being empty is what actually blocks, rather than the two query flags: a request the
+ * browser has not started, which is what an offline page has, reports neither loading nor failed
+ * while still having no list to read against
+ *
+ * @param currencies - The currency list as it stands
  * @param currenciesError - Whether fetching the currency list failed
  */
-export function getImportUploadBlockReason(currenciesLoading: boolean, currenciesError: boolean) {
-  if (currenciesError) return CURRENCIES_FAILED_UPLOAD_BLOCK
-  return currenciesLoading ? CURRENCIES_LOADING_UPLOAD_BLOCK : null
+export function getImportUploadBlockReason(currencies: Currency[], currenciesError: boolean) {
+  if (currencies.length > 0) return null
+  return currenciesError ? CURRENCIES_FAILED_UPLOAD_BLOCK : CURRENCIES_LOADING_UPLOAD_BLOCK
 }
 
 /**

--- a/frontend/src/pages/imports/utils/workflowOptions.ts
+++ b/frontend/src/pages/imports/utils/workflowOptions.ts
@@ -15,7 +15,7 @@ import {
   KIND_LABELS,
   KIND_RANKS,
 } from '@/pages/imports/constants'
-import type { ColumnMap, ImportAccountSource, ImportFileDraft } from '@/pages/imports/types'
+import type { ColumnMap, ImportAccountSource, ImportFileDraft, ImportUploadBlock } from '@/pages/imports/types'
 import { getImportAccountName } from './accountMapping'
 import { splitImportedValues } from './categoryMatching'
 import { unique } from './common'
@@ -74,7 +74,7 @@ export function getSupportedCurrencyCodes(currencies: Currency[]) {
 export function getImportUploadBlockReason(
   currencies: Currency[],
   currenciesError: boolean,
-): { message: string; isFailure: boolean } | null {
+): ImportUploadBlock | null {
   if (currencies.length > 0) return null
 
   return currenciesError

--- a/frontend/src/pages/imports/utils/workflowOptions.ts
+++ b/frontend/src/pages/imports/utils/workflowOptions.ts
@@ -65,12 +65,21 @@ export function getSupportedCurrencyCodes(currencies: Currency[]) {
  * browser has not started, which is what an offline page has, reports neither loading nor failed
  * while still having no list to read against
  *
+ * `isFailure` separates the two, because waiting a moment on an ordinary page load should not be
+ * dressed as an error while something the user has to act on should
+ *
  * @param currencies - The currency list as it stands
  * @param currenciesError - Whether fetching the currency list failed
  */
-export function getImportUploadBlockReason(currencies: Currency[], currenciesError: boolean) {
+export function getImportUploadBlockReason(
+  currencies: Currency[],
+  currenciesError: boolean,
+): { message: string; isFailure: boolean } | null {
   if (currencies.length > 0) return null
-  return currenciesError ? CURRENCIES_FAILED_UPLOAD_BLOCK : CURRENCIES_LOADING_UPLOAD_BLOCK
+
+  return currenciesError
+    ? { message: CURRENCIES_FAILED_UPLOAD_BLOCK, isFailure: true }
+    : { message: CURRENCIES_LOADING_UPLOAD_BLOCK, isFailure: false }
 }
 
 /**

--- a/frontend/src/pages/imports/utils/workflowOptions.ts
+++ b/frontend/src/pages/imports/utils/workflowOptions.ts
@@ -9,6 +9,8 @@ import {
   COLUMN_TARGETS,
   CREATE_ACCOUNT_VALUE,
   CREATE_CATEGORY_VALUE,
+  CURRENCIES_FAILED_UPLOAD_BLOCK,
+  CURRENCIES_LOADING_UPLOAD_BLOCK,
   DEFAULT_CATEGORY_ICON,
   KIND_LABELS,
   KIND_RANKS,
@@ -40,6 +42,31 @@ export function buildImportAccountOptions(accounts: AccountsOverview[]): Dropdow
         badge: account.is_archived ? ARCHIVED_ACCOUNT_BADGE : undefined,
       })),
   ]
+}
+
+/**
+ * Collects the currency codes the app supports, for the checks that only ask whether a cell holds
+ * one of them
+ *
+ * Built once from the loaded list and passed down, rather than each check scanning the list, since
+ * header detection asks the question for every cell of a file's first row
+ */
+export function getSupportedCurrencyCodes(currencies: Currency[]) {
+  return new Set(currencies.map((currency) => currency.id))
+}
+
+/**
+ * Says why a file cannot be uploaded yet, or null when it can
+ *
+ * Both flows read a file against the currency list, so staging one before that list is in hand
+ * would detect its header row and judge its amounts against nothing
+ *
+ * @param currenciesLoading - Whether the currency list is still being fetched
+ * @param currenciesError - Whether fetching the currency list failed
+ */
+export function getImportUploadBlockReason(currenciesLoading: boolean, currenciesError: boolean) {
+  if (currenciesError) return CURRENCIES_FAILED_UPLOAD_BLOCK
+  return currenciesLoading ? CURRENCIES_LOADING_UPLOAD_BLOCK : null
 }
 
 /**

--- a/frontend/tests/imports/fireflyPreview.test.ts
+++ b/frontend/tests/imports/fireflyPreview.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest'
 import type { AccountsOverview } from '@/api/accounts'
 import type { Category } from '@/api/categories'
+import type { Currency } from '@/api/currency'
 import type { Institution } from '@/api/institutions'
 import { CREATE_ACCOUNT_VALUE, CREATE_CATEGORY_VALUE } from '@/pages/imports/constants'
 import type { CsvRow } from '@/pages/imports/types'
@@ -22,6 +23,13 @@ const institution: Institution = {
   website: 'https://bank.example',
   logo_url: null,
 }
+
+const CURRENCIES: Currency[] = [
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+  { id: 'USD', name: 'US Dollar', symbol: '$', minor_unit_exponent: 2 },
+  { id: 'EUR', name: 'Euro', symbol: '€', minor_unit_exponent: 2 },
+  { id: 'JPY', name: 'Japanese Yen', symbol: '¥', minor_unit_exponent: 0 },
+]
 
 /**
  * Creates an account overview fixture for preview account mapping
@@ -113,6 +121,7 @@ function createOptions(overrides: Partial<Parameters<typeof buildFireflyPreviewR
     categoryCreateKinds: {},
     transferCategory,
     balanceAdjustmentCategory,
+    currencies: CURRENCIES,
     ...overrides,
   }
 }

--- a/frontend/tests/imports/fireflySkippedRows.test.ts
+++ b/frontend/tests/imports/fireflySkippedRows.test.ts
@@ -200,6 +200,19 @@ describe('forecastFireflyImport', () => {
     expect(skipped[0].reason).toBe('Invalid amount "-12.345"')
   })
 
+  it('reports an amount past the storable range the way the backend does', () => {
+    // The backend catches its parser's malformed, over-precise and out-of-range errors in one
+    // clause and reports all three as an invalid amount, so a different wording here would name
+    // the same skipped row two ways between the preview and the result
+    const { skippedRows: skipped } = forecastFireflyImport(
+      [createFireflyRow({ amount: '99999999999999999999.00' })],
+      createOptions(),
+    )
+
+    expect(skipped).toHaveLength(1)
+    expect(skipped[0].reason).toBe('Invalid amount "99999999999999999999.00"')
+  })
+
   it('reports the one amount that parses but cannot be stored once its sign is dropped', () => {
     // This import writes the magnitude, and the signed range holds one more value below zero than
     // above it, so this amount parses and its magnitude does not fit

--- a/frontend/tests/imports/fireflySkippedRows.test.ts
+++ b/frontend/tests/imports/fireflySkippedRows.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest'
 import type { AccountsOverview } from '@/api/accounts'
 import type { Category } from '@/api/categories'
+import type { Currency } from '@/api/currency'
 import { CREATE_ACCOUNT_VALUE } from '@/pages/imports/constants'
 import type { CsvRow } from '@/pages/imports/types'
 import {
@@ -14,6 +15,13 @@ import {
   FIREFLY_GENERIC_SKIP_REASON,
   FIREFLY_MISSING_REQUIRED_VALUES_REASON,
 } from '@/pages/imports/firefly/constants'
+
+const CURRENCIES: Currency[] = [
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+  { id: 'USD', name: 'US Dollar', symbol: '$', minor_unit_exponent: 2 },
+  { id: 'EUR', name: 'Euro', symbol: '€', minor_unit_exponent: 2 },
+  { id: 'JPY', name: 'Japanese Yen', symbol: '¥', minor_unit_exponent: 0 },
+]
 
 /**
  * Creates an account overview fixture for row resolution mapping
@@ -93,6 +101,7 @@ function createOptions(overrides: Partial<FireflyRowResolutionOptions> = {}): Fi
     categoryById: new Map([[groceries.id, groceries]]),
     categoryMappings: { Groceries: groceries.id },
     categoryCreateKinds: {},
+    currencies: CURRENCIES,
     transferCategory: createCategory({ id: 'transfer', name: 'Transfer', kind: 'transfer', is_system: true }),
     balanceAdjustmentCategory: createCategory({
       id: 'balance-adjustment',
@@ -179,6 +188,28 @@ describe('forecastFireflyImport', () => {
 
     expect(skipped).toHaveLength(1)
     expect(skipped[0].reason).toBe('Invalid amount "twelve"')
+  })
+
+  it('reports an amount carrying more decimal places than the account currency holds', () => {
+    const { skippedRows: skipped } = forecastFireflyImport(
+      [createFireflyRow({ amount: '-12.345' })],
+      createOptions(),
+    )
+
+    expect(skipped).toHaveLength(1)
+    expect(skipped[0].reason).toBe('Invalid amount "-12.345"')
+  })
+
+  it('reports the one amount that parses but cannot be stored once its sign is dropped', () => {
+    // This import writes the magnitude, and the signed range holds one more value below zero than
+    // above it, so this amount parses and its magnitude does not fit
+    const { skippedRows: skipped } = forecastFireflyImport(
+      [createFireflyRow({ amount: '-92233720368547758.08' })],
+      createOptions(),
+    )
+
+    expect(skipped).toHaveLength(1)
+    expect(skipped[0].reason).toBe('Amount is too large: "-92233720368547758.08"')
   })
 
   // Mapping the old and new names of one account onto it is how a rename is

--- a/frontend/tests/imports/importAmountPrecision.test.ts
+++ b/frontend/tests/imports/importAmountPrecision.test.ts
@@ -1,0 +1,250 @@
+/**
+ * Tests that the import judges an amount against the decimal places its currency actually has, and
+ * against the range the backend can store, so a value the commit would refuse is named against its
+ * row beforehand rather than failing the request
+ */
+import { describe, expect, it } from 'vitest'
+import type { AccountsOverview } from '@/api/accounts'
+import type { Category } from '@/api/categories'
+import type { Currency } from '@/api/currency'
+import {
+  EMPTY_COLUMN_MAP,
+  getRowAmountTooPreciseReason,
+  ROW_AMOUNT_TOO_LARGE_REASON,
+  ROW_AMOUNT_UNREADABLE_REASON,
+} from '@/pages/imports/constants'
+import type { ColumnMap, ImportFileDraft } from '@/pages/imports/types'
+import { buildImportPreviewRows, buildTransactionImportPayload, validateColumnValues } from '@/pages/imports/utils'
+import { toImportMinorUnits } from '@/pages/imports/utils/valueParsers'
+
+// PKR is here because the browser reports it as having no decimal places while the app's own table
+// gives it two, which is the disagreement these tests pin down. BHD stands for the three-decimal
+// currencies and JPY for the zero-decimal ones
+const CURRENCIES: Currency[] = [
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+  { id: 'PKR', name: 'Pakistani Rupee', symbol: '₨', minor_unit_exponent: 2 },
+  { id: 'JPY', name: 'Japanese Yen', symbol: '¥', minor_unit_exponent: 0 },
+  { id: 'BHD', name: 'Bahraini Dinar', symbol: 'BD', minor_unit_exponent: 3 },
+]
+
+const SUPPORTED_CURRENCY_CODES = new Set(CURRENCIES.map((currency) => currency.id))
+
+// The largest and smallest amounts a two-decimal currency can hold, as the text a file would carry
+const LARGEST_STORABLE = '92233720368547758.07'
+const SMALLEST_STORABLE = '-92233720368547758.08'
+
+const COLUMN_MAP: ColumnMap = {
+  ...EMPTY_COLUMN_MAP,
+  dt: 'Date',
+  amount: 'Amount',
+  category_id: 'Category',
+  currency: 'Currency',
+}
+
+const GROCERIES: Category = {
+  id: 'groceries',
+  group_id: null,
+  owner_id: null,
+  name: 'Groceries',
+  kind: 'expense',
+  icon: null,
+  is_system: false,
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+/**
+ * Creates an account fixture holding the given currency
+ */
+function createAccount(currency: string): AccountsOverview {
+  return {
+    id: 'account-1',
+    owner_id: null,
+    group_id: null,
+    account_kind: 'asset',
+    account_type: 'checking',
+    tax_advantaged_category_id: null,
+    name: 'Everyday',
+    institution: null,
+    currency,
+    current_balance: 0,
+    base_currency_current_balance: 0,
+    current_balance_fx_status: { state: 'complete', missing_pairs: [] },
+    credit_limit: null,
+    is_archived: false,
+    closed_at: null,
+  }
+}
+
+/**
+ * Creates a one-file draft holding a single row with the given amount and currency cell
+ */
+function createFile(amount: string, importedCurrency = ''): ImportFileDraft {
+  return {
+    id: 'file-1',
+    name: 'Everyday.csv',
+    size: 512,
+    headers: ['Date', 'Amount', 'Category', 'Currency'],
+    hasHeaderRow: true,
+    rows: [{ Date: '2026-04-11', Amount: amount, Category: 'Groceries', Currency: importedCurrency }],
+    error: null,
+  }
+}
+
+/**
+ * Builds the commit payload for one row of the given amount, written to an account of the given
+ * currency, with every other mapping already settled
+ */
+function buildPayload(amount: string, accountCurrency: string, importedCurrency = '') {
+  return buildTransactionImportPayload({
+    accountById: new Map([['account-1', createAccount(accountCurrency)]]),
+    accountCreateCurrencies: {},
+    accountCreateInstitutions: {},
+    accountCreateTypes: {},
+    accountMappings: { 'file-1': 'account-1' },
+    accountSources: [{ id: 'file-1', label: 'Everyday.csv', matchText: 'Everyday.csv', isCounterpartyOnly: false }],
+    categoryById: new Map([[GROCERIES.id, GROCERIES]]),
+    categoryCreateKinds: {},
+    categoryMappings: { Groceries: GROCERIES.id },
+    categoryTypesBySource: {},
+    columnMap: COLUMN_MAP,
+    columnValidationErrors: {},
+    currencies: CURRENCIES,
+    dateFormat: 'yearFirst',
+    files: [createFile(amount, importedCurrency)],
+    importedCategories: ['Groceries'],
+  })
+}
+
+/**
+ * Reads the single row problem a build produced, or null when it produced none
+ */
+function firstProblem(build: ReturnType<typeof buildPayload>) {
+  return build.rowProblems[0]?.reason ?? null
+}
+
+describe('converting an amount to minor units', () => {
+  it('reads the digits the file states rather than what a double rounds to', () => {
+    // 1.005 * 100 is 100.49999999999999 as a double, which used to round down to a whole 100 and
+    // pass as valid, and the commit then refused the exact decimal
+    expect(toImportMinorUnits('1.005', 2)).toBe('tooPrecise')
+    expect(toImportMinorUnits('1.00', 2)).toBe(100n)
+    expect(toImportMinorUnits('8.29', 2)).toBe(829n)
+  })
+
+  it('keeps trailing zeros droppable but refuses a digit the currency cannot hold', () => {
+    expect(toImportMinorUnits('12.3400', 2)).toBe(1234n)
+    expect(toImportMinorUnits('12.345', 2)).toBe('tooPrecise')
+  })
+
+  it('scales by the currency rather than by a hundred', () => {
+    expect(toImportMinorUnits('1234', 0)).toBe(1234n)
+    expect(toImportMinorUnits('12.34', 0)).toBe('tooPrecise')
+    expect(toImportMinorUnits('1.234', 3)).toBe(1234n)
+    expect(toImportMinorUnits('1.2345', 3)).toBe('tooPrecise')
+  })
+
+  it('reads a sign and comma grouping, and refuses anything else', () => {
+    expect(toImportMinorUnits('-12.34', 2)).toBe(-1234n)
+    expect(toImportMinorUnits('+12.34', 2)).toBe(1234n)
+    expect(toImportMinorUnits('1,234.56', 2)).toBe(123456n)
+    expect(toImportMinorUnits('$12.34', 2)).toBe('unreadable')
+    expect(toImportMinorUnits('1.234.567', 2)).toBe('unreadable')
+    expect(toImportMinorUnits('', 2)).toBe('unreadable')
+  })
+
+  it('holds both ends of the range the backend stores, and refuses one step past either', () => {
+    expect(toImportMinorUnits(LARGEST_STORABLE, 2)).toBe(9223372036854775807n)
+    expect(toImportMinorUnits(SMALLEST_STORABLE, 2)).toBe(-9223372036854775808n)
+    expect(toImportMinorUnits('92233720368547758.08', 2)).toBe('tooLarge')
+    expect(toImportMinorUnits('-92233720368547758.09', 2)).toBe('tooLarge')
+  })
+})
+
+describe('refusing a row whose amount its currency cannot hold', () => {
+  it('refuses an over-precise amount and blocks the commit rather than rounding it', () => {
+    const build = buildPayload('1.005', 'CAD')
+
+    expect(build.payload).toBeNull()
+    expect(build.rowProblems).toHaveLength(1)
+    expect(build.rowProblems[0].rowNumber).toBe(1)
+    expect(firstProblem(build)).toBe(getRowAmountTooPreciseReason('CAD'))
+  })
+
+  it('says how a period is read, so a thousands separator is not called extra decimals', () => {
+    const build = buildPayload('1.234', 'CAD')
+
+    expect(firstProblem(build)).toContain('more decimal places than CAD has')
+    expect(firstProblem(build)).toContain('never as a separator between thousands')
+  })
+
+  it('accepts the same value where the currency really has three decimal places', () => {
+    const build = buildPayload('1.234', 'BHD')
+
+    expect(build.rowProblems).toHaveLength(0)
+    expect(build.payload?.rows[0].amount).toBe('1.234')
+  })
+
+  it('refuses a decimal part in a currency that has none', () => {
+    expect(firstProblem(buildPayload('12.34', 'JPY'))).toBe(getRowAmountTooPreciseReason('JPY'))
+    expect(buildPayload('1234', 'JPY').rowProblems).toHaveLength(0)
+  })
+
+  it('refuses an amount past what can be stored and accepts both ends of the range', () => {
+    expect(firstProblem(buildPayload('92233720368547758.08', 'CAD'))).toBe(ROW_AMOUNT_TOO_LARGE_REASON)
+    expect(firstProblem(buildPayload('-92233720368547758.09', 'CAD'))).toBe(ROW_AMOUNT_TOO_LARGE_REASON)
+    expect(buildPayload(LARGEST_STORABLE, 'CAD').rowProblems).toHaveLength(0)
+    expect(buildPayload(SMALLEST_STORABLE, 'CAD').rowProblems).toHaveLength(0)
+  })
+
+  it('still calls a cell that is not a number unreadable rather than over-precise', () => {
+    expect(firstProblem(buildPayload('$12.34', 'CAD'))).toBe(ROW_AMOUNT_UNREADABLE_REASON)
+  })
+
+  it('judges the amount against the account currency, not the row currency column', () => {
+    // The commit stores the row in its account's currency and discards this column, so judging by
+    // the column would refuse rows the API accepts
+    const build = buildPayload('12.34', 'CAD', 'JPY')
+
+    expect(build.rowProblems).toHaveLength(0)
+  })
+})
+
+describe('validating a mapped currency column', () => {
+  it('refuses a three-letter value that is no currency', () => {
+    const result = validateColumnValues([createFile('12.34', 'ZZZ')], 'Currency', 'currency', SUPPORTED_CURRENCY_CODES)
+
+    expect(result.valid).toBe(false)
+    expect(result.message).toContain('"ZZZ"')
+  })
+
+  it('accepts a code the app supports, in either case', () => {
+    expect(validateColumnValues([createFile('12.34', 'cad')], 'Currency', 'currency', SUPPORTED_CURRENCY_CODES).valid).toBe(true)
+  })
+})
+
+describe('previewing an amount', () => {
+  it('scales by the table\'s exponent for a currency the browser reports differently', () => {
+    // A browser resolving PKR to zero fraction digits previewed 1234.56 as 123456 whole rupees
+    const rows = buildImportPreviewRows({
+      files: [createFile('1234.56')],
+      columnMap: COLUMN_MAP,
+      dateFormat: 'yearFirst',
+      missingRequiredColumnLabels: [],
+      currencies: CURRENCIES,
+      accountById: new Map([['account-1', createAccount('PKR')]]),
+      accountCreateCurrencies: {},
+      accountCreateInstitutions: {},
+      categoryById: new Map([[GROCERIES.id, GROCERIES]]),
+      categoryCreateKinds: {},
+      categoryTypesBySource: {},
+      institutionById: new Map(),
+      resolvedAccountMappings: { 'file-1': 'account-1' },
+      resolvedCategoryMappings: { Groceries: GROCERIES.id },
+      rowProblems: [],
+    })
+
+    expect(rows).toHaveLength(1)
+    expect(rows[0].currency).toBe('PKR')
+    expect(rows[0].transaction.amount).toBe(123456)
+  })
+})

--- a/frontend/tests/imports/importAmountPrecision.test.ts
+++ b/frontend/tests/imports/importAmountPrecision.test.ts
@@ -8,6 +8,7 @@ import type { AccountsOverview } from '@/api/accounts'
 import type { Category } from '@/api/categories'
 import type { Currency } from '@/api/currency'
 import {
+  CREATE_ACCOUNT_VALUE,
   EMPTY_COLUMN_MAP,
   getRowAmountTooPreciseReason,
   ROW_AMOUNT_TOO_LARGE_REASON,
@@ -116,6 +117,54 @@ function buildPayload(amount: string, accountCurrency: string, importedCurrency 
 }
 
 /**
+ * Builds the commit payload for one row whose account is queued for creation in the given currency,
+ * which is where the row's decimal places come from when no account exists yet
+ */
+function buildCreateAccountPayload(amount: string, createCurrency: string) {
+  return buildTransactionImportPayload({
+    accountById: new Map(),
+    accountCreateCurrencies: { 'file-1': createCurrency },
+    accountCreateInstitutions: {},
+    accountCreateTypes: { 'file-1': 'checking' },
+    accountMappings: { 'file-1': CREATE_ACCOUNT_VALUE },
+    accountSources: [{ id: 'file-1', label: 'Everyday.csv', matchText: 'Everyday.csv', isCounterpartyOnly: false }],
+    categoryById: new Map([[GROCERIES.id, GROCERIES]]),
+    categoryCreateKinds: {},
+    categoryMappings: { Groceries: GROCERIES.id },
+    categoryTypesBySource: {},
+    columnMap: COLUMN_MAP,
+    columnValidationErrors: {},
+    currencies: CURRENCIES,
+    dateFormat: 'yearFirst',
+    files: [createFile(amount)],
+    importedCategories: ['Groceries'],
+  })
+}
+
+/**
+ * Builds preview rows for one row of the given amount against an account of the given currency
+ */
+function buildPreview(amount: string, accountCurrency: string, importedCurrency = '') {
+  return buildImportPreviewRows({
+    files: [createFile(amount, importedCurrency)],
+    columnMap: COLUMN_MAP,
+    dateFormat: 'yearFirst',
+    missingRequiredColumnLabels: [],
+    currencies: CURRENCIES,
+    accountById: new Map([['account-1', createAccount(accountCurrency)]]),
+    accountCreateCurrencies: {},
+    accountCreateInstitutions: {},
+    categoryById: new Map([[GROCERIES.id, GROCERIES]]),
+    categoryCreateKinds: {},
+    categoryTypesBySource: {},
+    institutionById: new Map(),
+    resolvedAccountMappings: { 'file-1': 'account-1' },
+    resolvedCategoryMappings: { Groceries: GROCERIES.id },
+    rowProblems: [],
+  })
+}
+
+/**
  * Reads the single row problem a build produced, or null when it produced none
  */
 function firstProblem(build: ReturnType<typeof buildPayload>) {
@@ -201,11 +250,15 @@ describe('refusing a row whose amount its currency cannot hold', () => {
   })
 
   it('judges the amount against the account currency, not the row currency column', () => {
-    // The commit stores the row in its account's currency and discards this column, so judging by
-    // the column would refuse rows the API accepts
-    const build = buildPayload('12.34', 'CAD', 'JPY')
+    // The commit stores the row in its account's currency and discards this column, so reading the
+    // column would refuse rows the API accepts and accept rows it refuses. Both directions here
+    expect(buildPayload('12.34', 'CAD', 'JPY').rowProblems).toHaveLength(0)
+    expect(firstProblem(buildPayload('12.34', 'JPY', 'CAD'))).toBe(getRowAmountTooPreciseReason('JPY'))
+  })
 
-    expect(build.rowProblems).toHaveLength(0)
+  it('takes the currency chosen for an account queued for creation', () => {
+    expect(firstProblem(buildCreateAccountPayload('12.34', 'JPY'))).toBe(getRowAmountTooPreciseReason('JPY'))
+    expect(buildCreateAccountPayload('1234', 'JPY').rowProblems).toHaveLength(0)
   })
 })
 
@@ -224,27 +277,31 @@ describe('validating a mapped currency column', () => {
 
 describe('previewing an amount', () => {
   it('scales by the table\'s exponent for a currency the browser reports differently', () => {
-    // A browser resolving PKR to zero fraction digits previewed 1234.56 as 123456 whole rupees
-    const rows = buildImportPreviewRows({
-      files: [createFile('1234.56')],
-      columnMap: COLUMN_MAP,
-      dateFormat: 'yearFirst',
-      missingRequiredColumnLabels: [],
-      currencies: CURRENCIES,
-      accountById: new Map([['account-1', createAccount('PKR')]]),
-      accountCreateCurrencies: {},
-      accountCreateInstitutions: {},
-      categoryById: new Map([[GROCERIES.id, GROCERIES]]),
-      categoryCreateKinds: {},
-      categoryTypesBySource: {},
-      institutionById: new Map(),
-      resolvedAccountMappings: { 'file-1': 'account-1' },
-      resolvedCategoryMappings: { Groceries: GROCERIES.id },
-      rowProblems: [],
-    })
+    // A browser resolving PKR to zero fraction digits scaled 1234.56 down to 1235 minor units,
+    // losing the decimals the file stated
+    const rows = buildPreview('1234.56', 'PKR')
 
     expect(rows).toHaveLength(1)
     expect(rows[0].currency).toBe('PKR')
     expect(rows[0].transaction.amount).toBe(123456)
+  })
+
+  it('does not scale a zero-decimal currency by a hundred', () => {
+    const rows = buildPreview('1234', 'JPY')
+
+    expect(rows[0].currency).toBe('JPY')
+    expect(rows[0].transaction.amount).toBe(1234)
+  })
+
+  it('takes its currency from the account rather than the row currency column', () => {
+    const rows = buildPreview('12.34', 'CAD', 'JPY')
+
+    expect(rows[0].currency).toBe('CAD')
+    expect(rows[0].transaction.amount).toBe(1234)
+  })
+
+  it('leaves out a row whose amount the currency cannot hold instead of rounding it', () => {
+    // The commit refuses this row, and previewing it would show $1.00 for a cell reading 1.005
+    expect(buildPreview('1.005', 'CAD')).toHaveLength(0)
   })
 })

--- a/frontend/tests/imports/importColumnInference.test.ts
+++ b/frontend/tests/imports/importColumnInference.test.ts
@@ -22,6 +22,10 @@ function createFile(headers: string[], rows: ImportFileDraft['rows']): ImportFil
   }
 }
 
+// The codes a real currency column would hold, so a cell reading CAD is data and one reading
+// Amt is a header word
+const SUPPORTED_CURRENCY_CODES = new Set(['CAD', 'USD', 'EUR'])
+
 describe('import column inference', () => {
   it('keeps the account column and a transfer\'s counterparty account apart', () => {
     const files = [createFile(
@@ -32,7 +36,7 @@ describe('import column inference', () => {
       ],
     )]
 
-    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files)
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
 
     expect(map.account_id).toBe('Account')
     expect(map.counterparty_account_id).toBe('To account')
@@ -49,7 +53,7 @@ describe('import column inference', () => {
       ],
     )]
 
-    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files)
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
 
     expect(map.merchant_id).toBe('Counterparty')
     expect(map.counterparty_account_id).toBe('')
@@ -64,7 +68,7 @@ describe('import column inference', () => {
       ],
     )]
 
-    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files)
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
 
     expect(map.account_id).toBe('Account')
     expect(map.counterparty_account_id).toBe('Counterparty account')
@@ -80,7 +84,7 @@ describe('import column inference', () => {
       ],
     )]
 
-    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files)
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
 
     expect(map.account_id).toBe('')
     expect(map.counterparty_account_id).toBe('Destination account')
@@ -94,7 +98,7 @@ describe('import column inference', () => {
       ],
     )]
 
-    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files)
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
 
     expect(map.amount).toBe('Amount')
     expect(Object.values(map)).not.toContain('Balance')

--- a/frontend/tests/imports/importCounterpartyAccount.test.ts
+++ b/frontend/tests/imports/importCounterpartyAccount.test.ts
@@ -131,6 +131,7 @@ function buildPayload({
     accountCreateTypes,
     accountMappings,
     accountSources,
+    currencies,
     categoryById,
     categoryCreateKinds: {},
     categoryMappings,

--- a/frontend/tests/imports/importDateFormats.test.ts
+++ b/frontend/tests/imports/importDateFormats.test.ts
@@ -15,6 +15,9 @@ import {
 
 const ALL_FORMATS: ImportDateFormat[] = ['yearFirst', 'dayFirst', 'monthFirst', 'written']
 
+// The date column never consults it, so its contents do not matter here
+const SUPPORTED_CURRENCY_CODES = new Set(['CAD', 'USD'])
+
 /**
  * Creates a one-column file whose every row holds the given date
  */
@@ -192,13 +195,13 @@ describe('validating a date column', () => {
   it('accepts a column that could be read some way when no format is settled yet', () => {
     const files = [createDateFile(['15/03/2024', '2024-03-15'])]
 
-    expect(validateColumnValues(files, 'Date', 'dt').valid).toBe(true)
+    expect(validateColumnValues(files, 'Date', 'dt', SUPPORTED_CURRENCY_CODES).valid).toBe(true)
   })
 
   it('refuses the same column once a format is chosen, naming the value that broke it', () => {
     const files = [createDateFile(['15/03/2024', '2024-03-15'])]
 
-    const result = validateColumnValues(files, 'Date', 'dt', 'dayFirst')
+    const result = validateColumnValues(files, 'Date', 'dt', SUPPORTED_CURRENCY_CODES, 'dayFirst')
 
     expect(result.valid).toBe(false)
     expect(result.message).toContain('2024-03-15')
@@ -208,25 +211,25 @@ describe('validating a date column', () => {
   it('accepts a column that reads all the way through in the chosen format', () => {
     const files = [createDateFile(['15/03/2024', '02/04/2024'])]
 
-    expect(validateColumnValues(files, 'Date', 'dt', 'dayFirst').valid).toBe(true)
+    expect(validateColumnValues(files, 'Date', 'dt', SUPPORTED_CURRENCY_CODES, 'dayFirst').valid).toBe(true)
   })
 
   it('refuses a two-digit year that used to import as this century', () => {
     const files = [createDateFile(['15/03/24'])]
 
-    expect(validateColumnValues(files, 'Date', 'dt', 'dayFirst').valid).toBe(false)
+    expect(validateColumnValues(files, 'Date', 'dt', SUPPORTED_CURRENCY_CODES, 'dayFirst').valid).toBe(false)
   })
 
   it('names the written format in sentence case, without repeating the word', () => {
     const files = [createDateFile(['July 4th, 2024'])]
 
-    expect(validateColumnValues(files, 'Date', 'dt', 'written').message)
+    expect(validateColumnValues(files, 'Date', 'dt', SUPPORTED_CURRENCY_CODES, 'written').message)
       .toBe('Expected valid dates in the written format, such as April 30, 2026; every row must have a value. "July 4th, 2024" is not a valid date.')
   })
 
   it('names every format in sentence case', () => {
     const files = [createDateFile(['nonsense'])]
-    const named = (format: ImportDateFormat) => validateColumnValues(files, 'Date', 'dt', format).message
+    const named = (format: ImportDateFormat) => validateColumnValues(files, 'Date', 'dt', SUPPORTED_CURRENCY_CODES, format).message
 
     expect(named('yearFirst')).toContain('in the year first format, such as 2026-04-30')
     expect(named('dayFirst')).toContain('in the day first format, such as 30/04/2026')
@@ -237,13 +240,13 @@ describe('validating a date column', () => {
   it('accepts a real date whatever century it falls in', () => {
     const files = [createDateFile(['1899-12-31'])]
 
-    expect(validateColumnValues(files, 'Date', 'dt', 'yearFirst').valid).toBe(true)
+    expect(validateColumnValues(files, 'Date', 'dt', SUPPORTED_CURRENCY_CODES, 'yearFirst').valid).toBe(true)
   })
 
   it('does not blame the shape when the value is that shape but names no real day', () => {
     const files = [createDateFile(['2024-02-31'])]
 
-    const result = validateColumnValues(files, 'Date', 'dt', 'yearFirst')
+    const result = validateColumnValues(files, 'Date', 'dt', SUPPORTED_CURRENCY_CODES, 'yearFirst')
 
     expect(result.valid).toBe(false)
     expect(result.message).toContain('"2024-02-31" is not a valid date')

--- a/frontend/tests/imports/importHeaderDetection.test.ts
+++ b/frontend/tests/imports/importHeaderDetection.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests whether a file's first row is read as headings or as data, which decides whether that row
+ * is staged as a transaction and whether the columns carry the file's own names
+ */
+import { describe, expect, it } from 'vitest'
+import { buildParsedCsv } from '@/pages/imports/utils'
+
+const SUPPORTED_CURRENCY_CODES = new Set(['CAD', 'USD', 'EUR', 'JPY'])
+
+/**
+ * Splits CSV text into the records the parser hands over, dropping blank lines the way it does
+ */
+function toRecords(csv: string) {
+  return csv
+    .trim()
+    .split('\n')
+    .map((line) => line.split(',').map((cell) => cell.trim()))
+}
+
+/**
+ * Reads CSV text the way a staged file is built from it
+ */
+function stage(csv: string) {
+  return buildParsedCsv(toRecords(csv), SUPPORTED_CURRENCY_CODES)
+}
+
+describe('detecting a header row', () => {
+  it('reads a row of terse bank headings as headings, not as a transaction', () => {
+    // Every one of these is three letters, and asking the browser whether a code was a currency
+    // answered yes to all four, so the row scored as four data cells and was staged as a row
+    const parsed = stage(
+      'Day,Ref,Amt,Cur\n2026-04-11,INV-1,-12.34,CAD\n2026-04-12,INV-2,-8.00,CAD',
+    )
+
+    expect(parsed.hasHeaderRow).toBe(true)
+    expect(parsed.headers).toEqual(['Day', 'Ref', 'Amt', 'Cur'])
+    expect(parsed.rows).toHaveLength(2)
+    expect(parsed.rows[0]).toMatchObject({ Day: '2026-04-11', Amt: '-12.34', Cur: 'CAD' })
+  })
+
+  it('reads a heading row mixing a known alias with terse words as headings', () => {
+    // One recognized alias was not enough to save this row, because the data-like count only had
+    // to match the alias count rather than beat it
+    const parsed = stage('Date,Amt,Ref\n2026-04-11,-12.34,INV-1\n2026-04-12,-8.00,INV-2')
+
+    expect(parsed.hasHeaderRow).toBe(true)
+    expect(parsed.headers).toEqual(['Date', 'Amt', 'Ref'])
+    expect(parsed.rows).toHaveLength(2)
+  })
+
+  it('reads a currency code the app does not support as an ordinary word', () => {
+    // A single data-like cell in the first row was enough to rule the whole row out as headings,
+    // and ZZZ counted as one because the browser accepts any three letters
+    const parsed = stage('Day,Ref,ZZZ\n2026-04-11,-12.34,x\n2026-04-12,-8.00,y')
+
+    expect(parsed.hasHeaderRow).toBe(true)
+    expect(parsed.headers).toEqual(['Day', 'Ref', 'ZZZ'])
+  })
+
+  it('still reads a first row of real values as data, with columns numbered by position', () => {
+    const parsed = stage('2026-04-11,-12.34,CAD\n2026-04-12,-8.00,CAD')
+
+    expect(parsed.hasHeaderRow).toBe(false)
+    expect(parsed.headers).toEqual(['Column 1', 'Column 2', 'Column 3'])
+    expect(parsed.rows).toHaveLength(2)
+  })
+
+  it('still reads a supported code in a row of values as the currency it is', () => {
+    const parsed = stage('Chequing,CAD,x\nSavings,CAD,y')
+
+    expect(parsed.hasHeaderRow).toBe(false)
+    expect(parsed.headers).toEqual(['Column 1', 'Column 2', 'Column 3'])
+  })
+})

--- a/frontend/tests/imports/importHeaderDetection.test.ts
+++ b/frontend/tests/imports/importHeaderDetection.test.ts
@@ -8,7 +8,8 @@ import { buildParsedCsv } from '@/pages/imports/utils'
 const SUPPORTED_CURRENCY_CODES = new Set(['CAD', 'USD', 'EUR', 'JPY'])
 
 /**
- * Splits CSV text into the records the parser hands over, dropping blank lines the way it does
+ * Splits CSV text into the records the parser hands over, which for these fixtures is a split on
+ * lines and commas with each cell trimmed
  */
 function toRecords(csv: string) {
   return csv
@@ -39,8 +40,8 @@ describe('detecting a header row', () => {
   })
 
   it('reads a heading row mixing a known alias with terse words as headings', () => {
-    // One recognized alias was not enough to save this row, because the data-like count only had
-    // to match the alias count rather than beat it
+    // Amt and Ref both counted as currencies under the browser check, so two data-like cells
+    // outweighed the one recognized alias and the row was staged as a transaction
     const parsed = stage('Date,Amt,Ref\n2026-04-11,-12.34,INV-1\n2026-04-12,-8.00,INV-2')
 
     expect(parsed.hasHeaderRow).toBe(true)
@@ -50,7 +51,7 @@ describe('detecting a header row', () => {
 
   it('reads a currency code the app does not support as an ordinary word', () => {
     // A single data-like cell in the first row was enough to rule the whole row out as headings,
-    // and ZZZ counted as one because the browser accepts any three letters
+    // and all three of these counted as one because the browser accepts any three letters
     const parsed = stage('Day,Ref,ZZZ\n2026-04-11,-12.34,x\n2026-04-12,-8.00,y')
 
     expect(parsed.hasHeaderRow).toBe(true)

--- a/frontend/tests/imports/importPayloadDates.test.ts
+++ b/frontend/tests/imports/importPayloadDates.test.ts
@@ -4,10 +4,17 @@
  */
 import { describe, expect, it } from 'vitest'
 import type { Category } from '@/api/categories'
+import type { Currency } from '@/api/currency'
 import { EMPTY_COLUMN_MAP, ROW_DATE_BLANK_REASON, ROW_DATE_UNREADABLE_REASON } from '@/pages/imports/constants'
 import type { ColumnMap, ImportFileDraft } from '@/pages/imports/types'
 import { buildTransactionImportPayload } from '@/pages/imports/utils'
 import type { ImportDateFormat } from '@/pages/imports/utils/valueParsers'
+
+// The account these rows are written to has no currency of its own in this file's fixtures, so the
+// list only has to hold whatever the amount checks would read
+const CURRENCIES: Currency[] = [
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+]
 
 const CATEGORY: Category = {
   id: 'category-1',
@@ -52,6 +59,7 @@ function build(dates: string[], dateFormat: ImportDateFormat | null, columnValid
     accountCreateInstitutions: {},
     accountCreateTypes: {},
     accountMappings: { 'file-1': 'account-1' },
+    currencies: CURRENCIES,
     accountSources: [{ id: 'file-1', label: 'Checking.csv', matchText: 'Checking.csv', isCounterpartyOnly: false }],
     categoryById: new Map([[CATEGORY.id, CATEGORY]]),
     categoryCreateKinds: {},

--- a/frontend/tests/imports/importWorkflowOptions.test.ts
+++ b/frontend/tests/imports/importWorkflowOptions.test.ts
@@ -6,7 +6,14 @@ import type { AccountsOverview } from '@/api/accounts'
 import type { Category } from '@/api/categories'
 import type { Currency } from '@/api/currency'
 import type { Institution } from '@/api/institutions'
-import { COLUMN_TARGETS, CREATE_ACCOUNT_VALUE, CREATE_CATEGORY_VALUE, EMPTY_COLUMN_MAP } from '@/pages/imports/constants'
+import {
+  COLUMN_TARGETS,
+  CREATE_ACCOUNT_VALUE,
+  CREATE_CATEGORY_VALUE,
+  CURRENCIES_FAILED_UPLOAD_BLOCK,
+  CURRENCIES_LOADING_UPLOAD_BLOCK,
+  EMPTY_COLUMN_MAP,
+} from '@/pages/imports/constants'
 import type { ImportFileDraft } from '@/pages/imports/types'
 import {
   buildColumnTargetOptions,
@@ -20,7 +27,9 @@ import {
   getImportedMerchants,
   getImportedTags,
   getImportHeaders,
+  getImportUploadBlockReason,
   getMissingRequiredColumnLabels,
+  getSupportedCurrencyCodes,
   inferAccountMappings,
 } from '@/pages/imports/utils'
 
@@ -229,5 +238,41 @@ describe('archived accounts in account mapping', () => {
     expect(getArchivedAccountMatches([rowSource], { 'Old Savings': 'checking' }, accounts)).toEqual([])
     expect(getArchivedAccountMatches([counterpartySource], {}, accounts)).toEqual([])
     expect(getArchivedAccountMatches([rowSource], {}, [chequing])).toEqual([])
+  })
+})
+
+describe('blocking the upload until the currency list is in hand', () => {
+  const currencies: Currency[] = [
+    { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+  ]
+
+  it('lets a file be uploaded once the list has arrived', () => {
+    expect(getImportUploadBlockReason(currencies, false)).toBeNull()
+  })
+
+  it('blocks on an empty list, whether it failed or has simply not arrived', () => {
+    // A request the browser has not started, which is what an offline page has, reports neither
+    // loading nor failed, so the list itself is what decides rather than the request's state
+    expect(getImportUploadBlockReason([], false)).toBe(CURRENCIES_LOADING_UPLOAD_BLOCK)
+    expect(getImportUploadBlockReason([], true)).toBe(CURRENCIES_FAILED_UPLOAD_BLOCK)
+  })
+
+  it('says to reload only where the fetch actually failed', () => {
+    expect(getImportUploadBlockReason([], true)).toContain('Reload the page')
+    expect(getImportUploadBlockReason([], false)).not.toContain('Reload the page')
+  })
+})
+
+describe('collecting the supported currency codes', () => {
+  it('holds every code the list carries and nothing else', () => {
+    const codes = getSupportedCurrencyCodes([
+      { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+      { id: 'JPY', name: 'Japanese Yen', symbol: '\u00a5', minor_unit_exponent: 0 },
+    ])
+
+    expect(codes.has('CAD')).toBe(true)
+    expect(codes.has('JPY')).toBe(true)
+    expect(codes.has('ZZZ')).toBe(false)
+    expect(codes.size).toBe(2)
   })
 })

--- a/frontend/tests/imports/importWorkflowOptions.test.ts
+++ b/frontend/tests/imports/importWorkflowOptions.test.ts
@@ -253,13 +253,17 @@ describe('blocking the upload until the currency list is in hand', () => {
   it('blocks on an empty list, whether it failed or has simply not arrived', () => {
     // A request the browser has not started, which is what an offline page has, reports neither
     // loading nor failed, so the list itself is what decides rather than the request's state
-    expect(getImportUploadBlockReason([], false)).toBe(CURRENCIES_LOADING_UPLOAD_BLOCK)
-    expect(getImportUploadBlockReason([], true)).toBe(CURRENCIES_FAILED_UPLOAD_BLOCK)
+    expect(getImportUploadBlockReason([], false)).toEqual({ message: CURRENCIES_LOADING_UPLOAD_BLOCK, isFailure: false })
+    expect(getImportUploadBlockReason([], true)).toEqual({ message: CURRENCIES_FAILED_UPLOAD_BLOCK, isFailure: true })
   })
 
-  it('says to reload only where the fetch actually failed', () => {
-    expect(getImportUploadBlockReason([], true)).toContain('Reload the page')
-    expect(getImportUploadBlockReason([], false)).not.toContain('Reload the page')
+  it('marks only the failed case as one the user has to act on', () => {
+    // Waiting a moment on an ordinary page load should not be dressed as an error, so only the
+    // failure gets the error treatment and the instruction to reload
+    expect(getImportUploadBlockReason([], true)?.isFailure).toBe(true)
+    expect(getImportUploadBlockReason([], true)?.message).toContain('Reload the page')
+    expect(getImportUploadBlockReason([], false)?.isFailure).toBe(false)
+    expect(getImportUploadBlockReason([], false)?.message).not.toContain('Reload the page')
   })
 })
 


### PR DESCRIPTION
The import now gets everything about a currency from the currency table the backend stores amounts against: how many decimal places it has, and whether a three-letter code is a currency at all. Instead of the commit failing, the preview now catches an amount that doesn't fit its currency and says which row. It also shows each row in its account's currency, which is what it'll be imported in, and the upload waits for the list before it will take a file. The backend parser is fixed and no longer loses precision on long values or refuses amounts the column can hold.