### PR TITLE
Stop a slow load leaving the account page and a transaction's amount blank

### DIFF
--- a/frontend/src/hooks/useCurrencyListState.ts
+++ b/frontend/src/hooks/useCurrencyListState.ts
@@ -5,8 +5,8 @@ import type { CurrencyListState } from '@/utils/currencyStatus'
  * Reports whether the currency list is in hand, still on its way, or not coming
  *
  * This is the state of the list itself, so a list that has not arrived yet is never reported as one
- * that failed. A field holding a stored amount stands down on its own currency's decimal places
- * being unknown rather than on this, since a loaded list can still be missing that one currency, and
+ * that failed. A field holding a stored amount locks on its own currency's decimal places being
+ * unknown rather than on this, since a loaded list can still be missing that one currency, and
  * reads this only to say which of the reasons applies. A request that hangs is aborted by the
  * fetch's own timeout, so loading always ends
  */

--- a/frontend/src/hooks/useCurrencyListState.ts
+++ b/frontend/src/hooks/useCurrencyListState.ts
@@ -4,9 +4,11 @@ import type { CurrencyListState } from '@/utils/currencyStatus'
 /**
  * Reports whether the currency list is in hand, still on its way, or not coming
  *
- * Every surface that stands a field down or refuses a form reads this one rule, so a list that has not
- * arrived yet is never reported as one that failed. A request that hangs is aborted by the fetch's own
- * timeout, so loading always ends
+ * This is the state of the list itself, so a list that has not arrived yet is never reported as one
+ * that failed. A field holding a stored amount stands down on its own currency's decimal places
+ * being unknown rather than on this, since a loaded list can still be missing that one currency, and
+ * reads this only to say which of the reasons applies. A request that hangs is aborted by the
+ * fetch's own timeout, so loading always ends
  */
 export function useCurrencyListState(): CurrencyListState {
   const { data, isFetching } = useCurrencies()

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -6,6 +6,7 @@ import { useTaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import type { Transaction } from '@/api/transactions'
 import AccountIdentityCard from '@/pages/accounts/detail/components/identity/Card'
 import AccountDetailBackLink from '@/pages/accounts/detail/components/BackLink'
+import AccountDetailLoadingSkeleton from '@/pages/accounts/detail/components/LoadingSkeleton'
 import BalanceChartCard from '@/pages/accounts/detail/components/balance-chart/Card'
 import EditAccountIdentityModal from '@/pages/accounts/detail/components/edit-identity/Modal'
 import MonthlyCashFlowCard from '@/pages/accounts/detail/components/monthly-cash-flow/Card'
@@ -16,6 +17,7 @@ import TransactionListSection from '@/pages/transactions/components/ListSection'
 import { toTransactionListAccount } from '@/pages/transactions/types/transactionList'
 import CreateTransactionModal from '@/pages/transactions/components/transaction-modal/Modal'
 import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
+import { useSkeletonVisibility } from '@/pages/accounts/detail/hooks/useSkeletonVisibility'
 
 type DeleteExitPhase = 'idle' | 'pending' | 'modal' | 'page'
 
@@ -50,6 +52,11 @@ export default function AccountDetailPage() {
     data: linkedTaxAdvantagedCategory,
     error: linkedTaxAdvantagedCategoryError,
   } = useTaxAdvantagedCategory(linkedTaxAdvantagedCategoryId)
+
+  // A deletion holds a copy of the account, so this stays false throughout one and the page keeps
+  // rendering the copy rather than dropping into the loading branch mid-exit
+  const isAccountLoading = !visibleAccount && !error
+  const showSkeleton = useSkeletonVisibility(isAccountLoading)
 
   const openCreateTransaction = () => {
     if (visibleAccount?.is_archived) return
@@ -96,10 +103,14 @@ export default function AccountDetailPage() {
     if (deleteExitPhase === 'page') navigate('/accounts', { replace: true })
   }
 
-  if (!visibleAccount && !error) {
+  // The skeleton outlasts the request by its minimum display, so the account having arrived is not
+  // on its own a reason to leave this branch. An error is: it goes to the message below at once
+  // rather than finishing an animation first
+  if (!error && (isAccountLoading || showSkeleton)) {
     return (
       <div>
         <AccountDetailBackLink />
+        {showSkeleton && <AccountDetailLoadingSkeleton />}
       </div>
     )
   }

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -117,8 +117,17 @@ export default function AccountDetailPage() {
 
   if ((error && deleteExitPhase === 'idle') || !visibleAccount) {
     return (
-      <div>
-        <AccountDetailBackLink />
+      // Fills the height the page content area has left after its own padding, which is the whole
+      // viewport on mobile and the space beside the sidebar on desktop, so the message sits in the
+      // middle of what the reader can see. The padding subtracted here is the main element's own,
+      // set in App.tsx, and the two have to be changed together
+      <div className="relative flex min-h-[calc(100dvh-3.5rem)] flex-col items-center justify-center text-center min-[1050px]:min-h-[calc(100dvh-3.75rem)]">
+        {/* Out of the centred flow, so the message is centred against the area rather than against
+            the space left under the link */}
+        <div className="absolute left-0 top-0">
+          <AccountDetailBackLink />
+        </div>
+
         <h1 className="app-page-title">Account not found</h1>
         <p className="app-page-description">We couldn't load this account. It may have been deleted.</p>
       </div>

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { AnimatePresence, motion } from 'motion/react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { useNavigate, useParams } from 'react-router'
 import { useAccount, useAccounts, type Account } from '@/api/accounts'
 import { useTaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
@@ -12,7 +12,7 @@ import EditAccountIdentityModal from '@/pages/accounts/detail/components/edit-id
 import MonthlyCashFlowCard from '@/pages/accounts/detail/components/monthly-cash-flow/Card'
 import { TopCategoriesBySpendingCard } from '@/pages/accounts/detail/components/spending-breakdown/TopCategoriesCard'
 import { TopMerchantsBySpendingCard } from '@/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard'
-import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
+import { ACCOUNT_SKELETON_FADE_MS, EASE } from '@/pages/accounts/detail/constants/accountDetail'
 import TransactionListSection from '@/pages/transactions/components/ListSection'
 import { toTransactionListAccount } from '@/pages/transactions/types/transactionList'
 import CreateTransactionModal from '@/pages/transactions/components/transaction-modal/Modal'
@@ -57,6 +57,21 @@ export default function AccountDetailPage() {
   // rendering the copy rather than dropping into the loading branch mid-exit
   const isAccountLoading = !visibleAccount && !error
   const showSkeleton = useSkeletonVisibility(isAccountLoading)
+  const prefersReducedMotion = useReducedMotion() ?? false
+
+  // The placeholder has to outlive the moment it is dropped, or there is nothing left on screen to
+  // fade. The loading branch is held open until its exit finishes, and the page then enters with a
+  // fade of its own so the two hand over rather than one popping in behind the other
+  const [isSkeletonExiting, setIsSkeletonExiting] = useState(false)
+  const [hasShownSkeleton, setHasShownSkeleton] = useState(false)
+  const [wasShowingSkeleton, setWasShowingSkeleton] = useState(showSkeleton)
+  if (wasShowingSkeleton !== showSkeleton) {
+    setWasShowingSkeleton(showSkeleton)
+    if (showSkeleton) setHasShownSkeleton(true)
+    else setIsSkeletonExiting(true)
+  }
+
+  const skeletonFadeSeconds = prefersReducedMotion ? 0 : ACCOUNT_SKELETON_FADE_MS / 1000
 
   const openCreateTransaction = () => {
     if (visibleAccount?.is_archived) return
@@ -103,14 +118,26 @@ export default function AccountDetailPage() {
     if (deleteExitPhase === 'page') navigate('/accounts', { replace: true })
   }
 
-  // The skeleton outlasts the request by its minimum display, so the account having arrived is not
-  // on its own a reason to leave this branch. An error is: it goes to the message below at once
-  // rather than finishing an animation first
-  if (!error && (isAccountLoading || showSkeleton)) {
+  // The skeleton outlasts the request by its minimum display and then by its fade, so the account
+  // having arrived is not on its own a reason to leave this branch. An error is: it goes to the
+  // message below at once rather than finishing an animation first
+  if (!error && (isAccountLoading || showSkeleton || isSkeletonExiting)) {
     return (
       <div>
         <AccountDetailBackLink />
-        {showSkeleton && <AccountDetailLoadingSkeleton />}
+        <AnimatePresence onExitComplete={() => setIsSkeletonExiting(false)}>
+          {showSkeleton && (
+            <motion.div
+              key="account-detail-skeleton"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              exit={{ opacity: 0 }}
+              transition={{ duration: skeletonFadeSeconds, ease: EASE }}
+            >
+              <AccountDetailLoadingSkeleton />
+            </motion.div>
+          )}
+        </AnimatePresence>
       </div>
     )
   }
@@ -139,7 +166,9 @@ export default function AccountDetailPage() {
       {deleteExitPhase !== 'page' && (
         <motion.div
           key="account-detail-page"
-          initial={false}
+          // Fades in only where it is taking over from a placeholder that just faded out. Every
+          // other arrival, a cached account above all, is drawn straight away as it always was
+          initial={hasShownSkeleton && !prefersReducedMotion ? { opacity: 0, y: 0, filter: 'blur(0px)' } : false}
           animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
           exit={{ opacity: 0, y: 10, filter: 'blur(2px)' }}
           transition={{ duration: 0.22, ease: EASE }}

--- a/frontend/src/pages/accounts/detail/components/LoadingSkeleton.tsx
+++ b/frontend/src/pages/accounts/detail/components/LoadingSkeleton.tsx
@@ -55,7 +55,8 @@ function BreakdownCardSkeleton({ reducedMotion }: { reducedMotion: boolean }) {
 }
 
 /**
- * Stands in for the whole account detail page while the account request is in flight
+ * Stands in for the whole account detail page until the account is ready to render, which outlasts
+ * the request itself by the minimum the page holds this on screen for
  *
  * Built from the same grid and card classes the loaded page uses, so every card lands in the
  * position its placeholder occupied and nothing moves under the user. The blocks are hidden from

--- a/frontend/src/pages/accounts/detail/components/LoadingSkeleton.tsx
+++ b/frontend/src/pages/accounts/detail/components/LoadingSkeleton.tsx
@@ -1,0 +1,128 @@
+import { motion, useReducedMotion } from 'motion/react'
+
+// How many transaction rows the placeholder list shows. Enough to reach the fold on a laptop
+// without implying the account has exactly this many transactions
+const PLACEHOLDER_TRANSACTION_ROWS = 6
+
+/**
+ * One placeholder block, sweeping left to right unless the user asked for reduced motion
+ *
+ * @param className - Sizing for this block, since every placeholder is a different shape
+ * @param reducedMotion - Read once by the page rather than per block
+ */
+function SkeletonBlock({ className, reducedMotion }: { className: string; reducedMotion: boolean }) {
+  return (
+    <div
+      className={`relative overflow-hidden rounded-md ${className}`}
+      style={{ background: 'var(--app-border)' }}
+    >
+      {!reducedMotion && (
+        <motion.span
+          className="absolute inset-y-0 left-0 w-2/3"
+          initial={{ x: '-140%' }}
+          animate={{ x: '190%' }}
+          transition={{ duration: 1.15, ease: 'easeInOut', repeat: Infinity }}
+          style={{
+            background:
+              'linear-gradient(90deg, transparent, rgba(255, 255, 255, 0.62), transparent)',
+          }}
+        />
+      )}
+    </div>
+  )
+}
+
+/**
+ * Placeholder for one of the two spending breakdown cards, holding the card's own height so the
+ * row does not resize when the real cards arrive
+ */
+function BreakdownCardSkeleton({ reducedMotion }: { reducedMotion: boolean }) {
+  return (
+    <section className="app-card flex h-[440px] flex-col min-[1200px]:h-[400px]">
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <SkeletonBlock className="h-3 w-40" reducedMotion={reducedMotion} />
+        <SkeletonBlock className="h-7 w-28 rounded-full" reducedMotion={reducedMotion} />
+      </div>
+      <div className="flex flex-col gap-1.5">
+        {Array.from({ length: 5 }, (_, row) => (
+          <SkeletonBlock key={row} className="h-10 rounded-xl" reducedMotion={reducedMotion} />
+        ))}
+      </div>
+      <div className="flex-1" />
+      <SkeletonBlock className="h-4 w-full" reducedMotion={reducedMotion} />
+    </section>
+  )
+}
+
+/**
+ * Stands in for the whole account detail page while the account request is in flight
+ *
+ * Built from the same grid and card classes the loaded page uses, so every card lands in the
+ * position its placeholder occupied and nothing moves under the user. The blocks are hidden from
+ * assistive technology behind a single status line, since a screen reader announcing a dozen
+ * shapes says nothing a person can act on
+ */
+export default function AccountDetailLoadingSkeleton() {
+  const reducedMotion = useReducedMotion() ?? false
+
+  return (
+    <div>
+      <span role="status" className="sr-only">Loading account</span>
+
+      <div aria-hidden>
+        <div className="grid grid-cols-1 gap-5 min-[750px]:grid-cols-[320px_minmax(0,1fr)]">
+          <section className="app-card relative flex flex-col min-[750px]:min-h-[440px]">
+            <SkeletonBlock className="h-12 w-12 rounded-xl" reducedMotion={reducedMotion} />
+            <SkeletonBlock className="mt-4 h-6 w-48" reducedMotion={reducedMotion} />
+            <SkeletonBlock className="mt-2 h-4 w-32" reducedMotion={reducedMotion} />
+
+            <div className="mt-6 flex flex-col gap-3">
+              {Array.from({ length: 4 }, (_, fact) => (
+                <div key={fact} className="flex items-center justify-between gap-4">
+                  <SkeletonBlock className="h-3 w-24" reducedMotion={reducedMotion} />
+                  <SkeletonBlock className="h-3 w-16" reducedMotion={reducedMotion} />
+                </div>
+              ))}
+            </div>
+
+            <div className="flex-1" />
+            <SkeletonBlock className="h-16 w-full rounded-xl" reducedMotion={reducedMotion} />
+          </section>
+
+          <section className="app-card flex flex-col">
+            <div className="mb-4 flex items-center justify-between gap-4">
+              <SkeletonBlock className="h-3 w-32" reducedMotion={reducedMotion} />
+              <SkeletonBlock className="h-7 w-40 rounded-full" reducedMotion={reducedMotion} />
+            </div>
+            <SkeletonBlock className="h-9 w-56" reducedMotion={reducedMotion} />
+            <SkeletonBlock className="mt-6 min-h-[260px] flex-1" reducedMotion={reducedMotion} />
+          </section>
+        </div>
+
+        <div className="mt-5 grid grid-cols-1 gap-5 min-[750px]:grid-cols-2 min-[1600px]:grid-cols-3">
+          <BreakdownCardSkeleton reducedMotion={reducedMotion} />
+          <BreakdownCardSkeleton reducedMotion={reducedMotion} />
+          <div className="min-[750px]:col-span-2 min-[1600px]:col-span-1">
+            <section className="app-card flex h-[400px] flex-col">
+              <div className="mb-4 flex items-center justify-between gap-4">
+                <SkeletonBlock className="h-3 w-36" reducedMotion={reducedMotion} />
+                <SkeletonBlock className="h-7 w-28 rounded-full" reducedMotion={reducedMotion} />
+              </div>
+              <SkeletonBlock className="min-h-[200px] flex-1" reducedMotion={reducedMotion} />
+            </section>
+          </div>
+        </div>
+
+        <div className="mt-5">
+          <h2 className="mb-4 font-serif text-4xl font-medium leading-none">Transactions</h2>
+          <SkeletonBlock className="h-11 w-full rounded-xl" reducedMotion={reducedMotion} />
+          <div className="mt-4 flex flex-col gap-2">
+            {Array.from({ length: PLACEHOLDER_TRANSACTION_ROWS }, (_, row) => (
+              <SkeletonBlock key={row} className="h-14 rounded-xl" reducedMotion={reducedMotion} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/accounts/detail/constants/accountDetail.ts
+++ b/frontend/src/pages/accounts/detail/constants/accountDetail.ts
@@ -8,6 +8,14 @@ export const ACCOUNT_KIND_LABEL: Record<string, string> = {
 
 export const EASE = [0.25, 0.1, 0.25, 1] as const
 
+// An account already in the cache resolves in a few milliseconds, so the loading skeleton waits
+// this long before appearing rather than flickering through a load nobody perceives as slow
+export const ACCOUNT_SKELETON_DELAY_MS = 150
+
+// Once the skeleton is on screen it stays for at least this long, so an account arriving just
+// after it appears does not replace it mid-blink
+export const ACCOUNT_SKELETON_MINIMUM_MS = 300
+
 export const EDIT_ACCOUNT_IDENTITY_FIELD_IDS = {
   name: 'edit-account-name',
   institution: 'edit-account-institution',

--- a/frontend/src/pages/accounts/detail/constants/accountDetail.ts
+++ b/frontend/src/pages/accounts/detail/constants/accountDetail.ts
@@ -16,6 +16,11 @@ export const ACCOUNT_SKELETON_DELAY_MS = 150
 // after it appears does not replace it mid-blink
 export const ACCOUNT_SKELETON_MINIMUM_MS = 800
 
+// How long the placeholder takes to fade in, and to fade out once the account is ready. The page
+// waits out the fade before swapping in the real cards, so this is time added to every load that
+// shows a placeholder at all
+export const ACCOUNT_SKELETON_FADE_MS = 220
+
 export const EDIT_ACCOUNT_IDENTITY_FIELD_IDS = {
   name: 'edit-account-name',
   institution: 'edit-account-institution',

--- a/frontend/src/pages/accounts/detail/constants/accountDetail.ts
+++ b/frontend/src/pages/accounts/detail/constants/accountDetail.ts
@@ -14,7 +14,7 @@ export const ACCOUNT_SKELETON_DELAY_MS = 150
 
 // Once the skeleton is on screen it stays for at least this long, so an account arriving just
 // after it appears does not replace it mid-blink
-export const ACCOUNT_SKELETON_MINIMUM_MS = 300
+export const ACCOUNT_SKELETON_MINIMUM_MS = 800
 
 export const EDIT_ACCOUNT_IDENTITY_FIELD_IDS = {
   name: 'edit-account-name',

--- a/frontend/src/pages/accounts/detail/hooks/useSkeletonVisibility.ts
+++ b/frontend/src/pages/accounts/detail/hooks/useSkeletonVisibility.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef, useState } from 'react'
+import {
+  ACCOUNT_SKELETON_DELAY_MS,
+  ACCOUNT_SKELETON_MINIMUM_MS,
+} from '@/pages/accounts/detail/constants/accountDetail'
+
+/**
+ * Reports whether the loading skeleton should be on screen, holding it back on a fast load and
+ * holding it up on a load that finishes just after it appeared
+ *
+ * The skeleton is shown once the delay has elapsed, and stays for as long as the request is still
+ * running or the minimum has not expired, whichever ends later. A request that finishes inside the
+ * delay never shows one at all
+ *
+ * @param isLoading - Whether the thing the skeleton stands in for is still on its way
+ */
+export function useSkeletonVisibility(isLoading: boolean): boolean {
+  const [visible, setVisible] = useState(false)
+
+  // When the skeleton appeared, so the minimum can be measured from it. Null while nothing is shown
+  const shownAtRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (isLoading) {
+      if (shownAtRef.current !== null) return
+
+      const appearTimer = setTimeout(() => {
+        shownAtRef.current = Date.now()
+        setVisible(true)
+      }, ACCOUNT_SKELETON_DELAY_MS)
+
+      // Clears the timer when the request finishes inside the delay, so the skeleton never appears
+      // over a page that has already painted
+      return () => clearTimeout(appearTimer)
+    }
+
+    if (shownAtRef.current === null) return
+
+    const remaining = ACCOUNT_SKELETON_MINIMUM_MS - (Date.now() - shownAtRef.current)
+    if (remaining <= 0) {
+      shownAtRef.current = null
+      setVisible(false)
+      return
+    }
+
+    const hideTimer = setTimeout(() => {
+      shownAtRef.current = null
+      setVisible(false)
+    }, remaining)
+
+    return () => clearTimeout(hideTimer)
+  }, [isLoading])
+
+  return visible
+}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -158,9 +158,9 @@ export default function CreateTransactionModal({
   const selectedCurrencyExponent = knownCurrencyExponent ?? DEFAULT_MINOR_UNIT_EXPONENT
 
   // Asked of this transaction's own currency rather than of the table as a whole, so a currency the
-  // table does not carry keeps the field down instead of unlocking it empty over a stored amount.
+  // table does not carry keeps the field locked instead of unlocking it empty over a stored amount.
   // Editing only: an edit leaves a locked amount out of the patch, where a create would post the
-  // blank it leaves behind as a zero, and a new transaction has no stored amount to stand down over
+  // blank it leaves behind as a zero, and a new transaction has no stored amount to lock over
   const isAmountLocked = editing && knownCurrencyExponent === null
 
   useRestoreLockedAmount({ open, transaction, currencies, isAmountLocked, setForm })

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -159,8 +159,8 @@ export default function CreateTransactionModal({
 
   // Asked of this transaction's own currency rather than of the table as a whole, so a currency the
   // table does not carry keeps the field down instead of unlocking it empty over a stored amount.
-  // Editing only: a locked amount is left out of validation and sent as zero, and a new transaction
-  // has no stored amount to stand down over. Its click is refused before the modal opens anyway
+  // Editing only: an edit leaves a locked amount out of the patch, where a create would post the
+  // blank it leaves behind as a zero, and a new transaction has no stored amount to stand down over
   const isAmountLocked = editing && knownCurrencyExponent === null
 
   useRestoreLockedAmount({ open, transaction, currencies, isAmountLocked, setForm })

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -4,6 +4,7 @@ import { useCategories } from '@/api/categories'
 import { useCurrencies } from '@/api/currency'
 import { useCurrencyListState } from '@/hooks/useCurrencyListState'
 import { CURRENCY_LIST_LOADING } from '@/utils/currencyStatus'
+import { DEFAULT_MINOR_UNIT_EXPONENT, findCurrencyExponent } from '@/utils/moneyInput'
 import { useAuth } from '@/hooks/useAuth'
 import { KIND_LABELS } from '@/pages/transactions/components/transaction-modal/constants'
 import { buildInitialTransactionForm } from '@/pages/transactions/components/transaction-modal/utils/initialForm'
@@ -24,6 +25,7 @@ import TransactionReferencesSection from '@/pages/transactions/components/transa
 import TransactionTypeDirectionSection from '@/pages/transactions/components/transaction-modal/sections/TypeDirectionSection'
 import { useTransactionFormState } from '@/pages/transactions/components/transaction-modal/hooks/useFormState'
 import { useTransactionReferenceCreationModals } from '@/pages/transactions/components/transaction-modal/hooks/useReferenceCreationModals'
+import { useRestoreLockedAmount } from '@/pages/transactions/components/transaction-modal/hooks/useRestoreLockedAmount'
 import { useCategoryField } from '@/pages/transactions/components/transaction-modal/hooks/useCategoryField'
 import { useMerchantField } from '@/pages/transactions/components/transaction-modal/hooks/useMerchantField'
 import { useTagField } from '@/pages/transactions/components/transaction-modal/hooks/useTagField'
@@ -152,9 +154,16 @@ export default function CreateTransactionModal({
   )
   const selectedCurrency = currencies.find((c) => c.id === form.currency)
   const selectedCurrencySymbol = selectedCurrency?.symbol ?? ''
-  const selectedCurrencyExponent = selectedCurrency?.minor_unit_exponent ?? 2
-  // Only reachable while editing, since a create click is refused before the modal opens
-  const isAmountLocked = currencyState !== 'ready'
+  const knownCurrencyExponent = findCurrencyExponent(currencies, form.currency)
+  const selectedCurrencyExponent = knownCurrencyExponent ?? DEFAULT_MINOR_UNIT_EXPONENT
+
+  // Asked of this transaction's own currency rather than of the table as a whole, so a currency the
+  // table does not carry keeps the field down instead of unlocking it empty over a stored amount.
+  // Editing only: a locked amount is left out of validation and sent as zero, and a new transaction
+  // has no stored amount to stand down over. Its click is refused before the modal opens anyway
+  const isAmountLocked = editing && knownCurrencyExponent === null
+
+  useRestoreLockedAmount({ open, transaction, currencies, isAmountLocked, setForm })
 
   const { openRef, recordCreatedAccountId, flushDeferredRefresh, closeModal } = useDeferredTransactionRefresh({
     open,
@@ -337,9 +346,10 @@ export default function CreateTransactionModal({
             dateError={showError('date')}
             currencyOptions={currencyOptions}
             currencyValue={form.currency}
-            currencyPlaceholder={isAmountLocked ? CURRENCY_LIST_LOADING : 'Select...'}
+            currencyPlaceholder={currencyState === 'loading' ? CURRENCY_LIST_LOADING : 'Select...'}
             selectedCurrencySymbol={selectedCurrencySymbol}
             currencyExponent={selectedCurrencyExponent}
+            isAmountLocked={isAmountLocked}
             currencyState={currencyState}
             amount={form.amount}
             amountError={showError('amount')}

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useRestoreLockedAmount.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useRestoreLockedAmount.ts
@@ -1,0 +1,52 @@
+import { useEffect, useRef, type Dispatch, type SetStateAction } from 'react'
+import type { Currency } from '@/api/currency'
+import type { Transaction } from '@/api/transactions'
+import { findAmountInputString } from '@/pages/transactions/components/transaction-modal/utils/money'
+import type { TransactionFormValues } from '@/pages/transactions/components/transaction-modal/types'
+
+interface RestoreLockedAmountOptions {
+  open: boolean
+  transaction: Transaction | undefined
+  currencies: Currency[]
+  isAmountLocked: boolean
+  setForm: Dispatch<SetStateAction<TransactionFormValues>>
+}
+
+/**
+ * Fills the amount box in when the transaction's currency becomes known, for a modal that opened
+ * before the currency table arrived and therefore seeded the box blank
+ *
+ * Without this the box unlocks empty over a transaction that has an amount, and the form reads that
+ * as the user having cleared it, so validation demands an amount and the save is refused. The field
+ * is disabled for the whole time it is locked, so filling it in cannot overwrite anything typed
+ */
+export function useRestoreLockedAmount({
+  open,
+  transaction,
+  currencies,
+  isAmountLocked,
+  setForm,
+}: RestoreLockedAmountOptions): void {
+  // Whether this opening seeded the amount blank, which is the only case with anything to restore
+  const seededWithoutExponentRef = useRef(isAmountLocked)
+
+  // Re-armed on each opening, since the form is seeded again then and may again be seeded before
+  // the table lands. Only the opening matters: re-running as the table arrives would re-arm the
+  // flag the fill-in below has just cleared, and overwrite whatever was typed since
+  useEffect(() => {
+    if (!open) return
+
+    seededWithoutExponentRef.current = isAmountLocked
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  useEffect(() => {
+    if (!transaction || !seededWithoutExponentRef.current) return
+
+    const amount = findAmountInputString(transaction.amount, currencies, transaction.currency)
+    if (amount === null) return
+
+    seededWithoutExponentRef.current = false
+    setForm((current) => ({ ...current, amount }))
+  }, [transaction, currencies, setForm])
+}

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -23,11 +23,11 @@ interface TransactionDetailsSectionProps {
   amount: string
   amountError?: string | false
 
-  // Whether the amount stands down, decided by the modal from the transaction's own currency rather
+  // Whether the amount is locked, decided by the modal from the transaction's own currency rather
   // than recomputed here, so the field the form treats as locked is the field the user sees disabled
   isAmountLocked: boolean
 
-  // Which of the reasons the amount stands down for, since a list still arriving is worth waiting
+  // Which of the reasons the amount is locked for, since a list still arriving is worth waiting
   // out, one that failed is worth a reload, and one that simply does not carry the currency is
   // neither. The lock itself is decided above rather than read off this
   currencyState: CurrencyListState

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -7,6 +7,7 @@ import { useMoneyInput } from '@/hooks/useMoneyInput'
 import { getMoneyPlaceholder } from '@/utils/moneyInput'
 import {
   CURRENCY_AMOUNT_NOTICE,
+  CURRENCY_AMOUNT_UNKNOWN,
   CURRENCY_LIST_LOADING,
   CURRENCY_LIST_NOTICE,
   type CurrencyListState,
@@ -26,8 +27,9 @@ interface TransactionDetailsSectionProps {
   // than recomputed here, so the field the form treats as locked is the field the user sees disabled
   isAmountLocked: boolean
 
-  // Which of the two reasons the amount stands down for, since one is worth waiting out and the
-  // other is not
+  // Which of the reasons the amount stands down for, since a list still arriving is worth waiting
+  // out, one that failed is worth a reload, and one that simply does not carry the currency is
+  // neither. The lock itself is decided above rather than read off this
   currencyState: CurrencyListState
   currencyExponent: number
   notes: string
@@ -123,7 +125,7 @@ export default function TransactionDetailsSection({
                   </IconTooltip>
                 ) : (
                   <IconTooltip label="Amount unavailable" level="important" modalFieldTabStop>
-                    {CURRENCY_AMOUNT_NOTICE}
+                    {currencyState === 'unavailable' ? CURRENCY_AMOUNT_NOTICE : CURRENCY_AMOUNT_UNKNOWN}
                   </IconTooltip>
                 )}
               </span>

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/DetailsSection.tsx
@@ -22,8 +22,12 @@ interface TransactionDetailsSectionProps {
   amount: string
   amountError?: string | false
 
-  // Stands the amount down unless the currency table is in hand, since its decimal places are the only way
-  // to read or write the stored amount, and says which of the two reasons applies
+  // Whether the amount stands down, decided by the modal from the transaction's own currency rather
+  // than recomputed here, so the field the form treats as locked is the field the user sees disabled
+  isAmountLocked: boolean
+
+  // Which of the two reasons the amount stands down for, since one is worth waiting out and the
+  // other is not
   currencyState: CurrencyListState
   currencyExponent: number
   notes: string
@@ -47,6 +51,7 @@ export default function TransactionDetailsSection({
   selectedCurrencySymbol,
   amount,
   amountError,
+  isAmountLocked,
   currencyState,
   currencyExponent,
   notes,
@@ -57,7 +62,6 @@ export default function TransactionDetailsSection({
   onAmountBlur,
   onNotesChange,
 }: TransactionDetailsSectionProps) {
-  const isAmountLocked = currencyState !== 'ready'
   const amountInput = useMoneyInput({
     value: amount,
     exponent: currencyExponent,

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/money.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/money.ts
@@ -16,6 +16,8 @@ export function amountToInputString(amountMinor: number, exponent: number): stri
  * A stored amount can only be turned into text through the real decimal places, so a currency the
  * table does not carry yields nothing rather than a number scaled by the two-place fallback
  *
+ * The text is unsigned, since the form carries which way the money went in its direction field
+ *
  * @param amountMinor - The stored signed minor-unit amount
  * @param currencies - The currency table, which is empty until it downloads
  * @param code - The amount's own currency

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/money.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/money.ts
@@ -1,4 +1,5 @@
-import { fromMinorUnits, toMinorUnits } from '@/utils/moneyInput'
+import { findCurrencyExponent, fromMinorUnits, toMinorUnits } from '@/utils/moneyInput'
+import type { Currency } from '@/api/currency'
 import type { TransactionDirection } from '@/pages/transactions/components/transaction-modal/types'
 
 /**
@@ -6,6 +7,27 @@ import type { TransactionDirection } from '@/pages/transactions/components/trans
  */
 export function amountToInputString(amountMinor: number, exponent: number): string {
   return fromMinorUnits(Math.abs(amountMinor), exponent)
+}
+
+/**
+ * Converts a stored amount into input text through its own currency's decimal places, or returns
+ * null when the currency is not in the table
+ *
+ * A stored amount can only be turned into text through the real decimal places, so a currency the
+ * table does not carry yields nothing rather than a number scaled by the two-place fallback
+ *
+ * @param amountMinor - The stored signed minor-unit amount
+ * @param currencies - The currency table, which is empty until it downloads
+ * @param code - The amount's own currency
+ */
+export function findAmountInputString(
+  amountMinor: number,
+  currencies: Currency[],
+  code: string,
+): string | null {
+  const exponent = findCurrencyExponent(currencies, code)
+
+  return exponent === null ? null : amountToInputString(amountMinor, exponent)
 }
 
 /**

--- a/frontend/src/utils/currencyStatus.ts
+++ b/frontend/src/utils/currencyStatus.ts
@@ -10,6 +10,9 @@ export const CURRENCY_LIST_NOTICE = "We can't load the currency list right now. 
 /** Shown beside an amount field standing down, which needs the currency's decimal places to say anything */
 export const CURRENCY_AMOUNT_NOTICE = "We can't load the currency list right now, so this amount can't be shown or changed. Refresh the page to try again."
 
+/** Shown in that field's place when the list did load but does not carry that amount's own currency */
+export const CURRENCY_AMOUNT_UNKNOWN = "We don't have the decimal places for this amount's currency, so it can't be shown or changed."
+
 /** Shown when a form that creates something with an amount is refused because the list failed */
 export const CURRENCY_LIST_REFUSAL = "We can't load the currency list right now. Refresh the page to try again."
 

--- a/frontend/tests/transactions/transactionModal.test.ts
+++ b/frontend/tests/transactions/transactionModal.test.ts
@@ -14,6 +14,7 @@ import {
   amountInputToMinorUnits,
   amountToInputString,
   applyTransactionDirection,
+  findAmountInputString,
   getDirectionFromAmountInputSign,
 } from '@/pages/transactions/components/transaction-modal/utils/money'
 import {
@@ -124,6 +125,19 @@ describe('transaction modal helpers', () => {
     expect(amountInputToMinorUnits('123.45', 2)).toBe(12345)
     expect(applyTransactionDirection(12345, 'credit')).toBe(12345)
     expect(applyTransactionDirection(12345, 'debit')).toBe(-12345)
+  })
+
+  it('reads a stored amount back through its own currency and refuses one it cannot scale', () => {
+    // The modal fills its amount box from this when the currency table lands under an open modal,
+    // so a wrong answer here is a wrong amount shown over a transaction the user is about to save
+    expect(findAmountInputString(1234, currencies, 'CAD')).toBe('12.34')
+    expect(findAmountInputString(1234, currencies, 'JPY')).toBe('1234')
+    expect(findAmountInputString(-1234, currencies, 'CAD')).toBe('12.34')
+
+    // No table yet, and a currency the table does not carry, are the same answer: the amount cannot
+    // be turned into text, so nothing is offered rather than a figure scaled by the two-place default
+    expect(findAmountInputString(1234, [], 'JPY')).toBeNull()
+    expect(findAmountInputString(1234, currencies, 'KRW')).toBeNull()
   })
 
   it('builds create defaults from the selected account and edit defaults from the stored transaction', () => {


### PR DESCRIPTION
The account detail page draws its own layout in grey placeholder blocks while the account request is in flight. Its missing-account message sits centred in the content area instead of at the top left. The transaction modal fills its amount box as soon as that transaction's currency is known, and locks the box when that currency has no known decimal places rather than when the currency list is missing.
