### PR TITLE
Repair the filter overlays and two settings dialogs

### DIFF
--- a/frontend/src/components/filters/hooks/useMobileSheetEffects.ts
+++ b/frontend/src/components/filters/hooks/useMobileSheetEffects.ts
@@ -4,12 +4,8 @@ import { isInsideFloatingLayer } from '@/utils/floatingLayer'
 type MobileFilterSheetEffectsOptions = {
   isOpen: boolean
   onClose: () => void
-  // Sheets with their own glass controls behind the backdrop disable this, since a page-level
-  // filter would zero out the controls' backdrop-filter and make them vanish
-  dimPageContent?: boolean
-  // Full-screen surfaces disable this: setting overflow hidden on the page strips a sticky toolbar
-  // back to its in-flow position, and a full-screen modal already covers the page so no lock is
-  // needed
+  // A full-screen sheet disables this: setting overflow hidden on the page strips a sticky toolbar
+  // back to its in-flow position, and the sheet already covers the page so no lock is needed
   lockScroll?: boolean
 }
 
@@ -19,7 +15,6 @@ type MobileFilterSheetEffectsOptions = {
 export function useMobileFilterSheetEffects({
   isOpen,
   onClose,
-  dimPageContent = true,
   lockScroll = true,
 }: MobileFilterSheetEffectsOptions) {
   const panelRef = useRef<HTMLDivElement>(null)
@@ -46,16 +41,11 @@ export function useMobileFilterSheetEffects({
 
   useEffect(() => {
     const root = document.documentElement
-    const blurTarget = document.getElementById('app-page-content')
     const mobileNavigationToggle = document.getElementById('app-mobile-navigation-toggle')
     const previousOverflow = document.body.style.overflow
     const previousRootOverflow = root.style.overflow
     const previousRootOverscroll = root.style.overscrollBehavior
     const previousBodyOverscroll = document.body.style.overscrollBehavior
-    const previousBlurTargetFilter = blurTarget?.style.filter ?? ''
-    const previousBlurTargetOpacity = blurTarget?.style.opacity ?? ''
-    const previousBlurTargetTransition = blurTarget?.style.transition ?? ''
-    const previousBlurTargetWillChange = blurTarget?.style.willChange ?? ''
     const previousMobileNavigationToggleOpacity = mobileNavigationToggle?.style.opacity ?? ''
     const previousMobileNavigationTogglePointerEvents = mobileNavigationToggle?.style.pointerEvents ?? ''
     const previousMobileNavigationToggleTransition = mobileNavigationToggle?.style.transition ?? ''
@@ -67,10 +57,6 @@ export function useMobileFilterSheetEffects({
       document.body.style.overflow = 'hidden'
       document.body.style.overscrollBehavior = 'none'
     }
-    if (blurTarget) {
-      blurTarget.style.transition = 'filter 260ms cubic-bezier(0.22, 1, 0.36, 1), opacity 260ms cubic-bezier(0.22, 1, 0.36, 1)'
-      blurTarget.style.willChange = 'filter, opacity'
-    }
     if (mobileNavigationToggle) {
       mobileNavigationToggle.style.transition = 'opacity 220ms cubic-bezier(0.22, 1, 0.36, 1)'
       mobileNavigationToggle.style.willChange = 'opacity'
@@ -81,12 +67,6 @@ export function useMobileFilterSheetEffects({
       root.style.overscrollBehavior = previousRootOverscroll
       document.body.style.overflow = previousOverflow
       document.body.style.overscrollBehavior = previousBodyOverscroll
-      if (blurTarget) {
-        blurTarget.style.filter = previousBlurTargetFilter
-        blurTarget.style.opacity = previousBlurTargetOpacity
-        blurTarget.style.transition = previousBlurTargetTransition
-        blurTarget.style.willChange = previousBlurTargetWillChange
-      }
       if (mobileNavigationToggle) {
         mobileNavigationToggle.style.opacity = previousMobileNavigationToggleOpacity
         mobileNavigationToggle.style.pointerEvents = previousMobileNavigationTogglePointerEvents
@@ -97,23 +77,16 @@ export function useMobileFilterSheetEffects({
   }, [lockScroll])
 
   useEffect(() => {
-    const blurTarget = document.getElementById('app-page-content')
     const mobileNavigationToggle = document.getElementById('app-mobile-navigation-toggle')
-    if (!blurTarget && !mobileNavigationToggle) return undefined
+    if (!mobileNavigationToggle) return undefined
 
     const frame = window.requestAnimationFrame(() => {
-      if (blurTarget && dimPageContent) {
-        blurTarget.style.filter = isOpen ? 'blur(7px)' : 'blur(0px)'
-        blurTarget.style.opacity = isOpen ? '0.76' : '1'
-      }
-      if (mobileNavigationToggle) {
-        mobileNavigationToggle.style.opacity = isOpen ? '0' : '1'
-        mobileNavigationToggle.style.pointerEvents = isOpen ? 'none' : 'auto'
-      }
+      mobileNavigationToggle.style.opacity = isOpen ? '0' : '1'
+      mobileNavigationToggle.style.pointerEvents = isOpen ? 'none' : 'auto'
     })
 
     return () => window.cancelAnimationFrame(frame)
-  }, [isOpen, dimPageContent])
+  }, [isOpen])
 
   return panelRef
 }

--- a/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
@@ -5,6 +5,13 @@ import { X } from 'lucide-react'
 import { useMobileFilterSheetEffects } from '@/components/filters/hooks/useMobileSheetEffects'
 import { useModalScrollGuard } from '@/components/filters/hooks/useModalScrollGuard'
 
+// How much of the panel's own colour covers the page behind it. The sheet does not filter its own
+// backdrop: a backdrop-filter is recomputed for every frame in which anything above or inside it
+// repaints, and this one holds the whole scrollable filter list, so a single drag re-blurred the
+// screen on every frame. Nothing blurs the page instead, because the sheet covers it, so the mix has
+// to stay high enough that sharp page content does not read through
+const PANEL_OPACITY_PERCENT = 97
+
 type MobileFilterGlassPanelProps = {
   isOpen: boolean
   onClose: () => void
@@ -66,9 +73,7 @@ export function MobileFilterGlassPanel({
             // 100dvh tracks the dynamic viewport so the modal covers the screen even as the mobile
             // browser chrome shows or hides, leaving no strip of the list peeking below it
             height: '100dvh',
-            background: 'color-mix(in srgb, var(--app-input-bg) 88%, transparent)',
-            backdropFilter: 'blur(24px) saturate(160%)',
-            WebkitBackdropFilter: 'blur(24px) saturate(160%)',
+            background: `color-mix(in srgb, var(--app-input-bg) ${PANEL_OPACITY_PERCENT}%, transparent)`,
             paddingTop: 'env(safe-area-inset-top)',
             paddingBottom: 'env(safe-area-inset-bottom)',
           }}

--- a/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
@@ -101,8 +101,7 @@ export function MobileFilterGlassPanel({
           <div className="flex items-center justify-between gap-3 border-t px-5 py-4" style={{ borderColor: 'var(--app-border)' }}>
             <button
               type="button"
-              className="text-sm"
-              style={{ color: 'var(--app-text-muted)' }}
+              className="app-secondary-button"
               disabled={activeFacetCount === 0}
               onClick={clearAll}
             >

--- a/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/MobileFilterGlassPanel.tsx
@@ -5,13 +5,6 @@ import { X } from 'lucide-react'
 import { useMobileFilterSheetEffects } from '@/components/filters/hooks/useMobileSheetEffects'
 import { useModalScrollGuard } from '@/components/filters/hooks/useModalScrollGuard'
 
-// How much of the panel's own colour covers the page behind it. The sheet does not filter its own
-// backdrop: a backdrop-filter is recomputed for every frame in which anything above or inside it
-// repaints, and this one holds the whole scrollable filter list, so a single drag re-blurred the
-// screen on every frame. Nothing blurs the page instead, because the sheet covers it, so the mix has
-// to stay high enough that sharp page content does not read through
-const PANEL_OPACITY_PERCENT = 97
-
 type MobileFilterGlassPanelProps = {
   isOpen: boolean
   onClose: () => void
@@ -47,9 +40,7 @@ export function MobileFilterGlassPanel({
   isApplyDisabled = false,
   children,
 }: MobileFilterGlassPanelProps) {
-  // The full-screen modal covers the page, so the page-content dim is left off to keep the glass
-  // toolbar from breaking and because nothing behind the modal is visible anyway
-  const panelRef = useMobileFilterSheetEffects({ isOpen, onClose, dimPageContent: false, lockScroll: false })
+  const panelRef = useMobileFilterSheetEffects({ isOpen, onClose, lockScroll: false })
   const shouldReduceMotion = useReducedMotion()
 
   // Hold the page still behind the full-screen modal without overflow: hidden, which would strip the
@@ -73,7 +64,9 @@ export function MobileFilterGlassPanel({
             // 100dvh tracks the dynamic viewport so the modal covers the screen even as the mobile
             // browser chrome shows or hides, leaving no strip of the list peeking below it
             height: '100dvh',
-            background: `color-mix(in srgb, var(--app-input-bg) ${PANEL_OPACITY_PERCENT}%, transparent)`,
+            // Solid rather than translucent, so nothing behind shows through and nothing behind has
+            // to be blurred. A backdrop-filter here would be recomputed for every frame of a scroll
+            background: 'var(--app-input-bg)',
             paddingTop: 'env(safe-area-inset-top)',
             paddingBottom: 'env(safe-area-inset-bottom)',
           }}

--- a/frontend/src/components/list-controls/MobileFilterSheet.tsx
+++ b/frontend/src/components/list-controls/MobileFilterSheet.tsx
@@ -5,7 +5,7 @@ import { X } from 'lucide-react'
 import { useMobileFilterSheetEffects } from '@/components/filters/hooks/useMobileSheetEffects'
 import { useModalScrollGuard } from '@/components/filters/hooks/useModalScrollGuard'
 
-type MobileFilterGlassPanelProps = {
+type MobileFilterSheetProps = {
   isOpen: boolean
   onClose: () => void
   // Fires once the close animation finishes so the parent can unmount and release the scroll lock
@@ -23,13 +23,13 @@ type MobileFilterGlassPanelProps = {
 }
 
 /**
- * Renders the full-screen mobile filter modal shared by the account and transaction toolbars: the
+ * Renders the full-screen mobile filter sheet shared by the account and transaction toolbars: the
  * header with the active-count summary, the scrollable body slot, and the clear and apply footer.
  * The facet body is supplied as children so this component owns only the chrome. Full screen keeps
  * the body in a fixed scroll area, so resizing a facet's content never animates the container and
  * the layout stays stable
  */
-export function MobileFilterGlassPanel({
+export function MobileFilterSheet({
   isOpen,
   onClose,
   onExitComplete,
@@ -39,11 +39,11 @@ export function MobileFilterGlassPanel({
   applyFilters,
   isApplyDisabled = false,
   children,
-}: MobileFilterGlassPanelProps) {
+}: MobileFilterSheetProps) {
   const panelRef = useMobileFilterSheetEffects({ isOpen, onClose, lockScroll: false })
   const shouldReduceMotion = useReducedMotion()
 
-  // Hold the page still behind the full-screen modal without overflow: hidden, which would strip the
+  // Hold the page still behind the full-screen sheet without overflow: hidden, which would strip the
   // sticky toolbar back to its in-flow position
   useModalScrollGuard(panelRef, isOpen)
 
@@ -61,7 +61,7 @@ export function MobileFilterGlassPanel({
           aria-label={ariaLabel}
           className="fixed inset-x-0 top-0 z-[100] flex flex-col min-[750px]:hidden"
           style={{
-            // 100dvh tracks the dynamic viewport so the modal covers the screen even as the mobile
+            // 100dvh tracks the dynamic viewport so the sheet covers the screen even as the mobile
             // browser chrome shows or hides, leaving no strip of the list peeking below it
             height: '100dvh',
             // Solid rather than translucent, so nothing behind shows through and nothing behind has

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
@@ -145,8 +145,7 @@ export function FilterPanelBody({
         <motion.div layout={blockLayout} transition={transition} className="mt-3 flex items-center justify-between">
           <button
             type="button"
-            className="text-xs"
-            style={{ color: 'var(--app-text-muted)' }}
+            className="app-secondary-button"
             disabled={draft.activeFacetCount === 0}
             onClick={draft.clearAll}
           >

--- a/frontend/src/pages/accounts/components/toolbar/MobileFilterPanel.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/MobileFilterPanel.tsx
@@ -20,7 +20,7 @@ type MobileFilterPanelProps = {
 
 /**
  * Renders the mobile account filter: the account filter draft plumbed into the shared full-screen
- * glass modal, reusing the same draft and body as the desktop pill
+ * sheet, reusing the same draft and body as the desktop pill
  */
 export function MobileFilterPanel({
   isOpen,

--- a/frontend/src/pages/accounts/components/toolbar/MobileFilterPanel.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/MobileFilterPanel.tsx
@@ -1,5 +1,5 @@
 import type { OptionItem } from '@/components/filters/OptionList'
-import { MobileFilterGlassPanel } from '@/components/list-controls/MobileFilterGlassPanel'
+import { MobileFilterSheet } from '@/components/list-controls/MobileFilterSheet'
 import { useSeedDraftOnOpen } from '@/components/list-controls/useSeedDraftOnOpen'
 import { FilterPanelBody } from '@/pages/accounts/components/toolbar/FilterPanelBody'
 import { useAccountFilterDraft } from '@/pages/accounts/components/toolbar/useAccountFilterDraft'
@@ -37,7 +37,7 @@ export function MobileFilterPanel({
   useSeedDraftOnOpen(isOpen, draft.seedDraftFromFilters)
 
   return (
-    <MobileFilterGlassPanel
+    <MobileFilterSheet
       isOpen={isOpen}
       onClose={onClose}
       onExitComplete={onExitComplete}
@@ -47,6 +47,6 @@ export function MobileFilterPanel({
       applyFilters={draft.applyFilters}
     >
       <FilterPanelBody draft={draft} showFooter={false} mobile fillHeight />
-    </MobileFilterGlassPanel>
+    </MobileFilterSheet>
   )
 }

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryDetailsModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryDetailsModal.tsx
@@ -47,7 +47,7 @@ export default function TaxAdvantagedCategoryDetailsModal({
       open={open}
       onClose={onClose}
       titleId="tax-category-details-title"
-      panelClassName="flex max-h-[100dvh] min-h-[100dvh] w-full flex-col overflow-hidden rounded-none min-[620px]:min-h-0 min-[620px]:max-h-[calc(100dvh-2rem)] min-[620px]:max-w-[38rem] min-[620px]:overflow-visible min-[620px]:rounded-2xl"
+      panelClassName="flex max-h-[100dvh] min-h-[100dvh] w-full flex-col overflow-hidden rounded-none min-[620px]:min-h-0 min-[620px]:max-h-[calc(100dvh-2rem)] min-[620px]:max-w-[38rem] min-[620px]:rounded-2xl min-[1050px]:overflow-visible"
       level="stacked"
       boundsTooltips
     >
@@ -71,7 +71,10 @@ export default function TaxAdvantagedCategoryDetailsModal({
         </button>
       </div>
 
-      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden p-5 min-[620px]:overflow-visible">
+      {/* The stylesheet pins every modal panel to the full viewport height below 1050px, so the body
+          has to keep scrolling until that rule stops applying. Letting it overflow visible any earlier
+          puts content past the bottom of a fixed-height panel with no way to reach it */}
+      <div className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden p-5 min-[1050px]:overflow-visible">
         <div className="space-y-4">
           <div className="grid grid-cols-1 gap-3 min-[620px]:grid-cols-[minmax(0,3fr)_minmax(0,7fr)]">
             <div className="grid min-w-0 grid-cols-2 gap-2">

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/LimitDetailsModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/LimitDetailsModal.tsx
@@ -60,7 +60,7 @@ export default function TaxAdvantagedLimitDetailsModal({
     <ModalShell
       open={showAddTaxYear || Boolean(selectedLimit && selectedDraft)}
       onClose={onClose}
-      titleId="tax-limit-details-title"
+      titleId="tax-year-limit-title"
       panelClassName="flex max-h-[100dvh] min-h-[100dvh] w-full flex-col overflow-hidden rounded-none min-[620px]:min-h-0 min-[620px]:max-h-[calc(100dvh-2rem)] min-[620px]:max-w-[38rem] min-[620px]:rounded-2xl"
       level="stacked"
       boundsTooltips

--- a/frontend/src/pages/transactions/components/FilterLoadingOverlay.tsx
+++ b/frontend/src/pages/transactions/components/FilterLoadingOverlay.tsx
@@ -1,5 +1,11 @@
 import { motion } from 'motion/react'
 
+// How much of the page colour covers the content while a filter reloads. The overlay does not filter
+// its own backdrop: it holds a turning spinner, so the filter ran again for every frame of the load.
+// Blurring what it covers is not an option either, because the overlay renders inside that region and
+// would blur its own spinner and label, so the cover has to carry the separation on its own
+const OVERLAY_OPACITY_PERCENT = 92
+
 /**
  * Renders the blocking loading overlay used while transaction filters refresh data
  */
@@ -18,8 +24,7 @@ export default function TransactionFilterLoadingOverlay({
         placement === 'center' ? 'justify-center' : 'justify-start pt-24'
       }`}
       style={{
-        background: 'color-mix(in srgb, var(--app-bg) 72%, transparent)',
-        backdropFilter: 'blur(3px)',
+        background: `color-mix(in srgb, var(--app-bg) ${OVERLAY_OPACITY_PERCENT}%, transparent)`,
         touchAction: 'none',
       }}
       role="status"

--- a/frontend/src/pages/transactions/components/FilterLoadingOverlay.tsx
+++ b/frontend/src/pages/transactions/components/FilterLoadingOverlay.tsx
@@ -1,11 +1,5 @@
 import { motion } from 'motion/react'
 
-// How much of the page colour covers the content while a filter reloads. The overlay does not filter
-// its own backdrop: it holds a turning spinner, so the filter ran again for every frame of the load.
-// Blurring what it covers is not an option either, because the overlay renders inside that region and
-// would blur its own spinner and label, so the cover has to carry the separation on its own
-const OVERLAY_OPACITY_PERCENT = 92
-
 /**
  * Renders the blocking loading overlay used while transaction filters refresh data
  */
@@ -24,7 +18,9 @@ export default function TransactionFilterLoadingOverlay({
         placement === 'center' ? 'justify-center' : 'justify-start pt-24'
       }`}
       style={{
-        background: `color-mix(in srgb, var(--app-bg) ${OVERLAY_OPACITY_PERCENT}%, transparent)`,
+        // Solid rather than translucent, so nothing behind shows through and nothing has to be
+        // blurred. A backdrop-filter here would be recomputed for every frame the spinner turns
+        background: 'var(--app-bg)',
         touchAction: 'none',
       }}
       role="status"

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -206,8 +206,7 @@ export function FilterPanelBody({
         <motion.div layout={blockLayout} transition={transition} className="mt-3 flex items-center justify-between">
           <button
             type="button"
-            className="text-xs"
-            style={{ color: 'var(--app-text-muted)' }}
+            className="app-secondary-button"
             disabled={draft.activeFacetCount === 0}
             onClick={draft.clearAll}
           >

--- a/frontend/src/pages/transactions/components/toolbar/MobileFilterPanel.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/MobileFilterPanel.tsx
@@ -1,5 +1,5 @@
 import type { OptionItem } from '@/components/filters/OptionList'
-import { MobileFilterGlassPanel } from '@/components/list-controls/MobileFilterGlassPanel'
+import { MobileFilterSheet } from '@/components/list-controls/MobileFilterSheet'
 import { useSeedDraftOnOpen } from '@/components/list-controls/useSeedDraftOnOpen'
 import { FilterPanelBody } from '@/pages/transactions/components/toolbar/FilterPanelBody'
 import { useTransactionFilterDraft } from '@/pages/transactions/components/toolbar/useTransactionFilterDraft'
@@ -41,7 +41,7 @@ export function MobileFilterPanel({
   useSeedDraftOnOpen(isOpen, draft.seedDraftFromFilters)
 
   return (
-    <MobileFilterGlassPanel
+    <MobileFilterSheet
       isOpen={isOpen}
       onClose={onClose}
       onExitComplete={onExitComplete}
@@ -52,6 +52,6 @@ export function MobileFilterPanel({
       isApplyDisabled={draft.isApplyBlocked}
     >
       <FilterPanelBody draft={draft} showFooter={false} mobile fillHeight showAccountFilter={showAccountFilter} />
-    </MobileFilterGlassPanel>
+    </MobileFilterSheet>
   )
 }

--- a/frontend/src/pages/transactions/components/toolbar/MobileFilterPanel.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/MobileFilterPanel.tsx
@@ -23,7 +23,7 @@ type MobileFilterPanelProps = {
 
 /**
  * Renders the mobile transaction filter: the transaction filter draft plumbed into the shared
- * full-screen glass modal, reusing the same draft and body as the desktop pill
+ * full-screen sheet, reusing the same draft and body as the desktop pill
  */
 export function MobileFilterPanel({
   isOpen,


### PR DESCRIPTION
The mobile filter sheet and the transactions loading overlay are now solid colours, so the blur they used to draw on every frame is gone. In the same filter panels, Clear all takes the standard secondary button style and shows when it is disabled. The tax-advantaged category details dialog in settings also scrolls on a tablet rather than hiding its buttons off the bottom, and the year limit dialog beside it has an accessible name again.
