### PR TITLE
fix: rank merchants by usage that fades with age

### DIFF
--- a/backend/alembic/versions/6a1f132b9da2_index_transactions_by_merchant_and_date.py
+++ b/backend/alembic/versions/6a1f132b9da2_index_transactions_by_merchant_and_date.py
@@ -1,0 +1,34 @@
+"""Index transactions by merchant and date.
+
+The merchant listing sums a per-transaction weight over a bounded date range for each merchant,
+which the single-column index could not restrict, so every one of a merchant's rows was read and
+the ones outside the range discarded. Leading the new index on merchant_id keeps every lookup the
+single-column one served, which is why that one is dropped rather than left to be maintained on
+every write for nothing.
+
+Revision ID: 6a1f132b9da2
+Revises: 9563defdb8fd
+Create Date: 2026-08-05 23:59:30.236397
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "6a1f132b9da2"
+down_revision: str | Sequence[str] | None = "9563defdb8fd"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.drop_index(op.f("ix_transactions_merchant_id"), table_name="transactions")
+    op.create_index("ix_transactions_merchant_id_dt", "transactions", ["merchant_id", "dt"], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_transactions_merchant_id_dt", table_name="transactions")
+    op.create_index(op.f("ix_transactions_merchant_id"), "transactions", ["merchant_id"], unique=False)

--- a/backend/app/models/transaction.py
+++ b/backend/app/models/transaction.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import date, datetime
 
-from sqlalchemy import VARCHAR, BigInteger, CheckConstraint, Date, DateTime, ForeignKey, Numeric, Text, func
+from sqlalchemy import VARCHAR, BigInteger, CheckConstraint, Date, DateTime, ForeignKey, Index, Numeric, Text, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base, TransferCounterpartyScope
@@ -20,6 +20,10 @@ class Transaction(Base):
             "(counterparty_account_id IS NOT NULL) = (counterparty_account_scope IS NOT DISTINCT FROM 'TRACKED')",
             name="ck_transactions_counterparty_account_scope_matches_id",
         ),
+        # Serves the merchant listing, which sums a per-transaction weight over a bounded date
+        # range for each merchant. Leading on merchant_id means it also covers every lookup that
+        # filters on the merchant alone, so no separate index on that column is needed
+        Index("ix_transactions_merchant_id_dt", "merchant_id", "dt"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)
@@ -28,7 +32,7 @@ class Transaction(Base):
     dt: Mapped[date] = mapped_column(Date, nullable=False)
     # The create and edit routes require one, so this is null only on a transaction recorded before
     # that rule or brought in by an import whose file named no payee
-    merchant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("merchants.id"), index=True)
+    merchant_id: Mapped[uuid.UUID | None] = mapped_column(ForeignKey("merchants.id"))
     category_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("categories.id"), nullable=False)
     amount: Mapped[int] = mapped_column(BigInteger, nullable=False)  # In currency base units
     currency: Mapped[str] = mapped_column(VARCHAR(3), ForeignKey("currencies.id"), nullable=False)

--- a/backend/app/routes/merchants/listing_helpers.py
+++ b/backend/app/routes/merchants/listing_helpers.py
@@ -4,7 +4,7 @@ import uuid
 from collections.abc import Sequence
 from datetime import date, timedelta
 
-from sqlalchemy import func, select
+from sqlalchemy import Date, Integer, Numeric, cast, func, literal, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.category import Category
@@ -15,10 +15,21 @@ from app.routes.merchants.scope_filter_helpers import get_merchant_list_scope_fi
 from app.services.categories.transfer_rules import BALANCE_ADJUSTMENT_CATEGORY_NAME
 from app.utils.sql_search_helpers import escape_like_search_text
 
-# Recent-usage window that ranks the merchant dropdown so the merchants a user
-# transacts with most often surface first, a window shorter than the user's
-# history simply ranks by every transaction they have
-MERCHANT_FREQUENCY_WINDOW_DAYS = 90
+# How long a transaction takes to count for half of what it counted the day it was recorded. The
+# score fades smoothly instead of stopping at the 90-day window it replaces, so a merchant used
+# often a while ago still outranks one used a single time today
+MERCHANT_USAGE_HALF_LIFE_DAYS = 90
+
+# Transactions older than this are left out of the score. The oldest one still counted, dated at
+# exactly this age, is worth 0.36% of a transaction recorded today, so around 280 of them would be
+# needed to outweigh a single recent one, which is far beyond anything a real history holds
+MERCHANT_USAGE_CUTOFF_DAYS = 730
+
+# The score is rounded before it orders anything, because adding floating-point numbers is not
+# associative and the database does not promise to sum a merchant's rows in any fixed order. Two
+# merchants used identically would otherwise differ by a rounding step, never reach the name
+# tiebreaker, and swap places between requests, which pages a merchant twice or not at all
+MERCHANT_USAGE_SCORE_DECIMAL_PLACES = 6
 
 
 async def get_merchants_for_user(
@@ -28,8 +39,9 @@ async def get_merchants_for_user(
     search_text: str | None,
     limit: int | None,
     offset: int,
+    today: date,
 ) -> Sequence[Merchant]:
-    """Return merchants visible in the requested scope ranked by recent usage
+    """Return merchants visible in the requested scope ranked by decayed usage
 
     Args:
         db: Active database session
@@ -38,15 +50,27 @@ async def get_merchants_for_user(
         search_text: Optional name search text
         limit: Optional maximum number of merchants to return
         offset: Number of merchants to skip before returning rows
+        today: Current date in the requesting user's timezone, used to age each transaction
 
     Returns:
-        Merchants ordered by recent transaction count then name
+        Merchants ordered by decayed usage score, then name, then identifier
 
     Raises:
         HTTPException: User is not a member of the requested group
     """
-    recent_usage_cutoff = date.today() - timedelta(days=MERCHANT_FREQUENCY_WINDOW_DAYS)
-    recent_usage_count = func.count(Transaction.id)
+    usage_cutoff = today - timedelta(days=MERCHANT_USAGE_CUTOFF_DAYS)
+
+    # Subtracting one date from another gives whole days in Postgres, and SQLAlchemy casts the
+    # divisor so the division keeps its fraction instead of truncating to whole half-lives
+    transaction_age_days = cast(literal(today, Date) - Transaction.dt, Integer)
+    usage_weight = func.power(0.5, transaction_age_days / float(MERCHANT_USAGE_HALF_LIFE_DAYS))
+
+    # Summing no rows gives null, which Postgres sorts ahead of every number under DESC, so a
+    # merchant nobody has used would lead the list without this
+    decayed_usage_score = func.round(
+        cast(func.coalesce(func.sum(usage_weight), 0.0), Numeric),
+        MERCHANT_USAGE_SCORE_DECIMAL_PLACES,
+    )
 
     # Balance adjustments are written by the app rather than the user, and they carry the shared
     # Myself merchant, so counting them would let opening a few accounts push that merchant to the
@@ -56,14 +80,16 @@ async def get_merchants_for_user(
         Category.name == BALANCE_ADJUSTMENT_CATEGORY_NAME,
     )
 
-    # Count each merchant's transactions inside the recency window, the date lives
-    # in the join condition so merchants with no recent activity are kept and ranked last
+    # Score each merchant's transactions, the date bound living in the join condition so merchants
+    # with nothing to count are kept and ranked last. Bounding both ends in one comparison drops
+    # transactions past the cutoff and transactions dated ahead of the user's today, which would
+    # otherwise weigh more than one recorded now
     merchant_query = (
         select(Merchant)
         .outerjoin(
             Transaction,
             (Transaction.merchant_id == Merchant.id)
-            & (Transaction.dt >= recent_usage_cutoff)
+            & Transaction.dt.between(usage_cutoff, today)
             & Transaction.category_id.notin_(balance_adjustment_category_ids),
         )
         .where(get_merchant_list_scope_filter(user_id, group_id))
@@ -78,8 +104,10 @@ async def get_merchants_for_user(
         escaped_search_text = escape_like_search_text(normalized_search_text)
         merchant_query = merchant_query.where(Merchant.name.ilike(f"%{escaped_search_text}%", escape="\\"))
 
-    # Rank by recent usage and fall back to name so untouched merchants stay alphabetical
-    merchant_query = merchant_query.order_by(recent_usage_count.desc(), Merchant.name)
+    # Rank by decayed usage and fall back to name so untouched merchants stay alphabetical. The
+    # identifier settles what name cannot: a personal merchant and a group merchant may share one,
+    # and paging over a tie the database breaks differently each time repeats or skips a row
+    merchant_query = merchant_query.order_by(decayed_usage_score.desc(), Merchant.name, Merchant.id)
     if limit is not None:
         merchant_query = merchant_query.limit(limit).offset(offset)
 

--- a/backend/app/routes/merchants/router.py
+++ b/backend/app/routes/merchants/router.py
@@ -1,5 +1,6 @@
 """Merchant routes"""
 import uuid
+from datetime import datetime
 from typing import Annotated
 
 from fastapi import APIRouter, Depends, Query, status
@@ -15,6 +16,7 @@ from app.routes.merchants.listing_helpers import get_merchants_for_user
 from app.routes.merchants.merge_helpers import merge_merchant_into_replacement_for_user
 from app.routes.merchants.update_helpers import update_merchant_for_user
 from app.schemas.merchant import CreateMerchantRequest, MerchantResponse, MergeMerchantRequest, UpdateMerchantRequest
+from app.utils.dates import resolve_timezone
 
 router = APIRouter(prefix="/merchants", tags=["merchants"])
 
@@ -39,9 +41,15 @@ async def list_merchants(
         offset: Number of merchants to skip before returning rows
 
     Returns:
-        Merchants ordered by recent transaction count then name
+        Merchants ordered by decayed usage score, then name, then identifier
+
+    Raises:
+        HTTPException: User is not a member of the requested group, or the stored timezone does not resolve
     """
-    merchants = await get_merchants_for_user(db, user.id, group_id, q, limit, offset)
+    # The score drops transactions dated ahead of today, so today has to be the user's own date
+    # rather than the server's, or someone in a zone hours ahead loses the ones they just recorded
+    today = datetime.now(resolve_timezone(user.tz)).date()
+    merchants = await get_merchants_for_user(db, user.id, group_id, q, limit, offset, today)
     return merchants
 
 

--- a/backend/tests/routes/merchants/test_merchant_ranking.py
+++ b/backend/tests/routes/merchants/test_merchant_ranking.py
@@ -1,6 +1,7 @@
-from datetime import date, timedelta
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
-from app.routes.merchants.listing_helpers import MERCHANT_FREQUENCY_WINDOW_DAYS
+from app.routes.merchants.listing_helpers import MERCHANT_USAGE_CUTOFF_DAYS
 from tests.routes.merchants._helpers import (
     _create_merchant,
     _get_system_category_id,
@@ -8,7 +9,17 @@ from tests.routes.merchants._helpers import (
 )
 from tests.routes.support import _create_user, _get_auth_header
 
-# --- GET /merchants frequency ranking ---
+# --- GET /merchants usage ranking ---
+
+# The zone every test signup stores. The endpoint measures how old a transaction is against the
+# user's own date, so a test recording one dated today has to mean the user's today: the host
+# running the suite need not be in this zone, and can be a day ahead of it
+USER_TIMEZONE = ZoneInfo("America/Toronto")
+
+
+def _user_today():
+    """Return the current date in the timezone the test signup stores"""
+    return datetime.now(USER_TIMEZONE).date()
 
 
 async def _create_checking_account(client, headers):
@@ -43,7 +54,7 @@ async def _record_merchant_transactions(client, headers, account_id, category_id
         dt: Transaction date applied to every recorded row
     """
     for _ in range(count):
-        await client.post("/transactions", json={
+        resp = await client.post("/transactions", json={
             "account_id": account_id,
             "category_id": category_id,
             "merchant_id": merchant_id,
@@ -51,6 +62,9 @@ async def _record_merchant_transactions(client, headers, account_id, category_id
             "amount": -5000,
             "currency": "CAD",
         }, headers=headers)
+        # Every merchant scores zero when nothing is recorded, which several of these tests would
+        # read as the order they expect, so a refused create has to fail here rather than there
+        assert resp.status_code == 201, resp.text
 
 
 async def test_list_merchants_ignores_the_balance_adjustments_the_app_writes(client):
@@ -71,7 +85,7 @@ async def test_list_merchants_ignores_the_balance_adjustments_the_app_writes(cli
     account_id = await _create_checking_account(client, headers)
     category_id = await _get_system_category_id(client, headers)
     merchant_id = (await _create_merchant(client, headers, name="Corner Shop")).json()["id"]
-    await _record_merchant_transactions(client, headers, account_id, category_id, merchant_id, 1, date.today())
+    await _record_merchant_transactions(client, headers, account_id, category_id, merchant_id, 1, _user_today())
 
     resp = await client.get("/merchants", headers=headers)
 
@@ -79,11 +93,11 @@ async def test_list_merchants_ignores_the_balance_adjustments_the_app_writes(cli
 
 
 async def test_list_merchants_ranks_more_used_merchant_first(client):
-    """Merchants with more recent transactions rank above less used ones regardless of name."""
+    """Merchants used more often rank above less used ones regardless of name."""
     headers = _get_auth_header(await _create_user(client))
     category_id = await _get_system_category_id(client, headers)
     account_id = await _create_checking_account(client, headers)
-    recent_date = date.today() - timedelta(days=5)
+    recent_date = _user_today() - timedelta(days=5)
 
     # Names run reverse-alphabetical against usage so only frequency can produce this order
     least_used_id = (await _create_merchant(client, headers, name="Alpha Store")).json()["id"]
@@ -99,19 +113,38 @@ async def test_list_merchants_ranks_more_used_merchant_first(client):
     assert _own_merchant_names(resp) == ["Zulu Store", "Mike Store", "Alpha Store"]
 
 
-async def test_list_merchants_breaks_frequency_ties_by_name(client):
-    """Merchants with equal recent usage fall back to alphabetical order."""
+async def test_list_merchants_ranks_two_older_uses_above_one_newer_use(client):
+    """A modest lead in transactions outweighs a few days of recency, so the busier merchant leads."""
     headers = _get_auth_header(await _create_user(client))
     category_id = await _get_system_category_id(client, headers)
     account_id = await _create_checking_account(client, headers)
-    recent_date = date.today() - timedelta(days=5)
+    today = _user_today()
+
+    # Named against the expected order so alphabetical sorting alone cannot produce it
+    busy_id = (await _create_merchant(client, headers, name="Zulu Store")).json()["id"]
+    quiet_id = (await _create_merchant(client, headers, name="Alpha Store")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, busy_id, 2, today - timedelta(days=10))
+    await _record_merchant_transactions(client, headers, account_id, category_id, quiet_id, 1, today - timedelta(days=1))
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == 200
+    assert _own_merchant_names(resp) == ["Zulu Store", "Alpha Store"]
+
+
+async def test_list_merchants_breaks_usage_ties_by_name(client):
+    """Merchants with equal usage fall back to alphabetical order."""
+    headers = _get_auth_header(await _create_user(client))
+    category_id = await _get_system_category_id(client, headers)
+    account_id = await _create_checking_account(client, headers)
+    recent_date = _user_today() - timedelta(days=5)
 
     charlie_id = (await _create_merchant(client, headers, name="Charlie Market")).json()["id"]
     bravo_id = (await _create_merchant(client, headers, name="Bravo Market")).json()["id"]
     await _record_merchant_transactions(client, headers, account_id, category_id, charlie_id, 1, recent_date)
     await _record_merchant_transactions(client, headers, account_id, category_id, bravo_id, 1, recent_date)
 
-    # An untouched merchant ties every other at zero usage and sorts by name behind them
+    # An untouched merchant scores zero and sorts by name behind every merchant with any usage
     await _create_merchant(client, headers, name="Alpha Market")
 
     resp = await client.get("/merchants", headers=headers)
@@ -120,39 +153,105 @@ async def test_list_merchants_breaks_frequency_ties_by_name(client):
     assert _own_merchant_names(resp) == ["Bravo Market", "Charlie Market", "Alpha Market"]
 
 
-async def test_list_merchants_ignores_usage_outside_window(client):
-    """Transactions older than the recency window do not count toward ranking."""
+async def test_list_merchants_ranks_heavy_older_usage_above_one_recent_use(client):
+    """Usage decays with age rather than stopping at a window edge, so weight of history still wins."""
     headers = _get_auth_header(await _create_user(client))
     category_id = await _get_system_category_id(client, headers)
     account_id = await _create_checking_account(client, headers)
-    recent_date = date.today() - timedelta(days=5)
-    stale_date = date.today() - timedelta(days=MERCHANT_FREQUENCY_WINDOW_DAYS + 30)
+    today = _user_today()
 
+    # Five transactions aged 120 days score 5 * 0.5 ** (120 / 90) = 1.98, against 1.00 for one today
     stale_id = (await _create_merchant(client, headers, name="Stale Store")).json()["id"]
     fresh_id = (await _create_merchant(client, headers, name="Fresh Store")).json()["id"]
-    await _record_merchant_transactions(client, headers, account_id, category_id, stale_id, 5, stale_date)
-    await _record_merchant_transactions(client, headers, account_id, category_id, fresh_id, 1, recent_date)
+    await _record_merchant_transactions(client, headers, account_id, category_id, stale_id, 5, today - timedelta(days=120))
+    await _record_merchant_transactions(client, headers, account_id, category_id, fresh_id, 1, today)
 
     resp = await client.get("/merchants", headers=headers)
 
     assert resp.status_code == 200
-    assert _own_merchant_names(resp) == ["Fresh Store", "Stale Store"]
+    assert _own_merchant_names(resp) == ["Stale Store", "Fresh Store"]
 
 
-async def test_list_merchants_ranks_by_all_history_when_shorter_than_window(client):
-    """A user whose entire history fits inside the window ranks by every transaction."""
+async def test_list_merchants_ranks_recent_use_above_equally_frequent_older_use(client):
+    """Two merchants used the same number of times are separated by how recent those uses are."""
     headers = _get_auth_header(await _create_user(client))
     category_id = await _get_system_category_id(client, headers)
     account_id = await _create_checking_account(client, headers)
-    earliest_date = date.today() - timedelta(days=10)
-    latest_date = date.today() - timedelta(days=1)
+    today = _user_today()
 
-    busy_id = (await _create_merchant(client, headers, name="Busy Store")).json()["id"]
-    quiet_id = (await _create_merchant(client, headers, name="Quiet Store")).json()["id"]
-    await _record_merchant_transactions(client, headers, account_id, category_id, busy_id, 2, earliest_date)
-    await _record_merchant_transactions(client, headers, account_id, category_id, quiet_id, 1, latest_date)
+    # Both ages sit inside the 90-day window the old ranking counted, where these tied at three
+    # transactions each and sorted alphabetically. Names run against recency so only the decay
+    # can produce the order below
+    recent_id = (await _create_merchant(client, headers, name="Zulu Cafe")).json()["id"]
+    older_id = (await _create_merchant(client, headers, name="Alpha Cafe")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, recent_id, 3, today - timedelta(days=10))
+    await _record_merchant_transactions(client, headers, account_id, category_id, older_id, 3, today - timedelta(days=80))
 
     resp = await client.get("/merchants", headers=headers)
 
     assert resp.status_code == 200
-    assert _own_merchant_names(resp) == ["Busy Store", "Quiet Store"]
+    assert _own_merchant_names(resp) == ["Zulu Cafe", "Alpha Cafe"]
+
+
+async def test_list_merchants_counts_usage_at_the_cutoff(client):
+    """A transaction dated exactly at the cutoff still counts, so its merchant beats an unused one."""
+    headers = _get_auth_header(await _create_user(client))
+    category_id = await _get_system_category_id(client, headers)
+    account_id = await _create_checking_account(client, headers)
+    # Sits on the boundary deliberately, which is also why it is the one test here that midnight
+    # passing between this line and the request would flip
+    cutoff_date = _user_today() - timedelta(days=MERCHANT_USAGE_CUTOFF_DAYS)
+
+    used_id = (await _create_merchant(client, headers, name="Zulu Depot")).json()["id"]
+    await _create_merchant(client, headers, name="Alpha Depot")
+    await _record_merchant_transactions(client, headers, account_id, category_id, used_id, 1, cutoff_date)
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == 200
+    assert _own_merchant_names(resp) == ["Zulu Depot", "Alpha Depot"]
+
+
+async def test_list_merchants_ignores_usage_past_the_cutoff(client):
+    """Transactions older than the cutoff score nothing, so their merchant sorts among the unused."""
+    headers = _get_auth_header(await _create_user(client))
+    category_id = await _get_system_category_id(client, headers)
+    account_id = await _create_checking_account(client, headers)
+    today = _user_today()
+
+    # One day past the cutoff, pinning the excluded side of the boundary the way its sibling
+    # test pins the counted side
+    past_cutoff_date = today - timedelta(days=MERCHANT_USAGE_CUTOFF_DAYS + 1)
+
+    # Named to sort behind the merchant that was never used, so counting these transactions at all
+    # would lift it past that one. Naming it ahead would put it where a wrong answer lands anyway
+    past_cutoff_id = (await _create_merchant(client, headers, name="Zulu Bazaar")).json()["id"]
+    fresh_id = (await _create_merchant(client, headers, name="Fresh Store")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, past_cutoff_id, 5, past_cutoff_date)
+    await _record_merchant_transactions(client, headers, account_id, category_id, fresh_id, 1, today)
+
+    # Never used at all, and tied at zero with the merchant whose usage the cutoff discarded
+    await _create_merchant(client, headers, name="Beta Store")
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == 200
+    assert _own_merchant_names(resp) == ["Fresh Store", "Beta Store", "Zulu Bazaar"]
+
+
+async def test_list_merchants_ignores_future_dated_transactions(client):
+    """A transaction dated ahead of the user's today counts for nothing until that date arrives."""
+    headers = _get_auth_header(await _create_user(client))
+    category_id = await _get_system_category_id(client, headers)
+    account_id = await _create_checking_account(client, headers)
+    today = _user_today()
+
+    scheduled_id = (await _create_merchant(client, headers, name="Alpha Utility")).json()["id"]
+    used_id = (await _create_merchant(client, headers, name="Zulu Utility")).json()["id"]
+    await _record_merchant_transactions(client, headers, account_id, category_id, scheduled_id, 3, today + timedelta(days=30))
+    await _record_merchant_transactions(client, headers, account_id, category_id, used_id, 1, today)
+
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == 200
+    assert _own_merchant_names(resp) == ["Zulu Utility", "Alpha Utility"]

--- a/backend/tests/routes/test_stored_timezone.py
+++ b/backend/tests/routes/test_stored_timezone.py
@@ -182,6 +182,20 @@ async def test_the_category_listing_refuses_an_unresolvable_stored_timezone(clie
     assert UNRESOLVABLE_IDENTIFIER in resp.json()["detail"]
 
 
+async def test_the_merchant_listing_refuses_an_unresolvable_stored_timezone(client):
+    """The reader is told which value is at fault instead of getting a server error"""
+    signup_resp = await _create_user(client)
+    headers = _get_auth_header(signup_resp)
+    await _store_unresolvable_timezone()
+
+    # Merchants are ranked by how old each transaction is against the reader's own day, so the zone
+    # is needed before any row is read and a reader owning no merchants is refused just the same
+    resp = await client.get("/merchants", headers=headers)
+
+    assert resp.status_code == status.HTTP_422_UNPROCESSABLE_CONTENT
+    assert UNRESOLVABLE_IDENTIFIER in resp.json()["detail"]
+
+
 async def test_a_group_account_refusal_says_the_owner_setting_is_at_fault(client):
     """A group account is dated on its owner's day, which the member creating it cannot fix"""
     await _seed_currency()

--- a/frontend/src/pages/settings/components/merchant-settings-section/hooks/useList.ts
+++ b/frontend/src/pages/settings/components/merchant-settings-section/hooks/useList.ts
@@ -11,9 +11,10 @@ import {
  *
  * Rows key on id, name and default category together, rather than id alone, so an inline edit
  * that changes the name or default category re-reveals the row instead of leaving it showing
- * stale text until the next unrelated refetch. The server's own order, recent usage then name,
- * is left untouched: re-sorting here would interleave each new page among the loaded rows and
- * reshuffle the list on every load
+ * stale text until the next unrelated refetch. The server's own order, a usage score that fades
+ * with age and then name, is not re-sorted here, since that would interleave each new page among
+ * the loaded rows and reshuffle the list on every load. Creating or editing a merchant still loses
+ * it, because the cache update re-sorts every loaded page by name, an inline rename included
  */
 export function useMerchantSettingsList(locallyDeletedMerchantIds: string[]) {
   const {

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useMerchantField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useMerchantField.ts
@@ -101,8 +101,9 @@ export function useMerchantField({
     return [...map.values()]
   }, [createdMerchant, merchantReference.visibleItems])
 
-  // The backend already ranks merchants by recent usage then name, so preserve that order
-  // here instead of re-sorting and place any just-created merchant at the end
+  // The backend already ranks merchants by a usage score that fades with age, then name, so this
+  // keeps whatever order the loaded pages are in rather than re-sorting them. Creating or editing
+  // a merchant does lose that order, because the cache update re-sorts every loaded page by name
   const merchantOptions = useMemo(
     () => merchantCandidates.map((m) => ({ value: m.id, label: m.name })),
     [merchantCandidates],


### PR DESCRIPTION
The merchant picker counted only the last 90 days of transactions, so a heavily used merchant scored nothing once three months had passed since its last use, and lost to one used a single time this morning. It now ranks by how often a merchant is used, and an older transaction counts for less: the weight halves every 90 days, and anything past two years counts for nothing. Age is measured against the user's own date rather than the server's, so a transaction dated in the future doesn't count until that day arrives.