### PR TITLE
Stop computing dates from unreadable values

### DIFF
--- a/backend/app/routes/accounts/creation_helpers.py
+++ b/backend/app/routes/accounts/creation_helpers.py
@@ -70,7 +70,7 @@ async def create_account_with_initial_balance_history(
         Created account row pending commit
 
     Raises:
-        HTTPException: Anchor timezone does not refer to a zone this build carries
+        HTTPException: Anchor timezone is not a zone the app recognizes
     """
     account = Account(
         owner_id=creation_scope.owner_id,

--- a/backend/app/routes/accounts/creation_helpers.py
+++ b/backend/app/routes/accounts/creation_helpers.py
@@ -1,6 +1,5 @@
 """Account creation helpers"""
 from datetime import datetime
-from zoneinfo import ZoneInfo
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -13,6 +12,7 @@ from app.routes.accounts.response_loading_helpers import get_account_for_respons
 from app.routes.accounts.tax_advantaged_category_link_helpers import validate_create_account_tax_advantaged_category_link
 from app.schemas.account import CreateAccountRequest
 from app.services.cache_state import mark_cache_changed_for_scope
+from app.utils.dates import ACCOUNT_OWNER_PROFILE, OWN_PROFILE, resolve_timezone
 
 
 async def create_account_for_user(
@@ -31,11 +31,15 @@ async def create_account_for_user(
         Created account with derived balance fields
 
     Raises:
-        HTTPException: Account details, ownership, or linked tax-advantaged category are invalid
+        HTTPException: Account details, ownership, or linked tax-advantaged category are invalid, or the stored timezone does not resolve
     """
     await validate_create_account_request(db, data)
     creation_scope = await resolve_account_creation_scope(db, user, data.group_id)
     await validate_create_account_tax_advantaged_category_link(db, data, creation_scope, user.id)
+
+    # Resolved before anything is written, since the response date is read after the commit and a
+    # refusal there would leave the account created and the request failed
+    viewer_tz = resolve_timezone(user.tz)
 
     account = await create_account_with_initial_balance_history(db, data, creation_scope, user)
 
@@ -43,7 +47,7 @@ async def create_account_for_user(
     await mark_cache_changed_for_scope(db, user_id=account.owner_id, group_id=account.group_id)
     await db.commit()
 
-    response_date = datetime.now(ZoneInfo(user.tz)).date()
+    response_date = datetime.now(viewer_tz).date()
     response_account = await get_account_for_response(db, user, account.id, response_date)
     return response_account
 
@@ -64,6 +68,9 @@ async def create_account_with_initial_balance_history(
 
     Returns:
         Created account row pending commit
+
+    Raises:
+        HTTPException: Anchor timezone does not refer to a zone this build carries
     """
     account = Account(
         owner_id=creation_scope.owner_id,
@@ -80,7 +87,11 @@ async def create_account_with_initial_balance_history(
     db.add(account)
     await db.flush()
 
-    anchor_dt = account.created_at.astimezone(ZoneInfo(creation_scope.anchor_tz)).date()
+    # A group account anchors on the owner's day rather than the actor's, so a refusal has to say
+    # whose setting it could not read
+    anchor_stored_on = OWN_PROFILE if creation_scope.group_id is None else ACCOUNT_OWNER_PROFILE
+    anchor_tz = resolve_timezone(creation_scope.anchor_tz, stored_on=anchor_stored_on)
+    anchor_dt = account.created_at.astimezone(anchor_tz).date()
     db.add(AccountBalanceSnapshot(
         account_id=account.id,
         dt=anchor_dt,

--- a/backend/app/routes/accounts/router.py
+++ b/backend/app/routes/accounts/router.py
@@ -2,7 +2,6 @@
 import uuid
 from datetime import datetime
 from typing import Annotated
-from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -27,6 +26,7 @@ from app.schemas.account import (
     UpdateAccountRequest,
 )
 from app.schemas.dashboard import MonthlyIncomeExpense, RangeKind
+from app.utils.dates import resolve_timezone
 
 router = APIRouter(prefix="/accounts", tags=["accounts"])
 router.include_router(permissions_router)
@@ -46,8 +46,11 @@ async def list_accounts(
 
     Returns:
         Accounts the user can access
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
-    response_date = datetime.now(ZoneInfo(user.tz)).date()
+    response_date = datetime.now(resolve_timezone(user.tz)).date()
     accounts = await get_account_overviews_for_user(db, user, response_date)
     return accounts
 
@@ -69,9 +72,9 @@ async def get_account(
         Account with derived balance fields
 
     Raises:
-        HTTPException: User does not have read access
+        HTTPException: User does not have read access, or the stored timezone does not resolve
     """
-    response_date = datetime.now(ZoneInfo(user.tz)).date()
+    response_date = datetime.now(resolve_timezone(user.tz)).date()
     account = await get_account_response_for_user(db, account_id, user, response_date)
     return account
 
@@ -99,9 +102,9 @@ async def get_account_spending_breakdown_route(
         Spending breakdown for the account and range
 
     Raises:
-        HTTPException: User does not have read access
+        HTTPException: User does not have read access, or the stored timezone does not resolve
     """
-    as_of_dt = datetime.now(ZoneInfo(user.tz))
+    as_of_dt = datetime.now(resolve_timezone(user.tz))
     breakdown = await get_account_spending_breakdown_for_user(db, account_id, user.id, range_, as_of_dt)
     return breakdown
 
@@ -130,9 +133,9 @@ async def get_account_cash_flow_route(
         Oldest-first monthly income and expense totals
 
     Raises:
-        HTTPException: User does not have read access
+        HTTPException: User does not have read access, or the stored timezone does not resolve
     """
-    as_of_dt = datetime.now(ZoneInfo(user.tz))
+    as_of_dt = datetime.now(resolve_timezone(user.tz))
     cash_flow = await get_account_cash_flow_for_user(db, account_id, user.id, months, as_of_dt)
     return cash_flow
 
@@ -154,7 +157,7 @@ async def create_account(
         Created account with derived balance fields
 
     Raises:
-        HTTPException: Account details, ownership, or linked tax-advantaged category are invalid
+        HTTPException: Account details, ownership, or linked tax-advantaged category are invalid, or the stored timezone does not resolve
     """
     account = await create_account_for_user(db, user, data)
     return account
@@ -179,9 +182,9 @@ async def update_account(
         Updated account with derived balance fields
 
     Raises:
-        HTTPException: User lacks admin access or update fields are invalid
+        HTTPException: User lacks admin access or update fields are invalid, or the stored timezone does not resolve
     """
-    response_date = datetime.now(ZoneInfo(user.tz)).date()
+    response_date = datetime.now(resolve_timezone(user.tz)).date()
     account = await update_account_for_user(db, account_id, data, user, response_date)
     return account
 

--- a/backend/app/routes/base_budgets/router.py
+++ b/backend/app/routes/base_budgets/router.py
@@ -2,7 +2,6 @@
 import uuid
 from datetime import datetime
 from typing import Annotated
-from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, status
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,6 +27,7 @@ from app.schemas.budget import (
     CreateBudgetRequest,
     UpdateBaseBudgetRequest,
 )
+from app.utils.dates import resolve_timezone
 
 router = APIRouter(prefix="/base-budgets", tags=["base-budgets"])
 router.include_router(permissions_router)
@@ -52,9 +52,9 @@ async def update_base_budget(
         Updated base budget response
 
     Raises:
-        HTTPException: User lacks admin access or update fields are invalid
+        HTTPException: User lacks admin access or update fields are invalid, or the stored timezone does not resolve
     """
-    today = datetime.now(ZoneInfo(user.tz)).date()
+    today = datetime.now(resolve_timezone(user.tz)).date()
     return await update_base_budget_and_get_response(db, user, base_budget_id, data, today)
 
 
@@ -162,9 +162,9 @@ async def create_base_budget(
         Created base budget response
 
     Raises:
-        HTTPException: Currency, ownership, categories, or period cadence are invalid
+        HTTPException: Currency, ownership, categories, or period cadence are invalid, or the stored timezone does not resolve
     """
-    today = datetime.now(ZoneInfo(user.tz)).date()
+    today = datetime.now(resolve_timezone(user.tz)).date()
     return await create_base_budget_and_get_response(db, user, data, today)
 
 

--- a/backend/app/routes/dashboard/router.py
+++ b/backend/app/routes/dashboard/router.py
@@ -6,7 +6,6 @@ live in service modules, while this file wires the results together
 """
 from datetime import datetime as DateTime
 from typing import Annotated
-from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -31,6 +30,7 @@ from app.schemas.dashboard import (
     SpendingBreakdownResponse,
     SpendingComparisonResponse,
 )
+from app.utils.dates import resolve_timezone
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -43,10 +43,13 @@ def _get_viewer_local_now(user: User) -> DateTime:
 
     Returns:
         Viewer-local datetime for the user's timezone
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     from app.routes import dashboard as dashboard_routes
 
-    now = dashboard_routes.datetime.now(ZoneInfo(user.tz))
+    now = dashboard_routes.datetime.now(resolve_timezone(user.tz))
     return now
 
 
@@ -69,6 +72,9 @@ async def get_recent_activity_widget_route(
 
     Returns:
         Recent activity widget response
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     now = _get_viewer_local_now(user)
     response = await get_recent_activity_widget_for_user(db, user, window_days, now)
@@ -92,6 +98,9 @@ async def get_savings_rate_widget_route(
 
     Returns:
         Savings-rate widget response
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     now = _get_viewer_local_now(user)
     response = await get_savings_rate_widget_for_user(db, user, now)
@@ -117,6 +126,9 @@ async def get_net_worth_widget_route(
 
     Returns:
         Net-worth widget response
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     now = _get_viewer_local_now(user)
     response = await get_net_worth_widget_for_user(db, user, window_days, now)
@@ -139,6 +151,9 @@ async def get_credit_widget_route(
 
     Returns:
         Credit widget response
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     now = _get_viewer_local_now(user)
     response = await get_credit_widget_for_user(db, user, now)
@@ -165,6 +180,9 @@ async def get_spending_comparison_route(
 
     Returns:
         Spending comparison widget response
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     now = _get_viewer_local_now(user)
     response = await get_spending_comparison_for_user(db, user, range_, now)
@@ -191,6 +209,9 @@ async def get_spending_breakdown_route(
 
     Returns:
         Spending breakdown widget response
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     now = _get_viewer_local_now(user)
     response = await get_spending_breakdown_for_user(db, user, range_, now)

--- a/backend/app/routes/insights/router.py
+++ b/backend/app/routes/insights/router.py
@@ -4,7 +4,6 @@ import uuid
 from datetime import date
 from datetime import datetime as DateTime
 from typing import Annotated
-from zoneinfo import ZoneInfo
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy import delete, select
@@ -40,6 +39,7 @@ from app.services.insights import (
     get_period_at_a_glance,
     get_savings_rate_trend,
 )
+from app.utils.dates import resolve_timezone
 
 router = APIRouter(prefix="/insights", tags=["insights"])
 
@@ -72,10 +72,13 @@ def _get_viewer_local_now(user: User) -> DateTime:
 
     Returns:
         Viewer-local datetime for the user's timezone
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     from app.routes import insights as insights_routes
 
-    now = insights_routes.datetime.now(ZoneInfo(user.tz))
+    now = insights_routes.datetime.now(resolve_timezone(user.tz))
     return now
 
 
@@ -221,6 +224,9 @@ async def get_savings_rate_trend_route(
 
     Returns:
         Savings-rate trend response anchored to the viewer-local current month
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     return await get_savings_rate_trend(db, user, _get_viewer_local_now(user))
 

--- a/backend/app/routes/runway/router.py
+++ b/backend/app/routes/runway/router.py
@@ -108,6 +108,9 @@ async def get_runway(
     by the average monthly net expense over the last 12 completed months
     Expense refunds reduce expenses, while income and transfer-category
     transactions are excluded
+
+    Raises:
+        HTTPException: The stored timezone does not resolve
     """
     today = get_current_user_date(user)
     response = await get_runway_response(db, user, today)

--- a/backend/app/routes/users/date_helpers.py
+++ b/backend/app/routes/users/date_helpers.py
@@ -15,7 +15,7 @@ def get_current_user_date(user: User) -> date:
         Current date in the user's timezone
 
     Raises:
-        HTTPException: Stored timezone does not refer to a zone this build carries
+        HTTPException: Stored timezone is not a zone the app recognizes
     """
     current_date = datetime.now(resolve_timezone(user.tz)).date()
     return current_date

--- a/backend/app/routes/users/date_helpers.py
+++ b/backend/app/routes/users/date_helpers.py
@@ -1,8 +1,8 @@
 """User date helpers"""
 from datetime import date, datetime
-from zoneinfo import ZoneInfo
 
 from app.models.user import User
+from app.utils.dates import resolve_timezone
 
 
 def get_current_user_date(user: User) -> date:
@@ -13,6 +13,9 @@ def get_current_user_date(user: User) -> date:
 
     Returns:
         Current date in the user's timezone
+
+    Raises:
+        HTTPException: Stored timezone does not refer to a zone this build carries
     """
-    current_date = datetime.now(ZoneInfo(user.tz)).date()
+    current_date = datetime.now(resolve_timezone(user.tz)).date()
     return current_date

--- a/backend/app/services/accounts/snapshots.py
+++ b/backend/app/services/accounts/snapshots.py
@@ -7,7 +7,6 @@ mutations so the snapshot table stays aligned with account history
 import uuid
 from collections.abc import Sequence
 from datetime import date
-from zoneinfo import ZoneInfo
 
 from sqlalchemy import delete, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -17,6 +16,7 @@ from app.models.account import Account, AccountBalanceSnapshot
 from app.models.group import Group
 from app.models.transaction import Transaction
 from app.models.user import User
+from app.utils.dates import ACCOUNT_OWNER_PROFILE, resolve_timezone
 
 PersonalOwner = aliased(User)
 GroupOwner = aliased(User)
@@ -138,6 +138,9 @@ async def restore_zero_anchor_if_empty(db: AsyncSession, account_id: uuid.UUID) 
 
     Returns:
         None
+
+    Raises:
+        HTTPException: Owner's stored timezone does not refer to a zone this build carries
     """
     # Check whether any snapshot remains before rebuilding the account's zero anchor
     existing = await db.execute(
@@ -161,7 +164,7 @@ async def restore_zero_anchor_if_empty(db: AsyncSession, account_id: uuid.UUID) 
 
     db.add(AccountBalanceSnapshot(
         account_id=account_id,
-        dt=row.created_at.astimezone(ZoneInfo(row.tz)).date(),
+        dt=row.created_at.astimezone(resolve_timezone(row.tz, stored_on=ACCOUNT_OWNER_PROFILE)).date(),
         balance=0,
     ))
     await db.flush()

--- a/backend/app/services/accounts/snapshots.py
+++ b/backend/app/services/accounts/snapshots.py
@@ -140,7 +140,7 @@ async def restore_zero_anchor_if_empty(db: AsyncSession, account_id: uuid.UUID) 
         None
 
     Raises:
-        HTTPException: Owner's stored timezone does not refer to a zone this build carries
+        HTTPException: Owner's stored timezone is not a zone the app recognizes
     """
     # Check whether any snapshot remains before rebuilding the account's zero anchor
     existing = await db.execute(

--- a/backend/app/services/importers/shared/account_creation_helpers.py
+++ b/backend/app/services/importers/shared/account_creation_helpers.py
@@ -67,7 +67,7 @@ def _add_import_account_opening_snapshot(db: AsyncSession, account: Account, use
         None
 
     Raises:
-        HTTPException: Stored timezone does not refer to a zone this build carries
+        HTTPException: Stored timezone is not a zone the app recognizes
     """
     opening_snapshot = AccountBalanceSnapshot(
         account_id=account.id,

--- a/backend/app/services/importers/shared/account_creation_helpers.py
+++ b/backend/app/services/importers/shared/account_creation_helpers.py
@@ -1,7 +1,6 @@
 """Transaction import account creation helpers"""
 
 import uuid
-from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
 from sqlalchemy import select
@@ -14,6 +13,7 @@ from app.models.institution import Institution
 from app.models.user import User
 from app.schemas.transaction import TransactionImportCreateAccount
 from app.services.importers.shared.validation_helpers import strip_import_text_or_raise
+from app.utils.dates import resolve_timezone
 
 
 async def create_import_account(
@@ -65,10 +65,13 @@ def _add_import_account_opening_snapshot(db: AsyncSession, account: Account, use
 
     Returns:
         None
+
+    Raises:
+        HTTPException: Stored timezone does not refer to a zone this build carries
     """
     opening_snapshot = AccountBalanceSnapshot(
         account_id=account.id,
-        dt=account.created_at.astimezone(ZoneInfo(user_timezone)).date(),
+        dt=account.created_at.astimezone(resolve_timezone(user_timezone)).date(),
         balance=0,
     )
 

--- a/backend/app/services/tax_advantaged_categories/tac_limit_metric_helpers.py
+++ b/backend/app/services/tax_advantaged_categories/tac_limit_metric_helpers.py
@@ -39,7 +39,7 @@ async def get_tac_category_current_years(
         Current calendar year keyed by tax-advantaged category identifier
 
     Raises:
-        HTTPException: An owner's stored timezone does not refer to a zone this build carries
+        HTTPException: An owner's stored timezone is not a zone the app recognizes
     """
     owner_ids = {tax_advantaged_category.category_owner_user_id for tax_advantaged_category in tax_advantaged_categories}
 

--- a/backend/app/services/tax_advantaged_categories/tac_limit_metric_helpers.py
+++ b/backend/app/services/tax_advantaged_categories/tac_limit_metric_helpers.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.rls.functions import USER_TZ
 from app.models.account import TaxAdvantagedCategory, TaxAdvantagedCategoryLimit
+from app.utils.dates import CATEGORY_OWNER_PROFILE, resolve_timezone
 
 
 @dataclass(frozen=True)
@@ -36,6 +37,9 @@ async def get_tac_category_current_years(
 
     Returns:
         Current calendar year keyed by tax-advantaged category identifier
+
+    Raises:
+        HTTPException: An owner's stored timezone does not refer to a zone this build carries
     """
     owner_ids = {tax_advantaged_category.category_owner_user_id for tax_advantaged_category in tax_advantaged_categories}
 
@@ -46,7 +50,10 @@ async def get_tac_category_current_years(
         owner_timezones[owner_id] = await db.scalar(text(f"SELECT {USER_TZ}(:owner_id)"), {"owner_id": owner_id})
     current_years_by_tax_advantaged_category_id = {
         tax_advantaged_category.id: current_datetime_for_timezone(
-            ZoneInfo(owner_timezones[tax_advantaged_category.category_owner_user_id]),
+            resolve_timezone(
+                owner_timezones[tax_advantaged_category.category_owner_user_id],
+                stored_on=CATEGORY_OWNER_PROFILE,
+            ),
         ).year
         for tax_advantaged_category in tax_advantaged_categories
     }

--- a/backend/app/utils/dates.py
+++ b/backend/app/utils/dates.py
@@ -27,7 +27,7 @@ def resolve_timezone(tz: str, *, stored_on: str = OWN_PROFILE) -> ZoneInfo:
         Zone the identifier refers to
 
     Raises:
-        HTTPException: The identifier does not refer to a zone this build carries
+        HTTPException: The identifier is not a zone the app recognizes
     """
     try:
         return ZoneInfo(tz)

--- a/backend/app/utils/dates.py
+++ b/backend/app/utils/dates.py
@@ -1,5 +1,43 @@
 """Date utilities"""
 from datetime import date, datetime
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from fastapi import HTTPException, status
+
+# Which profile a timezone was read from, so a refusal points at the setting that has to change.
+# Two of these are worded without saying whose profile it is, because the same row is read both by
+# its owner and by everyone sharing it, and only the first of them can act on "your profile"
+OWN_PROFILE = "your profile"
+ACCOUNT_OWNER_PROFILE = "the profile that owns this account"
+CATEGORY_OWNER_PROFILE = "the profile that owns this category"
+
+
+def resolve_timezone(tz: str, *, stored_on: str = OWN_PROFILE) -> ZoneInfo:
+    """Return the zone for a stored IANA identifier
+
+    A stored identifier can outlive the zone database that accepted it, and every date the product
+    reports is calculated in one, so an identifier that no longer resolves refuses the request
+    rather than falling back to a calendar the user never chose
+
+    Args:
+        tz: IANA timezone identifier read from a stored profile
+        stored_on: Whose profile the identifier came from, used in the refusal
+
+    Returns:
+        Zone the identifier refers to
+
+    Raises:
+        HTTPException: The identifier does not refer to a zone this build carries
+    """
+    try:
+        return ZoneInfo(tz)
+    # ZoneInfo rejects a path-shaped key with ValueError before it looks anything up, and reports an
+    # identifier it cannot find with ZoneInfoNotFoundError
+    except (ZoneInfoNotFoundError, ValueError):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Timezone '{tz}' saved on {stored_on} is not recognized, so no date could be calculated",
+        ) from None
 
 
 def get_month_start_date(reference: date | datetime) -> date:

--- a/backend/tests/routes/test_stored_timezone.py
+++ b/backend/tests/routes/test_stored_timezone.py
@@ -1,0 +1,94 @@
+"""Route behaviour when a stored timezone no longer resolves"""
+
+from fastapi import status
+from sqlalchemy import func, select, update
+
+from app.models.account import Account
+from app.models.user import User
+from app.utils.dates import ACCOUNT_OWNER_PROFILE, OWN_PROFILE
+from tests.conftest import TestSession
+from tests.routes.support import SIGNUP_PAYLOAD, _create_account, _create_user, _get_auth_header, _seed_currency
+
+# An identifier no release of the IANA database carries. Signup validates against the zone database,
+# so a row only holds one of these when the value arrived another way, such as a restore from an
+# instance whose database carried identifiers this one does not
+UNRESOLVABLE_IDENTIFIER = "Mars/Olympus_Mons"
+
+
+async def _store_unresolvable_timezone(email: str = SIGNUP_PAYLOAD["email"]):
+    """Write an unresolvable timezone straight to the row, past the schema guarding every write
+
+    Args:
+        email: Address of the user whose stored timezone is replaced
+
+    Returns:
+        None
+    """
+    async with TestSession() as session:
+
+        # Replace the user's timezone with one no zone database resolves
+        await session.execute(update(User).where(User.email == email).values(tz=UNRESOLVABLE_IDENTIFIER))
+        await session.commit()
+
+
+async def _signup(client, *, email: str):
+    """Sign up a second user, so a group has an owner and a member
+
+    Args:
+        client: Async test client
+        email: Address for the new user
+
+    Returns:
+        API response from signing up the user
+    """
+    return await client.post("/auth/signup", json={**SIGNUP_PAYLOAD, "email": email})
+
+
+async def test_dashboard_refuses_an_unresolvable_stored_timezone(client):
+    """The reader is told which setting is at fault instead of getting a server error"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    await _store_unresolvable_timezone()
+
+    resp = await client.get("/dashboard/credit", headers=headers)
+
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert UNRESOLVABLE_IDENTIFIER in resp.json()["detail"]
+
+
+async def test_account_creation_writes_nothing_when_the_stored_timezone_is_unresolvable(client):
+    """The refusal lands before the commit, so a failed request leaves no account behind"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    await _store_unresolvable_timezone()
+
+    create_resp = await _create_account(client, headers)
+
+    assert create_resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert OWN_PROFILE in create_resp.json()["detail"]
+    async with TestSession() as session:
+
+        # Count every account row, since a refusal after the commit would leave one behind
+        account_count = await session.scalar(select(func.count()).select_from(Account))
+    assert account_count == 0
+
+
+async def test_a_group_account_refusal_says_the_owner_setting_is_at_fault(client):
+    """A group account is dated on its owner's day, which the member creating it cannot fix"""
+    await _seed_currency()
+    owner_resp = await _signup(client, email="owner@example.com")
+    member_resp = await _signup(client, email="member@example.com")
+    owner_headers = _get_auth_header(owner_resp)
+    member_headers = _get_auth_header(member_resp)
+    member_user_id = member_resp.json()["user"]["id"]
+
+    group_id = (await client.post("/groups", json={"name": "Household"}, headers=owner_headers)).json()["id"]
+    await client.post(f"/groups/{group_id}/members", json={"user_id": member_user_id}, headers=owner_headers)
+    await client.patch(f"/groups/{group_id}/members/{member_user_id}", json={"is_admin": True}, headers=owner_headers)
+    await _store_unresolvable_timezone("owner@example.com")
+
+    create_resp = await _create_account(client, member_headers, group_id=group_id)
+
+    assert create_resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert ACCOUNT_OWNER_PROFILE in create_resp.json()["detail"]
+    assert OWN_PROFILE not in create_resp.json()["detail"]

--- a/backend/tests/utils/test_dates.py
+++ b/backend/tests/utils/test_dates.py
@@ -1,0 +1,52 @@
+"""Stored timezone resolution tests"""
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.utils.dates import ACCOUNT_OWNER_PROFILE, resolve_timezone
+
+# An identifier no release of the IANA database carries, standing in for one that stopped
+# resolving after the zone database moved underneath a row already written
+UNRESOLVABLE_IDENTIFIER = "Mars/Olympus_Mons"
+
+# ZoneInfo rejects these before it looks anything up, so they take the other failure path
+PATH_SHAPED_IDENTIFIERS = ("/etc/passwd", "../etc/passwd", "")
+
+
+def test_a_real_identifier_resolves():
+    """The resolver is transparent for a zone the build carries"""
+    assert resolve_timezone("America/Toronto").key == "America/Toronto"
+
+
+def test_an_unresolvable_identifier_is_refused():
+    """A stored zone that no longer resolves refuses the request rather than reaching a date"""
+    with pytest.raises(HTTPException) as raised:
+        resolve_timezone(UNRESOLVABLE_IDENTIFIER)
+
+    assert raised.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+
+
+def test_the_refusal_quotes_the_stored_value():
+    """The reader is told which value failed, since nothing else on the page would say"""
+    with pytest.raises(HTTPException) as raised:
+        resolve_timezone(UNRESOLVABLE_IDENTIFIER)
+
+    assert UNRESOLVABLE_IDENTIFIER in raised.value.detail
+
+
+def test_the_refusal_says_whose_profile_the_value_came_from():
+    """A group account reads its owner's zone, so the reader is not sent to their own settings"""
+    with pytest.raises(HTTPException) as raised:
+        resolve_timezone(UNRESOLVABLE_IDENTIFIER, stored_on=ACCOUNT_OWNER_PROFILE)
+
+    assert ACCOUNT_OWNER_PROFILE in raised.value.detail
+    assert "your profile" not in raised.value.detail
+
+
+@pytest.mark.parametrize("identifier", PATH_SHAPED_IDENTIFIERS)
+def test_a_path_shaped_identifier_is_refused(identifier):
+    """A stored value shaped like a path is refused the same way rather than raising ValueError"""
+    with pytest.raises(HTTPException) as raised:
+        resolve_timezone(identifier)
+
+    assert raised.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT

--- a/frontend/src/pages/budgets/utils/budgetDetails.ts
+++ b/frontend/src/pages/budgets/utils/budgetDetails.ts
@@ -195,6 +195,10 @@ function buildBudgetPeriodPoint(
     return values
   }, {})
   const periodStart = parseCalendarDate(period.period_start)
+  // Sorting reads the same value through getYmdTime and stops on one it cannot read, so this states
+  // the same refusal rather than labelling the column with a day the calendar rolled forward
+  if (periodStart === null) throw new Error(`Expected a YYYY-MM-DD date, received "${period.period_start}"`)
+
   const { axisLabel, hasYearLabel } = getBudgetChartAxisLabel(periodStart, recurrenceFreq)
 
   return {
@@ -254,7 +258,9 @@ function getBudgetChartTimeline(baseBudget: BaseBudget, firstPeriodStart: string
   let cursor = firstPeriodStart
   let next = nextRecurringPeriodStart(baseBudget, cursor)
 
-  while (next <= endBoundYmd) {
+  // Only the first start can fail to read, since every later one is written by formatYmd. The
+  // column builder below refuses it either way, so this guards the type rather than the outcome
+  while (next !== null && next <= endBoundYmd) {
     timeline.push(next)
     cursor = next
     next = nextRecurringPeriodStart(baseBudget, cursor)

--- a/frontend/src/pages/budgets/utils/budgetPeriods.ts
+++ b/frontend/src/pages/budgets/utils/budgetPeriods.ts
@@ -6,7 +6,13 @@ import { addDays, addMonths, anchorDay, formatCalendarDate, parseCalendarDate } 
  * Converts a period start date into the backend recurrence anchor fields
  */
 export function recurrenceAnchorsFromStart(freq: RecurrenceFreq, periodStart: string) {
-  const { year, month, day } = parseCalendarDate(periodStart)
+  const parsed = parseCalendarDate(periodStart)
+  // A period start comes from a date column or a field that clamps to a real day, so this guards the
+  // type rather than a case seen in practice. The backend refuses an unreadable period_start
+  // whatever anchors accompany it, so leaving them unset adds no second failure
+  if (!parsed) return { recurrence_weekday: null, recurrence_dom: null, recurrence_month: null }
+
+  const { year, month, day } = parsed
   const start = new Date(year, month - 1, day)
 
   // Backend stores Monday as 0 for weekly recurrence anchors
@@ -24,10 +30,12 @@ export function recurrenceAnchorsFromStart(freq: RecurrenceFreq, periodStart: st
 }
 
 /**
- * Derives the inclusive end date for one-off budgets from the selected cadence
+ * Derives the inclusive end date for one-off budgets from the selected cadence, or null when the
+ * start is not a real date
  */
-export function oneOffPeriodEnd(form: BudgetFormState): CalendarDate {
+export function oneOffPeriodEnd(form: BudgetFormState): CalendarDate | null {
   const start = parseCalendarDate(form.periodStart)
+  if (!start) return null
 
   if (form.recurrenceFreq === 'weekly') {
     return addDays(start, 6)
@@ -48,9 +56,15 @@ export function cadenceSummary(form: BudgetFormState) {
   const safeLength = Number.isFinite(length) && length > 0 ? length : 1
   const name = form.name.trim() || 'Untitled'
 
+  const start = parseCalendarDate(form.periodStart)
+
   if (!form.recurs) {
     if (!form.periodStart) return `"${name}" is one-off`
-    return `"${name}" is one-off starting ${formatCalendarDate(parseCalendarDate(form.periodStart))} and ending ${formatCalendarDate(oneOffPeriodEnd(form))}`
+
+    const end = oneOffPeriodEnd(form)
+    if (!start || !end) return `"${name}" is one-off starting ${form.periodStart}`
+
+    return `"${name}" is one-off starting ${formatCalendarDate(start)} and ending ${formatCalendarDate(end)}`
   }
 
   let cadence: string
@@ -62,7 +76,9 @@ export function cadenceSummary(form: BudgetFormState) {
     cadence = safeLength === 1 ? 'yearly' : `every ${safeLength} years`
   }
 
-  return `"${name}" will repeat ${cadence} starting ${form.periodStart ? formatCalendarDate(parseCalendarDate(form.periodStart)) : 'the selected start date'}`
+  const startLabel = start ? formatCalendarDate(start) : (form.periodStart || 'the selected start date')
+
+  return `"${name}" will repeat ${cadence} starting ${startLabel}`
 }
 
 /**
@@ -81,7 +97,15 @@ export function budgetCadenceLabel(baseBudget: BaseBudget) {
  */
 export function formatBudgetPeriod(period: Budget | undefined) {
   if (!period) return 'No period yet'
-  return `${formatCalendarDate(parseCalendarDate(period.period_start))} - ${formatCalendarDate(parseCalendarDate(period.period_end))}`
+  return `${formatPeriodBound(period.period_start)} - ${formatPeriodBound(period.period_end)}`
+}
+
+/**
+ * Formats one end of a stored period, falling back to the value itself when it is not a real date
+ */
+function formatPeriodBound(ymd: string) {
+  const parsed = parseCalendarDate(ymd)
+  return parsed ? formatCalendarDate(parsed) : ymd
 }
 
 /**
@@ -135,10 +159,14 @@ function formatPeriodRange(start: CalendarDate, baseBudget: BaseBudget) {
 }
 
 /**
- * Returns the period start that immediately follows the supplied start after one recurrence cycle
+ * Returns the period start that immediately follows the supplied start after one recurrence cycle,
+ * or null when the supplied start is not a real date
  */
 export function nextRecurringPeriodStart(baseBudget: BaseBudget, periodStart: string) {
-  return formatYmd(addBudgetPeriod(parseCalendarDate(periodStart), baseBudget))
+  const start = parseCalendarDate(periodStart)
+  if (!start) return null
+
+  return formatYmd(addBudgetPeriod(start, baseBudget))
 }
 
 /**
@@ -148,7 +176,12 @@ export function nextBudgetPeriods(baseBudget: BaseBudget, latestPeriod: Budget |
   // Archived budgets stop generating periods, so there is nothing upcoming to preview
   if (!baseBudget.recurs || !latestPeriod || baseBudget.is_archived) return []
 
-  const nextStart = addBudgetPeriod(parseCalendarDate(latestPeriod.period_start), baseBudget)
+  // A stored start that is not a real date previews nothing, rather than previewing dates stepped
+  // from a day the calendar rolled forward
+  const latestStart = parseCalendarDate(latestPeriod.period_start)
+  if (!latestStart) return []
+
+  const nextStart = addBudgetPeriod(latestStart, baseBudget)
   const followingStart = addBudgetPeriod(nextStart, baseBudget)
 
   return [
@@ -164,8 +197,14 @@ export function missingRecurringPeriodStarts(baseBudget: BaseBudget, latestPerio
   if (!baseBudget.recurs || !latestPeriod) return []
 
   const todayDate = parseCalendarDate(today)
+  const latestStart = parseCalendarDate(latestPeriod.period_start)
+
+  // Creating periods from a start that is not a real date would write the rolled-forward day to the
+  // backend, so nothing is created until the stored value is fixed
+  if (!todayDate || !latestStart) return []
+
   const starts: string[] = []
-  let nextStart = addBudgetPeriod(parseCalendarDate(latestPeriod.period_start), baseBudget)
+  let nextStart = addBudgetPeriod(latestStart, baseBudget)
 
   // Create every elapsed start so stale budgets catch up after multiple missed cycles
   while (compareCalendarDates(nextStart, todayDate) <= 0) {

--- a/frontend/src/pages/budgets/utils/date.ts
+++ b/frontend/src/pages/budgets/utils/date.ts
@@ -1,12 +1,19 @@
 import type { CalendarDate } from '@/pages/budgets/types'
-import { DATE_FORMATS, formatDate } from '@/utils/date'
+import { DATE_FORMATS, formatDate, parseYmd } from '@/utils/date'
 
 /**
- * Parses a backend YYYY-MM-DD value into a plain calendar date
+ * Parses a backend YYYY-MM-DD value into a plain calendar date, returning null when it is not a
+ * real date
+ *
+ * The check runs through the shared parse so there is one definition of a day the calendar has, and
+ * so an impossible stored value cannot reach the period arithmetic below and step forward from a day
+ * that was silently rolled into the next month
  */
-export function parseCalendarDate(ymd: string): CalendarDate {
-  const [year, month, day] = ymd.split('-').map(Number)
-  return { year, month, day }
+export function parseCalendarDate(ymd: string): CalendarDate | null {
+  const parsed = parseYmd(ymd)
+  if (!parsed) return null
+
+  return { year: parsed.getFullYear(), month: parsed.getMonth() + 1, day: parsed.getDate() }
 }
 
 /**

--- a/frontend/src/pages/dashboard/utils/formatDashboardShortDate.ts
+++ b/frontend/src/pages/dashboard/utils/formatDashboardShortDate.ts
@@ -1,12 +1,12 @@
-import { DATE_FORMATS, formatDate } from '@/utils/date'
+import { DATE_FORMATS, formatDate, parseYmd } from '@/utils/date'
 
 /**
- * Formats backend YYYY-MM-DD or ISO date strings for compact dashboard labels
+ * Formats a backend YYYY-MM-DD value for compact dashboard labels, falling back to the value itself
+ * when it is not a real date, so the row keeps its amount rather than disappearing
  */
 export function formatDashboardShortDate(value: string) {
-  const [datePart] = value.split('T')
-  const [year, month, day] = datePart.split('-').map(Number)
-  if (!year || !month || !day) return 'Unknown'
+  const parsed = parseYmd(value)
+  if (!parsed) return value
 
-  return formatDate(new Date(year, month - 1, day), DATE_FORMATS.monthDay)
+  return formatDate(parsed, DATE_FORMATS.monthDay)
 }

--- a/frontend/src/pages/dashboard/utils/getSavingsRateSeries.ts
+++ b/frontend/src/pages/dashboard/utils/getSavingsRateSeries.ts
@@ -1,6 +1,6 @@
 import type { SavingsRateWidgetResponse } from '@/api/dashboard'
 import type { SavingsRateSeriesPoint } from '@/pages/dashboard/types/dashboard'
-import { DATE_FORMATS, formatDate } from '@/utils/date'
+import { DATE_FORMATS, formatDate, parseYmd } from '@/utils/date'
 
 /**
  * Converts monthly income/expense rows into chart-ready savings-rate bars
@@ -24,14 +24,14 @@ export function getSavingsRateSeries(
       rate = null
     }
 
-    const monthDate = new Date(`${row.month}T00:00:00`)
-    const monthLabel = formatDate(monthDate, DATE_FORMATS.month)
+    const monthDate = parseYmd(row.month)
+    const monthLabel = monthDate ? formatDate(monthDate, DATE_FORMATS.month) : row.month
     const year = row.month.slice(0, 4)
     const previousYear = rows[index - 1]?.month.slice(0, 4)
 
     return {
-      monthLabel: previousYear && previousYear !== year ? `${monthLabel} '${year.slice(2)}` : monthLabel,
-      fullLabel: formatDate(monthDate, DATE_FORMATS.longMonthYear),
+      monthLabel: monthDate && previousYear && previousYear !== year ? `${monthLabel} '${year.slice(2)}` : monthLabel,
+      fullLabel: monthDate ? formatDate(monthDate, DATE_FORMATS.longMonthYear) : row.month,
       rate,
       income: row.income,
       expenses: row.expenses,

--- a/frontend/src/pages/imports/firefly/utils/budgets.ts
+++ b/frontend/src/pages/imports/firefly/utils/budgets.ts
@@ -184,7 +184,7 @@ function buildLimitSchedule(limitRows: FireflyLimitRow[]): {
   for (const row of limitRows) {
     if (!row.start || !row.end || !row.amount || !row.currencyCode) continue
 
-    // A present date that names no real day marks the file as corrupted, so
+    // A present value that is not a real date marks the file as corrupted, so
     // the budget is refused loudly rather than the row quietly vanishing or
     // the backend failing the whole batch
     const start = parseYmd(row.start)

--- a/frontend/src/pages/imports/firefly/utils/derivation.ts
+++ b/frontend/src/pages/imports/firefly/utils/derivation.ts
@@ -18,7 +18,7 @@ import { parseYmd } from '@/utils/date'
 /**
  * Extracts the date part of a Firefly III timestamp, empty when unparseable
  *
- * A well-shaped date that names no real day, like the 31st of February, is
+ * A well-shaped value that is not a real date, like the 31st of February, is
  * unparseable too, so such rows fail here instead of failing the whole
  * upload batch on the backend
  */

--- a/frontend/src/pages/imports/utils/valueParsers.ts
+++ b/frontend/src/pages/imports/utils/valueParsers.ts
@@ -93,7 +93,7 @@ export function getPreviewDateLabel(ymd: string) {
 }
 
 /**
- * Splits a value into calendar parts under one format, without judging whether they name a real day
+ * Splits a value into calendar parts under one format, without judging whether they are a real date
  */
 function readCalendarDateParts(value: string, format: ImportDateFormat): CalendarDateParts | null {
   if (format === 'written') return readWrittenDateParts(value)

--- a/frontend/src/pages/insights/utils/netWorthChart.ts
+++ b/frontend/src/pages/insights/utils/netWorthChart.ts
@@ -1,6 +1,6 @@
 import { formatCurrency } from '@/utils/formatCurrency'
 import { formatCompactMoney, type CompactMoneyRule } from '@/utils/formatCompactMoney'
-import { DATE_FORMATS, formatDate } from '@/utils/date'
+import { DATE_FORMATS, formatDate, parseYmd } from '@/utils/date'
 
 export type NetWorthViewMode = 'overview' | 'composition'
 
@@ -236,10 +236,20 @@ function getGroupColor(group: NetWorthGroup) {
   )
 }
 
+/**
+ * Reads a YYYY-MM-DD date into the position the chart plots it at
+ *
+ * The position is UTC midnight built from the calendar parts rather than the browser's own midnight,
+ * because the tick spacing steps by a fixed day length and a daylight saving change inside the range
+ * would otherwise move a point off its day
+ *
+ * @throws When the string is not a real date. The series is built from a date column, so a
+ * value that shape means the response is broken rather than the data being unusual, and there is no
+ * position on a number line to fall back to the way a label can fall back to its raw string
+ */
 function dateStringToUtcMs(date: string) {
-  const [year, month, day] = date.split('-').map(Number)
-  if (year && month && day) return Date.UTC(year, month - 1, day)
+  const parsed = parseYmd(date)
+  if (parsed === null) throw new Error(`Expected a YYYY-MM-DD date, received "${date}"`)
 
-  const parsed = new Date(date)
-  return Date.UTC(parsed.getUTCFullYear(), parsed.getUTCMonth(), parsed.getUTCDate())
+  return Date.UTC(parsed.getFullYear(), parsed.getMonth(), parsed.getDate())
 }

--- a/frontend/src/pages/insights/utils/savingsRateTrend.ts
+++ b/frontend/src/pages/insights/utils/savingsRateTrend.ts
@@ -1,6 +1,6 @@
 import type { InsightsSavingsRateTrendResponse } from '@/api/insights'
 import type { SavingsRateHistoryPoint } from '@/pages/insights/types/savingsRate'
-import { DATE_FORMATS, formatDate } from '@/utils/date'
+import { DATE_FORMATS, formatDate, parseYmd } from '@/utils/date'
 import { getSavingsRate } from './money'
 
 /**
@@ -16,19 +16,19 @@ export function getSavingsRateHistory(
   const rows = response?.points ?? []
 
   return rows.map(([monthKey, income, expenses], index) => {
-    const month = new Date(`${monthKey}T00:00:00`)
+    const month = parseYmd(monthKey)
     const rate = income > 0
       ? getSavingsRate(income, expenses)
       : expenses > 0
         ? Number.NEGATIVE_INFINITY
         : null
-    const monthLabel = formatDate(month, DATE_FORMATS.month)
+    const monthLabel = month ? formatDate(month, DATE_FORMATS.month) : monthKey
 
     return {
       monthKey,
       monthLabel,
-      tickLabel: month.getMonth() === 0 ? `${monthLabel} '${String(month.getFullYear()).slice(2)}` : monthLabel,
-      fullLabel: formatDate(month, DATE_FORMATS.longMonthYear),
+      tickLabel: month?.getMonth() === 0 ? `${monthLabel} '${String(month.getFullYear()).slice(2)}` : monthLabel,
+      fullLabel: month ? formatDate(month, DATE_FORMATS.longMonthYear) : monthKey,
       rate,
       income,
       expenses,

--- a/frontend/src/pages/transactions/utils/date.ts
+++ b/frontend/src/pages/transactions/utils/date.ts
@@ -3,7 +3,7 @@ import { DATE_FORMATS, formatDate, parseYmd, getTodayYmd } from '@/utils/date'
 /**
  * Formats the full overview range label while treating YYYY-MM-DD inputs as calendar dates
  *
- * An end of the range that names no real day keeps its raw string, so the label states what it was
+ * An end of the range that is not a real date keeps its raw string, so the label states what it was
  * given rather than the day the date constructor would have rolled it forward to
  */
 export function formatOverviewRangeLabel(from: string, to: string): string {

--- a/frontend/src/utils/date.ts
+++ b/frontend/src/utils/date.ts
@@ -143,8 +143,8 @@ export function formatYmd(date: Date): string {
 }
 
 /**
- * Reads a "YYYY-MM-DD" string back into a date at local midnight, returning null when the string
- * does not name a real calendar day
+ * Reads a "YYYY-MM-DD" string back into a date at local midnight, returning null when it is not a
+ * real date
  *
  * Building the date from its parts rather than letting the browser parse the string keeps it on
  * the local calendar, since a bare date string is otherwise read as UTC and can land on the

--- a/frontend/tests/budgets/budgetDetails.test.ts
+++ b/frontend/tests/budgets/budgetDetails.test.ts
@@ -464,6 +464,22 @@ describe('budget details helpers', () => {
     expect(chartData.every((point) => !point.archived)).toBe(true)
   })
 
+  it('refuses to build a chart column for a period start that is not a real date', () => {
+    const baseBudget = createBaseBudget({ recurs: false })
+
+    // Passed straight to the chart builder rather than through getSortedBudgetPeriods, which reads
+    // the same value and stops on it first in the modal
+    const periods = [createBudget({ id: 'february', period_start: '2026-02-31' })]
+
+    expect(() => getBudgetDetailsChartData({
+      sortedPeriods: periods,
+      utilizationByBudgetId: new Map(),
+      chartCategories: [],
+      baseBudget,
+      today: ymd(2026, 3, 1),
+    })).toThrow('2026-02-31')
+  })
+
   it('labels weekly budget periods with their ISO week number', () => {
     const weeklyBudget = createBaseBudget({
       recurrence_freq: 'weekly',

--- a/frontend/tests/budgets/budgetPeriods.test.ts
+++ b/frontend/tests/budgets/budgetPeriods.test.ts
@@ -127,6 +127,27 @@ describe('budget period helpers', () => {
     ])
   })
 
+  it('backfills nothing from a stored start the calendar does not have', () => {
+    const baseBudget = createBaseBudget()
+    const latestPeriod = createBudget(baseBudget, { period_start: '2026-02-31' })
+
+    expect(missingRecurringPeriodStarts(baseBudget, latestPeriod, '2026-08-15')).toEqual([])
+  })
+
+  it('previews nothing from a stored start the calendar does not have', () => {
+    const baseBudget = createBaseBudget()
+    const latestPeriod = createBudget(baseBudget, { period_start: '2026-02-31' })
+
+    expect(nextBudgetPeriods(baseBudget, latestPeriod)).toEqual([])
+    expect(nextRecurringPeriodStart(baseBudget, '2026-02-31')).toBeNull()
+  })
+
+  it('keeps a period start the calendar does not have as its own label', () => {
+    expect(cadenceSummary(createForm({ recurs: false, periodStart: '2026-02-31' }))).toBe('"Groceries" is one-off starting 2026-02-31')
+    expect(cadenceSummary(createForm({ periodStart: '2026-02-31' }))).toBe('"Groceries" will repeat monthly starting 2026-02-31')
+    expect(oneOffPeriodEnd(createForm({ recurs: false, periodStart: '2026-02-31' }))).toBeNull()
+  })
+
   it('advances a monthly period start by exactly one recurrence cycle', () => {
     const baseBudget = createBaseBudget()
 

--- a/frontend/tests/dashboard/dashboardLogic.test.ts
+++ b/frontend/tests/dashboard/dashboardLogic.test.ts
@@ -25,6 +25,7 @@ import { getNetWorthSeries } from '@/pages/dashboard/utils/getNetWorthSeries'
 import { getRecentActivityRows } from '@/pages/dashboard/utils/getRecentActivityRows'
 import { getRunwayCaption } from '@/pages/dashboard/utils/getRunwayCaption'
 import { getRunwaySegments } from '@/pages/dashboard/utils/getRunwaySegments'
+import { getSavingsRateSeries } from '@/pages/dashboard/utils/getSavingsRateSeries'
 import {
   getSavingsRateChartData,
   getSavingsRateDisplay,
@@ -294,7 +295,26 @@ describe('dashboard logic helpers', () => {
 
   it('formats compact dashboard dates from backend date strings', () => {
     expect(formatDashboardShortDate('2026-01-05')).toBe('Jan 5')
-    expect(formatDashboardShortDate('bad-date')).toBe('Unknown')
+    expect(formatDashboardShortDate('bad-date')).toBe('bad-date')
+  })
+
+  it('keeps a dashboard date the calendar does not have instead of rolling it forward', () => {
+    expect(formatDashboardShortDate('2026-02-31')).toBe('2026-02-31')
+  })
+
+  it('refuses a dashboard date carrying a time, which the API never sends', () => {
+    expect(formatDashboardShortDate('2026-01-05T00:00:00')).toBe('2026-01-05T00:00:00')
+  })
+
+  it('keeps a savings-rate month the calendar does not have as its own label', () => {
+    const [point] = getSavingsRateSeries({
+      savings_rate_history: [{ month: '2026-02-31', income: 100, expenses: 50 }],
+      fx_status: fxStatus,
+    })
+
+    expect(point.monthLabel).toBe('2026-02-31')
+    expect(point.fullLabel).toBe('2026-02-31')
+    expect(point.rate).toBe(50)
   })
 
   it('builds spending comparison series and summary gaps without inventing values', () => {

--- a/frontend/tests/pages/insights/netWorthChart.test.ts
+++ b/frontend/tests/pages/insights/netWorthChart.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Covers how the net worth chart turns each point's date into the position it is plotted at, which
+ * is the one reader with no label to fall back to when the date is not a real one
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  getNetWorthChartData,
+  getNetWorthChartItems,
+  type NetWorthPoint,
+} from '@/pages/insights/utils/netWorthChart';
+
+const GROUPS = [{ id: 'cash', name: 'Cash', kind: 'asset' as const }];
+
+/**
+ * Builds a one-group series point carrying the supplied date
+ */
+function createPoint(date: string): NetWorthPoint {
+  return { date, dateLabel: date, tooltipLabel: date, total: 100, values: [100] };
+}
+
+describe('net worth chart positions', () => {
+  it('plots a point at the UTC midnight of its calendar day', () => {
+    const items = getNetWorthChartItems(GROUPS, 'overview');
+
+    const [point] = getNetWorthChartData([createPoint('2026-03-09')], items, 'overview');
+
+    expect(point.dateMs).toBe(Date.UTC(2026, 2, 9));
+  });
+
+  it('refuses a date the calendar does not have rather than plotting it in the next month', () => {
+    const items = getNetWorthChartItems(GROUPS, 'overview');
+
+    expect(() => getNetWorthChartData([createPoint('2026-02-31')], items, 'overview')).toThrow('2026-02-31');
+  });
+
+  it('refuses a date the browser would parse for itself', () => {
+    const items = getNetWorthChartItems(GROUPS, 'overview');
+
+    expect(() => getNetWorthChartData([createPoint('March 9, 2026')], items, 'overview')).toThrow();
+  });
+});

--- a/frontend/tests/pages/insights/savingsRateTrend.test.ts
+++ b/frontend/tests/pages/insights/savingsRateTrend.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Covers how the insights savings-rate trend labels each month, including a stored month key that
+ * is not a real date, which the browser would otherwise parse for itself
+ */
+import { describe, expect, it } from 'vitest';
+import type { FxStatus } from '@/api/shared/fx';
+import { getSavingsRateHistory } from '@/pages/insights/utils/savingsRateTrend';
+
+const FX_STATUS: FxStatus = { state: 'none', missing_pairs: [] };
+
+describe('getSavingsRateHistory', () => {
+  it('labels a month from its calendar parts', () => {
+    const [point] = getSavingsRateHistory({ points: [['2026-03-01', 100, 40]], fx_status: FX_STATUS });
+
+    expect(point.monthLabel).toBe('Mar');
+    expect(point.fullLabel).toBe('March 2026');
+  });
+
+  it('marks the first month of a year with its two-digit year', () => {
+    const [point] = getSavingsRateHistory({ points: [['2026-01-01', 100, 40]], fx_status: FX_STATUS });
+
+    expect(point.tickLabel).toBe("Jan '26");
+  });
+
+  it('keeps a month the calendar does not have as its own label', () => {
+    const [point] = getSavingsRateHistory({ points: [['2026-02-31', 100, 40]], fx_status: FX_STATUS });
+
+    expect(point.monthLabel).toBe('2026-02-31');
+    expect(point.tickLabel).toBe('2026-02-31');
+    expect(point.fullLabel).toBe('2026-02-31');
+  });
+});


### PR DESCRIPTION
One function on the backend turns the timezone saved on a profile into a zone, and where the stored identifier isn't one the app recognizes it refuses the request with the value in the message, so nothing computes or saves a date on a calendar the user never chose. On the frontend a value that isn't a real date shows as itself rather than as the day it would roll forward to. Neither can be produced through the product, so this covers one arriving another way, such as a database restore.
