### PR TITLE
fix: cap request sizes and check database identities

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -17,17 +17,26 @@ current_user_id_ctx: ContextVar[uuid.UUID | None] = ContextVar("current_user_id"
 # expire_on_commit=False keeps objects usable after commit without re-fetching
 async_session = async_sessionmaker(engine, expire_on_commit=False)
 
+# Written with the asyncpg placeholder style, since exec_driver_sql passes the statement
+# to the driver without the translation a SQLAlchemy text() construct would get
+_SET_IDENTITY_SQL = "SELECT set_config('app.current_user_id', $1, true)"
+
 
 def stamp_request_identity(connection) -> None:
-    """Stamp the request user onto a new transaction for row-level security"""
+    """Stamp the request user onto a new transaction for row-level security
+
+    Raises:
+        ValueError: The context variable holds a value that is not a UUID
+    """
     # Transaction-local so the value resets on commit and never leaks onto the
     # pooled connection, and re-stamped here whenever a request opens a new one
     user_id = current_user_id_ctx.get()
 
-    # The value is always a validated UUID or empty, so it is safe to inline, and a
-    # bound parameter is not available inside this connection-begin event
-    identity = str(user_id) if user_id is not None else ""
-    connection.exec_driver_sql(f"SELECT set_config('app.current_user_id', '{identity}', true)")
+    # Cast rather than trust the caller, so a value reaching the context variable from a
+    # job payload or a database column fails here instead of at policy evaluation. An
+    # absent identity stamps empty, which is what makes the policies match no rows
+    identity = "" if user_id is None else str(uuid.UUID(str(user_id)))
+    connection.exec_driver_sql(_SET_IDENTITY_SQL, (identity,))
 
 
 # The test suite registers this same listener on its own app-role engine so route

--- a/backend/app/db/rls/functions.py
+++ b/backend/app/db/rls/functions.py
@@ -152,17 +152,24 @@ _HELPERS: tuple[_Helper, ...] = (
     ),
     # Touch a group member's personal cache timestamp on their behalf, used when an admin
     # removing them must invalidate their cache even though the per-user write policy scopes
-    # cache writes to the caller. The group is an argument rather than looked up from the
-    # target's membership, because the caller has already deleted that membership by the time
-    # this runs, while the caller's own is still there. plpgsql rather than sql so a denied
-    # call raises instead of quietly inserting nothing, and IS DISTINCT FROM so a connection
-    # carrying no identity is refused rather than comparing to NULL and falling through
+    # cache writes to the caller. Both halves are needed: administering the named group alone
+    # would let anyone stamp any user, since creating a group makes the creator its admin, so
+    # the target has to be a member of that same group. The caller must therefore stamp before
+    # deleting the membership. plpgsql rather than sql so a denied call raises instead of
+    # quietly inserting nothing, and IS DISTINCT FROM so a connection carrying no identity is
+    # refused rather than comparing to NULL and falling through
     _Helper(
         f"""
     CREATE OR REPLACE FUNCTION {BUMP_GROUP_MEMBER_CACHE}(p_user_id uuid, p_group_id uuid) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
     BEGIN
-        IF p_user_id IS DISTINCT FROM {CURRENT_USER_ID}() AND NOT {IS_GROUP_ADMIN}(p_group_id) THEN
+        IF p_user_id IS DISTINCT FROM {CURRENT_USER_ID}() AND NOT (
+            {IS_GROUP_ADMIN}(p_group_id)
+            AND EXISTS (
+                SELECT 1 FROM public.group_members gm
+                WHERE gm.group_id = p_group_id AND gm.user_id = p_user_id
+            )
+        ) THEN
             RAISE EXCEPTION 'Not authorized to invalidate the cache for this user'
                 USING ERRCODE = 'insufficient_privilege';
         END IF;

--- a/backend/app/db/rls/functions.py
+++ b/backend/app/db/rls/functions.py
@@ -155,21 +155,23 @@ _HELPERS: tuple[_Helper, ...] = (
     # cache writes to the caller. Both halves are needed: administering the named group alone
     # would let anyone stamp any user, since creating a group makes the creator its admin, so
     # the target has to be a member of that same group. The caller must therefore stamp before
-    # deleting the membership. plpgsql rather than sql so a denied call raises instead of
-    # quietly inserting nothing, and IS DISTINCT FROM so a connection carrying no identity is
-    # refused rather than comparing to NULL and falling through
+    # deleting the membership. This narrows the reachable set rather than closing it, because
+    # an admin can add a user to their own group without that user agreeing, so the caller
+    # still gets there with the target's id and one extra call. plpgsql rather than sql so a
+    # denied call raises instead of quietly inserting nothing, and a null target or a
+    # connection carrying no identity is refused outright rather than compared to NULL
     _Helper(
         f"""
     CREATE OR REPLACE FUNCTION {BUMP_GROUP_MEMBER_CACHE}(p_user_id uuid, p_group_id uuid) RETURNS void
     LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
     BEGIN
-        IF p_user_id IS DISTINCT FROM {CURRENT_USER_ID}() AND NOT (
+        IF p_user_id IS NULL OR (p_user_id IS DISTINCT FROM {CURRENT_USER_ID}() AND NOT (
             {IS_GROUP_ADMIN}(p_group_id)
             AND EXISTS (
                 SELECT 1 FROM public.group_members gm
                 WHERE gm.group_id = p_group_id AND gm.user_id = p_user_id
             )
-        ) THEN
+        )) THEN
             RAISE EXCEPTION 'Not authorized to invalidate the cache for this user'
                 USING ERRCODE = 'insufficient_privilege';
         END IF;

--- a/backend/app/db/rls/functions.py
+++ b/backend/app/db/rls/functions.py
@@ -5,6 +5,10 @@ bypasses RLS, which both lets the policies see real membership and stops a polic
 queries a table from recursing into that table's own policy. Every helper is paired
 with the signature needed to drop it, so adding one is a single edit and revoking can
 never leave a function behind
+
+A helper whose argument list changes is a new function rather than a replacement, so the
+signature it used to have is retired through the obsolete list below and dropped by both
+the apply and the revoke path
 """
 
 from typing import NamedTuple
@@ -20,8 +24,14 @@ CAN_ACCESS_GROUP = "public.can_access_group"
 CAN_ACCESS_BASE_BUDGET = "public.can_access_base_budget"
 FIND_LOGIN_USER = "public.find_login_user"
 USER_TZ = "public.user_tz"
-BUMP_USER_CACHE = "public.bump_user_cache"
+BUMP_GROUP_MEMBER_CACHE = "public.bump_group_member_cache"
 BUDGET_SPEND_ROWS = "public.budget_spend_rows"
+
+# Signatures the app no longer creates, dropped wherever the helpers are applied or revoked.
+# bump_user_cache stamped whatever user id it was given, and the app role can execute every
+# function in the schema, so leaving it on an already-provisioned database would keep any
+# authenticated user able to invalidate any other user's cache
+_OBSOLETE_SIGNATURES: tuple[str, ...] = ("public.bump_user_cache(uuid)",)
 
 
 class _Helper(NamedTuple):
@@ -140,19 +150,30 @@ _HELPERS: tuple[_Helper, ...] = (
     """,
         f"{USER_TZ}(uuid)",
     ),
-    # Touch a user's personal cache timestamp on their behalf, used when an authorized
-    # action by another user, such as removing them from a group, must invalidate their
-    # cache even though the per-user write policy scopes cache writes to the caller
+    # Touch a group member's personal cache timestamp on their behalf, used when an admin
+    # removing them must invalidate their cache even though the per-user write policy scopes
+    # cache writes to the caller. The group is an argument rather than looked up from the
+    # target's membership, because the caller has already deleted that membership by the time
+    # this runs, while the caller's own is still there. plpgsql rather than sql so a denied
+    # call raises instead of quietly inserting nothing, and IS DISTINCT FROM so a connection
+    # carrying no identity is refused rather than comparing to NULL and falling through
     _Helper(
         f"""
-    CREATE OR REPLACE FUNCTION {BUMP_USER_CACHE}(p_user_id uuid) RETURNS void
-    LANGUAGE sql SECURITY DEFINER SET search_path = '' AS $$
+    CREATE OR REPLACE FUNCTION {BUMP_GROUP_MEMBER_CACHE}(p_user_id uuid, p_group_id uuid) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER SET search_path = '' AS $$
+    BEGIN
+        IF p_user_id IS DISTINCT FROM {CURRENT_USER_ID}() AND NOT {IS_GROUP_ADMIN}(p_group_id) THEN
+            RAISE EXCEPTION 'Not authorized to invalidate the cache for this user'
+                USING ERRCODE = 'insufficient_privilege';
+        END IF;
+
         INSERT INTO public.user_cache_states (user_id, changed_at, last_changed_session_id)
         VALUES (p_user_id, clock_timestamp(), NULL)
-        ON CONFLICT (user_id) DO UPDATE SET changed_at = clock_timestamp(), last_changed_session_id = NULL
+        ON CONFLICT (user_id) DO UPDATE SET changed_at = clock_timestamp(), last_changed_session_id = NULL;
+    END
     $$
     """,
-        f"{BUMP_USER_CACHE}(uuid)",
+        f"{BUMP_GROUP_MEMBER_CACHE}(uuid, uuid)",
     ),
     # Aggregate spend per tracked category for budgets the current user can access
     # The visibility check makes the function self-authorizing rather than trusting its
@@ -199,11 +220,19 @@ _HELPERS: tuple[_Helper, ...] = (
 
 def create_helper_functions(connection: Connection) -> None:
     """Create every SECURITY DEFINER helper the policies and the app rely on"""
+    _drop_obsolete_helper_functions(connection)
     for helper in _HELPERS:
         connection.execute(text(helper.create_sql))
 
 
 def drop_helper_functions(connection: Connection) -> None:
     """Drop every helper function when row-level security is removed"""
+    _drop_obsolete_helper_functions(connection)
     for helper in _HELPERS:
         connection.execute(text(f"DROP FUNCTION IF EXISTS {helper.drop_signature}"))
+
+
+def _drop_obsolete_helper_functions(connection: Connection) -> None:
+    """Drop retired helper signatures the app no longer creates"""
+    for signature in _OBSOLETE_SIGNATURES:
+        connection.execute(text(f"DROP FUNCTION IF EXISTS {signature}"))

--- a/backend/app/http_client.py
+++ b/backend/app/http_client.py
@@ -6,9 +6,14 @@ import httpx
 # hundred KB, so this bounds a hostile or compromised endpoint without constraining real use
 MAX_RESPONSE_BYTES = 5 * 1024 * 1024
 
-# The capped read decodes as it counts, so the rebuilt response must not keep the headers
-# describing the encoding and length of the original transfer
-_STALE_TRANSFER_HEADERS = (b"content-encoding", b"content-length")
+# Compression is declined so the counted bytes are the real ones. Counting after decoding
+# would let a hostile endpoint spend a few hundred compressed KB to allocate gigabytes, which
+# is the case the cap exists for, and bounding that any other way means decoding by hand
+_DECLINE_COMPRESSION = {"accept-encoding": "identity"}
+
+# The rebuilt response holds exactly the bytes that came off the wire, so it keeps the header
+# describing their encoding and drops the two describing how the transfer was framed
+_RETRANSFERRED_HEADERS = (b"content-length", b"transfer-encoding")
 
 
 class ResponseTooLargeError(httpx.RequestError):
@@ -36,7 +41,7 @@ class _CappedResponseClient(httpx.AsyncClient):
             **kwargs: Remaining httpx send arguments
 
         Returns:
-            The response, already read, with the headers describing the raw transfer removed
+            The response, already read, carrying the bytes that arrived on the wire
 
         Raises:
             ResponseTooLargeError: The body went past the cap
@@ -48,7 +53,8 @@ class _CappedResponseClient(httpx.AsyncClient):
         response = await super().send(request, stream=True, **kwargs)
         body = bytearray()
         try:
-            async for chunk in response.aiter_bytes():
+            # Raw rather than decoded, so the count is of bytes actually received
+            async for chunk in response.aiter_raw():
                 body += chunk
                 if len(body) > self.max_response_bytes:
                     raise ResponseTooLargeError(
@@ -57,12 +63,15 @@ class _CappedResponseClient(httpx.AsyncClient):
         finally:
             await response.aclose()
 
+        # A response to HEAD comes back reporting a length of zero rather than the size the
+        # origin declared, since the rebuild takes its length from the body actually read
         return httpx.Response(
             status_code=response.status_code,
             headers=[(name, value) for name, value in response.headers.raw
-                     if name.lower() not in _STALE_TRANSFER_HEADERS],
+                     if name.lower() not in _RETRANSFERRED_HEADERS],
             content=bytes(body),
             request=request,
+            history=response.history,
             extensions=response.extensions,
         )
 
@@ -76,4 +85,4 @@ def build_http_client(timeout: float) -> httpx.AsyncClient:
     Returns:
         An async client enforcing the response size cap
     """
-    return _CappedResponseClient(timeout=timeout)
+    return _CappedResponseClient(timeout=timeout, headers=_DECLINE_COMPRESSION)

--- a/backend/app/http_client.py
+++ b/backend/app/http_client.py
@@ -1,4 +1,4 @@
-"""Outbound HTTP client that bounds how much of a response it will read"""
+"""Outbound HTTP client that bounds the memory a response body can take"""
 
 import httpx
 
@@ -21,9 +21,16 @@ class ResponseTooLargeError(httpx.RequestError):
 
 
 class _CappedResponseClient(httpx.AsyncClient):
-    """Async client that stops reading a response body once it passes the cap"""
+    """Async client that abandons a response body once it takes more than the cap"""
 
     def __init__(self, *args, max_response_bytes: int = MAX_RESPONSE_BYTES, **kwargs) -> None:
+        """Build a client refusing a response body larger than the given cap
+
+        Args:
+            *args: httpx client arguments
+            max_response_bytes: Largest decoded response body accepted
+            **kwargs: Remaining httpx client arguments
+        """
         super().__init__(*args, **kwargs)
         self.max_response_bytes = max_response_bytes
 
@@ -68,7 +75,10 @@ class _CappedResponseClient(httpx.AsyncClient):
             headers=[(name, value) for name, value in response.headers.raw
                      if name.lower() not in _DROPPED_TRANSFER_HEADERS],
             content=bytes(body),
-            request=request,
+
+            # The response's own request rather than the one passed in, so a followed
+            # redirect reports the URL that actually answered
+            request=response.request,
             history=response.history,
             extensions=response.extensions,
         )

--- a/backend/app/http_client.py
+++ b/backend/app/http_client.py
@@ -1,0 +1,78 @@
+"""Outbound HTTP client that bounds how much of a response it will read"""
+
+import httpx
+
+# 5 MB. The largest body any caller legitimately reads is a multi-year FX series at a few
+# hundred KB, so this bounds a hostile or compromised endpoint without constraining real use
+MAX_RESPONSE_BYTES = 5 * 1024 * 1024
+
+# The capped read decodes as it counts, so the rebuilt response must not keep the headers
+# describing the encoding and length of the original transfer
+_STALE_TRANSFER_HEADERS = (b"content-encoding", b"content-length")
+
+
+class ResponseTooLargeError(httpx.RequestError):
+    """A response body went past the cap and was abandoned part-read
+
+    Subclasses the httpx error for an unreachable host so callers already handling a dead
+    provider treat an oversized one the same way, rather than raising through to a 500
+    """
+
+
+class _CappedResponseClient(httpx.AsyncClient):
+    """Async client that stops reading a response body once it passes the cap"""
+
+    def __init__(self, *args, max_response_bytes: int = MAX_RESPONSE_BYTES, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.max_response_bytes = max_response_bytes
+
+    async def send(self, request: httpx.Request, *, stream: bool = False, **kwargs) -> httpx.Response:
+        """Read a response through a byte counter and return it with its body loaded
+
+        Args:
+            request: Request to send
+            stream: Unsupported, since a caller reading the stream itself would not be counted
+            **kwargs: Remaining httpx send arguments
+
+        Returns:
+            The response, already read, with the headers describing the raw transfer removed
+
+        Raises:
+            ResponseTooLargeError: The body went past the cap
+            RuntimeError: A streaming read was asked for
+        """
+        if stream:
+            raise RuntimeError("This client reads responses itself, so it cannot stream one")
+
+        response = await super().send(request, stream=True, **kwargs)
+        body = bytearray()
+        try:
+            async for chunk in response.aiter_bytes():
+                body += chunk
+                if len(body) > self.max_response_bytes:
+                    raise ResponseTooLargeError(
+                        f"Response body exceeded {self.max_response_bytes} bytes", request=request
+                    )
+        finally:
+            await response.aclose()
+
+        return httpx.Response(
+            status_code=response.status_code,
+            headers=[(name, value) for name, value in response.headers.raw
+                     if name.lower() not in _STALE_TRANSFER_HEADERS],
+            content=bytes(body),
+            request=request,
+            extensions=response.extensions,
+        )
+
+
+def build_http_client(timeout: float) -> httpx.AsyncClient:
+    """Return an async HTTP client that refuses a response body past the cap
+
+    Args:
+        timeout: Per-request timeout in seconds
+
+    Returns:
+        An async client enforcing the response size cap
+    """
+    return _CappedResponseClient(timeout=timeout)

--- a/backend/app/http_client.py
+++ b/backend/app/http_client.py
@@ -13,7 +13,7 @@ _DECLINE_COMPRESSION = {"accept-encoding": "identity"}
 
 # The rebuilt response holds exactly the bytes that came off the wire, so it keeps the header
 # describing their encoding and drops the two describing how the transfer was framed
-_RETRANSFERRED_HEADERS = (b"content-length", b"transfer-encoding")
+_DROPPED_TRANSFER_HEADERS = (b"content-length", b"transfer-encoding")
 
 
 class ResponseTooLargeError(httpx.RequestError):
@@ -63,12 +63,12 @@ class _CappedResponseClient(httpx.AsyncClient):
         finally:
             await response.aclose()
 
-        # A response to HEAD comes back reporting a length of zero rather than the size the
-        # origin declared, since the rebuild takes its length from the body actually read
+        # A response to HEAD comes back with no Content-Length at all, rather than the size
+        # the origin declared, since the rebuild takes its length from the body actually read
         return httpx.Response(
             status_code=response.status_code,
             headers=[(name, value) for name, value in response.headers.raw
-                     if name.lower() not in _RETRANSFERRED_HEADERS],
+                     if name.lower() not in _DROPPED_TRANSFER_HEADERS],
             content=bytes(body),
             request=request,
             history=response.history,

--- a/backend/app/http_client.py
+++ b/backend/app/http_client.py
@@ -14,8 +14,9 @@ _STALE_TRANSFER_HEADERS = (b"content-encoding", b"content-length")
 class ResponseTooLargeError(httpx.RequestError):
     """A response body went past the cap and was abandoned part-read
 
-    Subclasses the httpx error for an unreachable host so callers already handling a dead
-    provider treat an oversized one the same way, rather than raising through to a 500
+    Subclasses httpx's base error for a failed request so callers already handling a
+    timeout or an unreachable provider treat an oversized one the same way, rather than
+    letting it raise through to a 500
     """
 
 

--- a/backend/app/http_client.py
+++ b/backend/app/http_client.py
@@ -6,14 +6,9 @@ import httpx
 # hundred KB, so this bounds a hostile or compromised endpoint without constraining real use
 MAX_RESPONSE_BYTES = 5 * 1024 * 1024
 
-# Compression is declined so the counted bytes are the real ones. Counting after decoding
-# would let a hostile endpoint spend a few hundred compressed KB to allocate gigabytes, which
-# is the case the cap exists for, and bounding that any other way means decoding by hand
-_DECLINE_COMPRESSION = {"accept-encoding": "identity"}
-
-# The rebuilt response holds exactly the bytes that came off the wire, so it keeps the header
-# describing their encoding and drops the two describing how the transfer was framed
-_DROPPED_TRANSFER_HEADERS = (b"content-length", b"transfer-encoding")
+# The rebuilt response holds decoded bytes, so none of the headers describing how the
+# original arrived still apply to it
+_DROPPED_TRANSFER_HEADERS = (b"content-encoding", b"content-length", b"transfer-encoding")
 
 
 class ResponseTooLargeError(httpx.RequestError):
@@ -41,7 +36,7 @@ class _CappedResponseClient(httpx.AsyncClient):
             **kwargs: Remaining httpx send arguments
 
         Returns:
-            The response, already read, carrying the bytes that arrived on the wire
+            The response, already read and decoded
 
         Raises:
             ResponseTooLargeError: The body went past the cap
@@ -53,8 +48,11 @@ class _CappedResponseClient(httpx.AsyncClient):
         response = await super().send(request, stream=True, **kwargs)
         body = bytearray()
         try:
-            # Raw rather than decoded, so the count is of bytes actually received
-            async for chunk in response.aiter_raw():
+            # Decoded rather than raw, so the count is of memory held rather than bytes
+            # received. A compressed chunk expands before the count sees it, so the peak is
+            # the cap plus one chunk's expansion, which these few low-concurrency calls can
+            # absorb. Bounding it exactly would mean decompressing by hand
+            async for chunk in response.aiter_bytes():
                 body += chunk
                 if len(body) > self.max_response_bytes:
                     raise ResponseTooLargeError(
@@ -85,4 +83,4 @@ def build_http_client(timeout: float) -> httpx.AsyncClient:
     Returns:
         An async client enforcing the response size cap
     """
-    return _CappedResponseClient(timeout=timeout, headers=_DECLINE_COMPRESSION)
+    return _CappedResponseClient(timeout=timeout)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config.oidc import OIDC_PROVIDER_CONFIGS
 from app.config.runtime import ALLOWED_ORIGINS, RUNTIME
 from app.database import async_session, verify_app_role_is_unprivileged
+from app.request_security import RequestBodySizeLimitMiddleware
 from app.routes.accounts import router as account_router
 from app.routes.app_version import router as app_version_router
 from app.routes.auth import router as auth_router
@@ -56,7 +57,12 @@ app = FastAPI(title="Lumina Finance API", lifespan=_lifespan)
 set_email_sender(build_email_sender())
 
 
-# CORS — origins from env
+# Added before CORS so CORS ends up the outer layer, since middleware wraps in reverse order
+# of addition and a rejected oversized body still has to carry its CORS headers
+app.add_middleware(RequestBodySizeLimitMiddleware)
+
+
+# CORS origins from env
 _allowed_origins = list(ALLOWED_ORIGINS)
 
 app.add_middleware(

--- a/backend/app/request_security.py
+++ b/backend/app/request_security.py
@@ -2,11 +2,14 @@
 
 import json
 
+from fastapi import HTTPException
+
 # 10 MB. The frontend batches a transaction import into 750 KB requests, and the one
 # request it cannot split, a Firefly III budget import, is a few MB at its largest
 MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024
 
-_TOO_LARGE_BODY = json.dumps({"detail": "Request body is too large"}).encode()
+_TOO_LARGE_DETAIL = "Request body is too large"
+_TOO_LARGE_BODY = json.dumps({"detail": _TOO_LARGE_DETAIL}).encode()
 
 
 def _too_large_response_start() -> dict:
@@ -27,11 +30,13 @@ def _too_large_response_start() -> dict:
 
 
 class RequestBodySizeLimitMiddleware:
-    """Reject a request whose body is larger than the cap before any route runs
+    """Refuse a request body larger than the cap
 
-    The body is read and counted here rather than as the route pulls it, because a route
-    that never reads its body, such as one working only from cookies, would otherwise let
-    an unbounded stream through uncounted
+    A declared length over the cap is refused before the route runs and before a byte is
+    read. Anything else is counted as the route pulls it, rather than being read here, so
+    an unauthenticated connection costs no more than the server already holds for it. A
+    route that never reads its body is never counted, which the server bounds on its own
+    by pausing the socket once nothing is consuming
     """
 
     def __init__(self, app, max_body_bytes: int = MAX_REQUEST_BODY_BYTES) -> None:
@@ -45,93 +50,67 @@ class RequestBodySizeLimitMiddleware:
         self.max_body_bytes = max_body_bytes
 
     async def __call__(self, scope, receive, send) -> None:
-        """Count the request body, rejecting it past the cap, then run the app over it"""
+        """Refuse an oversized body, otherwise run the app over a counted one"""
         # Lifespan and websocket traffic carry no request body to count
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return
 
-        declared_length, carries_body = _read_body_headers(scope)
-
-        # A request declaring neither a length nor a chunked encoding carries no body, so it
-        # is handed straight on and keeps reading from the server rather than from a replay
-        if not carries_body:
-            await self.app(scope, receive, send)
-            return
-
-        # A declared length refuses an oversized body without reading any of it
+        declared_length = _declared_body_length(scope)
         if declared_length is not None and declared_length > self.max_body_bytes:
             await self._reject(send)
             return
 
-        body = bytearray()
-        more_body = True
-        while more_body:
-            message = await receive()
-
-            # A client that disconnects mid-body leaves the app to handle the disconnect
-            if message["type"] != "http.request":
-                await self.app(scope, _replay(bytes(body), receive, message), send)
-                return
-
-            body += message.get("body", b"")
-            if len(body) > self.max_body_bytes:
-                await self._reject(send)
-                return
-            more_body = message.get("more_body", False)
-
-        await self.app(scope, _replay(bytes(body), receive), send)
+        await self.app(scope, _counting_receive(receive, self.max_body_bytes), send)
 
     async def _reject(self, send) -> None:
-        """Send the 413 the app would otherwise have to produce after reading the body"""
+        """Answer the 413 directly, which is available because no route has started yet"""
         await send(_too_large_response_start())
         await send({"type": "http.response.body", "body": _TOO_LARGE_BODY})
 
 
-def _read_body_headers(scope) -> tuple[int | None, bool]:
-    """Return the declared body length and whether the request carries a body at all
+def _declared_body_length(scope) -> int | None:
+    """Return the body length the request declares, or None when it declares none
 
-    A declared length that will not parse still counts as carrying one, leaving the running
-    count to decide it rather than letting a malformed header skip the guard
+    A length that will not parse reads as undeclared, leaving the running count to decide
+    rather than letting a malformed header skip the guard
 
     Args:
         scope: ASGI connection scope
 
     Returns:
-        The declared length or None, paired with whether a body is expected
+        The declared length, or None
     """
-    declared_length = None
-    carries_body = False
     for name, value in scope["headers"]:
         if name == b"content-length":
-            declared_length = int(value) if value.isdigit() else None
-            carries_body = carries_body or value != b"0"
-        elif name == b"transfer-encoding":
-            carries_body = carries_body or b"chunked" in value.lower()
-    return declared_length, carries_body
+            return int(value) if value.isdigit() else None
+    return None
 
 
-def _replay(body: bytes, receive, trailing_message: dict | None = None):
-    """Return a receive callable handing the buffered body to the app
+def _counting_receive(receive, max_body_bytes: int):
+    """Return a receive callable refusing the body once it passes the cap
 
-    Once the buffer runs out it falls back to the server's own receive, so an app waiting
-    on a disconnect waits for the real one. Answering with a disconnect of its own would
-    tell a streaming response the client had gone the moment the body was read
+    The refusal is raised rather than written, because the route is already running and
+    waiting on this call. FastAPI re-raises an HTTPException out of its body parsing, so it
+    is rendered as the same 413 by the handler every other one goes through
 
     Args:
-        body: Request body already read and counted
-        receive: The server's receive, used once the buffer is spent
-        trailing_message: Message that ended the read early, such as a disconnect
+        receive: The server's receive
+        max_body_bytes: Largest request body accepted
 
     Returns:
         An ASGI receive callable
     """
-    messages = [{"type": "http.request", "body": bytes(body), "more_body": trailing_message is not None}]
-    if trailing_message is not None:
-        messages.append(trailing_message)
+    counted = 0
 
-    async def replay_receive():
-        """Return the next buffered message, then whatever the server sends next"""
-        return messages.pop(0) if messages else await receive()
+    async def counting_receive():
+        """Pass the next message through, counting the body as it goes"""
+        nonlocal counted
+        message = await receive()
+        if message["type"] == "http.request":
+            counted += len(message.get("body", b""))
+            if counted > max_body_bytes:
+                raise HTTPException(status_code=413, detail=_TOO_LARGE_DETAIL)
+        return message
 
-    return replay_receive
+    return counting_receive

--- a/backend/app/request_security.py
+++ b/backend/app/request_security.py
@@ -71,7 +71,7 @@ class RequestBodySizeLimitMiddleware:
 
             # A client that disconnects mid-body leaves the app to handle the disconnect
             if message["type"] != "http.request":
-                await self.app(scope, _replay(body, message), send)
+                await self.app(scope, _replay(body, receive, message), send)
                 return
 
             body += message.get("body", b"")
@@ -80,7 +80,7 @@ class RequestBodySizeLimitMiddleware:
                 return
             more_body = message.get("more_body", False)
 
-        await self.app(scope, _replay(bytes(body)), send)
+        await self.app(scope, _replay(bytes(body), receive), send)
 
     async def _reject(self, send) -> None:
         """Send the 413 the app would otherwise have to produce after reading the body"""
@@ -111,11 +111,16 @@ def _read_body_headers(scope) -> tuple[int | None, bool]:
     return declared_length, carries_body
 
 
-def _replay(body: bytes, trailing_message: dict | None = None):
+def _replay(body: bytes, receive, trailing_message: dict | None = None):
     """Return a receive callable handing the buffered body to the app
+
+    Once the buffer runs out it falls back to the server's own receive, so an app waiting
+    on a disconnect waits for the real one. Answering with a disconnect of its own would
+    tell a streaming response the client had gone the moment the body was read
 
     Args:
         body: Request body already read and counted
+        receive: The server's receive, used once the buffer is spent
         trailing_message: Message that ended the read early, such as a disconnect
 
     Returns:
@@ -125,8 +130,8 @@ def _replay(body: bytes, trailing_message: dict | None = None):
     if trailing_message is not None:
         messages.append(trailing_message)
 
-    async def receive():
-        """Return the next buffered message, then behave as a client that has gone away"""
-        return messages.pop(0) if messages else {"type": "http.disconnect"}
+    async def replay_receive():
+        """Return the next buffered message, then whatever the server sends next"""
+        return messages.pop(0) if messages else await receive()
 
-    return receive
+    return replay_receive

--- a/backend/app/request_security.py
+++ b/backend/app/request_security.py
@@ -36,7 +36,16 @@ class RequestBodySizeLimitMiddleware:
             await self.app(scope, receive, send)
             return
 
-        if self._is_declared_length_over_cap(scope):
+        declared_length, carries_body = _read_body_headers(scope)
+
+        # A request declaring neither a length nor a chunked encoding carries no body, so it
+        # is handed straight on and keeps reading from the server rather than from a replay
+        if not carries_body:
+            await self.app(scope, receive, send)
+            return
+
+        # A declared length refuses an oversized body without reading any of it
+        if declared_length is not None and declared_length > self.max_body_bytes:
             await self._reject(send)
             return
 
@@ -58,21 +67,33 @@ class RequestBodySizeLimitMiddleware:
 
         await self.app(scope, _replay(bytes(body)), send)
 
-    def _is_declared_length_over_cap(self, scope) -> bool:
-        """Whether the request declares a Content-Length larger than the cap
-
-        A declared length lets an oversized body be refused without reading it. A missing
-        or unparseable one is not trusted either way, since the counter above decides
-        """
-        for name, value in scope["headers"]:
-            if name == b"content-length":
-                return value.isdigit() and int(value) > self.max_body_bytes
-        return False
-
     async def _reject(self, send) -> None:
         """Send the 413 the app would otherwise have to produce after reading the body"""
         await send(_TOO_LARGE_RESPONSE_START)
         await send({"type": "http.response.body", "body": _TOO_LARGE_BODY})
+
+
+def _read_body_headers(scope) -> tuple[int | None, bool]:
+    """Return the declared body length and whether the request carries a body at all
+
+    A declared length that will not parse still counts as carrying one, leaving the running
+    count to decide it rather than letting a malformed header skip the guard
+
+    Args:
+        scope: ASGI connection scope
+
+    Returns:
+        The declared length or None, paired with whether a body is expected
+    """
+    declared_length = None
+    carries_body = False
+    for name, value in scope["headers"]:
+        if name == b"content-length":
+            declared_length = int(value) if value.isdigit() else None
+            carries_body = carries_body or value != b"0"
+        elif name == b"transfer-encoding":
+            carries_body = carries_body or b"chunked" in value.lower()
+    return declared_length, carries_body
 
 
 def _replay(body: bytes, trailing_message: dict | None = None):

--- a/backend/app/request_security.py
+++ b/backend/app/request_security.py
@@ -71,7 +71,7 @@ class RequestBodySizeLimitMiddleware:
 
             # A client that disconnects mid-body leaves the app to handle the disconnect
             if message["type"] != "http.request":
-                await self.app(scope, _replay(body, receive, message), send)
+                await self.app(scope, _replay(bytes(body), receive, message), send)
                 return
 
             body += message.get("body", b"")

--- a/backend/app/request_security.py
+++ b/backend/app/request_security.py
@@ -1,11 +1,96 @@
 """Request body size guard middleware"""
 
-from fastapi import Request
+import json
+
+# 10 MB. The frontend batches a transaction import into 750 KB requests, and the one
+# request it cannot split, a Firefly III budget import, is a few MB at its largest
+MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024
+
+_TOO_LARGE_BODY = json.dumps({"detail": "Request body is too large"}).encode()
+_TOO_LARGE_RESPONSE_START = {
+    "type": "http.response.start",
+    "status": 413,
+    "headers": [
+        (b"content-type", b"application/json"),
+        (b"content-length", str(len(_TOO_LARGE_BODY)).encode()),
+    ],
+}
 
 
-def request_is_https(request: Request) -> bool:
-    """Return whether the original client request used HTTPS."""
-    forwarded_proto = request.headers.get("x-forwarded-proto")
-    if forwarded_proto:
-        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
-    return request.url.scheme == "https"
+class RequestBodySizeLimitMiddleware:
+    """Reject a request whose body is larger than the cap before any route runs
+
+    The body is read and counted here rather than as the route pulls it, because a route
+    that never reads its body, such as one working only from cookies, would otherwise let
+    an unbounded stream through uncounted
+    """
+
+    def __init__(self, app, max_body_bytes: int = MAX_REQUEST_BODY_BYTES) -> None:
+        self.app = app
+        self.max_body_bytes = max_body_bytes
+
+    async def __call__(self, scope, receive, send) -> None:
+        """Count the request body, rejecting it past the cap, then run the app over it"""
+        # Lifespan and websocket traffic carry no request body to count
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        if self._is_declared_length_over_cap(scope):
+            await self._reject(send)
+            return
+
+        body = bytearray()
+        more_body = True
+        while more_body:
+            message = await receive()
+
+            # A client that disconnects mid-body leaves the app to handle the disconnect
+            if message["type"] != "http.request":
+                await self.app(scope, _replay(body, message), send)
+                return
+
+            body += message.get("body", b"")
+            if len(body) > self.max_body_bytes:
+                await self._reject(send)
+                return
+            more_body = message.get("more_body", False)
+
+        await self.app(scope, _replay(bytes(body)), send)
+
+    def _is_declared_length_over_cap(self, scope) -> bool:
+        """Whether the request declares a Content-Length larger than the cap
+
+        A declared length lets an oversized body be refused without reading it. A missing
+        or unparseable one is not trusted either way, since the counter above decides
+        """
+        for name, value in scope["headers"]:
+            if name == b"content-length":
+                return value.isdigit() and int(value) > self.max_body_bytes
+        return False
+
+    async def _reject(self, send) -> None:
+        """Send the 413 the app would otherwise have to produce after reading the body"""
+        await send(_TOO_LARGE_RESPONSE_START)
+        await send({"type": "http.response.body", "body": _TOO_LARGE_BODY})
+
+
+def _replay(body: bytes, trailing_message: dict | None = None):
+    """Return a receive callable handing the buffered body to the app
+
+    Args:
+        body: Request body already read and counted
+        trailing_message: Message that ended the read early, such as a disconnect
+
+    Returns:
+        An ASGI receive callable
+    """
+    messages = [{"type": "http.request", "body": bytes(body), "more_body": trailing_message is not None}]
+    if trailing_message is not None:
+        messages.append(trailing_message)
+
+    async def receive():
+        """Return the next buffered message, then behave as a client that has gone away"""
+        return messages.pop(0) if messages else {"type": "http.disconnect"}
+
+    return receive

--- a/backend/app/request_security.py
+++ b/backend/app/request_security.py
@@ -7,14 +7,23 @@ import json
 MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024
 
 _TOO_LARGE_BODY = json.dumps({"detail": "Request body is too large"}).encode()
-_TOO_LARGE_RESPONSE_START = {
-    "type": "http.response.start",
-    "status": 413,
-    "headers": [
-        (b"content-type", b"application/json"),
-        (b"content-length", str(len(_TOO_LARGE_BODY)).encode()),
-    ],
-}
+
+
+def _too_large_response_start() -> dict:
+    """Return a fresh 413 response-start message
+
+    Rebuilt per rejection rather than shared, because the CORS layer wrapping this one
+    appends its headers into the message it is handed, and a shared one would carry one
+    request's origin onto the next
+    """
+    return {
+        "type": "http.response.start",
+        "status": 413,
+        "headers": [
+            (b"content-type", b"application/json"),
+            (b"content-length", str(len(_TOO_LARGE_BODY)).encode()),
+        ],
+    }
 
 
 class RequestBodySizeLimitMiddleware:
@@ -26,6 +35,12 @@ class RequestBodySizeLimitMiddleware:
     """
 
     def __init__(self, app, max_body_bytes: int = MAX_REQUEST_BODY_BYTES) -> None:
+        """Wrap an ASGI app, refusing a request body larger than the given cap
+
+        Args:
+            app: ASGI application this wraps
+            max_body_bytes: Largest request body accepted
+        """
         self.app = app
         self.max_body_bytes = max_body_bytes
 
@@ -69,7 +84,7 @@ class RequestBodySizeLimitMiddleware:
 
     async def _reject(self, send) -> None:
         """Send the 413 the app would otherwise have to produce after reading the body"""
-        await send(_TOO_LARGE_RESPONSE_START)
+        await send(_too_large_response_start())
         await send({"type": "http.response.body", "body": _TOO_LARGE_BODY})
 
 

--- a/backend/app/routes/auth/cookie_helpers.py
+++ b/backend/app/routes/auth/cookie_helpers.py
@@ -7,7 +7,6 @@ from app.config.oidc import (
     OIDC_AUTHORIZATION_REQUEST_EXPIRE_SECONDS,
     OIDC_REAUTH_STEPUP_TOKEN_EXPIRE_SECONDS,
 )
-from app.request_security import request_is_https
 
 _COOKIE_KEY = "refresh_token"
 _COOKIE_PATH = "/"
@@ -24,6 +23,18 @@ _OIDC_BINDING_COOKIE_MAX_AGE = OIDC_AUTHORIZATION_REQUEST_EXPIRE_SECONDS
 OIDC_REAUTH_STEPUP_COOKIE_KEY = "oidc_reauth_stepup"
 _OIDC_REAUTH_STEPUP_COOKIE_PATH = "/"
 _OIDC_REAUTH_STEPUP_COOKIE_MAX_AGE = OIDC_REAUTH_STEPUP_TOKEN_EXPIRE_SECONDS
+
+
+def request_is_https(request: Request) -> bool:
+    """Return whether the original client request used HTTPS
+
+    The proxy header is what the deployed app sees, since it terminates TLS in front of
+    the application and forwards over plain HTTP
+    """
+    forwarded_proto = request.headers.get("x-forwarded-proto")
+    if forwarded_proto:
+        return forwarded_proto.split(",", 1)[0].strip().lower() == "https"
+    return request.url.scheme == "https"
 
 
 def set_refresh_cookie(request: Request, response: Response, token: str) -> None:

--- a/backend/app/routes/groups/members/removal_helpers.py
+++ b/backend/app/routes/groups/members/removal_helpers.py
@@ -10,7 +10,7 @@ from app.routes.groups.membership_helpers import (
     get_group_membership_or_404,
     get_group_owner_id,
 )
-from app.services.cache_state import mark_group_cache_changed, mark_user_cache_changed_privileged
+from app.services.cache_state import mark_group_cache_changed, mark_group_member_cache_changed
 
 
 async def remove_group_member(
@@ -57,6 +57,8 @@ async def remove_group_member(
     await db.delete(target_membership)
 
     # The removed member may not be the caller, so invalidate their cache through the
-    # privileged helper that the per-user write policy would otherwise block
-    await mark_user_cache_changed_privileged(db, member_id)
+    # privileged helper that the per-user write policy would otherwise block. The group
+    # is passed because the helper authorizes the call against the caller's admin
+    # membership, the target's having just been deleted
+    await mark_group_member_cache_changed(db, member_id, group_id)
     await db.commit()

--- a/backend/app/routes/groups/members/removal_helpers.py
+++ b/backend/app/routes/groups/members/removal_helpers.py
@@ -51,14 +51,14 @@ async def remove_group_member(
     else:
         target_membership = await get_group_member_or_404(db, group_id, member_id)
 
-    # Bump the group cache while the caller is still a member, since a self-leave
-    # removes the membership the group write policy checks
+    # Both bumps run while the memberships still exist, because each is checked against one
+    # of them: the group write policy against the caller's, which a self-leave removes, and
+    # the privileged member bump against the target's. Deleting first fails either one
     await mark_group_cache_changed(db, group_id)
-    await db.delete(target_membership)
 
     # The removed member may not be the caller, so invalidate their cache through the
-    # privileged helper that the per-user write policy would otherwise block. The group
-    # is passed because the helper authorizes the call against the caller's admin
-    # membership, the target's having just been deleted
+    # privileged helper that the per-user write policy would otherwise block
     await mark_group_member_cache_changed(db, member_id, group_id)
+
+    await db.delete(target_membership)
     await db.commit()

--- a/backend/app/services/app_version.py
+++ b/backend/app/services/app_version.py
@@ -6,10 +6,12 @@ import time
 import httpx
 
 from app.config.runtime import APP_VERSION, UPDATE_CHECKS_ENABLED
+from app.http_client import build_http_client
 
 GITHUB_LATEST_RELEASE_URL = "https://api.github.com/repos/Lumina-Finance/lumina-finance/releases/latest"
 DOCKER_TAG_URL_TEMPLATE = "https://hub.docker.com/v2/repositories/luminahq/lumina-finance/tags/{tag}"
 UPDATE_CHECK_CACHE_SECONDS = 6 * 60 * 60
+_HTTP_TIMEOUT_SECONDS = 5.0
 
 _VERSION_PATTERN = re.compile(r"^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 _update_check_cache: tuple[str, float, dict[str, str] | None] | None = None
@@ -82,7 +84,7 @@ async def _fetch_latest_github_release(client: httpx.AsyncClient | None) -> dict
         Latest GitHub release payload, or None when it cannot be fetched
     """
     should_close_client = client is None
-    http_client = client or httpx.AsyncClient(timeout=5.0)
+    http_client = client or build_http_client(timeout=_HTTP_TIMEOUT_SECONDS)
 
     try:
         # GitHub is the source for the latest release candidate
@@ -108,7 +110,7 @@ async def _docker_tag_exists(docker_tag: str, client: httpx.AsyncClient | None) 
         Whether the exact Docker Hub image tag exists
     """
     should_close_client = client is None
-    http_client = client or httpx.AsyncClient(timeout=5.0)
+    http_client = client or build_http_client(timeout=_HTTP_TIMEOUT_SECONDS)
 
     try:
         # Docker Hub must have the exact normalised version tag before users see an update

--- a/backend/app/services/auth/oidc_client.py
+++ b/backend/app/services/auth/oidc_client.py
@@ -11,6 +11,8 @@ import httpx
 import jwt
 from fastapi import HTTPException, status
 
+from app.http_client import build_http_client
+
 _DISCOVERY_PATH = "/.well-known/openid-configuration"
 _HTTP_TIMEOUT_SECONDS = 10.0
 
@@ -29,8 +31,8 @@ _jwks_cache: dict[str, tuple[float, jwt.PyJWKSet]] = {}
 
 
 def _http_client() -> httpx.AsyncClient:
-    """Return a short-lived HTTP client with the shared timeout"""
-    return httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS)
+    """Return a short-lived HTTP client with the shared timeout and response size cap"""
+    return build_http_client(timeout=_HTTP_TIMEOUT_SECONDS)
 
 
 async def _fetch_json(url: str) -> dict[str, Any]:

--- a/backend/app/services/cache_state/__init__.py
+++ b/backend/app/services/cache_state/__init__.py
@@ -10,8 +10,8 @@ from app.services.cache_state.status import (
 from app.services.cache_state.updates import (
     mark_cache_changed_for_scope,
     mark_group_cache_changed,
+    mark_group_member_cache_changed,
     mark_user_cache_changed,
-    mark_user_cache_changed_privileged,
 )
 
 __all__ = [
@@ -21,7 +21,7 @@ __all__ = [
     "get_visible_cache_status",
     "mark_cache_changed_for_scope",
     "mark_group_cache_changed",
+    "mark_group_member_cache_changed",
     "mark_user_cache_changed",
-    "mark_user_cache_changed_privileged",
     "select_user_group_ids",
 ]

--- a/backend/app/services/cache_state/updates.py
+++ b/backend/app/services/cache_state/updates.py
@@ -7,7 +7,7 @@ from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.db.rls.functions import BUMP_USER_CACHE
+from app.db.rls.functions import BUMP_GROUP_MEMBER_CACHE
 from app.dependencies import get_current_session_id
 from app.models.cache_state import GroupCacheState, UserCacheState
 
@@ -25,21 +25,33 @@ async def mark_user_cache_changed(db: AsyncSession, user_id: uuid.UUID) -> None:
     await _upsert_cache_state(db, UserCacheState, "user_id", user_id)
 
 
-async def mark_user_cache_changed_privileged(db: AsyncSession, user_id: uuid.UUID) -> None:
-    """Record a personal-scope change for a user who may not be the caller
+async def mark_group_member_cache_changed(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    group_id: uuid.UUID,
+) -> None:
+    """Record a personal-scope change for a member of a group the caller administers
 
     Removing a member from a group must invalidate that member's cache, which the
     per-user write policy blocks when an admin removes someone else, so this routes
-    through a security-definer helper that bypasses the per-user scoping
+    through a security-definer helper that bypasses the per-user scoping. The helper
+    refuses unless the caller is the member or an admin of the group given here
 
     Args:
         db: Active database session
         user_id: User scope that changed
+        group_id: Group whose admin is making the change
 
     Returns:
         None
+
+    Raises:
+        ProgrammingError: The caller is neither the member nor an admin of the group
     """
-    await db.execute(text(f"SELECT {BUMP_USER_CACHE}(:user_id)"), {"user_id": user_id})
+    await db.execute(
+        text(f"SELECT {BUMP_GROUP_MEMBER_CACHE}(:user_id, :group_id)"),
+        {"user_id": user_id, "group_id": group_id},
+    )
 
 
 async def mark_group_cache_changed(db: AsyncSession, group_id: uuid.UUID) -> None:

--- a/backend/app/services/cache_state/updates.py
+++ b/backend/app/services/cache_state/updates.py
@@ -35,18 +35,20 @@ async def mark_group_member_cache_changed(
     Removing a member from a group must invalidate that member's cache, which the
     per-user write policy blocks when an admin removes someone else, so this routes
     through a security-definer helper that bypasses the per-user scoping. The helper
-    refuses unless the caller is the member or an admin of the group given here
+    refuses unless the caller is the member, or administers the given group and the
+    member belongs to it, so it has to be called before the membership is deleted
 
     Args:
         db: Active database session
         user_id: User scope that changed
-        group_id: Group whose admin is making the change
+        group_id: Group the user belongs to and the caller administers
 
     Returns:
         None
 
     Raises:
-        ProgrammingError: The caller is neither the member nor an admin of the group
+        ProgrammingError: The caller is not the member, or does not administer a group
+            the member belongs to
     """
     await db.execute(
         text(f"SELECT {BUMP_GROUP_MEMBER_CACHE}(:user_id, :group_id)"),

--- a/backend/app/services/fx/frankfurter_provider.py
+++ b/backend/app/services/fx/frankfurter_provider.py
@@ -10,6 +10,7 @@ from typing import TypeVar
 import httpx
 
 from app.config.fx import FRANKFURTER_URL
+from app.http_client import build_http_client
 from app.services.fx.errors import FxRateError
 from app.services.fx.frankfurter_request_helpers import (
     request_frankfurter_rate_response,
@@ -65,7 +66,7 @@ class FrankfurterProvider:
         if self.client is not None:
             return await self._get_rate(self.client, normalized_base, normalized_quote, rate_date)
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+        async with build_http_client(timeout=self.timeout) as client:
             return await self._get_rate(client, normalized_base, normalized_quote, rate_date)
 
     async def _get_rate(
@@ -107,7 +108,7 @@ class FrankfurterProvider:
         if self.client is not None:
             return await self._get_rates(self.client, normalized_base, normalized_quote, start_date, end_date)
 
-        async with httpx.AsyncClient(timeout=self.timeout) as client:
+        async with build_http_client(timeout=self.timeout) as client:
             return await self._get_rates(client, normalized_base, normalized_quote, start_date, end_date)
 
     async def _get_rates(

--- a/backend/tests/routes/test_request_body_limit.py
+++ b/backend/tests/routes/test_request_body_limit.py
@@ -1,0 +1,65 @@
+from collections.abc import AsyncIterator
+
+from app.config.runtime import ALLOWED_ORIGINS
+from app.request_security import MAX_REQUEST_BODY_BYTES
+
+# Any authenticated route works, since the body is counted before routing decides anything
+_TARGET_PATH = "/transactions/import"
+
+
+def _oversized_payload() -> bytes:
+    """Return a body one byte past the cap"""
+    return b"x" * (MAX_REQUEST_BODY_BYTES + 1)
+
+
+async def _stream_oversized_payload() -> AsyncIterator[bytes]:
+    """Yield an oversized body in chunks, so the request carries no declared length"""
+    chunk = b"x" * (1024 * 1024)
+    for _ in range(MAX_REQUEST_BODY_BYTES // len(chunk) + 1):
+        yield chunk
+
+
+async def test_declared_oversized_body_is_refused(client):
+    """A body whose Content-Length is past the cap is refused with 413"""
+    response = await client.post(_TARGET_PATH, content=_oversized_payload())
+
+    assert response.status_code == 413
+    assert response.json() == {"detail": "Request body is too large"}
+
+
+async def test_undeclared_oversized_body_is_refused(client):
+    """A chunked body with no declared length is counted and refused once it passes the cap"""
+    response = await client.post(_TARGET_PATH, content=_stream_oversized_payload())
+
+    assert response.status_code == 413
+
+
+async def test_body_under_the_cap_reaches_the_route(client):
+    """A body within the cap is passed through, so the route decides the outcome
+
+    Unauthenticated here, so the route answers 401 rather than 413, which is what shows the
+    middleware handed the request on rather than rejecting it
+    """
+    response = await client.post(_TARGET_PATH, json={"rows": []})
+
+    assert response.status_code != 413
+
+
+async def test_refusal_carries_cors_headers(client):
+    """A refused body still carries CORS headers, so a browser reports the 413 rather than a CORS failure
+
+    The middleware is installed before CORS so CORS wraps it. Reversed, the rejection would
+    leave the response without the headers and the browser would report the wrong problem
+    """
+    # An unconfigured deployment allows every origin, in which case the header echoes
+    # whichever one the request carried
+    origin = "http://localhost:5173" if ALLOWED_ORIGINS[0] == "*" else ALLOWED_ORIGINS[0]
+
+    response = await client.post(
+        _TARGET_PATH,
+        content=_oversized_payload(),
+        headers={"Origin": origin},
+    )
+
+    assert response.status_code == 413
+    assert response.headers["access-control-allow-origin"] == origin

--- a/backend/tests/routes/test_request_body_limit.py
+++ b/backend/tests/routes/test_request_body_limit.py
@@ -2,8 +2,11 @@ from collections.abc import AsyncIterator
 
 from app.config.runtime import ALLOWED_ORIGINS
 from app.request_security import MAX_REQUEST_BODY_BYTES
+from tests.routes.support import _create_user, _get_auth_header
 
-# Any authenticated route works, since the body is counted before routing decides anything
+# Any route works for the declared-length refusal, which happens before routing decides
+# anything. The counted refusal needs one that reads a body, and an authenticated caller,
+# since the route has to get far enough to read it
 _TARGET_PATH = "/transactions/import"
 
 
@@ -28,10 +31,17 @@ async def test_declared_oversized_body_is_refused(client):
 
 
 async def test_undeclared_oversized_body_is_refused(client):
-    """A chunked body with no declared length is counted and refused once it passes the cap"""
-    response = await client.post(_TARGET_PATH, content=_stream_oversized_payload())
+    """A chunked body with no declared length is counted as the route reads it and refused
+
+    Authenticated, because the count only happens once the route reaches its body, and an
+    unauthenticated caller is turned away before that
+    """
+    headers = _get_auth_header(await _create_user(client))
+
+    response = await client.post(_TARGET_PATH, content=_stream_oversized_payload(), headers=headers)
 
     assert response.status_code == 413
+    assert response.json() == {"detail": "Request body is too large"}
 
 
 async def test_body_under_the_cap_reaches_the_route(client):

--- a/backend/tests/routes/test_request_body_limit.py
+++ b/backend/tests/routes/test_request_body_limit.py
@@ -2,11 +2,10 @@ from collections.abc import AsyncIterator
 
 from app.config.runtime import ALLOWED_ORIGINS
 from app.request_security import MAX_REQUEST_BODY_BYTES
-from tests.routes.support import _create_user, _get_auth_header
 
 # Any route works for the declared-length refusal, which happens before routing decides
-# anything. The counted refusal needs one that reads a body, and an authenticated caller,
-# since the route has to get far enough to read it
+# anything. The counted refusal needs a route that reads a body, which this one does before
+# it resolves its dependencies, so an unauthenticated caller still reaches the count
 _TARGET_PATH = "/transactions/import"
 
 
@@ -33,12 +32,10 @@ async def test_declared_oversized_body_is_refused(client):
 async def test_undeclared_oversized_body_is_refused(client):
     """A chunked body with no declared length is counted as the route reads it and refused
 
-    Authenticated, because the count only happens once the route reaches its body, and an
-    unauthenticated caller is turned away before that
+    Unauthenticated, and still a 413 rather than a 401, because the framework reads the body
+    before it resolves the dependency that would reject the caller
     """
-    headers = _get_auth_header(await _create_user(client))
-
-    response = await client.post(_TARGET_PATH, content=_stream_oversized_payload(), headers=headers)
+    response = await client.post(_TARGET_PATH, content=_stream_oversized_payload())
 
     assert response.status_code == 413
     assert response.json() == {"detail": "Request body is too large"}

--- a/backend/tests/routes/test_request_body_limit.py
+++ b/backend/tests/routes/test_request_body_limit.py
@@ -37,12 +37,13 @@ async def test_undeclared_oversized_body_is_refused(client):
 async def test_body_under_the_cap_reaches_the_route(client):
     """A body within the cap is passed through, so the route decides the outcome
 
-    Unauthenticated here, so the route answers 401 rather than 413, which is what shows the
-    middleware handed the request on rather than rejecting it
+    Unauthenticated here, so the answer is the route's own rejection rather than the guard's,
+    which is what shows the request was handed on. A 404 would mean the path below has been
+    renamed and this stopped testing anything
     """
     response = await client.post(_TARGET_PATH, json={"rows": []})
 
-    assert response.status_code != 413
+    assert response.status_code not in (413, 404)
 
 
 async def test_refusal_carries_cors_headers(client):

--- a/backend/tests/routes/test_request_body_limit.py
+++ b/backend/tests/routes/test_request_body_limit.py
@@ -63,3 +63,20 @@ async def test_refusal_carries_cors_headers(client):
 
     assert response.status_code == 413
     assert response.headers["access-control-allow-origin"] == origin
+
+
+async def test_a_refusal_does_not_inherit_an_earlier_requests_origin(client):
+    """One rejection's CORS headers must not survive onto the next
+
+    The CORS layer writes its headers into the response message it is handed, so a shared
+    message would carry the first caller's origin onto every later rejection, including one
+    the CORS layer never looked at
+    """
+    origin = "http://localhost:5173" if ALLOWED_ORIGINS[0] == "*" else ALLOWED_ORIGINS[0]
+    await client.post(_TARGET_PATH, content=_oversized_payload(), headers={"Origin": origin})
+
+    without_origin = await client.post(_TARGET_PATH, content=_oversized_payload())
+
+    assert without_origin.status_code == 413
+    assert "access-control-allow-origin" not in without_origin.headers
+    assert "vary" not in without_origin.headers

--- a/backend/tests/services/test_http_client.py
+++ b/backend/tests/services/test_http_client.py
@@ -12,31 +12,51 @@ _URL = "https://provider.example/data"
 _SMALL_CAP_BYTES = 64
 
 
-def _client_returning(response: httpx.Response) -> httpx.AsyncClient:
-    """Return a capped client whose transport always answers with the given response
+def _streamed(content: bytes, chunk_size: int = 1024 * 1024, **kwargs) -> httpx.Response:
+    """Return a response delivering its body in chunks, the way a real transport does
+
+    A response built from plain bytes arrives already read, which is not what the client
+    meets in production and would hide whether the counting path works at all
+
+    Args:
+        content: Body the response delivers
+        chunk_size: Bytes per chunk
+        **kwargs: Remaining httpx.Response arguments, such as headers
+
+    Returns:
+        A streaming response
+    """
+    async def chunks() -> AsyncIterator[bytes]:
+        """Yield the body one chunk at a time"""
+        for start in range(0, len(content), chunk_size):
+            yield content[start:start + chunk_size]
+
+    return httpx.Response(200, content=chunks(), **kwargs)
+
+
+def _client_returning(build_response, max_response_bytes: int = MAX_RESPONSE_BYTES) -> httpx.AsyncClient:
+    """Return a capped client whose transport answers with a freshly built response
 
     Built directly rather than through build_http_client, which takes no transport because
     nothing in the application needs to substitute one
 
     Args:
-        response: Response the transport hands back for every request
+        build_response: Callable returning the response for a request
+        max_response_bytes: Cap the client enforces
 
     Returns:
         A capped client wired to that transport
     """
-    return _CappedResponseClient(timeout=1.0, transport=httpx.MockTransport(lambda request: response))
-
-
-async def _oversized_chunks() -> AsyncIterator[bytes]:
-    """Yield a body past the cap in chunks, so the response declares no length"""
-    chunk = b"x" * (1024 * 1024)
-    for _ in range(MAX_RESPONSE_BYTES // len(chunk) + 1):
-        yield chunk
+    return _CappedResponseClient(
+        timeout=1.0,
+        max_response_bytes=max_response_bytes,
+        transport=httpx.MockTransport(lambda request: build_response()),
+    )
 
 
 async def test_response_within_the_cap_is_returned_whole():
     """A normal response is read and handed back with its body and request intact"""
-    client = _client_returning(httpx.Response(200, json={"rate": "1.35"}))
+    client = _client_returning(lambda: _streamed(b'{"rate": "1.35"}'))
 
     async with client:
         response = await client.get(_URL)
@@ -48,17 +68,9 @@ async def test_response_within_the_cap_is_returned_whole():
     response.raise_for_status()
 
 
-async def test_declared_oversized_response_is_refused():
+async def test_oversized_response_is_refused():
     """A response body past the cap raises rather than being read into memory"""
-    client = _client_returning(httpx.Response(200, content=b"x" * (MAX_RESPONSE_BYTES + 1)))
-
-    async with client, pytest.raises(ResponseTooLargeError):
-        await client.get(_URL)
-
-
-async def test_undeclared_oversized_response_is_refused():
-    """A streamed response with no declared length is counted as it arrives"""
-    client = _client_returning(httpx.Response(200, content=_oversized_chunks()))
+    client = _client_returning(lambda: _streamed(b"x" * (MAX_RESPONSE_BYTES + 1)))
 
     async with client, pytest.raises(ResponseTooLargeError):
         await client.get(_URL)
@@ -66,35 +78,16 @@ async def test_undeclared_oversized_response_is_refused():
 
 async def test_oversized_response_is_caught_as_a_transport_failure():
     """The error reaches callers that only handle httpx transport failures"""
-    client = _client_returning(httpx.Response(200, content=b"x" * (MAX_RESPONSE_BYTES + 1)))
+    client = _client_returning(lambda: _streamed(b"x" * (MAX_RESPONSE_BYTES + 1)))
 
     async with client, pytest.raises(httpx.RequestError):
         await client.get(_URL)
 
 
-async def test_compressed_response_decodes_once():
-    """A gzipped body is decoded as it is counted, and the rebuilt response does not decode it again"""
-    payload = b'{"rate": "1.35"}'
-    client = _client_returning(httpx.Response(
-        200,
-        content=gzip.compress(payload),
-        headers={"content-encoding": "gzip", "content-type": "application/json"},
-    ))
-
-    async with client:
-        response = await client.get(_URL)
-
-    assert response.json() == {"rate": "1.35"}
-
-
 async def test_response_exactly_at_the_cap_is_returned():
     """A body the same size as the cap is accepted, so the limit is not off by one"""
     payload = b"x" * _SMALL_CAP_BYTES
-    client = _CappedResponseClient(
-        timeout=1.0,
-        max_response_bytes=_SMALL_CAP_BYTES,
-        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=payload)),
-    )
+    client = _client_returning(lambda: _streamed(payload, chunk_size=16), max_response_bytes=_SMALL_CAP_BYTES)
 
     async with client:
         response = await client.get(_URL)
@@ -104,24 +97,70 @@ async def test_response_exactly_at_the_cap_is_returned():
 
 async def test_response_one_byte_over_the_cap_is_refused():
     """One byte more than the cap is refused, so the limit is not off by one the other way"""
-    client = _CappedResponseClient(
-        timeout=1.0,
+    client = _client_returning(
+        lambda: _streamed(b"x" * (_SMALL_CAP_BYTES + 1), chunk_size=16),
         max_response_bytes=_SMALL_CAP_BYTES,
-        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=b"x" * (_SMALL_CAP_BYTES + 1))),
     )
 
     async with client, pytest.raises(ResponseTooLargeError):
         await client.get(_URL)
 
 
+async def test_compression_is_declined():
+    """The client asks for no compression, so the bytes it counts are the bytes that arrived
+
+    Counting after decoding would let a few hundred compressed KB expand into gigabytes
+    inside the process before the cap was ever consulted
+    """
+    sent_headers = {}
+
+    def record(request: httpx.Request) -> httpx.Response:
+        """Record the request headers and answer with an empty body"""
+        sent_headers.update(request.headers)
+        return _streamed(b"{}")
+
+    client = _CappedResponseClient(
+        timeout=1.0,
+        headers={"accept-encoding": "identity"},
+        transport=httpx.MockTransport(record),
+    )
+
+    async with client:
+        await client.get(_URL)
+
+    assert sent_headers["accept-encoding"] == "identity"
+
+
+async def test_a_compressed_body_is_counted_compressed_and_still_decodes():
+    """A provider compressing anyway is counted on its compressed size and still reads correctly
+
+    The rebuilt response holds the bytes that arrived, so it keeps the header saying how they
+    are encoded and the caller decodes them exactly once
+    """
+    payload = b'{"rate": "1.35"}'
+    compressed = gzip.compress(payload)
+    client = _client_returning(
+        lambda: _streamed(compressed, headers={"content-encoding": "gzip", "content-type": "application/json"}),
+        max_response_bytes=len(compressed),
+    )
+
+    async with client:
+        response = await client.get(_URL)
+
+    assert response.json() == {"rate": "1.35"}
+
+
 def test_the_application_factory_carries_the_cap():
-    """The builder the application calls returns a client holding the cap"""
-    assert build_http_client(timeout=1.0).max_response_bytes == MAX_RESPONSE_BYTES
+    """The builder the application calls returns a client holding the cap and declining compression"""
+    client = build_http_client(timeout=1.0)
+
+    assert client.max_response_bytes == MAX_RESPONSE_BYTES
+    assert client.headers["accept-encoding"] == "identity"
 
 
 async def test_streaming_is_refused():
     """Asking this client to stream raises, since a caller-read body would go uncounted"""
-    client = _client_returning(httpx.Response(200, json={"rate": "1.35"}))
+    client = _client_returning(lambda: _streamed(b'{"rate": "1.35"}'))
 
     async with client, pytest.raises(RuntimeError):
         async with client.stream("GET", _URL):

--- a/backend/tests/services/test_http_client.py
+++ b/backend/tests/services/test_http_client.py
@@ -4,9 +4,12 @@ from collections.abc import AsyncIterator
 import httpx
 import pytest
 
-from app.http_client import MAX_RESPONSE_BYTES, ResponseTooLargeError, _CappedResponseClient
+from app.http_client import MAX_RESPONSE_BYTES, ResponseTooLargeError, _CappedResponseClient, build_http_client
 
 _URL = "https://provider.example/data"
+
+# Small enough to exercise the boundary without building megabytes of test data
+_SMALL_CAP_BYTES = 64
 
 
 def _client_returning(response: httpx.Response) -> httpx.AsyncClient:
@@ -82,6 +85,33 @@ async def test_compressed_response_decodes_once():
         response = await client.get(_URL)
 
     assert response.json() == {"rate": "1.35"}
+
+
+async def test_response_exactly_at_the_cap_is_returned():
+    """A body the same size as the cap is accepted, so the limit is not off by one"""
+    payload = b"x" * _SMALL_CAP_BYTES
+    client = _CappedResponseClient(
+        timeout=1.0,
+        max_response_bytes=_SMALL_CAP_BYTES,
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=payload)),
+    )
+
+    async with client:
+        response = await client.get(_URL)
+
+    assert response.content == payload
+
+
+async def test_response_one_byte_over_the_cap_is_refused():
+    """One byte more than the cap is refused, so the limit is not off by one the other way"""
+    client = _CappedResponseClient(
+        timeout=1.0,
+        max_response_bytes=_SMALL_CAP_BYTES,
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=b"x" * (_SMALL_CAP_BYTES + 1))),
+    )
+
+    async with client, pytest.raises(ResponseTooLargeError):
+        await client.get(_URL)
 
 
 def test_the_application_factory_carries_the_cap():

--- a/backend/tests/services/test_http_client.py
+++ b/backend/tests/services/test_http_client.py
@@ -72,8 +72,9 @@ async def test_oversized_response_is_refused():
     """A response body past the cap raises rather than being read into memory"""
     client = _client_returning(lambda: _streamed(b"x" * (MAX_RESPONSE_BYTES + 1)))
 
-    async with client, pytest.raises(ResponseTooLargeError):
-        await client.get(_URL)
+    async with client:
+        with pytest.raises(ResponseTooLargeError):
+            await client.get(_URL)
 
 
 async def test_oversized_response_is_caught_as_a_transport_failure():
@@ -86,8 +87,9 @@ async def test_oversized_response_is_caught_as_a_transport_failure():
     client = _client_returning(lambda: _streamed(b"x" * (_SMALL_CAP_BYTES + 1), chunk_size=16),
                                max_response_bytes=_SMALL_CAP_BYTES)
 
-    async with client, pytest.raises(httpx.RequestError):
-        await client.get(_URL)
+    async with client:
+        with pytest.raises(httpx.RequestError):
+            await client.get(_URL)
 
 
 async def test_response_exactly_at_the_cap_is_returned():
@@ -108,8 +110,9 @@ async def test_response_one_byte_over_the_cap_is_refused():
         max_response_bytes=_SMALL_CAP_BYTES,
     )
 
-    async with client, pytest.raises(ResponseTooLargeError):
-        await client.get(_URL)
+    async with client:
+        with pytest.raises(ResponseTooLargeError):
+            await client.get(_URL)
 
 
 def _gzipped(payload: bytes) -> httpx.Response:
@@ -131,8 +134,9 @@ async def test_a_compressed_body_is_counted_after_it_expands():
 
     client = _client_returning(lambda: _gzipped(payload), max_response_bytes=_SMALL_CAP_BYTES)
 
-    async with client, pytest.raises(ResponseTooLargeError):
-        await client.get(_URL)
+    async with client:
+        with pytest.raises(ResponseTooLargeError):
+            await client.get(_URL)
 
 
 async def test_a_compressed_body_within_the_cap_decodes_once():
@@ -159,7 +163,9 @@ async def test_streaming_is_refused():
     """Asking this client to stream raises, since a caller-read body would go uncounted"""
     client = _client_returning(lambda: _streamed(b'{"rate": "1.35"}'))
 
-    # Matched on the message, since httpx's own streaming errors are RuntimeError too
-    async with client, pytest.raises(RuntimeError, match="cannot stream"):
-        async with client.stream("GET", _URL):
-            pass
+    async with client:
+
+        # Matched on the message, since httpx's own streaming errors are RuntimeError too
+        with pytest.raises(RuntimeError, match="cannot stream"):
+            async with client.stream("GET", _URL):
+                pass

--- a/backend/tests/services/test_http_client.py
+++ b/backend/tests/services/test_http_client.py
@@ -1,0 +1,98 @@
+import gzip
+from collections.abc import AsyncIterator
+
+import httpx
+import pytest
+
+from app.http_client import MAX_RESPONSE_BYTES, ResponseTooLargeError, _CappedResponseClient
+
+_URL = "https://provider.example/data"
+
+
+def _client_returning(response: httpx.Response) -> httpx.AsyncClient:
+    """Return a capped client whose transport always answers with the given response
+
+    Built directly rather than through build_http_client, which takes no transport because
+    nothing in the application needs to substitute one
+
+    Args:
+        response: Response the transport hands back for every request
+
+    Returns:
+        A capped client wired to that transport
+    """
+    return _CappedResponseClient(timeout=1.0, transport=httpx.MockTransport(lambda request: response))
+
+
+async def _oversized_chunks() -> AsyncIterator[bytes]:
+    """Yield a body past the cap in chunks, so the response declares no length"""
+    chunk = b"x" * (1024 * 1024)
+    for _ in range(MAX_RESPONSE_BYTES // len(chunk) + 1):
+        yield chunk
+
+
+async def test_response_within_the_cap_is_returned_whole():
+    """A normal response is read and handed back with its body and request intact"""
+    client = _client_returning(httpx.Response(200, json={"rate": "1.35"}))
+
+    async with client:
+        response = await client.get(_URL)
+
+    assert response.json() == {"rate": "1.35"}
+    assert response.status_code == 200
+
+    # raise_for_status needs the request, which is lost if the rebuilt response omits it
+    response.raise_for_status()
+
+
+async def test_declared_oversized_response_is_refused():
+    """A response body past the cap raises rather than being read into memory"""
+    client = _client_returning(httpx.Response(200, content=b"x" * (MAX_RESPONSE_BYTES + 1)))
+
+    async with client, pytest.raises(ResponseTooLargeError):
+        await client.get(_URL)
+
+
+async def test_undeclared_oversized_response_is_refused():
+    """A streamed response with no declared length is counted as it arrives"""
+    client = _client_returning(httpx.Response(200, content=_oversized_chunks()))
+
+    async with client, pytest.raises(ResponseTooLargeError):
+        await client.get(_URL)
+
+
+async def test_oversized_response_is_caught_as_a_transport_failure():
+    """The error reaches callers that only handle httpx transport failures"""
+    client = _client_returning(httpx.Response(200, content=b"x" * (MAX_RESPONSE_BYTES + 1)))
+
+    async with client, pytest.raises(httpx.RequestError):
+        await client.get(_URL)
+
+
+async def test_compressed_response_decodes_once():
+    """A gzipped body is decoded as it is counted, and the rebuilt response does not decode it again"""
+    payload = b'{"rate": "1.35"}'
+    client = _client_returning(httpx.Response(
+        200,
+        content=gzip.compress(payload),
+        headers={"content-encoding": "gzip", "content-type": "application/json"},
+    ))
+
+    async with client:
+        response = await client.get(_URL)
+
+    assert response.json() == {"rate": "1.35"}
+
+
+def test_the_application_factory_carries_the_cap():
+    """The builder the application calls returns a client holding the cap"""
+    assert build_http_client(timeout=1.0).max_response_bytes == MAX_RESPONSE_BYTES
+
+
+async def test_streaming_is_refused():
+    """Asking this client to stream raises, since a caller-read body would go uncounted"""
+    client = _client_returning(httpx.Response(200, json={"rate": "1.35"}))
+
+    async with client, pytest.raises(RuntimeError):
+        async with client.stream("GET", _URL):
+            pass

--- a/backend/tests/services/test_http_client.py
+++ b/backend/tests/services/test_http_client.py
@@ -106,56 +106,47 @@ async def test_response_one_byte_over_the_cap_is_refused():
         await client.get(_URL)
 
 
-async def test_compression_is_declined():
-    """The client asks for no compression, so the bytes it counts are the bytes that arrived
-
-    Counting after decoding would let a few hundred compressed KB expand into gigabytes
-    inside the process before the cap was ever consulted
-    """
-    sent_headers = {}
-
-    def record(request: httpx.Request) -> httpx.Response:
-        """Record the request headers and answer with an empty body"""
-        sent_headers.update(request.headers)
-        return _streamed(b"{}")
-
-    client = _CappedResponseClient(
-        timeout=1.0,
-        headers={"accept-encoding": "identity"},
-        transport=httpx.MockTransport(record),
+def _gzipped(payload: bytes) -> httpx.Response:
+    """Return a streaming gzip response carrying the given payload"""
+    return _streamed(
+        gzip.compress(payload),
+        headers={"content-encoding": "gzip", "content-type": "application/json"},
     )
 
-    async with client:
+
+async def test_a_compressed_body_is_counted_after_it_expands():
+    """The cap measures the memory a body takes, not the bytes that carried it
+
+    A payload that compresses well is small on the wire and large in memory, and the memory
+    is what the cap exists to bound, so this one is refused despite arriving under the cap
+    """
+    payload = b"x" * (_SMALL_CAP_BYTES * 100)
+    assert len(gzip.compress(payload)) < _SMALL_CAP_BYTES
+
+    client = _client_returning(lambda: _gzipped(payload), max_response_bytes=_SMALL_CAP_BYTES)
+
+    async with client, pytest.raises(ResponseTooLargeError):
         await client.get(_URL)
 
-    assert sent_headers["accept-encoding"] == "identity"
 
+async def test_a_compressed_body_within_the_cap_decodes_once():
+    """A compressed body under the cap is decoded as it is counted and not decoded again
 
-async def test_a_compressed_body_is_counted_compressed_and_still_decodes():
-    """A provider compressing anyway is counted on its compressed size and still reads correctly
-
-    The rebuilt response holds the bytes that arrived, so it keeps the header saying how they
-    are encoded and the caller decodes them exactly once
+    The rebuilt response holds decoded bytes, so keeping the header saying they were gzipped
+    would have the caller try to decode them a second time
     """
-    payload = b'{"rate": "1.35"}'
-    compressed = gzip.compress(payload)
-    client = _client_returning(
-        lambda: _streamed(compressed, headers={"content-encoding": "gzip", "content-type": "application/json"}),
-        max_response_bytes=len(compressed),
-    )
+    client = _client_returning(lambda: _gzipped(b'{"rate": "1.35"}'))
 
     async with client:
         response = await client.get(_URL)
 
     assert response.json() == {"rate": "1.35"}
+    assert "content-encoding" not in response.headers
 
 
 def test_the_application_factory_carries_the_cap():
-    """The builder the application calls returns a client holding the cap and declining compression"""
-    client = build_http_client(timeout=1.0)
-
-    assert client.max_response_bytes == MAX_RESPONSE_BYTES
-    assert client.headers["accept-encoding"] == "identity"
+    """The builder the application calls returns a client holding the cap"""
+    assert build_http_client(timeout=1.0).max_response_bytes == MAX_RESPONSE_BYTES
 
 
 async def test_streaming_is_refused():

--- a/backend/tests/services/test_http_client.py
+++ b/backend/tests/services/test_http_client.py
@@ -77,8 +77,14 @@ async def test_oversized_response_is_refused():
 
 
 async def test_oversized_response_is_caught_as_a_transport_failure():
-    """The error reaches callers that only handle httpx transport failures"""
-    client = _client_returning(lambda: _streamed(b"x" * (MAX_RESPONSE_BYTES + 1)))
+    """The error reaches callers that only handle httpx transport failures
+
+    The FX helpers catch httpx.RequestError and the OIDC client catches httpx.HTTPError, so
+    an error outside that hierarchy would reach a route as a 500 rather than the provider
+    failure each of them already reports
+    """
+    client = _client_returning(lambda: _streamed(b"x" * (_SMALL_CAP_BYTES + 1), chunk_size=16),
+                               max_response_bytes=_SMALL_CAP_BYTES)
 
     async with client, pytest.raises(httpx.RequestError):
         await client.get(_URL)
@@ -153,6 +159,7 @@ async def test_streaming_is_refused():
     """Asking this client to stream raises, since a caller-read body would go uncounted"""
     client = _client_returning(lambda: _streamed(b'{"rate": "1.35"}'))
 
-    async with client, pytest.raises(RuntimeError):
+    # Matched on the message, since httpx's own streaming errors are RuntimeError too
+    async with client, pytest.raises(RuntimeError, match="cannot stream"):
         async with client.stream("GET", _URL):
             pass

--- a/backend/tests/test_database_identity.py
+++ b/backend/tests/test_database_identity.py
@@ -11,6 +11,7 @@ class RecordingConnection:
     """Stand-in for a database connection that records what it was asked to run"""
 
     def __init__(self) -> None:
+        """Start with nothing recorded"""
         self.statements: list[tuple[str, tuple]] = []
 
     def exec_driver_sql(self, statement: str, parameters: tuple) -> None:

--- a/backend/tests/test_database_identity.py
+++ b/backend/tests/test_database_identity.py
@@ -1,0 +1,76 @@
+"""Row-level security identity stamping tests"""
+
+import uuid
+
+import pytest
+
+from app.database import current_user_id_ctx, stamp_request_identity
+
+
+class RecordingConnection:
+    """Stand-in for a database connection that records what it was asked to run"""
+
+    def __init__(self) -> None:
+        self.statements: list[tuple[str, tuple]] = []
+
+    def exec_driver_sql(self, statement: str, parameters: tuple) -> None:
+        """Record one driver-level statement and the parameters bound to it"""
+        self.statements.append((statement, parameters))
+
+
+def _stamp_with(value) -> RecordingConnection:
+    """Stamp a connection with the given context value and return the connection
+
+    Args:
+        value: Value placed on the request identity context variable
+
+    Returns:
+        The connection the stamp was applied to
+    """
+    connection = RecordingConnection()
+    token = current_user_id_ctx.set(value)
+    try:
+        stamp_request_identity(connection)
+    finally:
+        current_user_id_ctx.reset(token)
+    return connection
+
+
+def test_stamp_binds_the_identity_rather_than_inlining_it():
+    """The user id is bound as a parameter, so it never becomes part of the statement"""
+    user_id = uuid.uuid4()
+
+    connection = _stamp_with(user_id)
+
+    statement, parameters = connection.statements[0]
+    assert parameters == (str(user_id),)
+    assert str(user_id) not in statement
+
+
+def test_stamp_accepts_a_uuid_string():
+    """A well-formed string identity stamps its canonical form"""
+    user_id = uuid.uuid4()
+
+    connection = _stamp_with(str(user_id).upper())
+
+    assert connection.statements[0][1] == (str(user_id),)
+
+
+def test_stamp_is_empty_without_an_identity():
+    """No identity stamps empty, which is what makes the policies match no rows"""
+    connection = _stamp_with(None)
+
+    assert connection.statements[0][1] == ("",)
+
+
+def test_stamp_rejects_a_value_that_is_not_a_uuid():
+    """A non-UUID identity raises at the stamp instead of reaching the database"""
+    connection = RecordingConnection()
+    token = current_user_id_ctx.set("' OR true --")
+    try:
+        with pytest.raises(ValueError):
+            stamp_request_identity(connection)
+    finally:
+        current_user_id_ctx.reset(token)
+
+    assert connection.statements == []

--- a/backend/tests/test_request_body_middleware.py
+++ b/backend/tests/test_request_body_middleware.py
@@ -128,6 +128,65 @@ async def test_request_without_a_body_is_passed_straight_through():
     assert kept_the_original == [True]
 
 
+async def test_the_app_keeps_reading_from_the_server_after_the_body():
+    """Once the buffered body is spent the app reads on from the server, not from a stand-in
+
+    Answering with a disconnect of its own would tell a streaming response the client had
+    gone the moment its body was read
+    """
+    server_messages = [
+        {"type": "http.request", "body": b"payload", "more_body": False},
+        {"type": "http.disconnect"},
+    ]
+    read_after_the_body: list[dict] = []
+
+    async def receive():
+        """Deliver the next message the server has"""
+        return server_messages.pop(0)
+
+    async def app(scope, app_receive, send):
+        """Read the body, then keep listening as a streaming response would"""
+        await app_receive()
+        read_after_the_body.append(await app_receive())
+
+    async def send(message):
+        """Ignore the response"""
+
+    middleware = RequestBodySizeLimitMiddleware(app, max_body_bytes=_CAP_BYTES)
+    await middleware(_scope([(b"content-length", b"7")]), receive, send)
+
+    # The server's own disconnect, reached because the replay fell through to it
+    assert read_after_the_body == [{"type": "http.disconnect"}]
+    assert server_messages == []
+
+
+async def test_a_client_vanishing_mid_body_leaves_the_app_to_handle_it():
+    """A disconnect part way through a body is passed on with the bytes read so far"""
+    server_messages = [
+        {"type": "http.request", "body": b"half", "more_body": True},
+        {"type": "http.disconnect"},
+    ]
+    seen: list[dict] = []
+
+    async def receive():
+        """Deliver the next message the server has"""
+        return server_messages.pop(0)
+
+    async def app(scope, app_receive, send):
+        """Read until the client is reported gone"""
+        seen.append(await app_receive())
+        seen.append(await app_receive())
+
+    async def send(message):
+        """Ignore the response"""
+
+    middleware = RequestBodySizeLimitMiddleware(app, max_body_bytes=_CAP_BYTES)
+    await middleware(_scope([(b"transfer-encoding", b"chunked")]), receive, send)
+
+    assert seen[0]["body"] == b"half"
+    assert seen[1] == {"type": "http.disconnect"}
+
+
 @pytest.mark.parametrize("scope_type", ["lifespan", "websocket"])
 async def test_non_http_traffic_is_untouched(scope_type):
     """Startup and websocket connections carry no body and go straight to the app"""

--- a/backend/tests/test_request_body_middleware.py
+++ b/backend/tests/test_request_body_middleware.py
@@ -1,0 +1,150 @@
+"""Request body size guard tests driving the middleware as a plain ASGI app
+
+The route-level tests cover the wiring inside the application. These drive the middleware
+directly with a small cap, which is what makes the boundary and the replayed body cheap
+enough to assert exactly
+"""
+
+import pytest
+
+from app.request_security import RequestBodySizeLimitMiddleware
+
+_CAP_BYTES = 64
+
+
+async def _echo_app(scope, receive, send) -> None:
+    """Minimal ASGI app answering with whatever body it was handed"""
+    body = bytearray()
+    more_body = True
+    while more_body:
+        message = await receive()
+        if message["type"] != "http.request":
+            break
+        body += message.get("body", b"")
+        more_body = message.get("more_body", False)
+
+    await send({"type": "http.response.start", "status": 200, "headers": []})
+    await send({"type": "http.response.body", "body": bytes(body)})
+
+
+def _scope(headers: list[tuple[bytes, bytes]]) -> dict:
+    """Return an HTTP connection scope carrying the given headers"""
+    return {"type": "http", "method": "POST", "path": "/", "headers": headers}
+
+
+async def _send_body(body: bytes, *, chunked: bool = False) -> tuple[int, bytes]:
+    """Run the guarded echo app over a request body and return its answer
+
+    Args:
+        body: Request body to deliver
+        chunked: Deliver in chunks with no declared length, as a chunked request does
+
+    Returns:
+        The response status paired with the body the app answered with
+    """
+    if chunked:
+        headers = [(b"transfer-encoding", b"chunked")]
+        pieces = [body[index:index + 16] for index in range(0, len(body), 16)] or [b""]
+    else:
+        headers = [(b"content-length", str(len(body)).encode())]
+        pieces = [body]
+
+    messages = [
+        {"type": "http.request", "body": piece, "more_body": index < len(pieces) - 1}
+        for index, piece in enumerate(pieces)
+    ]
+    answered: list[dict] = []
+
+    async def receive():
+        """Deliver the next request message, then report the client as gone"""
+        return messages.pop(0) if messages else {"type": "http.disconnect"}
+
+    async def send(message):
+        """Record one response message"""
+        answered.append(message)
+
+    middleware = RequestBodySizeLimitMiddleware(_echo_app, max_body_bytes=_CAP_BYTES)
+    await middleware(_scope(headers), receive, send)
+
+    return answered[0]["status"], answered[1]["body"]
+
+
+async def test_body_at_the_cap_reaches_the_app_unchanged():
+    """A body the size of the cap is accepted and arrives byte for byte"""
+    payload = bytes(range(64))
+
+    status, echoed = await _send_body(payload)
+
+    assert status == 200
+    assert echoed == payload
+
+
+async def test_body_one_byte_over_the_cap_is_refused():
+    """One byte past the cap is refused, so the limit is not off by one"""
+    status, _ = await _send_body(b"x" * (_CAP_BYTES + 1))
+
+    assert status == 413
+
+
+async def test_chunked_body_at_the_cap_reaches_the_app_unchanged():
+    """A chunked body within the cap is reassembled in order and passed on whole"""
+    payload = bytes(range(64))
+
+    status, echoed = await _send_body(payload, chunked=True)
+
+    assert status == 200
+    assert echoed == payload
+
+
+async def test_chunked_body_over_the_cap_is_refused_without_a_declared_length():
+    """A chunked body is counted as it arrives, so no declared length is needed to refuse it"""
+    status, _ = await _send_body(b"x" * (_CAP_BYTES + 1), chunked=True)
+
+    assert status == 413
+
+
+async def test_request_without_a_body_is_passed_straight_through():
+    """A request declaring no body keeps the server's own receive rather than a buffered replay
+
+    Nothing is read, which matters because a server that only sends a request message once
+    the app asks for one would otherwise be waited on for a body that never arrives
+    """
+    kept_the_original: list[bool] = []
+
+    async def receive():
+        """Never reached, since neither the guard nor the stub app below reads"""
+        raise AssertionError("a request with no body must not be read")
+
+    async def app(scope, app_receive, send):
+        """Record whether the app was handed the original receive or a replay"""
+        kept_the_original.append(app_receive is receive)
+
+    async def send(message):
+        """Ignore the response"""
+
+    middleware = RequestBodySizeLimitMiddleware(app, max_body_bytes=_CAP_BYTES)
+    await middleware(_scope([(b"accept", b"application/json")]), receive, send)
+
+    assert kept_the_original == [True]
+
+
+@pytest.mark.parametrize("scope_type", ["lifespan", "websocket"])
+async def test_non_http_traffic_is_untouched(scope_type):
+    """Startup and websocket connections carry no body and go straight to the app"""
+    seen: list[str] = []
+
+    async def app(scope, receive, send):
+        """Record the scope it was reached with"""
+        seen.append(scope["type"])
+
+    async def receive():
+        """Never called"""
+        raise AssertionError("the guard must not read a non-HTTP connection")
+
+    async def send(message):
+        """Never called"""
+
+    middleware = RequestBodySizeLimitMiddleware(app, max_body_bytes=_CAP_BYTES)
+    await middleware({"type": scope_type}, receive, send)
+
+    assert seen == [scope_type]

--- a/backend/tests/test_request_body_middleware.py
+++ b/backend/tests/test_request_body_middleware.py
@@ -184,6 +184,10 @@ async def test_a_client_vanishing_mid_body_leaves_the_app_to_handle_it():
     await middleware(_scope([(b"transfer-encoding", b"chunked")]), receive, send)
 
     assert seen[0]["body"] == b"half"
+
+    # more_body is what keeps the app reading. False here would have a route treat a
+    # truncated upload as a whole one and never reach the disconnect below
+    assert seen[0]["more_body"] is True
     assert seen[1] == {"type": "http.disconnect"}
 
 

--- a/backend/tests/test_request_body_middleware.py
+++ b/backend/tests/test_request_body_middleware.py
@@ -1,19 +1,20 @@
 """Request body size guard tests driving the middleware as a plain ASGI app
 
 The route-level tests cover the wiring inside the application. These drive the middleware
-directly with a small cap, which is what makes the boundary and the replayed body cheap
-enough to assert exactly
+directly with a small cap, which is what makes the boundary and the counting cheap enough
+to assert exactly
 """
 
 import pytest
+from fastapi import HTTPException
 
 from app.request_security import RequestBodySizeLimitMiddleware
 
 _CAP_BYTES = 64
 
 
-async def _echo_app(scope, receive, send) -> None:
-    """Minimal ASGI app answering with whatever body it was handed"""
+async def _reading_app(scope, receive, send) -> None:
+    """Minimal ASGI app answering with whatever body it reads"""
     body = bytearray()
     more_body = True
     while more_body:
@@ -32,15 +33,15 @@ def _scope(headers: list[tuple[bytes, bytes]]) -> dict:
     return {"type": "http", "method": "POST", "path": "/", "headers": headers}
 
 
-async def _send_body(body: bytes, *, chunked: bool = False) -> tuple[int, bytes]:
-    """Run the guarded echo app over a request body and return its answer
+def _delivery(body: bytes, *, chunked: bool):
+    """Return the request messages and headers for delivering a body
 
     Args:
         body: Request body to deliver
-        chunked: Deliver in chunks with no declared length, as a chunked request does
+        chunked: Deliver in pieces with no declared length, as a chunked request does
 
     Returns:
-        The response status paired with the body the app answered with
+        The headers paired with the messages the server would send
     """
     if chunked:
         headers = [(b"transfer-encoding", b"chunked")]
@@ -53,6 +54,20 @@ async def _send_body(body: bytes, *, chunked: bool = False) -> tuple[int, bytes]
         {"type": "http.request", "body": piece, "more_body": index < len(pieces) - 1}
         for index, piece in enumerate(pieces)
     ]
+    return headers, messages
+
+
+async def _send_body(body: bytes, *, chunked: bool = False) -> tuple[int, bytes]:
+    """Run the guarded app over a request body and return its answer
+
+    Args:
+        body: Request body to deliver
+        chunked: Deliver in pieces with no declared length
+
+    Returns:
+        The response status paired with the body the app answered with
+    """
+    headers, messages = _delivery(body, chunked=chunked)
     answered: list[dict] = []
 
     async def receive():
@@ -63,7 +78,7 @@ async def _send_body(body: bytes, *, chunked: bool = False) -> tuple[int, bytes]
         """Record one response message"""
         answered.append(message)
 
-    middleware = RequestBodySizeLimitMiddleware(_echo_app, max_body_bytes=_CAP_BYTES)
+    middleware = RequestBodySizeLimitMiddleware(_reading_app, max_body_bytes=_CAP_BYTES)
     await middleware(_scope(headers), receive, send)
 
     return answered[0]["status"], answered[1]["body"]
@@ -79,11 +94,29 @@ async def test_body_at_the_cap_reaches_the_app_unchanged():
     assert echoed == payload
 
 
-async def test_body_one_byte_over_the_cap_is_refused():
-    """One byte past the cap is refused, so the limit is not off by one"""
-    status, _ = await _send_body(b"x" * (_CAP_BYTES + 1))
+async def test_declared_body_over_the_cap_is_refused_before_the_app_runs():
+    """A declared length past the cap is answered directly, with the app never reached"""
+    reached: list[str] = []
 
-    assert status == 413
+    async def app(scope, receive, send):
+        """Record that the app ran, which it should not"""
+        reached.append(scope["path"])
+
+    answered: list[dict] = []
+
+    async def receive():
+        """Never called, since an oversized declared length is refused unread"""
+        raise AssertionError("an oversized declared length must not be read")
+
+    async def send(message):
+        """Record one response message"""
+        answered.append(message)
+
+    middleware = RequestBodySizeLimitMiddleware(app, max_body_bytes=_CAP_BYTES)
+    await middleware(_scope([(b"content-length", str(_CAP_BYTES + 1).encode())]), receive, send)
+
+    assert answered[0]["status"] == 413
+    assert reached == []
 
 
 async def test_chunked_body_at_the_cap_reaches_the_app_unchanged():
@@ -96,99 +129,59 @@ async def test_chunked_body_at_the_cap_reaches_the_app_unchanged():
     assert echoed == payload
 
 
-async def test_chunked_body_over_the_cap_is_refused_without_a_declared_length():
-    """A chunked body is counted as it arrives, so no declared length is needed to refuse it"""
-    status, _ = await _send_body(b"x" * (_CAP_BYTES + 1), chunked=True)
+async def test_chunked_body_over_the_cap_is_refused_as_it_arrives():
+    """A body with no declared length is counted while the route reads it and cut off at the cap"""
+    with pytest.raises(HTTPException) as refusal:
+        await _send_body(b"x" * (_CAP_BYTES + 1), chunked=True)
 
-    assert status == 413
+    assert refusal.value.status_code == 413
 
 
-async def test_request_without_a_body_is_passed_straight_through():
-    """A request declaring no body keeps the server's own receive rather than a buffered replay
+async def test_a_lying_declared_length_is_still_caught():
+    """A body larger than the length it declares is refused on the running count"""
+    headers = [(b"content-length", b"1")]
+    messages = [{"type": "http.request", "body": b"x" * (_CAP_BYTES + 1), "more_body": False}]
 
-    Nothing is read, which matters because a server that only sends a request message once
-    the app asks for one would otherwise be waited on for a body that never arrives
+    async def receive():
+        """Deliver the oversized body the header understated"""
+        return messages.pop(0)
+
+    async def send(message):
+        """Ignore the response"""
+
+    middleware = RequestBodySizeLimitMiddleware(_reading_app, max_body_bytes=_CAP_BYTES)
+
+    with pytest.raises(HTTPException) as refusal:
+        await middleware(_scope(headers), receive, send)
+
+    assert refusal.value.status_code == 413
+
+
+async def test_a_route_that_ignores_its_body_is_never_counted():
+    """Nothing is read on the guard's own initiative, which is what keeps a connection cheap
+
+    An unread body is bounded by the server pausing the socket once nothing consumes it, so
+    counting here would cost memory rather than save it
     """
-    kept_the_original: list[bool] = []
+    async def app(scope, receive, send):
+        """Answer without ever reading the body, as a cookie-only route does"""
+        await send({"type": "http.response.start", "status": 204, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    answered: list[dict] = []
 
     async def receive():
-        """Never reached, since neither the guard nor the stub app below reads"""
-        raise AssertionError("a request with no body must not be read")
-
-    async def app(scope, app_receive, send):
-        """Record whether the app was handed the original receive or a replay"""
-        kept_the_original.append(app_receive is receive)
+        """Never called, since neither the guard nor the app above reads"""
+        raise AssertionError("the guard must not read a body the route ignores")
 
     async def send(message):
-        """Ignore the response"""
-
-    middleware = RequestBodySizeLimitMiddleware(app, max_body_bytes=_CAP_BYTES)
-    await middleware(_scope([(b"accept", b"application/json")]), receive, send)
-
-    assert kept_the_original == [True]
-
-
-async def test_the_app_keeps_reading_from_the_server_after_the_body():
-    """Once the buffered body is spent the app reads on from the server, not from a stand-in
-
-    Answering with a disconnect of its own would tell a streaming response the client had
-    gone the moment its body was read
-    """
-    server_messages = [
-        {"type": "http.request", "body": b"payload", "more_body": False},
-        {"type": "http.disconnect"},
-    ]
-    read_after_the_body: list[dict] = []
-
-    async def receive():
-        """Deliver the next message the server has"""
-        return server_messages.pop(0)
-
-    async def app(scope, app_receive, send):
-        """Read the body, then keep listening as a streaming response would"""
-        await app_receive()
-        read_after_the_body.append(await app_receive())
-
-    async def send(message):
-        """Ignore the response"""
-
-    middleware = RequestBodySizeLimitMiddleware(app, max_body_bytes=_CAP_BYTES)
-    await middleware(_scope([(b"content-length", b"7")]), receive, send)
-
-    # The server's own disconnect, reached because the replay fell through to it
-    assert read_after_the_body == [{"type": "http.disconnect"}]
-    assert server_messages == []
-
-
-async def test_a_client_vanishing_mid_body_leaves_the_app_to_handle_it():
-    """A disconnect part way through a body is passed on with the bytes read so far"""
-    server_messages = [
-        {"type": "http.request", "body": b"half", "more_body": True},
-        {"type": "http.disconnect"},
-    ]
-    seen: list[dict] = []
-
-    async def receive():
-        """Deliver the next message the server has"""
-        return server_messages.pop(0)
-
-    async def app(scope, app_receive, send):
-        """Read until the client is reported gone"""
-        seen.append(await app_receive())
-        seen.append(await app_receive())
-
-    async def send(message):
-        """Ignore the response"""
+        """Record one response message"""
+        answered.append(message)
 
     middleware = RequestBodySizeLimitMiddleware(app, max_body_bytes=_CAP_BYTES)
     await middleware(_scope([(b"transfer-encoding", b"chunked")]), receive, send)
 
-    assert seen[0]["body"] == b"half"
-
-    # more_body is what keeps the app reading. False here would have a route treat a
-    # truncated upload as a whole one and never reach the disconnect below
-    assert seen[0]["more_body"] is True
-    assert seen[1] == {"type": "http.disconnect"}
+    assert answered[0]["status"] == 204
 
 
 @pytest.mark.parametrize("scope_type", ["lifespan", "websocket"])

--- a/backend/tests/test_rls_isolation.py
+++ b/backend/tests/test_rls_isolation.py
@@ -366,3 +366,10 @@ async def test_cache_bump_is_refused_without_a_request_identity():
     async with _act_as(None) as session:
         with pytest.raises(ProgrammingError, match="Not authorized"):
             await session.execute(_BUMP_MEMBER_CACHE, {"user_id": uuid.uuid4(), "group_id": uuid.uuid4()})
+
+
+async def test_cache_bump_is_refused_for_a_null_target():
+    """A null target is refused rather than matching a null identity and skipping the check"""
+    async with _act_as(None) as session:
+        with pytest.raises(ProgrammingError, match="Not authorized"):
+            await session.execute(_BUMP_MEMBER_CACHE, {"user_id": None, "group_id": uuid.uuid4()})

--- a/backend/tests/test_rls_isolation.py
+++ b/backend/tests/test_rls_isolation.py
@@ -19,6 +19,7 @@ from app.database import current_user_id_ctx
 from app.models.account import Account
 from app.models.base import AccountKind, AccountType, CategoryKind, RecurrenceFreq
 from app.models.budget import BaseBudget, Budget, BudgetTrackedCategory
+from app.models.cache_state import UserCacheState
 from app.models.category import Category
 from app.models.currency import Currency
 from app.models.group import Group, GroupMember
@@ -281,6 +282,21 @@ async def test_cache_bump_is_refused_for_a_stranger(users):
             await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_a.id, "group_id": uuid.uuid4()})
 
 
+async def _read_cache_changed_at(user_id):
+    """Return a user's cache timestamp, read as the owner so the per-user policy does not hide it
+
+    Args:
+        user_id: User whose cache row is read
+
+    Returns:
+        The recorded change time, or None when no row exists
+    """
+    async with TestSession() as session:
+        return await session.scalar(
+            select(UserCacheState.changed_at).where(UserCacheState.user_id == user_id)
+        )
+
+
 async def test_group_admin_can_bump_a_member_just_removed(group_with_admin_and_member):
     """An admin can invalidate the cache of a member whose membership they have already deleted
 
@@ -293,6 +309,12 @@ async def test_group_admin_can_bump_a_member_just_removed(group_with_admin_and_m
             delete(GroupMember).where(GroupMember.group_id == group.id, GroupMember.user_id == user_b.id)
         )
         await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_b.id, "group_id": group.id})
+
+        # Committed so the row can be read back as the owner, since the removed member's
+        # cache row is exactly what the caller's own policy would hide from them
+        await session.commit()
+
+    assert await _read_cache_changed_at(user_b.id) is not None
 
 
 async def test_user_can_bump_their_own_cache_leaving_a_group(group_with_admin_and_member):
@@ -307,6 +329,9 @@ async def test_user_can_bump_their_own_cache_leaving_a_group(group_with_admin_an
             delete(GroupMember).where(GroupMember.group_id == group.id, GroupMember.user_id == user_b.id)
         )
         await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_b.id, "group_id": group.id})
+        await session.commit()
+
+    assert await _read_cache_changed_at(user_b.id) is not None
 
 
 async def test_cache_bump_is_refused_without_a_request_identity():

--- a/backend/tests/test_rls_isolation.py
+++ b/backend/tests/test_rls_isolation.py
@@ -34,7 +34,8 @@ async def _act_as(user_id):
 
     The identity is set on the same context variable the app uses, so the session's
     begin listener stamps it for the policies, mirroring a real request. Nothing is
-    committed, so writes attempted inside the block never persist
+    committed here, so a write inside the block is discarded unless the test commits it
+    deliberately, and the per-test truncation clears whatever a test does commit
     """
     token = current_user_id_ctx.set(user_id)
     try:
@@ -297,24 +298,50 @@ async def _read_cache_changed_at(user_id):
         )
 
 
-async def test_group_admin_can_bump_a_member_just_removed(group_with_admin_and_member):
-    """An admin can invalidate the cache of a member whose membership they have already deleted
+async def test_group_admin_can_bump_a_member_of_that_group(group_with_admin_and_member):
+    """An admin can invalidate the cache of someone who belongs to the group they administer"""
+    group, user_a, user_b = group_with_admin_and_member
+    async with _act_as(user_a.id) as session:
+        await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_b.id, "group_id": group.id})
 
-    The removal route deletes the membership before bumping, so the helper has to authorize
-    against the caller's own admin membership rather than the target's
+        # Committed so the row can be read back as the owner, since another user's cache
+        # row is exactly what the caller's own policy would hide from them
+        await session.commit()
+
+    assert await _read_cache_changed_at(user_b.id) is not None
+
+
+async def test_cache_bump_is_refused_for_a_group_the_target_does_not_belong_to(users):
+    """Administering a group is not enough on its own, since anyone can create one
+
+    A user who creates a group is made its admin, so a check resting on that alone would let
+    anyone invalidate anyone's cache by naming a group of their own
+    """
+    user_a, user_b = users
+    own_group = Group(owner_id=user_b.id, name="B Only")
+    async with TestSession() as session:
+        session.add(own_group)
+        await session.flush()
+        session.add(GroupMember(group_id=own_group.id, user_id=user_b.id, is_admin=True))
+        await session.commit()
+
+    async with _act_as(user_b.id) as session:
+        with pytest.raises(ProgrammingError, match="Not authorized"):
+            await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_a.id, "group_id": own_group.id})
+
+
+async def test_cache_bump_is_refused_once_the_member_is_gone(group_with_admin_and_member):
+    """The membership has to still be there, which is what forces the bump before the removal
+
+    Swapping those two lines in the removal route fails here rather than passing silently
     """
     group, user_a, user_b = group_with_admin_and_member
     async with _act_as(user_a.id) as session:
         await session.execute(
             delete(GroupMember).where(GroupMember.group_id == group.id, GroupMember.user_id == user_b.id)
         )
-        await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_b.id, "group_id": group.id})
-
-        # Committed so the row can be read back as the owner, since the removed member's
-        # cache row is exactly what the caller's own policy would hide from them
-        await session.commit()
-
-    assert await _read_cache_changed_at(user_b.id) is not None
+        with pytest.raises(ProgrammingError, match="Not authorized"):
+            await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_b.id, "group_id": group.id})
 
 
 async def test_user_can_bump_their_own_cache_leaving_a_group(group_with_admin_and_member):

--- a/backend/tests/test_rls_isolation.py
+++ b/backend/tests/test_rls_isolation.py
@@ -6,12 +6,13 @@ runtime app role, which is subject to the policies, to prove they actually keep
 one user's data out of another user's reach at the database level
 """
 
+import uuid
 from contextlib import asynccontextmanager
 from datetime import UTC, date, datetime
 from decimal import Decimal
 
 import pytest
-from sqlalchemy import select, text
+from sqlalchemy import delete, select, text
 from sqlalchemy.exc import ProgrammingError
 
 from app.database import current_user_id_ctx
@@ -243,3 +244,73 @@ async def test_budget_spend_rows_returns_nothing_to_unauthorized_readers(users):
     async with _act_as(user_b.id) as session:
         other_rows = (await session.execute(spend_query, {"budget_ids": [budget.id]})).all()
         assert other_rows == []
+
+
+_BUMP_MEMBER_CACHE = text("SELECT public.bump_group_member_cache(:user_id, :group_id)")
+
+
+@pytest.fixture
+async def group_with_admin_and_member(users):
+    """Seed a group whose owner is an admin and whose second user is a plain member"""
+    user_a, user_b = users
+    group = Group(owner_id=user_a.id, name="A Family")
+    async with TestSession() as session:
+        session.add(group)
+        await session.flush()
+        session.add_all([
+            GroupMember(group_id=group.id, user_id=user_a.id, is_admin=True),
+            GroupMember(group_id=group.id, user_id=user_b.id),
+        ])
+        await session.commit()
+    return group, user_a, user_b
+
+
+async def test_cache_bump_is_refused_for_a_group_the_caller_does_not_administer(group_with_admin_and_member):
+    """A plain member cannot invalidate another member's cache through the privileged helper"""
+    group, user_a, user_b = group_with_admin_and_member
+    async with _act_as(user_b.id) as session:
+        with pytest.raises(ProgrammingError, match="Not authorized"):
+            await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_a.id, "group_id": group.id})
+
+
+async def test_cache_bump_is_refused_for_a_stranger(users):
+    """A user outside every group of the target cannot invalidate the target's cache"""
+    user_a, user_b = users
+    async with _act_as(user_b.id) as session:
+        with pytest.raises(ProgrammingError, match="Not authorized"):
+            await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_a.id, "group_id": uuid.uuid4()})
+
+
+async def test_group_admin_can_bump_a_member_just_removed(group_with_admin_and_member):
+    """An admin can invalidate the cache of a member whose membership they have already deleted
+
+    The removal route deletes the membership before bumping, so the helper has to authorize
+    against the caller's own admin membership rather than the target's
+    """
+    group, user_a, user_b = group_with_admin_and_member
+    async with _act_as(user_a.id) as session:
+        await session.execute(
+            delete(GroupMember).where(GroupMember.group_id == group.id, GroupMember.user_id == user_b.id)
+        )
+        await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_b.id, "group_id": group.id})
+
+
+async def test_user_can_bump_their_own_cache_leaving_a_group(group_with_admin_and_member):
+    """A member leaving a group invalidates their own cache through the same call
+
+    Their own membership is gone by then, so the group branch is false and the self branch
+    is what carries it
+    """
+    group, _, user_b = group_with_admin_and_member
+    async with _act_as(user_b.id) as session:
+        await session.execute(
+            delete(GroupMember).where(GroupMember.group_id == group.id, GroupMember.user_id == user_b.id)
+        )
+        await session.execute(_BUMP_MEMBER_CACHE, {"user_id": user_b.id, "group_id": group.id})
+
+
+async def test_cache_bump_is_refused_without_a_request_identity():
+    """A connection carrying no identity is refused rather than treated as a match"""
+    async with _act_as(None) as session:
+        with pytest.raises(ProgrammingError, match="Not authorized"):
+            await session.execute(_BUMP_MEMBER_CACHE, {"user_id": uuid.uuid4(), "group_id": uuid.uuid4()})


### PR DESCRIPTION
The row-level security identity is converted to a UUID and bound as a parameter before any transaction carries it, so a value arriving from a job payload or a database column fails at the stamp rather than reaching the policies as text. The privileged cache bump takes a group as well as a user, and refuses unless the caller is that user or administers a group the user belongs to, which is why group member removal invalidates the member's cache before deleting their membership rather than after. A request over 10 MB is refused with a 413. It is counted as the route reads it, so an unauthenticated connection costs the server no more than it already spends on one, and outbound calls stop reading a response past 5 MB, which covers the FX provider, the update check and any sign-in provider an operator configures.
