### PR TITLE
Stop animations replaying when nothing changed

### DIFF
--- a/frontend/src/components/charts/useChartEntranceAnimation.ts
+++ b/frontend/src/components/charts/useChartEntranceAnimation.ts
@@ -1,0 +1,110 @@
+import { useCallback, useState } from 'react'
+
+// Recharts resolves 'auto' against the reduced-motion setting itself, through a detector that
+// subscribes to the media query and re-renders when it changes. Handing that value back while the
+// entrance is armed keeps the preference authoritative and live, so this hook only ever takes
+// animation away and never forces it on. While the preference is set recharts runs no animation and
+// reports no end, so the entrance simply stays armed and ready for the day it is turned off
+const ARMED_ANIMATION_VALUE = 'auto'
+
+/** Value recharts accepts for a graphical item's `isAnimationActive` prop */
+export type ChartAnimationActive = boolean | typeof ARMED_ANIMATION_VALUE
+
+type ChartEntranceAnimation = {
+  isAnimationActive: ChartAnimationActive
+  onAnimationEnd: () => void
+}
+
+type ChartEntranceResolution = {
+  armed: boolean
+  isAnimationActive: ChartAnimationActive
+}
+
+// Separates one drawn value from the next inside a signature. The point count is written in front
+// of them so a series of one string value cannot read the same as a series of several numbers
+const SIGNATURE_VALUE_SEPARATOR = ','
+
+/**
+ * Builds a signature that changes when the values a chart draws change
+ *
+ * @param series - The points the chart draws
+ * @param getValue - Reads the drawn value from one point, joining several with a separator of its
+ * own where an item draws more than one
+ * @returns The signature to hand {@link useChartEntranceAnimation}
+ */
+export function getChartDataSignature<T>(
+  series: readonly T[],
+  getValue: (point: T) => number | string | null | undefined,
+): string {
+  // Walks every point, so callers hold it behind a useMemo over the series they already derive
+  return `${series.length}:${series.map(getValue).join(SIGNATURE_VALUE_SEPARATOR)}`
+}
+
+/**
+ * Decides whether a chart's entrance animation should be playing
+ *
+ * @param previousSignature - Signature the chart last rendered with
+ * @param dataSignature - Signature of the values the chart is rendering now
+ * @param armed - Whether the entrance is currently allowed to play
+ * @returns The armed flag to hold and the value to hand recharts
+ */
+export function resolveChartEntranceAnimation({
+  previousSignature,
+  dataSignature,
+  armed,
+}: {
+  previousSignature: string | number
+  dataSignature: string | number
+  armed: boolean
+}): ChartEntranceResolution {
+  const nextArmed = armed || previousSignature !== dataSignature
+
+  return {
+    armed: nextArmed,
+    isAnimationActive: nextArmed ? ARMED_ANIMATION_VALUE : false,
+  }
+}
+
+/**
+ * Plays a recharts graphical item's entrance once, then leaves it static until its values change
+ *
+ * Recharts keys an item's animation off the identity of the shapes it computes, and a bar or a pie
+ * rebuilds those on every render, so an animated one replays its entrance whenever anything
+ * re-renders the chart, pointer movement included.
+ *
+ * @param dataSignature - A value derived from what the chart draws, changing when those values do.
+ * It has to cover everything that moves the drawn shapes, which includes a scale the reader can
+ * switch and any key an ancestor remounts the plot on, not only the plotted numbers
+ * @returns Props to spread onto one `Bar`, `Line`, `Area` or `Pie`
+ */
+export function useChartEntranceAnimation({
+  dataSignature,
+}: {
+  dataSignature: string | number
+}): ChartEntranceAnimation {
+  const [armed, setArmed] = useState(true)
+  const [renderedSignature, setRenderedSignature] = useState(dataSignature)
+
+  const resolved = resolveChartEntranceAnimation({
+    previousSignature: renderedSignature,
+    dataSignature,
+    armed,
+  })
+
+  // Compared during render rather than in an effect, because recharts commits an item's finished
+  // geometry as the starting point of its next animation, so arming after new values have already
+  // rendered would interpolate a shape into itself and move nothing. The comparison is held in
+  // state rather than a ref so a render React discards takes it along: a ref would keep the
+  // mutation while losing the queued update, leaving a chart that never arms again
+  if (renderedSignature !== dataSignature) {
+    setRenderedSignature(dataSignature)
+    setArmed(resolved.armed)
+  }
+
+  // Recharts drives the animation from an effect that lists this callback among its dependencies,
+  // so a new function on each render would tear the animation down and start it again, which is the
+  // replay this hook exists to stop
+  const onAnimationEnd = useCallback(() => setArmed(false), [])
+
+  return { isAnimationActive: resolved.isAnimationActive, onAnimationEnd }
+}

--- a/frontend/src/hooks/useCursorTooltip.ts
+++ b/frontend/src/hooks/useCursorTooltip.ts
@@ -7,7 +7,7 @@ import {
 } from 'react'
 import { applyCursorTooltipPosition } from '@/utils/tooltipPosition'
 
-type CursorTooltipPointer = {
+export type CursorTooltipPointer = {
   clientX: number
   clientY: number
 }

--- a/frontend/src/pages/accounts/AccountsPage.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.tsx
@@ -28,10 +28,15 @@ export default function AccountsPage() {
   const requireCurrencies = useCurrencyGuard()
   const [createModalKey, setCreateModalKey] = useState(0)
   const { user } = useAuth()
-  const { data: accounts, isFetching: accountsLoading, error } = useAccounts()
+  const { data: accounts, isFetching, error } = useAccounts()
   const { data: taxAdvantagedCategories } = useTaxAdvantagedCategories()
 
   const allRows = useMemo(() => accounts ?? [], [accounts])
+
+  // A fetch that already has rows to show leaves them in place, so adding an account no longer
+  // drops the whole list through its exit animation and plays it back in. A fetch with nothing to
+  // show still gets the spinner, which covers first load and the retry after a failed one alike
+  const accountsLoading = isFetching && allRows.length === 0
   const rows = useMemo(() => allRows.filter((account) => !account.is_archived), [allRows])
   const archivedRows = useMemo(() => allRows.filter((account) => account.is_archived), [allRows])
   const displayCurrency = user!.base_currency

--- a/frontend/src/pages/accounts/components/ListSection.tsx
+++ b/frontend/src/pages/accounts/components/ListSection.tsx
@@ -97,6 +97,14 @@ export default function AccountListSection({
             <motion.div
               key={account.id}
               layout={prefersReducedMotion ? false : 'position'}
+              // Without this motion re-measures every row on any re-render, so a change in page
+              // coordinates that has nothing to do with the list moves them: opening a modal below
+              // the fullscreen breakpoint pins the body at its scroll offset, which shifts every
+              // row's page position without moving it on screen, and the rows slide it back. The
+              // array is rebuilt whenever the account data, the filters or the search change, which
+              // covers every moment a row can be added, removed, reordered, or grow a line and push
+              // the rows below it down
+              layoutDependency={accounts}
               className="overflow-hidden"
               initial={prefersReducedMotion ? false : { opacity: 0, height: 0 }}
               animate={{ opacity: 1, height: 'auto' }}

--- a/frontend/src/pages/accounts/detail/components/balance-chart/Chart.tsx
+++ b/frontend/src/pages/accounts/detail/components/balance-chart/Chart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, type MouseEvent as ReactMouseEvent } from 'react'
+import { useEffect, useMemo, useRef, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   Area,
   AreaChart,
@@ -11,6 +11,10 @@ import {
   DeferredChartTooltipOverlay,
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import {
   getRechartsTooltipPoint,
   getRechartsTooltipPointer,
@@ -79,6 +83,18 @@ function BalanceXAxisTick({
 export function BalanceChart({ accountId, snapshot }: BalanceChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<BalanceChartDataPoint>>(null)
+
+  // The series carries one point per day in the range whether or not any balances have arrived, so
+  // the plot is drawn flat at zero while the card is still concealed. Arming on the values means the
+  // one animation the reader sees runs as the real balances are revealed
+  const dataSignature = useMemo(
+    () => `${snapshot.chartDataKey}:${getChartDataSignature(
+      snapshot.chartSeries,
+      (point) => point[snapshot.chartDataKey],
+    )}`,
+    [snapshot.chartDataKey, snapshot.chartSeries],
+  )
+  const balanceEntrance = useChartEntranceAnimation({ dataSignature })
 
   /**
    * Shows the active balance point from Recharts payload, index, or date label fallback
@@ -178,6 +194,7 @@ export function BalanceChart({ accountId, snapshot }: BalanceChartProps) {
               stroke={snapshot.chartLineColor}
               strokeWidth={2}
               fill={`url(#balanceFill-${accountId})`}
+              {...balanceEntrance}
             />
             {snapshot.yearBoundary && (
               <ReferenceLine

--- a/frontend/src/pages/accounts/detail/components/balance-chart/Chart.tsx
+++ b/frontend/src/pages/accounts/detail/components/balance-chart/Chart.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, type MouseEvent as ReactMouseEvent } from 'react'
+import { motion, useReducedMotion } from 'motion/react'
 import {
   Area,
   AreaChart,
@@ -11,10 +12,7 @@ import {
   DeferredChartTooltipOverlay,
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
-import {
-  getChartDataSignature,
-  useChartEntranceAnimation,
-} from '@/components/charts/useChartEntranceAnimation'
+import { getChartDataSignature } from '@/components/charts/useChartEntranceAnimation'
 import {
   getRechartsTooltipPoint,
   getRechartsTooltipPointer,
@@ -29,6 +27,10 @@ import type {
 import { BalanceChartTooltipContent } from './TooltipContent'
 
 const BALANCE_AXIS_EDGE_PADDING_PX = 4
+
+// Length and shape of the reveal that draws the balance line in from the left
+const BALANCE_REVEAL_SECONDS = 1.5
+const BALANCE_REVEAL_EASING = [0.37, 0, 0.63, 1] as const
 
 type BalanceChartProps = {
   accountId: string
@@ -84,17 +86,21 @@ export function BalanceChart({ accountId, snapshot }: BalanceChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<BalanceChartDataPoint>>(null)
 
-  // The series carries one point per day in the range whether or not any balances have arrived, so
-  // the plot is drawn flat at zero while the card is still concealed. Arming on the values means the
-  // one animation the reader sees runs as the real balances are revealed
-  const dataSignature = useMemo(
+  const prefersReducedMotion = useReducedMotion()
+
+  // Recharts draws an area's entrance as a reveal over a line that already sits in its final shape,
+  // so anything recomputing the plotted points part way through replaces the animation with one
+  // whose start and end are the same, and the rest of the line appears at once. The reveal is
+  // therefore driven from here instead, over a plot recharts never animates, which no recomputation
+  // can interrupt. The series carries one point per day in the range whether or not any balances
+  // have arrived, so the key holds the plot steady until the real ones land and then reveals once
+  const revealKey = useMemo(
     () => `${snapshot.chartDataKey}:${getChartDataSignature(
       snapshot.chartSeries,
       (point) => point[snapshot.chartDataKey],
     )}`,
     [snapshot.chartDataKey, snapshot.chartSeries],
   )
-  const balanceEntrance = useChartEntranceAnimation({ dataSignature })
 
   /**
    * Shows the active balance point from Recharts payload, index, or date label fallback
@@ -143,6 +149,17 @@ export function BalanceChart({ accountId, snapshot }: BalanceChartProps) {
           Not enough history yet
         </div>
       ) : (
+        <motion.div
+          key={revealKey}
+          className="h-full w-full"
+          initial={prefersReducedMotion ? false : { clipPath: 'inset(0 100% 0 0)' }}
+          animate={{ clipPath: 'inset(0 0% 0 0)' }}
+          transition={
+            prefersReducedMotion
+              ? { duration: 0 }
+              : { duration: BALANCE_REVEAL_SECONDS, ease: BALANCE_REVEAL_EASING }
+          }
+        >
         <ResponsiveContainer width="100%" height="100%">
           <AreaChart
             data={snapshot.chartSeries}
@@ -194,7 +211,7 @@ export function BalanceChart({ accountId, snapshot }: BalanceChartProps) {
               stroke={snapshot.chartLineColor}
               strokeWidth={2}
               fill={`url(#balanceFill-${accountId})`}
-              {...balanceEntrance}
+              isAnimationActive={false}
             />
             {snapshot.yearBoundary && (
               <ReferenceLine
@@ -212,6 +229,7 @@ export function BalanceChart({ accountId, snapshot }: BalanceChartProps) {
             )}
           </AreaChart>
         </ResponsiveContainer>
+        </motion.div>
       )}
       {snapshot.chartSeries.length >= 2 && (
         <DeferredChartTooltipOverlay

--- a/frontend/src/pages/accounts/detail/components/monthly-cash-flow/BarChart.tsx
+++ b/frontend/src/pages/accounts/detail/components/monthly-cash-flow/BarChart.tsx
@@ -1,4 +1,4 @@
-import { useRef, type MouseEvent as ReactMouseEvent } from 'react'
+import { useMemo, useRef, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   Bar,
   BarChart,
@@ -15,6 +15,10 @@ import {
   getRechartsTooltipPointer,
   type RechartsTooltipState,
 } from '@/components/charts/rechartsTooltip'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import type { CashFlowBar } from '@/pages/accounts/detail/utils/cashFlowChartViewModel'
 import { MonthlyCashFlowTooltipContent } from './TooltipContent'
 
@@ -54,6 +58,14 @@ export function MonthlyCashFlowBarChart({
 }: MonthlyCashFlowBarChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<CashFlowBar>>(null)
+
+  // Income and expense both sit on Bar's default duration and begin, so one entrance instance
+  // serves both, armed by whichever value changes
+  const dataSignature = useMemo(
+    () => getChartDataSignature(data, (point) => `${point.income}|${point.expense}`),
+    [data],
+  )
+  const barsEntrance = useChartEntranceAnimation({ dataSignature })
 
   /**
    * Shows the active cash flow bar from Recharts payload, index, or label fallback
@@ -109,6 +121,7 @@ export function MonthlyCashFlowBarChart({
             radius={[4, 4, 0, 0]}
             maxBarSize={24}
             opacity={0.85}
+            {...barsEntrance}
           />
           <Bar
             dataKey="expense"
@@ -116,6 +129,7 @@ export function MonthlyCashFlowBarChart({
             radius={[4, 4, 0, 0]}
             maxBarSize={24}
             opacity={0.85}
+            {...barsEntrance}
           />
         </BarChart>
       </ResponsiveContainer>

--- a/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
+import { useEffect, useMemo, useRef, useState, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   Bar,
   BarChart,
@@ -17,6 +17,10 @@ import {
   getRechartsTooltipPointer,
   type RechartsTooltipState,
 } from '@/components/charts/rechartsTooltip'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import ArchivedBandsLayer from '@/pages/budgets/components/budget-details-modal/ArchivedBands'
 import { getArchivedChartStretches } from '@/pages/budgets/components/budget-details-modal/archivedStretches'
 import {
@@ -99,13 +103,19 @@ export default function BudgetHistoryChart({
   const currentPeriodKey = chartData.find((point) => point.isCurrent)?.periodKey
   const [isMobile, setIsMobile] = useState(() => window.matchMedia(BUDGET_CHART_MOBILE_QUERY).matches)
 
-  // Recharts keys a bar's animation off the identity of the rectangles it computes, and that identity
-  // changes on every render, so an animated bar replays its entrance whenever anything re-renders the
-  // chart. Pointer movement re-renders it on every event, which leaves the plot repainting frame by
-  // frame for as long as the pointer keeps moving. Animation is therefore switched off as soon as the
-  // entrance has played, leaving the bars static for the rest of the chart's life
-  const [barsAnimating, setBarsAnimating] = useState(true)
-  const stopBarAnimation = () => setBarsAnimating(false)
+  // Every stacked segment of one period animates on the same delay and duration, so they finish
+  // together and one entrance state serves all of them
+  const dataSignature = useMemo(
+    () => getChartDataSignature(
+      chartData,
+      (point) => [
+        point.utilizationPct,
+        ...(point.categories?.map((category) => category.utilizationPct) ?? []),
+      ].join('|'),
+    ),
+    [chartData],
+  )
+  const barsEntrance = useChartEntranceAnimation({ dataSignature })
 
   useEffect(() => {
     const mobileQuery = window.matchMedia(BUDGET_CHART_MOBILE_QUERY)
@@ -241,9 +251,8 @@ export default function BudgetHistoryChart({
                     />
                   )}
                   barSize={barSize}
-                  isAnimationActive={barsAnimating}
                   animationBegin={MODAL_SURFACE_TRANSITION_MS}
-                  onAnimationEnd={stopBarAnimation}
+                  {...barsEntrance}
                 />
               )) : (
                 <Bar
@@ -259,9 +268,8 @@ export default function BudgetHistoryChart({
                     />
                   )}
                   barSize={barSize}
-                  isAnimationActive={barsAnimating}
                   animationBegin={MODAL_SURFACE_TRANSITION_MS}
-                  onAnimationEnd={stopBarAnimation}
+                  {...barsEntrance}
                 />
               )}
               <ReferenceLine

--- a/frontend/src/pages/dashboard/widgets/net-worth/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/net-worth/Chart.tsx
@@ -15,6 +15,10 @@ import {
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
 import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
+import {
   DASHBOARD_NET_WORTH_X_AXIS_LABEL_PADDING,
   DASHBOARD_NET_WORTH_X_AXIS_TICK_COUNT,
   DASHBOARD_X_AXIS_TICK_FONT_SIZE,
@@ -122,6 +126,11 @@ export function NetWorthChart({ data, displayCurrency }: NetWorthChartProps) {
     () => new Map(data.map((point) => [point.date, point])),
     [data],
   )
+  const dataSignature = useMemo(
+    () => getChartDataSignature(data, (point) => point.value),
+    [data],
+  )
+  const lineEntrance = useChartEntranceAnimation({ dataSignature })
   const lineColor = getNetWorthLineColor(data)
 
   /**
@@ -194,6 +203,7 @@ export function NetWorthChart({ data, displayCurrency }: NetWorthChartProps) {
             stroke={lineColor}
             strokeWidth={1.5}
             dot={false}
+            {...lineEntrance}
           />
         </LineChart>
       </ResponsiveContainer>

--- a/frontend/src/pages/dashboard/widgets/savings-rate/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/savings-rate/Chart.tsx
@@ -1,4 +1,4 @@
-import { useRef, type MouseEvent as ReactMouseEvent } from 'react'
+import { useMemo, useRef, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   Bar,
   BarChart,
@@ -16,6 +16,10 @@ import {
   DeferredChartTooltipOverlay,
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import { SavingsCurrentBoundary } from '@/pages/dashboard/components/SavingsCurrentBoundary'
 import { DASHBOARD_X_AXIS_TICK_FONT_SIZE } from '@/pages/dashboard/constants/chart'
 import {
@@ -73,6 +77,14 @@ export function SavingsRateChart({
 }: SavingsRateChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<SavingsRateChartPoint>>(null)
+
+  // The cap switches the plot to a fixed vertical scale without touching a single rate, so every
+  // bar changes height while the values behind them stand still
+  const dataSignature = useMemo(
+    () => `${capSavingsRateChart}:${getChartDataSignature(data, (point) => point.chartRate)}`,
+    [capSavingsRateChart, data],
+  )
+  const barEntrance = useChartEntranceAnimation({ dataSignature })
 
   /**
    * Shows the active savings rate point only when Recharts resolves a chart datum
@@ -153,7 +165,7 @@ export function SavingsRateChart({
           <SavingsCurrentBoundary
             currentLabel={data[data.length - 1].monthLabel}
           />
-          <Bar dataKey="chartRate" radius={[3, 3, 0, 0]} maxBarSize={28}>
+          <Bar dataKey="chartRate" radius={[3, 3, 0, 0]} maxBarSize={28} {...barEntrance}>
             {data.map((entry, index) => {
               const tier = getSavingsRateTier(entry.rate)
               return (

--- a/frontend/src/pages/dashboard/widgets/spending-breakdown/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-breakdown/Chart.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react'
+import { useMemo, useRef } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import {
   Cell,
@@ -10,10 +10,14 @@ import type { CategoryBreakdownEntry } from '@/api/dashboard'
 import { AppScrambledNumber } from '@/components/display/ScrambledNumber'
 import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
+import {
   BREAKDOWN_DONUT_TRANSITION,
   BREAKDOWN_PIE_ANIMATION_MS,
 } from '@/pages/dashboard/constants/animation'
-import { useCursorTooltip } from '@/hooks/useCursorTooltip'
+import { useCursorTooltip, type CursorTooltipPointer } from '@/hooks/useCursorTooltip'
 import { formatDashboardMoney } from '@/pages/dashboard/utils/formatDashboardMoney'
 import {
   getSpendingBreakdownEntryColor,
@@ -31,6 +35,67 @@ type SpendingBreakdownChartProps = {
   displayCurrency: string
   summary: SpendingBreakdownSummary
   shouldReduceMotion: boolean
+}
+
+/**
+ * Renders one donut, holding its entrance animation for exactly as long as the donut itself lives
+ *
+ * The mode and range controls swap the donut behind an AnimatePresence, so the outgoing one is
+ * still on screen finishing its own sweep while the incoming one starts. An entrance state held by
+ * the parent would be shared between them, and the outgoing donut reaching its end would cut the
+ * incoming one short
+ */
+function SpendingBreakdownDonut({
+  entries,
+  summary,
+  onSliceEnter,
+  onSliceLeave,
+}: {
+  entries: CategoryBreakdownEntry[]
+  summary: SpendingBreakdownSummary
+  onSliceEnter: (entry: CategoryBreakdownEntry, event: CursorTooltipPointer) => void
+  onSliceLeave: () => void
+}) {
+  const dataSignature = useMemo(
+    () => getChartDataSignature(entries, (entry) => entry.amount),
+    [entries],
+  )
+  const pieEntrance = useChartEntranceAnimation({ dataSignature })
+
+  return (
+    <ResponsiveContainer width="100%" height="100%">
+      <PieChart>
+        <Pie
+          data={entries}
+          cx="50%"
+          cy="50%"
+          innerRadius="68%"
+          outerRadius="92%"
+          paddingAngle={3}
+          dataKey="amount"
+          nameKey="name"
+          stroke="none"
+          animationDuration={BREAKDOWN_PIE_ANIMATION_MS}
+          animationEasing="ease-out"
+          {...pieEntrance}
+          onMouseEnter={(_sector, index, event) => {
+            onSliceEnter(entries[index], event)
+          }}
+          onMouseMove={(_sector, index, event) => {
+            onSliceEnter(entries[index], event)
+          }}
+          onMouseLeave={onSliceLeave}
+        >
+          {entries.map((entry) => (
+            <Cell
+              key={entry.category_id}
+              fill={getSpendingBreakdownEntryColor(entry, summary)}
+            />
+          ))}
+        </Pie>
+      </PieChart>
+    </ResponsiveContainer>
+  )
 }
 
 /**
@@ -83,38 +148,12 @@ export function SpendingBreakdownChart({
           exit={shouldReduceMotion ? undefined : { opacity: 0, scale: 1.015 }}
           transition={shouldReduceMotion ? { duration: 0 } : BREAKDOWN_DONUT_TRANSITION}
         >
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie
-                data={entries}
-                cx="50%"
-                cy="50%"
-                innerRadius="68%"
-                outerRadius="92%"
-                paddingAngle={3}
-                dataKey="amount"
-                nameKey="name"
-                stroke="none"
-                isAnimationActive={!shouldReduceMotion}
-                animationDuration={shouldReduceMotion ? 0 : BREAKDOWN_PIE_ANIMATION_MS}
-                animationEasing="ease-out"
-                onMouseEnter={(_sector, index, event) => {
-                  showTooltip(entries[index], event)
-                }}
-                onMouseMove={(_sector, index, event) => {
-                  showTooltip(entries[index], event)
-                }}
-                onMouseLeave={hideTooltip}
-              >
-                {entries.map((entry) => (
-                  <Cell
-                    key={entry.category_id}
-                    fill={getSpendingBreakdownEntryColor(entry, summary)}
-                  />
-                ))}
-              </Pie>
-            </PieChart>
-          </ResponsiveContainer>
+          <SpendingBreakdownDonut
+            entries={entries}
+            summary={summary}
+            onSliceEnter={showTooltip}
+            onSliceLeave={hideTooltip}
+          />
         </motion.div>
       </AnimatePresence>
       <CursorTooltipPortal

--- a/frontend/src/pages/dashboard/widgets/spending-comparison/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-comparison/Chart.tsx
@@ -1,4 +1,4 @@
-import { useRef, type MouseEvent as ReactMouseEvent } from 'react'
+import { useMemo, useRef, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   Area,
   AreaChart,
@@ -11,6 +11,10 @@ import {
   DeferredChartTooltipOverlay,
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import { DASHBOARD_X_AXIS_TICK_FONT_SIZE } from '@/pages/dashboard/constants/chart'
 import type { SpendingComparisonSeriesPoint } from '@/pages/dashboard/types/dashboard'
 import {
@@ -84,6 +88,15 @@ export function SpendingComparisonChart({
 }: SpendingComparisonChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<SpendingComparisonSeriesPoint>>(null)
+
+  // Both areas are drawn against one shared vertical scale taken from the two series together, so a
+  // change in either moves both. One signature and one entrance keeps them animating together
+  // rather than leaving the untouched series to jump to its rescaled position
+  const dataSignature = useMemo(
+    () => getChartDataSignature(data, (point) => `${point.previous}|${point.current}`),
+    [data],
+  )
+  const areasEntrance = useChartEntranceAnimation({ dataSignature })
 
   /**
    * Shows a tooltip only when Recharts resolves a point with current or previous values
@@ -163,6 +176,7 @@ export function SpendingComparisonChart({
             strokeDasharray="4 3"
             fill="url(#spendPreviousFill)"
             connectNulls={false}
+            {...areasEntrance}
           />
           <Area
             xAxisId="plot"
@@ -172,6 +186,7 @@ export function SpendingComparisonChart({
             strokeWidth={2.5}
             fill="url(#spendCurrentFill)"
             connectNulls={false}
+            {...areasEntrance}
           />
         </AreaChart>
       </ResponsiveContainer>

--- a/frontend/src/pages/insights/components/cash-flow-card/BarChart.tsx
+++ b/frontend/src/pages/insights/components/cash-flow-card/BarChart.tsx
@@ -1,4 +1,5 @@
 import {
+  useMemo,
   useRef,
   type MouseEvent as ReactMouseEvent,
 } from 'react'
@@ -17,6 +18,10 @@ import {
   type ChartTooltipPointer,
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import { DASHBOARD_X_AXIS_TICK_FONT_SIZE } from '@/pages/dashboard/constants/chart'
 import type { CashFlowBarBucket } from '@/pages/insights/types/cashFlow'
 import { formatSignedCurrency, getSignedAmountColor } from '@/pages/insights/utils/money'
@@ -116,6 +121,11 @@ export function CashFlowBarChart({
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<CashFlowBarBucket>>(null)
   const hasActivity = buckets.some((bucket) => bucket.inflow > 0 || bucket.outflow > 0)
   const yAxisWidth = getCashFlowYAxisWidth(buckets, displayCurrency)
+  const dataSignature = useMemo(
+    () => getChartDataSignature(buckets, (bucket) => bucket.net),
+    [buckets],
+  )
+  const barEntrance = useChartEntranceAnimation({ dataSignature })
 
   /**
    * Shows the bar tooltip for the active Recharts bucket
@@ -182,7 +192,7 @@ export function CashFlowBarChart({
               tickFormatter={(value) => formatCurrency(Number(value), displayCurrency)}
             />
             <ReferenceLine y={0} stroke="var(--app-border-strong)" strokeWidth={1} />
-            <Bar dataKey="net" radius={4} maxBarSize={40}>
+            <Bar dataKey="net" radius={4} maxBarSize={40} {...barEntrance}>
               {buckets.map((bucket) => (
                 <Cell
                   key={bucket.rangeLabel}

--- a/frontend/src/pages/insights/components/income-expense-breakdown-card/PieChart.tsx
+++ b/frontend/src/pages/insights/components/income-expense-breakdown-card/PieChart.tsx
@@ -13,6 +13,10 @@ import type { InsightsBreakdownCategoryKind } from '@/api/insights'
 import { BreakdownCrossoverBadge } from '@/components/display/BreakdownCrossoverBadge'
 import { ChartTooltipTitle, ChartTooltipValue } from '@/components/charts/TooltipContent'
 import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import { useCursorTooltip } from '@/hooks/useCursorTooltip'
 import type { BreakdownEntry } from '@/pages/insights/types/incomeExpenseBreakdown'
 import {
@@ -89,6 +93,11 @@ export function IncomeExpensePieChart({
     [entries, mode],
   )
   const legendMinHeight = getBreakdownLegendMinHeight(legendEntries.length)
+  const dataSignature = useMemo(
+    () => getChartDataSignature(entries, (entry) => entry.amount),
+    [entries],
+  )
+  const pieEntrance = useChartEntranceAnimation({ dataSignature })
 
   function getBreakdownColor(entry: BreakdownEntry) {
     return getCategoryColor({
@@ -136,6 +145,7 @@ export function IncomeExpensePieChart({
                 showEntryTooltip(entries[index], event)
               }}
               onMouseLeave={hideTooltip}
+              {...pieEntrance}
             >
               {entries.map((entry) => (
                 <Cell key={entry.id} fill={getSpacedBreakdownColor(entry)} />

--- a/frontend/src/pages/insights/components/net-worth-card/Chart.tsx
+++ b/frontend/src/pages/insights/components/net-worth-card/Chart.tsx
@@ -21,6 +21,10 @@ import {
   type ChartTooltipPointer,
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import { DASHBOARD_X_AXIS_TICK_FONT_SIZE } from '@/pages/dashboard/constants/chart'
 import { formatCurrency } from '@/utils/formatCurrency'
 import {
@@ -245,6 +249,27 @@ export function NetWorthChart({
   )
   const legendAnimationKey = `${mode}-${legendItems.map((item) => item.id).join('|')}`
 
+  // One signature spanning everything the plot draws, in both modes. The mapped items and the total
+  // line share a vertical scale taken from all of them together, so a change in any one moves the
+  // rest, and the mode belongs in it because switching modes unmounts and remounts the items with
+  // the same values behind them
+  const dataSignature = useMemo(
+    () => `${mode}:${getChartDataSignature(
+      deltaSeries,
+      (point) => [
+        ...chartItems.map((_item, index) => Number(point[getChartKey(index)] ?? 0)),
+        point.totalChange,
+      ].join('|'),
+    )}`,
+    [chartItems, deltaSeries, mode],
+  )
+  const compositionAreasEntrance = useChartEntranceAnimation({ dataSignature })
+
+  // The bars all sit on Bar's own defaults and one instance serves them, but the line runs on
+  // Line's longer default and would be cut short by the bars' end if it shared theirs
+  const overviewBarsEntrance = useChartEntranceAnimation({ dataSignature })
+  const overviewLineEntrance = useChartEntranceAnimation({ dataSignature })
+
   /**
    * Shows the tooltip for the active Recharts date bucket
    */
@@ -344,6 +369,7 @@ export function NetWorthChart({
                     fill={item.color}
                     fillOpacity={0.65}
                     activeDot={false}
+                    {...compositionAreasEntrance}
                   />
                 ))
               ) : (
@@ -356,6 +382,7 @@ export function NetWorthChart({
                       fill={item.color}
                       maxBarSize={34}
                       radius={4}
+                      {...overviewBarsEntrance}
                     />
                   ))}
                   <Line
@@ -365,6 +392,7 @@ export function NetWorthChart({
                     strokeWidth={2.5}
                     dot={false}
                     activeDot={{ r: 4, strokeWidth: 0 }}
+                    {...overviewLineEntrance}
                   />
                 </>
               )}

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Chart.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Chart.tsx
@@ -1,4 +1,4 @@
-import { useRef, type MouseEvent as ReactMouseEvent } from 'react'
+import { useMemo, useRef, type MouseEvent as ReactMouseEvent } from 'react'
 import {
   Bar,
   BarChart,
@@ -14,6 +14,10 @@ import {
   type ChartTooltipPointer,
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import { SavingsCurrentBoundary } from '@/pages/dashboard/components/SavingsCurrentBoundary'
 import { DASHBOARD_X_AXIS_TICK_FONT_SIZE } from '@/pages/dashboard/constants/chart'
 import type { SavingsRateHistoryPoint } from '@/pages/insights/types/savingsRate'
@@ -160,6 +164,18 @@ export function SavingsRateChart({
     capRates,
   })
 
+  // The bar height comes from chartRate, the fill from the uncapped rate and isCurrent, and the
+  // capped plot switches to a fixed vertical scale that changes every height without changing a
+  // single rate, so all four have to arm the entrance
+  const dataSignature = useMemo(
+    () => `${capRates}:${getChartDataSignature(
+      chartPoints,
+      (point) => `${point.chartRate}|${point.rate}|${point.isCurrent}`,
+    )}`,
+    [capRates, chartPoints],
+  )
+  const barEntrance = useChartEntranceAnimation({ dataSignature })
+
   /**
    * Shows the bar tooltip for the active Recharts savings-rate point
    */
@@ -253,7 +269,7 @@ export function SavingsRateChart({
                 />
               )}
               {currentPoint && <SavingsCurrentBoundary currentLabel={currentPoint.monthKey} />}
-              <Bar dataKey="chartRate" radius={[3, 3, 0, 0]} maxBarSize={30}>
+              <Bar dataKey="chartRate" radius={[3, 3, 0, 0]} maxBarSize={30} {...barEntrance}>
                 {chartPoints.map((entry: SavingsRateChartPoint) => {
                   const tier = getSavingsRateTier(entry.rate)
                   return (

--- a/frontend/src/pages/transactions/components/top-band/TopCategoriesChart.tsx
+++ b/frontend/src/pages/transactions/components/top-band/TopCategoriesChart.tsx
@@ -26,6 +26,10 @@ import {
   getRechartsTooltipPointer,
   type RechartsTooltipState,
 } from '@/components/charts/rechartsTooltip'
+import {
+  getChartDataSignature,
+  useChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { formatCurrency } from '@/utils/formatCurrency'
@@ -41,6 +45,10 @@ import type { OverviewCategorySpend } from '@/pages/transactions/components/top-
 import { getTopCategoriesFxStatusMessage } from '@/pages/transactions/utils/fxTooltipMessages'
 
 const emptyTopCategoryHeight = TOP_CATEGORY_LIMIT * TOP_CATEGORY_ROW_HEIGHT
+
+// Overrides Bar's own 400 ms default, holding the entrance this chart ran before its animation
+// state moved to the shared hook
+const TOP_CATEGORY_BAR_ENTRANCE_DURATION_MS = 550
 
 function getTopCategoryTooltipKey(point: OverviewCategorySpend) {
   return point.name
@@ -131,7 +139,17 @@ export default function TopCategoriesChart({
     () => new Map(categorySpend.map((category) => [category.name, category])),
     [categorySpend],
   )
-  const chartAnimationDuration = prefersReducedMotion ? 0 : 550
+
+  // The plot is remounted on this key whenever the filters or the range change, and a fresh mount
+  // has to arm the entrance even when the new filters happen to leave the same five categories
+  const dataSignature = useMemo(
+    () => `${chartAnimationKey}:${getChartDataSignature(
+      categorySpend,
+      (point) => `${point.name}|${point.amount}`,
+    )}`,
+    [categorySpend, chartAnimationKey],
+  )
+  const topCategoryBarEntrance = useChartEntranceAnimation({ dataSignature })
   const contentTransition = { duration: prefersReducedMotion ? 0 : 0.24, ease: [0.25, 0.1, 0.25, 1] } as const
 
   /**
@@ -232,8 +250,8 @@ export default function TopCategoriesChart({
                     dataKey="amount"
                     radius={[0, 5, 5, 0]}
                     barSize={16}
-                    isAnimationActive={!prefersReducedMotion}
-                    animationDuration={chartAnimationDuration}
+                    animationDuration={TOP_CATEGORY_BAR_ENTRANCE_DURATION_MS}
+                    {...topCategoryBarEntrance}
                   >
                     {categorySpend.map((_, index) => (
                       <Cell

--- a/frontend/tests/components/charts/chartEntranceAnimation.test.ts
+++ b/frontend/tests/components/charts/chartEntranceAnimation.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Covers the entrance-animation policy every recharts chart shares
+ *
+ * These tests catch regressions where a chart keeps animating after its entrance, which makes
+ * pointer movement repaint the plot frame by frame, or stops animating for good, which makes a
+ * range or mode switch snap to its new shape instead of transitioning
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  getChartDataSignature,
+  resolveChartEntranceAnimation,
+} from '@/components/charts/useChartEntranceAnimation'
+
+describe('chart entrance animation policy', () => {
+  it('leaves recharts to decide while the entrance is armed', () => {
+    expect(resolveChartEntranceAnimation({
+      previousSignature: 'a',
+      dataSignature: 'a',
+      armed: true,
+    })).toEqual({ armed: true, isAnimationActive: 'auto' })
+  })
+
+  it('holds animation off once the entrance has ended and the values are unchanged', () => {
+    expect(resolveChartEntranceAnimation({
+      previousSignature: 'a',
+      dataSignature: 'a',
+      armed: false,
+    })).toEqual({ armed: false, isAnimationActive: false })
+  })
+
+  it('arms again when the drawn values change', () => {
+    expect(resolveChartEntranceAnimation({
+      previousSignature: 'a',
+      dataSignature: 'b',
+      armed: false,
+    })).toEqual({ armed: true, isAnimationActive: 'auto' })
+  })
+
+  it('stays armed when the values change mid-entrance', () => {
+    expect(resolveChartEntranceAnimation({
+      previousSignature: 'a',
+      dataSignature: 'b',
+      armed: true,
+    })).toEqual({ armed: true, isAnimationActive: 'auto' })
+  })
+})
+
+describe('chart data signature', () => {
+  it('changes when a drawn value changes', () => {
+    const before = [{ net: 10 }, { net: 20 }]
+    const after = [{ net: 10 }, { net: 21 }]
+
+    expect(getChartDataSignature(before, (point) => point.net))
+      .not.toBe(getChartDataSignature(after, (point) => point.net))
+  })
+
+  it('holds steady when the series is rebuilt with the same values', () => {
+    const first = [{ net: 10 }, { net: 20 }]
+    const second = [{ net: 10 }, { net: 20 }]
+
+    expect(getChartDataSignature(first, (point) => point.net))
+      .toBe(getChartDataSignature(second, (point) => point.net))
+  })
+
+  it('separates a point leaving the series from a value changing', () => {
+    const twoPoints = [{ net: 1 }, { net: 2 }]
+    const onePoint = [{ net: 12 }]
+
+    expect(getChartDataSignature(twoPoints, (point) => point.net))
+      .not.toBe(getChartDataSignature(onePoint, (point) => point.net))
+  })
+
+  it('changes when only one of several drawn values changes', () => {
+    const before = [{ income: 5, expense: 3 }]
+    const after = [{ income: 5, expense: 4 }]
+    const readBoth = (point: { income: number, expense: number }) => `${point.income}|${point.expense}`
+
+    expect(getChartDataSignature(before, readBoth)).not.toBe(getChartDataSignature(after, readBoth))
+  })
+
+  it('changes when a series of equal length reorders', () => {
+    const before = [{ net: 1 }, { net: 2 }]
+    const after = [{ net: 2 }, { net: 1 }]
+
+    expect(getChartDataSignature(before, (point) => point.net))
+      .not.toBe(getChartDataSignature(after, (point) => point.net))
+  })
+})


### PR DESCRIPTION
Every chart plays its entrance once and then holds still, so moving the pointer over a plot no longer restarts it. The account balance chart takes its reveal from the app rather than the charting library, which cut the animation short whenever it recomputed the plot mid-draw. The account rows hold their place through a redraw that has nothing to do with the list and through a background refetch, so opening a modal at phone width leaves them where they are and adding an account animates only the new row.
