### PR TITLE
feat: say what an imported account does not get

### DIFF
--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -176,6 +176,19 @@ export const AMOUNT_CONVENTION_NOTE = 'Imported amounts carry their own directio
 // one account that source is not offered. The matched account names follow it
 export const ARCHIVED_ACCOUNT_MATCH_EXPLANATION = 'An archived account takes no new transactions, so it is not offered as a choice here. Unarchive one of these to import rows into it, which means leaving this import and uploading your file again:'
 
+// Shown once any source on either table is answered create, since nothing else in the flow says
+// what an account made this way is and is not given
+export const CREATED_ACCOUNT_TITLE = 'New Accounts'
+export const CREATED_ACCOUNT_EXPLANATION = 'Accounts imported as new accounts (by selecting "Create New Account" in the "Existing Account" column) won\'t create starting balance nor credit limits automatically:'
+// A balance adjustment rather than a field, because an account that already exists has no starting
+// balance to set. Left to the user to want one rather than told to enter one, since a Firefly
+// export carries its own opening balances and the import writes those as balance adjustments
+// already
+export const CREATED_ACCOUNT_BALANCE_NOTE = 'If you\'d like to enter a starting balance of an imported account, please create a balance adjustment transaction in that account'
+// The edit button this describes is the pencil on the account's own card, which is the only place a
+// credit limit can be set once the account exists
+export const CREATED_ACCOUNT_CREDIT_LIMIT_NOTE = 'If you\'d like to set a credit limit for that account, you can do so by opening it from Accounts and using the edit button on its card'
+
 // Shown in place of a mapping step whose list could not be fetched at all, since answering one
 // against nothing maps every value to a new record and duplicates what the user already has
 export const ACCOUNTS_LOAD_FAILURE_TITLE = 'Your accounts could not be loaded'

--- a/frontend/src/pages/imports/firefly/sections/FireflyAccountMappingStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyAccountMappingStep.tsx
@@ -4,7 +4,12 @@ import {
   ACCOUNTS_LOAD_FAILURE_EXPLANATION,
   ACCOUNTS_LOAD_FAILURE_TITLE,
   ACCOUNT_TYPE_OPTIONS,
+  CREATED_ACCOUNT_BALANCE_NOTE,
+  CREATED_ACCOUNT_CREDIT_LIMIT_NOTE,
+  CREATED_ACCOUNT_EXPLANATION,
+  CREATED_ACCOUNT_TITLE,
 } from '@/pages/imports/constants'
+import { isCreatingImportAccount } from '@/pages/imports/utils'
 import { ImportAccountMappingTable, EmptyState, ImportLoadFailure, ImportNotice, ImportStep } from '@/pages/imports/components'
 import type { FireflyImportWorkflow } from '@/pages/imports/firefly/hooks'
 
@@ -90,6 +95,44 @@ export function FireflyAccountMappingStep({
     setInstitutionModalTarget('')
   }
 
+  const accountRows = trackedAccountNames.map((sourceAccount) => {
+    const value = accountMappings[sourceAccount] ?? ''
+    const account = accountById.get(value)
+    const createDetails = accountCreateDetails[sourceAccount]
+
+    return {
+      id: sourceAccount,
+      source: sourceAccount,
+      value,
+
+      // Keeps an account the dropdown has stopped offering, which here means one archived
+      // since it was chosen, visible on its row rather than reading as unanswered
+      selectedOption: account ? { value, label: account.name } : undefined,
+
+      autoFilled: autoFilledAccountSources.has(sourceAccount),
+
+      // Both sides of a Firefly transfer take rows, so no source here is counterparty-only
+      isCounterpartyOnly: false,
+
+      isArchivedAccount: account?.is_archived ?? false,
+      isHandAnswered: handAnsweredAccountSources.has(sourceAccount),
+      accountType: account?.account_type ?? '',
+      accountCurrency: account?.currency ?? '',
+      accountInstitution: account?.institution?.id ?? '',
+      createType: createDetails?.accountType ?? '',
+      createCurrency: createDetails?.currency ?? '',
+      createInstitution: createDetails?.institutionId ?? '',
+      onChange: (nextValue: string) => updateFireflyAccountMapping(sourceAccount, nextValue),
+      onCreateTypeChange: (nextValue: string) => setAccountCreateTypes((current) => ({ ...current, [sourceAccount]: nextValue })),
+      onCreateCurrencyChange: (nextValue: string) => setAccountCreateCurrencies((current) => ({ ...current, [sourceAccount]: nextValue })),
+      onCreateInstitutionChange: (nextValue: string) => setAccountCreateInstitutions((current) => ({ ...current, [sourceAccount]: nextValue })),
+    }
+  })
+
+  // Held back until the account list has landed, since every tracked name resolves to create until
+  // it does, which would show the notice and then drop it once the names match
+  const isCreatingAccount = !accountsLoading && isCreatingImportAccount(accountRows)
+
   return (
     <ImportStep
       index="02"
@@ -113,58 +156,36 @@ export function FireflyAccountMappingStep({
           description="Upload the transactions CSV first."
         />
       ) : (
-        <ImportAccountMappingTable
-          rows={trackedAccountNames.map((sourceAccount) => {
-            const value = accountMappings[sourceAccount] ?? ''
-            const account = accountById.get(value)
-            const createDetails = accountCreateDetails[sourceAccount]
-
-            return {
-              id: sourceAccount,
-              source: sourceAccount,
-              value,
-
-              // Keeps an account the dropdown has stopped offering, which here means one archived
-              // since it was chosen, visible on its row rather than reading as unanswered
-              selectedOption: account ? { value, label: account.name } : undefined,
-
-              autoFilled: autoFilledAccountSources.has(sourceAccount),
-
-              // Both sides of a Firefly transfer take rows, so no source here is counterparty-only
-              isCounterpartyOnly: false,
-
-              isArchivedAccount: account?.is_archived ?? false,
-              isHandAnswered: handAnsweredAccountSources.has(sourceAccount),
-              accountType: account?.account_type ?? '',
-              accountCurrency: account?.currency ?? '',
-              accountInstitution: account?.institution?.id ?? '',
-              createType: createDetails?.accountType ?? '',
-              createCurrency: createDetails?.currency ?? '',
-              createInstitution: createDetails?.institutionId ?? '',
-              onChange: (nextValue: string) => updateFireflyAccountMapping(sourceAccount, nextValue),
-              onCreateTypeChange: (nextValue: string) => setAccountCreateTypes((current) => ({ ...current, [sourceAccount]: nextValue })),
-              onCreateCurrencyChange: (nextValue: string) => setAccountCreateCurrencies((current) => ({ ...current, [sourceAccount]: nextValue })),
-              onCreateInstitutionChange: (nextValue: string) => setAccountCreateInstitutions((current) => ({ ...current, [sourceAccount]: nextValue })),
-            }
-          })}
-          options={accountOptions}
-          accountTypeOptions={ACCOUNT_TYPE_OPTIONS}
-          currencyOptions={currencyOptions}
-          institutionOptions={institutionOptions}
-          disabled={accountsLoading}
-          currenciesDisabled={currenciesLoading}
-          institutionsDisabled={institutionsLoading}
-          selectedRowIds={selectedAccountRows}
-          batchAccountType={batchAccountType}
-          batchAccountCurrency={batchAccountCurrency}
-          batchAccountInstitution={batchAccountInstitution}
-          onBatchAccountTypeChange={setBatchAccountType}
-          onBatchAccountCurrencyChange={setBatchAccountCurrency}
-          onBatchAccountInstitutionChange={setBatchAccountInstitution}
-          onSelectedRowsChange={setSelectedAccountRows}
-          onCreateInstitution={(query, rowId) => openInstitutionModal(query, rowId)}
-          onBatchCreateInstitution={(query) => openInstitutionModal(query, 'batch')}
-        />
+        <>
+          {isCreatingAccount && (
+            <ImportNotice
+              title={CREATED_ACCOUNT_TITLE}
+              items={[CREATED_ACCOUNT_BALANCE_NOTE, CREATED_ACCOUNT_CREDIT_LIMIT_NOTE]}
+            >
+              {CREATED_ACCOUNT_EXPLANATION}
+            </ImportNotice>
+          )}
+          <ImportAccountMappingTable
+            rows={accountRows}
+            options={accountOptions}
+            accountTypeOptions={ACCOUNT_TYPE_OPTIONS}
+            currencyOptions={currencyOptions}
+            institutionOptions={institutionOptions}
+            disabled={accountsLoading}
+            currenciesDisabled={currenciesLoading}
+            institutionsDisabled={institutionsLoading}
+            selectedRowIds={selectedAccountRows}
+            batchAccountType={batchAccountType}
+            batchAccountCurrency={batchAccountCurrency}
+            batchAccountInstitution={batchAccountInstitution}
+            onBatchAccountTypeChange={setBatchAccountType}
+            onBatchAccountCurrencyChange={setBatchAccountCurrency}
+            onBatchAccountInstitutionChange={setBatchAccountInstitution}
+            onSelectedRowsChange={setSelectedAccountRows}
+            onCreateInstitution={(query, rowId) => openInstitutionModal(query, rowId)}
+            onBatchCreateInstitution={(query) => openInstitutionModal(query, 'batch')}
+          />
+        </>
       )}
       <CreateInstitutionModal
         key={institutionModalKey}

--- a/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
@@ -10,9 +10,14 @@ import {
   CLEARED_ACCOUNT_SOURCES_TITLE,
   COUNTERPARTY_ONLY_EXPLANATION,
   COUNTERPARTY_ONLY_TABLE_TITLE,
+  CREATED_ACCOUNT_BALANCE_NOTE,
+  CREATED_ACCOUNT_CREDIT_LIMIT_NOTE,
+  CREATED_ACCOUNT_EXPLANATION,
+  CREATED_ACCOUNT_TITLE,
   UNSET_BATCH_INSTITUTION,
 } from '@/pages/imports/constants'
 import type { ImportAccountSource } from '@/pages/imports/types'
+import { isCreatingImportAccount } from '@/pages/imports/utils'
 import { ImportAccountMappingTable, EmptyState, ImportLoadFailure, ImportNotice, ImportStep } from '@/pages/imports/components'
 import type { TransactionImportWorkflow } from '@/pages/imports/hooks'
 
@@ -164,6 +169,12 @@ export function ImportAccountMappingStep({
 
   const importedSources = accountMappingSources.filter((source) => !source.isCounterpartyOnly)
   const counterpartySources = accountMappingSources.filter((source) => source.isCounterpartyOnly)
+  const importedRows = buildRows(importedSources)
+  const counterpartyRows = buildRows(counterpartySources)
+
+  // Both tables create accounts, so one notice covers them and reads every row of the step. Held
+  // back until the account list has landed, since rows rest on create until it does
+  const isCreatingAccount = !accountsLoading && isCreatingImportAccount([...importedRows, ...counterpartyRows])
 
   return (
     <ImportStep index="03" title="Account Mapping">
@@ -211,8 +222,16 @@ export function ImportAccountMappingStep({
               {ARCHIVED_ACCOUNT_MATCH_EXPLANATION}
             </ImportNotice>
           )}
+          {isCreatingAccount && (
+            <ImportNotice
+              title={CREATED_ACCOUNT_TITLE}
+              items={[CREATED_ACCOUNT_BALANCE_NOTE, CREATED_ACCOUNT_CREDIT_LIMIT_NOTE]}
+            >
+              {CREATED_ACCOUNT_EXPLANATION}
+            </ImportNotice>
+          )}
           <ImportAccountMappingTable
-            rows={buildRows(importedSources)}
+            rows={importedRows}
             options={accountOptions}
             batchAccountType={batchAccountType}
             batchAccountCurrency={batchAccountCurrency}
@@ -232,7 +251,7 @@ export function ImportAccountMappingStep({
                 </p>
               </div>
               <ImportAccountMappingTable
-                rows={buildRows(counterpartySources)}
+                rows={counterpartyRows}
                 options={counterpartyAccountOptions}
                 batchAccountType={counterpartyBatchType}
                 batchAccountCurrency={counterpartyBatchCurrency}

--- a/frontend/src/pages/imports/utils/accountMapping.ts
+++ b/frontend/src/pages/imports/utils/accountMapping.ts
@@ -57,6 +57,19 @@ export function countImportAccountRowStates(rows: ImportAccountRowAnswer[]) {
 }
 
 /**
+ * Whether any mapping row on a step is answered create, which is what the new-account notice is for
+ *
+ * A row counts whether or not its type and currency are filled in, since choosing to create is what
+ * the notice is about, which is why this does not go through `getImportAccountRowState` and its
+ * stricter idea of an answered row
+ *
+ * @param rows - Every mapping row on the step, from both its tables
+ */
+export function isCreatingImportAccount(rows: Array<{ value: string }>): boolean {
+  return rows.some((row) => row.value === CREATE_ACCOUNT_VALUE)
+}
+
+/**
  * Whether the batch bar's Apply may edit a row
  *
  * Apply fills in what the user has not settled, so it leaves alone an account they picked or that

--- a/frontend/tests/imports/importCreatedAccountNotice.test.ts
+++ b/frontend/tests/imports/importCreatedAccountNotice.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Tests when the new-account notice shows, so the step never claims an account is being created
+ * when none is, and never goes quiet on a row that is
+ */
+import { describe, expect, it } from 'vitest'
+import { CREATE_ACCOUNT_VALUE } from '@/pages/imports/constants'
+import { OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
+import { isCreatingImportAccount } from '@/pages/imports/utils'
+
+describe('when the new-account notice shows', () => {
+  it('stays hidden while every source points at an account that already exists', () => {
+    expect(isCreatingImportAccount([{ value: 'account-1' }, { value: 'account-2' }])).toBe(false)
+  })
+
+  it('stays hidden for the outside answer, an unanswered row and an empty step', () => {
+    expect(isCreatingImportAccount([{ value: OUTSIDE_ACCOUNT_VALUE }])).toBe(false)
+    expect(isCreatingImportAccount([{ value: '' }])).toBe(false)
+    expect(isCreatingImportAccount([])).toBe(false)
+  })
+
+  // The notice is about having chosen to create, which happens before the type and currency
+  // dropdowns are touched, so it cannot wait for a row to be finished
+  it('shows for a create row with nothing else filled in yet', () => {
+    expect(isCreatingImportAccount([{ value: CREATE_ACCOUNT_VALUE }])).toBe(true)
+  })
+
+  it('shows where one row among several is set to create', () => {
+    expect(
+      isCreatingImportAccount([
+        { value: 'account-1' },
+        { value: OUTSIDE_ACCOUNT_VALUE },
+        { value: CREATE_ACCOUNT_VALUE },
+      ]),
+    ).toBe(true)
+  })
+})


### PR DESCRIPTION
Answering a source with Create New Account now brings up a notice on the account mapping step of both import flows. Instead of the shortfall turning up later as imported balances that come out short, the notice says an imported account gets no starting balance and no credit limit, and where to set each afterwards.
