### PR TITLE
fix: resolve a category's owner timezone before saving

### DIFF
--- a/backend/app/routes/tax_advantaged_categories/router.py
+++ b/backend/app/routes/tax_advantaged_categories/router.py
@@ -38,6 +38,9 @@ async def list_tax_advantaged_categories(
 
     Returns:
         Tax-advantaged categories owned by the authenticated user with current-year limits attached
+
+    Raises:
+        HTTPException: Owner's stored timezone cannot be read
     """
     tax_advantaged_categories = await get_tax_advantaged_categories_with_metrics_for_owner(db, user.id)
     return tax_advantaged_categories
@@ -60,7 +63,7 @@ async def create_tax_advantaged_category(
         Created tax-advantaged category with current-year limits attached
 
     Raises:
-        HTTPException: Tax treatment, group scope, or currency is invalid
+        HTTPException: Tax treatment, group scope, or currency is invalid, or the owner's stored timezone cannot be read
     """
     tax_advantaged_category = await create_tax_advantaged_category_with_metrics(db, user.id, data)
     return tax_advantaged_category
@@ -83,7 +86,8 @@ async def get_tax_advantaged_category(
         Owned tax-advantaged category with current-year limits attached
 
     Raises:
-        HTTPException: Tax-advantaged category does not exist or belongs to another user
+        HTTPException: Tax-advantaged category does not exist, belongs to another user, or its owner's
+            stored timezone cannot be read
     """
     tax_advantaged_category = await get_tax_advantaged_category_with_metrics_for_owner(db, tax_advantaged_category_id, user.id)
     return tax_advantaged_category
@@ -108,7 +112,8 @@ async def update_tax_advantaged_category(
         Updated tax-advantaged category with current-year limits attached
 
     Raises:
-        HTTPException: Tax-advantaged category is inaccessible or a supplied field is invalid
+        HTTPException: Tax-advantaged category is inaccessible, a supplied field is invalid, or its
+            owner's stored timezone cannot be read
     """
     tax_advantaged_category = await update_tax_advantaged_category_with_metrics(db, tax_advantaged_category_id, user.id, data)
     return tax_advantaged_category

--- a/backend/app/routes/tax_advantaged_categories/router.py
+++ b/backend/app/routes/tax_advantaged_categories/router.py
@@ -40,7 +40,7 @@ async def list_tax_advantaged_categories(
         Tax-advantaged categories owned by the authenticated user with current-year limits attached
 
     Raises:
-        HTTPException: Owner's stored timezone cannot be read
+        HTTPException: Owner row cannot be read, or its stored timezone is not a zone the app recognizes
     """
     tax_advantaged_categories = await get_tax_advantaged_categories_with_metrics_for_owner(db, user.id)
     return tax_advantaged_categories
@@ -63,7 +63,8 @@ async def create_tax_advantaged_category(
         Created tax-advantaged category with current-year limits attached
 
     Raises:
-        HTTPException: Tax treatment, group scope, or currency is invalid, or the owner's stored timezone cannot be read
+        HTTPException: Tax treatment, group scope, or currency is invalid, the owner row cannot be read,
+            or its stored timezone is not a zone the app recognizes
     """
     tax_advantaged_category = await create_tax_advantaged_category_with_metrics(db, user.id, data)
     return tax_advantaged_category
@@ -86,8 +87,8 @@ async def get_tax_advantaged_category(
         Owned tax-advantaged category with current-year limits attached
 
     Raises:
-        HTTPException: Tax-advantaged category does not exist, belongs to another user, or its owner's
-            stored timezone cannot be read
+        HTTPException: Tax-advantaged category does not exist, belongs to another user, the owner row
+            cannot be read, or its stored timezone is not a zone the app recognizes
     """
     tax_advantaged_category = await get_tax_advantaged_category_with_metrics_for_owner(db, tax_advantaged_category_id, user.id)
     return tax_advantaged_category
@@ -112,8 +113,8 @@ async def update_tax_advantaged_category(
         Updated tax-advantaged category with current-year limits attached
 
     Raises:
-        HTTPException: Tax-advantaged category is inaccessible, a supplied field is invalid, or its
-            owner's stored timezone cannot be read
+        HTTPException: Tax-advantaged category is inaccessible, a supplied field is invalid, the owner
+            row cannot be read, or its stored timezone is not a zone the app recognizes
     """
     tax_advantaged_category = await update_tax_advantaged_category_with_metrics(db, tax_advantaged_category_id, user.id, data)
     return tax_advantaged_category

--- a/backend/app/routes/tax_advantaged_categories/tac_category_creation_helpers.py
+++ b/backend/app/routes/tax_advantaged_categories/tac_category_creation_helpers.py
@@ -32,18 +32,19 @@ async def create_tax_advantaged_category_with_metrics(
         Created tax-advantaged category with current-year metrics attached
 
     Raises:
-        HTTPException: Tax treatment, group scope, or currency is invalid, or the owner's stored
-            timezone cannot be read
+        HTTPException: Tax treatment, group scope, or currency is invalid, the owner row cannot be
+            read, or its stored timezone is not a zone the app recognizes
     """
     validate_tax_advantaged_category_tax_treatment(data.tax_treatment)
     await validate_tax_advantaged_category_group_scope(db, data.group_id, owner_id)
     await validate_tax_advantaged_category_currency(db, data.currency)
 
-    # Resolved before anything is written, since the response metrics are read after the commit and a
-    # refusal there would leave the category created and the request failed
-    owner_timezones = await get_category_owner_timezones(db, {owner_id})
-
+    # Built before the zone is fetched so the lookup is keyed by the same owner the metrics read it
+    # back under, and resolved before anything is written, since the response metrics are read after
+    # the commit and a refusal there would leave the category created and the request failed
     tax_advantaged_category = build_tac_category(owner_id, data)
+    owner_timezones = await get_category_owner_timezones(db, {tax_advantaged_category.category_owner_user_id})
+
     db.add(tax_advantaged_category)
 
     # Mark the tax-advantaged category scope stale before committing the new category

--- a/backend/app/routes/tax_advantaged_categories/tac_category_creation_helpers.py
+++ b/backend/app/routes/tax_advantaged_categories/tac_category_creation_helpers.py
@@ -13,7 +13,7 @@ from app.routes.tax_advantaged_categories.tac_category_helpers import (
 )
 from app.schemas.tax_advantaged_category import CreateTaxAdvantagedCategoryRequest
 from app.services.cache_state import mark_cache_changed_for_scope
-from app.services.tax_advantaged_categories import attach_tax_advantaged_category_metrics
+from app.services.tax_advantaged_categories import attach_tax_advantaged_category_metrics, get_category_owner_timezones
 
 
 async def create_tax_advantaged_category_with_metrics(
@@ -32,11 +32,16 @@ async def create_tax_advantaged_category_with_metrics(
         Created tax-advantaged category with current-year metrics attached
 
     Raises:
-        HTTPException: Tax treatment, group scope, or currency is invalid
+        HTTPException: Tax treatment, group scope, or currency is invalid, or the owner's stored
+            timezone cannot be read
     """
     validate_tax_advantaged_category_tax_treatment(data.tax_treatment)
     await validate_tax_advantaged_category_group_scope(db, data.group_id, owner_id)
     await validate_tax_advantaged_category_currency(db, data.currency)
+
+    # Resolved before anything is written, since the response metrics are read after the commit and a
+    # refusal there would leave the category created and the request failed
+    owner_timezones = await get_category_owner_timezones(db, {owner_id})
 
     tax_advantaged_category = build_tac_category(owner_id, data)
     db.add(tax_advantaged_category)
@@ -45,5 +50,5 @@ async def create_tax_advantaged_category_with_metrics(
     await mark_cache_changed_for_scope(db, user_id=tax_advantaged_category.category_owner_user_id, group_id=tax_advantaged_category.group_id)
     await db.commit()
     await db.refresh(tax_advantaged_category)
-    await attach_tax_advantaged_category_metrics(db, [tax_advantaged_category])
+    await attach_tax_advantaged_category_metrics(db, [tax_advantaged_category], owner_timezones)
     return tax_advantaged_category

--- a/backend/app/routes/tax_advantaged_categories/tac_category_detail_helpers.py
+++ b/backend/app/routes/tax_advantaged_categories/tac_category_detail_helpers.py
@@ -25,8 +25,8 @@ async def get_tax_advantaged_category_with_metrics_for_owner(
         Owned tax-advantaged category with current-year metrics attached
 
     Raises:
-        HTTPException: Tax-advantaged category does not exist or belongs to another user, or the owner's
-            stored timezone cannot be read
+        HTTPException: Tax-advantaged category does not exist or belongs to another user, the owner row
+            cannot be read, or its stored timezone is not a zone the app recognizes
     """
     tax_advantaged_category = await get_owned_tax_advantaged_category_or_404(db, tax_advantaged_category_id, owner_id)
     owner_timezones = await get_category_owner_timezones(db, {tax_advantaged_category.category_owner_user_id})

--- a/backend/app/routes/tax_advantaged_categories/tac_category_detail_helpers.py
+++ b/backend/app/routes/tax_advantaged_categories/tac_category_detail_helpers.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import TaxAdvantagedCategory
 from app.routes.tax_advantaged_categories.tac_category_helpers import get_owned_tax_advantaged_category_or_404
-from app.services.tax_advantaged_categories import attach_tax_advantaged_category_metrics
+from app.services.tax_advantaged_categories import attach_tax_advantaged_category_metrics, get_category_owner_timezones
 
 
 async def get_tax_advantaged_category_with_metrics_for_owner(
@@ -25,8 +25,10 @@ async def get_tax_advantaged_category_with_metrics_for_owner(
         Owned tax-advantaged category with current-year metrics attached
 
     Raises:
-        HTTPException: Tax-advantaged category does not exist or belongs to another user
+        HTTPException: Tax-advantaged category does not exist or belongs to another user, or the owner's
+            stored timezone cannot be read
     """
     tax_advantaged_category = await get_owned_tax_advantaged_category_or_404(db, tax_advantaged_category_id, owner_id)
-    await attach_tax_advantaged_category_metrics(db, [tax_advantaged_category])
+    owner_timezones = await get_category_owner_timezones(db, {tax_advantaged_category.category_owner_user_id})
+    await attach_tax_advantaged_category_metrics(db, [tax_advantaged_category], owner_timezones)
     return tax_advantaged_category

--- a/backend/app/routes/tax_advantaged_categories/tac_category_listing_helpers.py
+++ b/backend/app/routes/tax_advantaged_categories/tac_category_listing_helpers.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import TaxAdvantagedCategory
 from app.routes.tax_advantaged_categories.tac_category_helpers import get_tax_advantaged_categories_for_owner
-from app.services.tax_advantaged_categories import attach_tax_advantaged_category_metrics
+from app.services.tax_advantaged_categories import attach_tax_advantaged_category_metrics, get_category_owner_timezones
 
 
 async def get_tax_advantaged_categories_with_metrics_for_owner(
@@ -22,7 +22,14 @@ async def get_tax_advantaged_categories_with_metrics_for_owner(
 
     Returns:
         Tax-advantaged categories with current-year metrics attached
+
+    Raises:
+        HTTPException: An owner row cannot be read, or its stored timezone is not a zone the app recognizes
     """
     tax_advantaged_categories = await get_tax_advantaged_categories_for_owner(db, owner_id)
-    await attach_tax_advantaged_category_metrics(db, tax_advantaged_categories)
+    owner_timezones = await get_category_owner_timezones(
+        db,
+        {tax_advantaged_category.category_owner_user_id for tax_advantaged_category in tax_advantaged_categories},
+    )
+    await attach_tax_advantaged_category_metrics(db, tax_advantaged_categories, owner_timezones)
     return tax_advantaged_categories

--- a/backend/app/routes/tax_advantaged_categories/tac_category_update_helpers.py
+++ b/backend/app/routes/tax_advantaged_categories/tac_category_update_helpers.py
@@ -12,7 +12,7 @@ from app.routes.tax_advantaged_categories.tac_category_helpers import (
 )
 from app.schemas.tax_advantaged_category import UpdateTaxAdvantagedCategoryRequest
 from app.services.cache_state import mark_cache_changed_for_scope
-from app.services.tax_advantaged_categories import attach_tax_advantaged_category_metrics
+from app.services.tax_advantaged_categories import attach_tax_advantaged_category_metrics, get_category_owner_timezones
 
 
 async def update_tax_advantaged_category_with_metrics(
@@ -33,16 +33,23 @@ async def update_tax_advantaged_category_with_metrics(
         Updated tax-advantaged category with current-year metrics attached
 
     Raises:
-        HTTPException: Tax-advantaged category is inaccessible or a supplied field is invalid
+        HTTPException: Tax-advantaged category is inaccessible, a supplied field is invalid, or the
+            owner's stored timezone cannot be read
     """
     tax_advantaged_category = await get_owned_tax_advantaged_category_or_404(db, tax_advantaged_category_id, owner_id)
     previous_group_id = tax_advantaged_category.group_id
     updates = data.model_dump(exclude_unset=True)
+    if updates:
+        await validate_tac_category_updates(db, updates, owner_id)
+
+    # Resolved before the category is changed, since the response metrics are read after the commit
+    # and a refusal there would leave the category updated and the request failed
+    owner_timezones = await get_category_owner_timezones(db, {tax_advantaged_category.category_owner_user_id})
+
     if not updates:
-        await attach_tax_advantaged_category_metrics(db, [tax_advantaged_category])
+        await attach_tax_advantaged_category_metrics(db, [tax_advantaged_category], owner_timezones)
         return tax_advantaged_category
 
-    await validate_tac_category_updates(db, updates, owner_id)
     apply_tac_category_updates(tax_advantaged_category, updates)
 
     # Mark the previous scope stale because updates can affect tax-advantaged category metrics there
@@ -58,5 +65,5 @@ async def update_tax_advantaged_category_with_metrics(
 
     await db.commit()
     await db.refresh(tax_advantaged_category)
-    await attach_tax_advantaged_category_metrics(db, [tax_advantaged_category])
+    await attach_tax_advantaged_category_metrics(db, [tax_advantaged_category], owner_timezones)
     return tax_advantaged_category

--- a/backend/app/routes/tax_advantaged_categories/tac_category_update_helpers.py
+++ b/backend/app/routes/tax_advantaged_categories/tac_category_update_helpers.py
@@ -33,8 +33,8 @@ async def update_tax_advantaged_category_with_metrics(
         Updated tax-advantaged category with current-year metrics attached
 
     Raises:
-        HTTPException: Tax-advantaged category is inaccessible, a supplied field is invalid, or the
-            owner's stored timezone cannot be read
+        HTTPException: Tax-advantaged category is inaccessible, a supplied field is invalid, the owner
+            row cannot be read, or its stored timezone is not a zone the app recognizes
     """
     tax_advantaged_category = await get_owned_tax_advantaged_category_or_404(db, tax_advantaged_category_id, owner_id)
     previous_group_id = tax_advantaged_category.group_id

--- a/backend/app/services/tax_advantaged_categories/__init__.py
+++ b/backend/app/services/tax_advantaged_categories/__init__.py
@@ -1,5 +1,6 @@
 """Tax-advantaged category metric service"""
 
+import uuid
 from collections.abc import Sequence
 from datetime import datetime
 from zoneinfo import ZoneInfo
@@ -9,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.account import TaxAdvantagedCategory
 from app.services.tax_advantaged_categories.tac_limit_metric_helpers import (
     attach_tac_limit_metrics,
+    get_category_owner_timezones,
     get_tac_category_current_years,
     get_tac_limit_metrics,
 )
@@ -16,6 +18,11 @@ from app.services.tax_advantaged_categories.tac_transfer_metric_helpers import (
     attach_tac_transfer_totals,
     get_tac_transfer_totals,
 )
+
+__all__ = [
+    "attach_tax_advantaged_category_metrics",
+    "get_category_owner_timezones",
+]
 
 
 def _get_current_datetime_for_timezone(timezone: ZoneInfo) -> datetime:
@@ -34,6 +41,7 @@ def _get_current_datetime_for_timezone(timezone: ZoneInfo) -> datetime:
 async def attach_tax_advantaged_category_metrics(
     db: AsyncSession,
     tax_advantaged_categories: Sequence[TaxAdvantagedCategory],
+    owner_timezones: dict[uuid.UUID, ZoneInfo],
 ) -> None:
     """Attach current-year limits and transfer tallies to tax-advantaged category rows
 
@@ -43,14 +51,15 @@ async def attach_tax_advantaged_category_metrics(
     Args:
         db: Active database session
         tax_advantaged_categories: Tax-advantaged category rows to enrich in place
+        owner_timezones: Zone keyed by category owner identifier, from get_category_owner_timezones
     """
     if not tax_advantaged_categories:
         return
 
     tax_advantaged_category_ids = [tax_advantaged_category.id for tax_advantaged_category in tax_advantaged_categories]
-    current_years_by_tax_advantaged_category_id = await get_tac_category_current_years(
-        db,
+    current_years_by_tax_advantaged_category_id = get_tac_category_current_years(
         tax_advantaged_categories,
+        owner_timezones,
         _get_current_datetime_for_timezone,
     )
     limit_metrics = await get_tac_limit_metrics(db, tax_advantaged_category_ids, current_years_by_tax_advantaged_category_id)

--- a/backend/app/services/tax_advantaged_categories/tac_limit_metric_helpers.py
+++ b/backend/app/services/tax_advantaged_categories/tac_limit_metric_helpers.py
@@ -1,17 +1,22 @@
 """TAC limit metric helpers"""
 
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime
 from zoneinfo import ZoneInfo
 
+from fastapi import HTTPException, status
 from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.rls.functions import USER_TZ
 from app.models.account import TaxAdvantagedCategory, TaxAdvantagedCategoryLimit
 from app.utils.dates import CATEGORY_OWNER_PROFILE, resolve_timezone
+
+# Refusal for an owner row the helper cannot read. users.tz is NOT NULL, so an empty answer means
+# the row itself is absent rather than a profile someone left without a timezone
+MISSING_CATEGORY_OWNER_DETAIL = "The profile that owns this category could not be read, so no date could be calculated"
 
 
 @dataclass(frozen=True)
@@ -23,37 +28,54 @@ class TacLimitMetrics:
     category_ids_with_accrued_limit_rows: set[uuid.UUID]
 
 
-async def get_tac_category_current_years(
+async def get_category_owner_timezones(
     db: AsyncSession,
+    owner_ids: Iterable[uuid.UUID],
+) -> dict[uuid.UUID, ZoneInfo]:
+    """Return the zone stored on each category owner's profile
+
+    Takes owner identifiers rather than category rows so a category being created can resolve its
+    owner's zone before it is written, which keeps a refusal from leaving a saved category behind
+
+    Args:
+        db: Active database session
+        owner_ids: Identifiers of the users owning the categories being enriched
+
+    Returns:
+        Zone keyed by category owner identifier
+
+    Raises:
+        HTTPException: An owner row cannot be read, or its stored timezone is not a zone the app recognizes
+    """
+    # Fetch owner time zones through the helper since other owners' user rows are not
+    # directly visible, so current-year metrics use each owner's local calendar
+    owner_timezones: dict[uuid.UUID, ZoneInfo] = {}
+    for owner_id in set(owner_ids):
+        stored_tz = await db.scalar(text(f"SELECT {USER_TZ}(:owner_id)"), {"owner_id": owner_id})
+        if stored_tz is None:
+            raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=MISSING_CATEGORY_OWNER_DETAIL)
+        owner_timezones[owner_id] = resolve_timezone(stored_tz, stored_on=CATEGORY_OWNER_PROFILE)
+    return owner_timezones
+
+
+def get_tac_category_current_years(
     tax_advantaged_categories: Sequence[TaxAdvantagedCategory],
+    owner_timezones: dict[uuid.UUID, ZoneInfo],
     current_datetime_for_timezone: Callable[[ZoneInfo], datetime],
 ) -> dict[uuid.UUID, int]:
     """Return the current calendar year for each TAC category
 
     Args:
-        db: Active database session
         tax_advantaged_categories: Tax-advantaged categories being enriched
+        owner_timezones: Zone keyed by category owner identifier
         current_datetime_for_timezone: Clock function for timezone-aware current dates
 
     Returns:
         Current calendar year keyed by tax-advantaged category identifier
-
-    Raises:
-        HTTPException: An owner's stored timezone is not a zone the app recognizes
     """
-    owner_ids = {tax_advantaged_category.category_owner_user_id for tax_advantaged_category in tax_advantaged_categories}
-
-    # Fetch owner time zones through the helper since other owners' user rows are not
-    # directly visible, so current-year metrics use each owner's local calendar
-    owner_timezones: dict[uuid.UUID, str] = {}
-    for owner_id in owner_ids:
-        owner_timezones[owner_id] = await db.scalar(text(f"SELECT {USER_TZ}(:owner_id)"), {"owner_id": owner_id})
     current_years_by_tax_advantaged_category_id = {
         tax_advantaged_category.id: current_datetime_for_timezone(
-            resolve_timezone(
-                owner_timezones[tax_advantaged_category.category_owner_user_id],
-                stored_on=CATEGORY_OWNER_PROFILE,
-            ),
+            owner_timezones[tax_advantaged_category.category_owner_user_id],
         ).year
         for tax_advantaged_category in tax_advantaged_categories
     }

--- a/backend/tests/routes/tax_advantaged_categories/test_tax_advantaged_categories.py
+++ b/backend/tests/routes/tax_advantaged_categories/test_tax_advantaged_categories.py
@@ -563,6 +563,20 @@ async def test_update_without_the_setting_leaves_it_alone(client):
     assert resp.json()["counts_internal_transfers"] is True
 
 
+async def test_update_with_an_empty_body_still_returns_the_metrics(client):
+    """An update that sets no field takes a path of its own, which still answers with the derived fields."""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    category_id = (await _create_tax_advantaged_category(client, headers)).json()["id"]
+
+    resp = await client.patch(f"/tax-advantaged-categories/{category_id}", json={}, headers=headers)
+
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "TFSA"
+    assert resp.json()["ytd_contributions"] == 0
+    assert resp.json()["current_year_contribution_limit"] is None
+
+
 async def _setup_category_with_two_accounts(client, headers, **overrides):
     """Create a tax-advantaged category and two accounts linked to it
 

--- a/backend/tests/routes/test_stored_timezone.py
+++ b/backend/tests/routes/test_stored_timezone.py
@@ -123,6 +123,7 @@ async def test_category_update_writes_nothing_when_the_stored_timezone_is_unreso
     )
 
     assert update_resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert UNRESOLVABLE_IDENTIFIER in update_resp.json()["detail"]
     async with TestSession() as session:
 
         # Read the stored name back, since a refusal after the commit would have saved the new one
@@ -130,6 +131,42 @@ async def test_category_update_writes_nothing_when_the_stored_timezone_is_unreso
             select(TaxAdvantagedCategory.name).where(TaxAdvantagedCategory.id == uuid.UUID(category_id)),
         )
     assert stored_name == "TFSA"
+
+
+async def test_an_invalid_category_payload_is_reported_before_the_timezone(client):
+    """Validation runs above the timezone lookup, so a bad field is what the user is told about"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    category_id = (await _create_tax_advantaged_category(client, headers)).json()["id"]
+    await _store_unresolvable_timezone()
+
+    create_resp = await client.post(
+        "/tax-advantaged-categories",
+        json={"name": "RRSP", "tax_treatment": "taxable", "currency": "CAD"},
+        headers=headers,
+    )
+    update_resp = await client.patch(
+        f"/tax-advantaged-categories/{category_id}",
+        json={"tax_treatment": "taxable"},
+        headers=headers,
+    )
+
+    assert create_resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert update_resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert create_resp.json()["detail"] == "Tax-advantaged categories require a non-taxable tax treatment"
+    assert update_resp.json()["detail"] == "Tax-advantaged categories require a non-taxable tax treatment"
+
+
+async def test_a_reader_with_no_categories_is_not_refused(client):
+    """The owners whose zones are needed come from the rows found, so an empty list needs none"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    await _store_unresolvable_timezone()
+
+    resp = await client.get("/tax-advantaged-categories", headers=headers)
+
+    assert resp.status_code == status.HTTP_200_OK
+    assert resp.json() == []
 
 
 async def test_the_category_listing_refuses_an_unresolvable_stored_timezone(client):

--- a/backend/tests/routes/test_stored_timezone.py
+++ b/backend/tests/routes/test_stored_timezone.py
@@ -1,9 +1,11 @@
 """Route behaviour when a stored timezone no longer resolves"""
 
+import uuid
+
 from fastapi import status
 from sqlalchemy import func, select, update
 
-from app.models.account import Account
+from app.models.account import Account, TaxAdvantagedCategory
 from app.models.user import User
 from app.utils.dates import ACCOUNT_OWNER_PROFILE, OWN_PROFILE
 from tests.conftest import TestSession
@@ -44,6 +46,23 @@ async def _signup(client, *, email: str):
     return await client.post("/auth/signup", json={**SIGNUP_PAYLOAD, "email": email})
 
 
+async def _create_tax_advantaged_category(client, headers):
+    """Create a personal tax-advantaged category
+
+    Args:
+        client: Async test client
+        headers: Authorization header for the creating user
+
+    Returns:
+        API response from creating the category
+    """
+    return await client.post(
+        "/tax-advantaged-categories",
+        json={"name": "TFSA", "tax_treatment": "tax_free", "currency": "CAD"},
+        headers=headers,
+    )
+
+
 async def test_dashboard_refuses_an_unresolvable_stored_timezone(client):
     """The reader is told which setting is at fault instead of getting a server error"""
     signup_resp = await _create_user(client)
@@ -71,6 +90,59 @@ async def test_account_creation_writes_nothing_when_the_stored_timezone_is_unres
         # Count every account row, since a refusal after the commit would leave one behind
         account_count = await session.scalar(select(func.count()).select_from(Account))
     assert account_count == 0
+
+
+async def test_category_creation_writes_nothing_when_the_stored_timezone_is_unresolvable(client):
+    """The refusal lands before the commit, so a failed request leaves no category behind"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    await _store_unresolvable_timezone()
+
+    create_resp = await _create_tax_advantaged_category(client, headers)
+
+    assert create_resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert UNRESOLVABLE_IDENTIFIER in create_resp.json()["detail"]
+    async with TestSession() as session:
+
+        # Count every tax-advantaged category row, since a refusal after the commit would leave one behind
+        category_count = await session.scalar(select(func.count()).select_from(TaxAdvantagedCategory))
+    assert category_count == 0
+
+
+async def test_category_update_writes_nothing_when_the_stored_timezone_is_unresolvable(client):
+    """A refused update leaves the category as it was rather than saving and then failing"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    category_id = (await _create_tax_advantaged_category(client, headers)).json()["id"]
+    await _store_unresolvable_timezone()
+
+    update_resp = await client.patch(
+        f"/tax-advantaged-categories/{category_id}",
+        json={"name": "RRSP"},
+        headers=headers,
+    )
+
+    assert update_resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    async with TestSession() as session:
+
+        # Read the stored name back, since a refusal after the commit would have saved the new one
+        stored_name = await session.scalar(
+            select(TaxAdvantagedCategory.name).where(TaxAdvantagedCategory.id == uuid.UUID(category_id)),
+        )
+    assert stored_name == "TFSA"
+
+
+async def test_the_category_listing_refuses_an_unresolvable_stored_timezone(client):
+    """The reader is told which value is at fault instead of getting a server error"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    await _create_tax_advantaged_category(client, headers)
+    await _store_unresolvable_timezone()
+
+    resp = await client.get("/tax-advantaged-categories", headers=headers)
+
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert UNRESOLVABLE_IDENTIFIER in resp.json()["detail"]
 
 
 async def test_a_group_account_refusal_says_the_owner_setting_is_at_fault(client):

--- a/backend/tests/services/tax_advantaged_categories/test_owner_timezones.py
+++ b/backend/tests/services/tax_advantaged_categories/test_owner_timezones.py
@@ -27,5 +27,5 @@ async def test_an_absent_owner_row_is_refused(db):
 
 
 async def test_no_owner_ids_returns_an_empty_map(db):
-    """A reader with no categories asks for no zones, which must not reach the database"""
+    """A reader with no categories asks for no zones and gets none, rather than a refusal"""
     assert await get_category_owner_timezones(db, set()) == {}

--- a/backend/tests/services/tax_advantaged_categories/test_owner_timezones.py
+++ b/backend/tests/services/tax_advantaged_categories/test_owner_timezones.py
@@ -1,0 +1,31 @@
+"""Owner timezone lookup behind tax-advantaged category metrics"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.services.tax_advantaged_categories import get_category_owner_timezones
+from app.services.tax_advantaged_categories.tac_limit_metric_helpers import MISSING_CATEGORY_OWNER_DETAIL
+
+# An owner identifier no user row carries. The lookup is a security-definer function that bypasses
+# row-level security, so an empty answer means the row is gone rather than hidden from the caller
+ABSENT_OWNER_ID = uuid.UUID("00000000-0000-0000-0000-0000000000ff")
+
+
+async def test_an_absent_owner_row_is_refused(db):
+    """A missing owner row refuses the request rather than building a zone out of nothing
+
+    Tested here rather than through a route because a request whose own user row is gone fails
+    authentication before any handler runs
+    """
+    with pytest.raises(HTTPException) as raised:
+        await get_category_owner_timezones(db, {ABSENT_OWNER_ID})
+
+    assert raised.value.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert raised.value.detail == MISSING_CATEGORY_OWNER_DETAIL
+
+
+async def test_no_owner_ids_returns_an_empty_map(db):
+    """A reader with no categories asks for no zones, which must not reach the database"""
+    assert await get_category_owner_timezones(db, set()) == {}

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Plus } from 'lucide-react'
 import type { AccountsOverview } from '@/api/accounts'
+import { ApiError } from '@/api/auth'
 import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { useCurrencies } from '@/api/currency'
 import { useTaxAdvantagedCategories } from '@/api/tax-advantaged-categories'
@@ -11,6 +12,25 @@ import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 import TaxAdvantagedCategoriesTable from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/table/CategoriesTable'
 import TaxAdvantagedCategoryModal from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryModal'
 import { useTaxAdvantagedCategoryList } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCategoryList'
+
+const LIST_ERROR_FALLBACK = 'Refresh the page or try again later.'
+
+/**
+ * Says why the category list is missing, quoting the API's own sentence where it sent one, so a
+ * refusal that says which setting is at fault reaches the reader instead of an empty section
+ */
+function CategoriesLoadError({ detail }: { detail: string }) {
+  return (
+    <div className="py-3" role="alert">
+      <p className="text-sm font-semibold" style={{ color: 'var(--app-text)' }}>
+        Categories could not load
+      </p>
+      <p className="mt-1 text-sm leading-6" style={{ color: 'var(--app-text-subtle)' }}>
+        {detail}
+      </p>
+    </div>
+  )
+}
 
 /**
  * Settings section for managing tax-advantaged categories, combining search, creation and a
@@ -26,7 +46,10 @@ export default function TaxAdvantagedCategoriesSection({
   userTimezone?: string
 }) {
   const { data: currencies = [] } = useCurrencies()
-  const { data: plans = [], isLoading } = useTaxAdvantagedCategories()
+  const { data: plans = [], isLoading, isError, error } = useTaxAdvantagedCategories()
+  // Cached categories from an earlier session survive a failed request, since the query cache is
+  // persisted, so the message sits above them rather than throwing a readable list away
+  const listErrorDetail = isError ? (error instanceof ApiError ? error.message : LIST_ERROR_FALLBACK) : null
   const [openCategoryId, setOpenCategoryId] = useState<string | null>(null)
   // Held apart from the selection so the panel keeps its contents while it animates out
   const [isCategoryOpen, setIsCategoryOpen] = useState(false)
@@ -84,7 +107,9 @@ export default function TaxAdvantagedCategoriesSection({
             </button>
           </div>
 
-          {isLoading ? null : plans.length === 0 ? (
+          {listErrorDetail && <CategoriesLoadError detail={listErrorDetail} />}
+
+          {isLoading || (listErrorDetail && plans.length === 0) ? null : plans.length === 0 ? (
             <p className="py-3 text-center italic text-sm" style={{ color: 'var(--app-text-subtle)' }}>
               No tax-advantaged categories yet.
             </p>

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
@@ -13,20 +13,33 @@ import TaxAdvantagedCategoriesTable from '@/pages/settings/components/tax-advant
 import TaxAdvantagedCategoryModal from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryModal'
 import { useTaxAdvantagedCategoryList } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCategoryList'
 
-const LIST_ERROR_FALLBACK = 'Refresh the page or try again later.'
-
 /**
  * Says why the category list is missing, quoting the API's own sentence where it sent one, so a
  * refusal that says which setting is at fault reaches the reader instead of an empty section
+ *
+ * Where the API sent no sentence, the offer to refresh is a button rather than an anchor, since it
+ * acts on the page the reader is already on rather than taking them anywhere
  */
-function CategoriesLoadError({ detail }: { detail: string }) {
+function CategoriesLoadError({ detail }: { detail: string | null }) {
   return (
-    <div className="py-3" role="alert">
+    <div className="py-3 text-center" role="alert">
       <p className="text-sm font-semibold" style={{ color: 'var(--app-text)' }}>
         Categories could not load
       </p>
       <p className="mt-1 text-sm leading-6" style={{ color: 'var(--app-text-subtle)' }}>
-        {detail}
+        {detail ?? (
+          <>
+            <button
+              type="button"
+              className="underline underline-offset-2"
+              style={{ color: 'var(--app-accent)' }}
+              onClick={() => window.location.reload()}
+            >
+              Refresh the page
+            </button>
+            {' or try again later.'}
+          </>
+        )}
       </p>
     </div>
   )
@@ -49,7 +62,7 @@ export default function TaxAdvantagedCategoriesSection({
   const { data: plans = [], isLoading, isError, error } = useTaxAdvantagedCategories()
   // Cached categories from an earlier session survive a failed request, since the query cache is
   // persisted, so the message sits above them rather than throwing a readable list away
-  const listErrorDetail = isError ? (error instanceof ApiError ? error.message : LIST_ERROR_FALLBACK) : null
+  const listErrorDetail = error instanceof ApiError ? error.message : null
   const [openCategoryId, setOpenCategoryId] = useState<string | null>(null)
   // Held apart from the selection so the panel keeps its contents while it animates out
   const [isCategoryOpen, setIsCategoryOpen] = useState(false)
@@ -107,9 +120,9 @@ export default function TaxAdvantagedCategoriesSection({
             </button>
           </div>
 
-          {listErrorDetail && <CategoriesLoadError detail={listErrorDetail} />}
+          {isError && <CategoriesLoadError detail={listErrorDetail} />}
 
-          {isLoading || (listErrorDetail && plans.length === 0) ? null : plans.length === 0 ? (
+          {isLoading || (isError && plans.length === 0) ? null : plans.length === 0 ? (
             <p className="py-3 text-center italic text-sm" style={{ color: 'var(--app-text-subtle)' }}>
               No tax-advantaged categories yet.
             </p>


### PR DESCRIPTION
The tax-advantaged category routes work out the owner's timezone before anything is written, so a request that cannot resolve it fails without leaving a category saved behind. An owner row the lookup cannot read answers with a message saying so rather than a server error. In Settings, the tax-advantaged section shows that message rather than reporting an empty list.