### PR TITLE
fix: count overview spending by expense category and outflow

### DIFF
--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -63,7 +63,7 @@ class DailyCashFlow(BaseModel):
 
 
 class OutlierTransaction(BaseModel):
-    """A large expense-side transaction contribution surfaced as unusual."""
+    """A transaction surfaced as one of the period's largest single outflows."""
 
     id: uuid.UUID
     merchant_name: str | None

--- a/backend/app/services/transactions/overview/__init__.py
+++ b/backend/app/services/transactions/overview/__init__.py
@@ -116,7 +116,6 @@ async def get_transactions_overview(
     )
     total_inflow, total_outflow = sum_overview_net_flow(daily_cash_flow)
     outliers, outliers_fx_status = await convert_overview_outliers(
-        category_total_rows=category_total_rows,
         outlier_candidate_rows=outlier_candidate_rows,
         accounts_by_id=accounts_by_id,
         converter=clone_overview_converter(shared_converter),

--- a/backend/app/services/transactions/overview/categories.py
+++ b/backend/app/services/transactions/overview/categories.py
@@ -42,6 +42,8 @@ async def convert_overview_top_categories(
         name, current_total = category_totals.get(row.category_id, (row.category_name, 0))
         category_totals[row.category_id] = (name, current_total + converted_total)
 
+    # A category counts as spending only while its refunds leave the total negative, so one that
+    # refunds cancel out drops from the list rather than being ranked last
     top_categories = [
         TopCategorySpend(category_id=category_id, category_name=name, total=total)
         for category_id, (name, total) in category_totals.items()

--- a/backend/app/services/transactions/overview/outliers.py
+++ b/backend/app/services/transactions/overview/outliers.py
@@ -6,10 +6,12 @@ from app.schemas.fx import FxStatus
 from app.schemas.transaction import OutlierTransaction
 from app.services.fx import FxConverter
 
+# How many transactions the most expensive transactions panel has room for
+_OVERVIEW_OUTLIER_LIMIT = 3
+
 
 async def convert_overview_outliers(
     *,
-    category_total_rows,
     outlier_candidate_rows,
     accounts_by_id: dict[uuid.UUID, Account],
     converter: FxConverter,
@@ -18,7 +20,6 @@ async def convert_overview_outliers(
     """Convert and rank overview outlier transactions
 
     Args:
-        category_total_rows: Category total rows used to cap outlier contribution
         outlier_candidate_rows: Candidate transaction rows eligible for outlier ranking
         accounts_by_id: Account rows keyed by account ID
         converter: Request-scoped FX converter
@@ -27,29 +28,6 @@ async def convert_overview_outliers(
     Returns:
         Top converted outlier response rows and FX status for the conversion
     """
-    category_totals: dict[uuid.UUID, int] = {}
-
-    # Convert category totals into base-currency spend caps for each outlier category
-    for row in category_total_rows:
-        currency = accounts_by_id[row.account_id].currency
-        converted_total = await converter.convert_minor_units(
-            int(row.total or 0),
-            base=currency,
-            quote=base_currency,
-            rate_date=row.date,
-        )
-        if converted_total is None:
-            continue
-
-        category_totals[row.category_id] = category_totals.get(row.category_id, 0) + converted_total
-
-    # Cap each category's outlier contribution at that category's converted spend total
-    remaining_by_category = {
-        category_id: -total
-        for category_id, total in category_totals.items()
-        if total < 0
-    }
-
     converted_outlier_candidates = []
 
     # Convert candidate transactions so outliers can be ranked across account currencies
@@ -66,22 +44,17 @@ async def convert_overview_outliers(
 
         converted_outlier_candidates.append((row, converted_amount))
 
-    outliers = []
-
-    # Rank converted candidates and apply category caps before returning the top rows
-    for row, converted_amount in sorted(converted_outlier_candidates, key=lambda item: item[1]):
-        remaining = remaining_by_category.get(row.category_id, 0)
-        if remaining <= 0:
-            continue
-        amount = -min(-converted_amount, remaining)
-        remaining_by_category[row.category_id] = remaining + amount
-        outliers.append(OutlierTransaction(
+    # Rank by each transaction's own converted outflow, so a purchase refunded later still counts
+    converted_outlier_candidates.sort(key=lambda candidate: candidate[1])
+    outliers = [
+        OutlierTransaction(
             id=row.id,
             merchant_name=row.merchant_name,
             notes=row.notes,
             amount=int(row.amount),
             currency=accounts_by_id[row.account_id].currency,
             dt=row.date,
-        ))
-
-    return outliers[:3], converter.get_status()
+        )
+        for row, _converted_amount in converted_outlier_candidates[:_OVERVIEW_OUTLIER_LIMIT]
+    ]
+    return outliers, converter.get_status()

--- a/backend/app/services/transactions/overview/queries.py
+++ b/backend/app/services/transactions/overview/queries.py
@@ -99,7 +99,7 @@ async def get_overview_category_total_rows(db: AsyncSession, transaction_filters
     Returns:
         SQLAlchemy rows containing category, account, date, and total values
     """
-    # Aggregate income and expense totals by category, account, and date for conversion
+    # Aggregate expense totals by category, account, and date for conversion
     return (
         await db.execute(
             select(
@@ -111,7 +111,10 @@ async def get_overview_category_total_rows(db: AsyncSession, transaction_filters
             )
             .join(Category, Transaction.category_id == Category.id)
             .where(transaction_filters)
-            .where(Category.kind.in_([CategoryKind.EXPENSE, CategoryKind.INCOME]))
+
+            # Spending is what an expense category nets once its refunds are taken off, so an
+            # income category stays out even when a reversal leaves it negative for the period
+            .where(Category.kind == CategoryKind.EXPENSE)
             .group_by(Transaction.category_id, Category.name, Transaction.account_id, Transaction.dt),
         )
     ).all()
@@ -121,14 +124,14 @@ async def get_overview_outlier_candidate_rows(db: AsyncSession, transaction_filt
     """Return candidate outlier transaction rows for an overview
 
     The query loads negative income or expense transactions with merchant data
-    so the conversion layer can rank the largest converted spending rows
+    so the conversion layer can rank the largest converted outflows
 
     Args:
         db: Active database session
         transaction_filters: SQLAlchemy filters shared by overview queries
 
     Returns:
-        SQLAlchemy rows for expense-side transactions eligible for outlier ranking
+        SQLAlchemy rows for transactions eligible for outlier ranking
     """
     # Fetch negative income or expense transactions that can be ranked as outliers
     return (
@@ -140,7 +143,6 @@ async def get_overview_outlier_candidate_rows(db: AsyncSession, transaction_filt
                 Transaction.notes,
                 Transaction.amount,
                 Transaction.dt.label("date"),
-                Transaction.category_id,
             )
             .outerjoin(Merchant, Transaction.merchant_id == Merchant.id)
             .join(Category, Transaction.category_id == Category.id)

--- a/backend/tests/routes/transactions/test_overview.py
+++ b/backend/tests/routes/transactions/test_overview.py
@@ -62,6 +62,7 @@ async def test_transactions_overview_net_flow_excludes_balance_adjustments(clien
     assert data["daily_cash_flow"] == [
         {"date": "2026-03-15", "end_date": "2026-03-15", "inflow": 12_500, "outflow": -5_500},
     ]
+    assert [row["amount"] for row in data["outliers"]] == [-4_000]
 
 
 async def test_transactions_overview_net_flow_converts_foreign_accounts(client, monkeypatch):
@@ -390,14 +391,16 @@ async def test_transactions_overview_explicit_archived_account_is_allowed(client
     assert data["total_outflow"] == -30_000
 
 
-async def test_transactions_overview_top_categories_use_net_expense_side_categories(client):
-    """Top categories net refunds and include net-negative income categories."""
+async def test_transactions_overview_top_categories_cover_expense_categories_only(client):
+    """Top categories net refunds inside expense categories and leave income categories out."""
     headers, account_id, expense_category_id = await _setup_user_with_deps(client)
     transfer_category_id = (await _create_category(client, headers, name="Main Transfer", kind="transfer")).json()["id"]
     income_category_id = (await _create_category(client, headers, name="Main Income", kind="income")).json()["id"]
     over_refund_category_id = (await _create_category(client, headers, name="Over Refund", kind="expense")).json()["id"]
 
-    await _create_transaction(client, headers, account_id, transfer_category_id, amount=-20_000)
+    await _create_transaction(
+        client, headers, account_id, transfer_category_id, amount=-20_000, counterparty_account_scope="outside",
+    )
     await _create_transaction(client, headers, account_id, income_category_id, amount=-15_000)
     await _create_transaction(client, headers, account_id, expense_category_id, amount=-4_000)
     await _create_transaction(client, headers, account_id, expense_category_id, amount=-3_000)
@@ -410,10 +413,178 @@ async def test_transactions_overview_top_categories_use_net_expense_side_categor
     assert resp.status_code == 200
     data = resp.json()
     assert [(row["category_id"], row["total"]) for row in data["top_categories"]] == [
-        (income_category_id, -15_000),
         (expense_category_id, -5_000),
     ]
     assert data["top_categories_fx_status"] == {"state": "none", "missing_pairs": []}
+
+
+async def test_transactions_overview_top_categories_drop_a_category_refunded_to_zero(client):
+    """A category whose refunds exactly cancel its spending is not spending for the period."""
+    headers, account_id, expense_category_id = await _setup_user_with_deps(client)
+    cancelled_category_id = (await _create_category(client, headers, name="Cancelled Expense")).json()["id"]
+
+    await _create_transaction(client, headers, account_id, cancelled_category_id, amount=-6_000)
+    await _create_transaction(client, headers, account_id, cancelled_category_id, amount=6_000)
+    await _create_transaction(client, headers, account_id, expense_category_id, amount=-3_000)
+
+    resp = await client.get("/transactions/overview", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [(row["category_id"], row["total"]) for row in data["top_categories"]] == [
+        (expense_category_id, -3_000),
+    ]
+
+
+async def test_transactions_overview_refund_nets_against_its_category_and_counts_as_inflow(client):
+    """A refund reduces its own category's spend while still arriving as money in."""
+    headers, account_id, expense_category_id = await _setup_user_with_deps(client)
+
+    await _create_transaction(client, headers, account_id, expense_category_id, amount=-10_000)
+    await _create_transaction(client, headers, account_id, expense_category_id, amount=4_500)
+
+    resp = await client.get("/transactions/overview", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [(row["category_id"], row["total"]) for row in data["top_categories"]] == [
+        (expense_category_id, -5_500),
+    ]
+    assert data["total_inflow"] == 4_500
+    assert data["total_outflow"] == -10_000
+
+
+async def test_transactions_overview_refund_after_its_period_leaves_no_top_category(client):
+    """A period holding only the refund reports inflow and no spending category."""
+    headers, account_id, expense_category_id = await _setup_user_with_deps(client)
+
+    await _create_transaction(client, headers, account_id, expense_category_id, amount=-10_000, dt="2026-03-15")
+    await _create_transaction(client, headers, account_id, expense_category_id, amount=4_500, dt="2026-04-20")
+
+    resp = await client.get(
+        "/transactions/overview",
+        params={"from_date": "2026-04-01", "to_date": "2026-04-30"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["top_categories"] == []
+    assert data["outliers"] == []
+    assert data["total_inflow"] == 4_500
+    assert data["total_outflow"] == 0
+
+
+async def test_transactions_overview_income_loss_ranks_as_outlier_without_being_a_top_category(client):
+    """An income reversal is one of the largest outflows without counting as spending."""
+    headers, account_id, expense_category_id = await _setup_user_with_deps(client)
+    income_category_id = (await _create_category(client, headers, name="Main Income", kind="income")).json()["id"]
+
+    await _create_transaction(client, headers, account_id, income_category_id, amount=-12_000)
+    await _create_transaction(client, headers, account_id, expense_category_id, amount=-3_000)
+
+    resp = await client.get("/transactions/overview", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [(row["category_id"], row["total"]) for row in data["top_categories"]] == [
+        (expense_category_id, -3_000),
+    ]
+    assert [row["amount"] for row in data["outliers"]] == [-12_000, -3_000]
+    assert data["total_outflow"] == -15_000
+
+
+async def test_transactions_overview_unconvertible_income_row_leaves_top_categories_clean(client, monkeypatch):
+    """A missing rate that only an income row needed no longer marks top categories incomplete."""
+    from app.services.fx import FrankfurterProvider, FxRateNotFoundError
+
+    async def fake_get_rates(self, base, quote, start_date, end_date):
+        raise FxRateNotFoundError()
+
+    monkeypatch.setattr(FrankfurterProvider, "get_rates", fake_get_rates)
+
+    async with TestSession() as session:
+        session.add(Currency(id="ABC", name="Unsupported Test Currency", symbol="A", minor_unit_exponent=2))
+        await session.commit()
+
+    headers, cad_account_id, category_id = await _setup_user_with_deps(client)
+    income_category_id = (await _create_category(client, headers, name="Main Income", kind="income")).json()["id"]
+    abc_account_id = (await _create_account(
+        client,
+        headers,
+        name="ABC Chequing",
+        currency="ABC",
+    )).json()["id"]
+
+    await _create_transaction(client, headers, cad_account_id, category_id, amount=-5_000)
+    await _create_transaction(
+        client,
+        headers,
+        abc_account_id,
+        income_category_id,
+        amount=-12_000,
+        currency="ABC",
+    )
+
+    resp = await client.get("/transactions/overview", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [(row["category_id"], row["total"]) for row in data["top_categories"]] == [
+        (category_id, -5_000),
+    ]
+    assert data["top_categories_fx_status"] == {"state": "none", "missing_pairs": []}
+    assert [row["amount"] for row in data["outliers"]] == [-5_000]
+    assert data["outliers_fx_status"] == {
+        "state": "incomplete",
+        "missing_pairs": [{"base": "ABC", "quote": "CAD"}],
+    }
+
+
+async def test_transactions_overview_panels_report_fx_status_for_their_own_conversions(client, monkeypatch):
+    """An unconvertible refund marks top categories incomplete and leaves outliers untouched."""
+    from app.services.fx import FrankfurterProvider, FxRateNotFoundError
+
+    async def fake_get_rates(self, base, quote, start_date, end_date):
+        raise FxRateNotFoundError()
+
+    monkeypatch.setattr(FrankfurterProvider, "get_rates", fake_get_rates)
+
+    async with TestSession() as session:
+        session.add(Currency(id="ABC", name="Unsupported Test Currency", symbol="A", minor_unit_exponent=2))
+        await session.commit()
+
+    headers, cad_account_id, category_id = await _setup_user_with_deps(client)
+    abc_account_id = (await _create_account(
+        client,
+        headers,
+        name="ABC Chequing",
+        currency="ABC",
+    )).json()["id"]
+
+    await _create_transaction(client, headers, cad_account_id, category_id, amount=-5_000)
+    await _create_transaction(
+        client,
+        headers,
+        abc_account_id,
+        category_id,
+        amount=90_000,
+        currency="ABC",
+    )
+
+    resp = await client.get("/transactions/overview", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [(row["category_id"], row["total"]) for row in data["top_categories"]] == [
+        (category_id, -5_000),
+    ]
+    assert data["top_categories_fx_status"] == {
+        "state": "incomplete",
+        "missing_pairs": [{"base": "ABC", "quote": "CAD"}],
+    }
+    assert [row["amount"] for row in data["outliers"]] == [-5_000]
+    assert data["outliers_fx_status"] == {"state": "none", "missing_pairs": []}
 
 
 async def test_transactions_overview_top_categories_convert_and_rank_foreign_accounts(client, monkeypatch):
@@ -518,15 +689,17 @@ async def test_transactions_overview_top_categories_report_incomplete_fx(client,
     }
 
 
-async def test_transactions_overview_outliers_include_income_loss_transactions(client):
-    """Most expensive transactions include income losses but exclude transfers."""
+async def test_transactions_overview_outliers_rank_by_each_transactions_own_outflow(client):
+    """Most expensive transactions rank by outflow alone, so a refunded purchase still ranks."""
     headers, account_id, expense_category_id = await _setup_user_with_deps(client)
     transfer_category_id = (await _create_category(client, headers, name="Main Transfer", kind="transfer")).json()["id"]
     income_category_id = (await _create_category(client, headers, name="Main Income", kind="income")).json()["id"]
     refunded_category_id = (await _create_category(client, headers, name="Refunded Expense", kind="expense")).json()["id"]
     over_refund_category_id = (await _create_category(client, headers, name="Over-refunded Expense", kind="expense")).json()["id"]
 
-    await _create_transaction(client, headers, account_id, transfer_category_id, amount=-20_000)
+    await _create_transaction(
+        client, headers, account_id, transfer_category_id, amount=-20_000, counterparty_account_scope="outside",
+    )
     await _create_transaction(client, headers, account_id, income_category_id, amount=-15_000)
     await _create_transaction(client, headers, account_id, refunded_category_id, amount=-10_000)
     await _create_transaction(client, headers, account_id, refunded_category_id, amount=4_000)
@@ -539,7 +712,7 @@ async def test_transactions_overview_outliers_include_income_loss_transactions(c
 
     assert resp.status_code == 200
     data = resp.json()
-    assert [row["amount"] for row in data["outliers"]] == [-15_000, -10_000, -4_000]
+    assert [row["amount"] for row in data["outliers"]] == [-15_000, -10_000, -9_000]
     assert data["outliers_fx_status"] == {"state": "none", "missing_pairs": []}
 
 

--- a/frontend/src/pages/transactions/components/top-band/MostExpensiveTransactionsPanel.tsx
+++ b/frontend/src/pages/transactions/components/top-band/MostExpensiveTransactionsPanel.tsx
@@ -47,7 +47,7 @@ export default function MostExpensiveTransactionsPanel({
           placement="bottom"
           widthClassName="w-64"
         >
-          Shows the three largest net expense-side transaction contributors in the selected period
+          The three largest single outflows in the selected period, excluding transfers. A refund is its own transaction, so it does not reduce the amounts shown here.
         </IconTooltip>
         <FxStatusBadge
           label="Most expensive transactions FX status"

--- a/frontend/src/pages/transactions/components/top-band/TopCategoriesChart.tsx
+++ b/frontend/src/pages/transactions/components/top-band/TopCategoriesChart.tsx
@@ -185,7 +185,7 @@ export default function TopCategoriesChart({
           placement="bottom"
           widthClassName="w-64"
         >
-          The top 5 categories ranked by net expense-side total in the selected period. The progress bar is relative to the highest-spend category, not an absolute scale.
+          The top 5 expense categories in the selected period, each totalled after its refunds and dropped once those refunds cancel the spending. The progress bar is relative to the highest-spend category, not an absolute scale.
         </IconTooltip>
         <FxStatusBadge
           label="Top categories FX status"


### PR DESCRIPTION
The transactions overview counts spending as expense categories netted against their refunds. An income category with a net loss no longer appears among top categories, and the most expensive transactions panel ranks each transaction by its own outflow rather than limiting how much of a category's total it will attribute to individual rows. Each panel's currency warning covers only the conversions it performs.
