### PR TITLE
fix: lock the filter's amount range until currencies load

### DIFF
--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -56,7 +56,7 @@ const MIN_DELETE_SPINNER_MS = 1000
  * Coordinates account identity edits, archive changes, and destructive deletion from one modal workflow
  *
  * Opens whether or not the currency table arrived. Everything except the credit limit is independent of
- * it, and that one field stands down when the account's currency is missing from the table, since its
+ * it, and that one field locks when the account's currency is missing from the table, since its
  * stored amount can only be read or written through that currency's decimal places
  */
 export default function EditAccountIdentityModal({

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -8,11 +8,17 @@ import { FacetSelectDropdown } from '@/components/list-controls/FacetSelectDropd
 import { FILTER_GLASS_SPRING } from '@/components/list-controls/toolbarStyles'
 import { joinClassNames } from '@/utils/classNames'
 import { getMoneyPlaceholder } from '@/utils/moneyInput'
+import {
+  CURRENCY_AMOUNT_NOTICE,
+  CURRENCY_AMOUNT_UNKNOWN,
+  CURRENCY_LIST_LOADING,
+  type CurrencyListState,
+} from '@/utils/currencyStatus'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
 import { ReferenceFacet } from '@/pages/transactions/components/toolbar/ReferenceFacet'
+import type { AmountDraft } from '@/pages/transactions/utils/amountRange'
 import {
   FILTER_FACETS,
-  type AmountDraft,
   type FacetConfig,
   type MultiSelections,
   type TransactionFilterDraft,
@@ -23,6 +29,16 @@ const NO_DISABLED_FACETS = new Set<string>()
 
 // The account facet is disabled on an account's own transaction list, where the scope is fixed
 const ACCOUNT_DISABLED_FACETS = new Set(['accounts'])
+
+/**
+ * Names why the amount range cannot be shown or changed, for the line the currency note usually holds
+ */
+function getAmountLockNote(currencyListState: CurrencyListState): string {
+  if (currencyListState === 'loading') return CURRENCY_LIST_LOADING
+  if (currencyListState === 'unavailable') return CURRENCY_AMOUNT_NOTICE
+
+  return CURRENCY_AMOUNT_UNKNOWN
+}
 
 /**
  * Renders the shared filter panel body: the facet tabs, the active facet editor, the removable
@@ -135,7 +151,7 @@ export function FilterPanelBody({
             exit={{ opacity: 0 }}
             transition={{ duration: shouldReduceMotion ? 0 : 0.15 }}
           >
-            <FacetEditor
+            <SectionEditor
               facet={activeFacet}
               options={draft.getFacetOptions(activeFacet.id)}
               selectedValues={draft.selections[activeFacet.id] ?? []}
@@ -145,6 +161,8 @@ export function FilterPanelBody({
               amountSymbol={draft.amountSymbol}
               amountCurrencyNote={draft.amountCurrencyNote}
               amountExponent={draft.amountExponent}
+              isAmountLocked={draft.isAmountLocked}
+              currencyListState={draft.currencyListState}
               hasCrossedAmountBounds={draft.hasCrossedAmountBounds}
               amountRangeMessageId={amountRangeMessageId}
               hasCrossedDateRange={draft.hasCrossedDateRange}
@@ -258,7 +276,7 @@ function DateFacetInput({
   )
 }
 
-type FacetEditorProps = {
+type SectionEditorProps = {
   facet: FacetConfig
   options: OptionItem[]
   selectedValues: string[]
@@ -269,6 +287,11 @@ type FacetEditorProps = {
   amountCurrencyNote: string
   // Decimal places of the currency the amount range matches, for parsing and normalizing input
   amountExponent: number
+  // Passed down rather than recomputed here, so the section the draft treats as locked is the one
+  // the user sees disabled
+  isAmountLocked: boolean
+  // Which of the reasons the amount section is locked, for the message shown in its place
+  currencyListState: CurrencyListState
   // True while the minimum sits above the maximum once both are rounded to the currency's minor
   // units, which no transaction can satisfy
   hasCrossedAmountBounds: boolean
@@ -297,10 +320,10 @@ type FacetEditorProps = {
 }
 
 /**
- * Renders the editor for the active facet: a searchable list for multi-select facets, a server
- * search for merchants and tags, and labelled inputs for the amount and date ranges
+ * Renders the editor for the section being edited: a searchable list for the multi-select ones, a
+ * server search for merchants and tags, and labelled inputs for the amount and date ranges
  */
-function FacetEditor({
+function SectionEditor({
   facet,
   options,
   selectedValues,
@@ -310,6 +333,8 @@ function FacetEditor({
   amountSymbol,
   amountCurrencyNote,
   amountExponent,
+  isAmountLocked,
+  currencyListState,
   hasCrossedAmountBounds,
   amountRangeMessageId,
   hasCrossedDateRange,
@@ -325,7 +350,7 @@ function FacetEditor({
   onTagMatchChange,
   onAmountChange,
   onDateRangeChange,
-}: FacetEditorProps) {
+}: SectionEditorProps) {
   const shouldReduceMotion = useReducedMotion()
   const tagMatchThumbId = useId()
   // Called on every render regardless of facet kind so the rules of hooks hold, since the amount
@@ -366,7 +391,10 @@ function FacetEditor({
                       key={option.value}
                       type="button"
                       aria-pressed={isSelected}
-                      className="rounded-full border px-3 py-1 text-sm transition-colors hover:bg-[var(--app-accent-soft)]"
+                      // Picking the currency is what decides which minor units the bounds are counted
+                      // in, so it goes dead with them rather than letting the two come apart
+                      disabled={isAmountLocked}
+                      className="rounded-full border px-3 py-1 text-sm transition-colors hover:bg-[var(--app-accent-soft)] disabled:cursor-not-allowed disabled:opacity-60"
                       style={
                         isSelected
                           ? { background: 'var(--app-accent-soft)', borderColor: 'transparent', color: 'var(--app-accent)', fontWeight: 500 }
@@ -400,8 +428,9 @@ function FacetEditor({
                   </span>
                 )}
                 <input
-                  className={joinClassNames('app-input', amountSymbol && 'pl-8', hasCrossedAmountBounds && 'app-input-error')}
-                  placeholder={getMoneyPlaceholder(amountExponent)}
+                  className={joinClassNames('app-input disabled:cursor-not-allowed disabled:opacity-60', amountSymbol && 'pl-8', hasCrossedAmountBounds && 'app-input-error')}
+                  placeholder={isAmountLocked ? undefined : getMoneyPlaceholder(amountExponent)}
+                  disabled={isAmountLocked}
                   aria-invalid={hasCrossedAmountBounds}
                   aria-describedby={hasCrossedAmountBounds ? amountRangeMessageId : undefined}
                   {...minAmountInput}
@@ -423,8 +452,9 @@ function FacetEditor({
                   </span>
                 )}
                 <input
-                  className={joinClassNames('app-input', amountSymbol && 'pl-8', hasCrossedAmountBounds && 'app-input-error')}
-                  placeholder="Any"
+                  className={joinClassNames('app-input disabled:cursor-not-allowed disabled:opacity-60', amountSymbol && 'pl-8', hasCrossedAmountBounds && 'app-input-error')}
+                  placeholder={isAmountLocked ? undefined : 'Any'}
+                  disabled={isAmountLocked}
                   aria-invalid={hasCrossedAmountBounds}
                   aria-describedby={hasCrossedAmountBounds ? amountRangeMessageId : undefined}
                   {...maxAmountInput}
@@ -433,7 +463,7 @@ function FacetEditor({
             </label>
           </div>
           <p className="px-0.5 text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-            {amountCurrencyNote}
+            {isAmountLocked ? getAmountLockNote(currencyListState) : amountCurrencyNote}
           </p>
         </div>
       </div>

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -12,6 +12,7 @@ import {
   CURRENCY_RANGE_LOADING,
   CURRENCY_RANGE_NOTICE,
   CURRENCY_RANGE_UNKNOWN,
+  CURRENCY_REFRESH_ACTION,
   type CurrencyListState,
 } from '@/utils/currencyStatus'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
@@ -32,12 +33,28 @@ const ACCOUNT_DISABLED_FACETS = new Set(['accounts'])
 
 /**
  * Names why the amount range cannot be shown or changed, for the line the currency note usually holds
+ *
+ * A failed list is the one case the user can act on, so the way out is a control that reloads rather
+ * than a sentence telling them to do it themselves
  */
-function getAmountLockNote(currencyListState: CurrencyListState): string {
+function AmountLockNote({ currencyListState }: { currencyListState: CurrencyListState }) {
   if (currencyListState === 'loading') return CURRENCY_RANGE_LOADING
-  if (currencyListState === 'unavailable') return CURRENCY_RANGE_NOTICE
+  if (currencyListState !== 'unavailable') return CURRENCY_RANGE_UNKNOWN
 
-  return CURRENCY_RANGE_UNKNOWN
+  return (
+    <>
+      {CURRENCY_RANGE_NOTICE}{' '}
+      <button
+        type="button"
+        className="underline underline-offset-2"
+        style={{ color: 'inherit' }}
+        onClick={() => window.location.reload()}
+      >
+        {CURRENCY_REFRESH_ACTION}
+      </button>
+      .
+    </>
+  )
 }
 
 /**
@@ -468,8 +485,13 @@ function SectionEditor({
               </div>
             </label>
           </div>
-          <p className="px-0.5 text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-            {isAmountLocked ? getAmountLockNote(currencyListState) : amountCurrencyNote}
+          {/* A locked range takes the warning colour rather than the muted one the currency note
+              uses, so the reason the fields cannot be typed into carries the weight the fields lost */}
+          <p
+            className="px-0.5 text-xs"
+            style={{ color: isAmountLocked ? 'var(--app-warning-text)' : 'var(--app-text-subtle)' }}
+          >
+            {isAmountLocked ? <AmountLockNote currencyListState={currencyListState} /> : amountCurrencyNote}
           </p>
         </div>
       </div>

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -9,9 +9,9 @@ import { FILTER_GLASS_SPRING } from '@/components/list-controls/toolbarStyles'
 import { joinClassNames } from '@/utils/classNames'
 import { getMoneyPlaceholder } from '@/utils/moneyInput'
 import {
-  CURRENCY_AMOUNT_NOTICE,
-  CURRENCY_AMOUNT_UNKNOWN,
-  CURRENCY_LIST_LOADING,
+  CURRENCY_RANGE_LOADING,
+  CURRENCY_RANGE_NOTICE,
+  CURRENCY_RANGE_UNKNOWN,
   type CurrencyListState,
 } from '@/utils/currencyStatus'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
@@ -34,10 +34,10 @@ const ACCOUNT_DISABLED_FACETS = new Set(['accounts'])
  * Names why the amount range cannot be shown or changed, for the line the currency note usually holds
  */
 function getAmountLockNote(currencyListState: CurrencyListState): string {
-  if (currencyListState === 'loading') return CURRENCY_LIST_LOADING
-  if (currencyListState === 'unavailable') return CURRENCY_AMOUNT_NOTICE
+  if (currencyListState === 'loading') return CURRENCY_RANGE_LOADING
+  if (currencyListState === 'unavailable') return CURRENCY_RANGE_NOTICE
 
-  return CURRENCY_AMOUNT_UNKNOWN
+  return CURRENCY_RANGE_UNKNOWN
 }
 
 /**
@@ -162,6 +162,7 @@ export function FilterPanelBody({
               amountCurrencyNote={draft.amountCurrencyNote}
               amountExponent={draft.amountExponent}
               isAmountLocked={draft.isAmountLocked}
+              isAmountCurrencyLocked={draft.isAmountCurrencyLocked}
               currencyListState={draft.currencyListState}
               hasCrossedAmountBounds={draft.hasCrossedAmountBounds}
               amountRangeMessageId={amountRangeMessageId}
@@ -287,10 +288,13 @@ type SectionEditorProps = {
   amountCurrencyNote: string
   // Decimal places of the currency the amount range matches, for parsing and normalizing input
   amountExponent: number
-  // Passed down rather than recomputed here, so the section the draft treats as locked is the one
+  // Passed down rather than recomputed here, so the fields the draft treats as locked are the ones
   // the user sees disabled
   isAmountLocked: boolean
-  // Which of the reasons the amount section is locked, for the message shown in its place
+  // True only while an applied bound is waiting for its currency, which is when changing the choice
+  // would leave that bound counted in a currency nothing on screen names
+  isAmountCurrencyLocked: boolean
+  // Which of the reasons the fields are locked, for the note under them
   currencyListState: CurrencyListState
   // True while the minimum sits above the maximum once both are rounded to the currency's minor
   // units, which no transaction can satisfy
@@ -321,7 +325,8 @@ type SectionEditorProps = {
 
 /**
  * Renders the editor for the section being edited: a searchable list for the multi-select ones, a
- * server search for merchants and tags, and labelled inputs for the amount and date ranges
+ * server search for merchants and tags, a currency chip row and two bounds for the amount, and
+ * labelled inputs for the date range
  */
 function SectionEditor({
   facet,
@@ -334,6 +339,7 @@ function SectionEditor({
   amountCurrencyNote,
   amountExponent,
   isAmountLocked,
+  isAmountCurrencyLocked,
   currencyListState,
   hasCrossedAmountBounds,
   amountRangeMessageId,
@@ -391,9 +397,9 @@ function SectionEditor({
                       key={option.value}
                       type="button"
                       aria-pressed={isSelected}
-                      // Picking the currency is what decides which minor units the bounds are counted
-                      // in, so it goes dead with them rather than letting the two come apart
-                      disabled={isAmountLocked}
+                      // Picking the currency is what decides which minor units a bound is counted in,
+                      // so the choice is held still while an applied bound is waiting for its own
+                      disabled={isAmountCurrencyLocked}
                       className="rounded-full border px-3 py-1 text-sm transition-colors hover:bg-[var(--app-accent-soft)] disabled:cursor-not-allowed disabled:opacity-60"
                       style={
                         isSelected

--- a/frontend/src/pages/transactions/components/toolbar/hooks/useRestoreAmountRange.ts
+++ b/frontend/src/pages/transactions/components/toolbar/hooks/useRestoreAmountRange.ts
@@ -15,6 +15,10 @@ import type { TransactionListFilters } from '@/pages/transactions/types/transact
  * back over it. Only an applied bound that could not be shown arms the fill, and the fields refuse
  * input for as long as one is waiting, so nothing typed can be overwritten
  *
+ * Nothing reaches this yet: applied filters are held in component state that a page load clears, and
+ * the currency table never leaves the cache once it arrives, so a bound can only be applied while its
+ * decimal places are already known. Filters that survive a page load are what make it live
+ *
  * @param filters - The applied filters, whose bounds are what gets restored
  * @param currencies - The currency table, which is empty until it downloads
  * @param setAmount - Writes the bounds into the draft

--- a/frontend/src/pages/transactions/components/toolbar/hooks/useRestoreAmountRange.ts
+++ b/frontend/src/pages/transactions/components/toolbar/hooks/useRestoreAmountRange.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef, type Dispatch, type SetStateAction } from 'react'
+import type { Currency } from '@/api/currency'
+import {
+  findAmountRangeDraft,
+  isAppliedRangeWaitingOnCurrency,
+  type AmountDraft,
+} from '@/pages/transactions/utils/amountRange'
+import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
+
+/**
+ * Fills the amount bounds in when their currency's decimal places arrive, for a filter panel that
+ * seeded them blank because it opened before the currency table did
+ *
+ * Without this the fields unlock empty over an applied range, and the next Apply writes that blank
+ * back over it. Only an applied bound that could not be shown arms the fill, and the fields refuse
+ * input for as long as one is waiting, so nothing typed can be overwritten
+ *
+ * @param filters - The applied filters, whose bounds are what gets restored
+ * @param currencies - The currency table, which is empty until it downloads
+ * @param setAmount - Writes the bounds into the draft
+ * @returns Records whether there is anything to restore, for the draft to call as it seeds
+ */
+export function useRestoreAmountRange(
+  filters: TransactionListFilters,
+  currencies: Currency[],
+  setAmount: Dispatch<SetStateAction<AmountDraft>>,
+): () => void {
+  const waitingRef = useRef(isAppliedRangeWaitingOnCurrency(filters, currencies))
+
+  useEffect(() => {
+    if (!waitingRef.current) return
+
+    const appliedAmount = findAmountRangeDraft(filters, currencies)
+    if (appliedAmount === null) return
+
+    waitingRef.current = false
+    setAmount(appliedAmount)
+  }, [filters, currencies, setAmount])
+
+  // Re-armed by each seeding rather than on an open prop, since the desktop pill seeds from its own
+  // open handler and the mobile sheet from the rising edge of its open prop, and only the draft
+  // itself is called by both
+  return useCallback(() => {
+    waitingRef.current = isAppliedRangeWaitingOnCurrency(filters, currencies)
+  }, [filters, currencies])
+}

--- a/frontend/src/pages/transactions/components/toolbar/useTransactionFilterDraft.ts
+++ b/frontend/src/pages/transactions/components/toolbar/useTransactionFilterDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Bookmark, Calendar, Coins, Store, Tag, Wallet } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { OptionItem } from '@/components/filters/OptionList'
@@ -14,9 +14,11 @@ import {
   findAmountRangeDraft,
   isAmountRangeCrossed,
   isAmountRangeLocked,
+  isAppliedRangeWaitingOnCurrency,
   type AmountDraft,
 } from '@/pages/transactions/utils/amountRange'
 import { isDateRangeCrossed } from '@/pages/transactions/utils/dateRange'
+import { useRestoreAmountRange } from '@/pages/transactions/components/toolbar/hooks/useRestoreAmountRange'
 import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
 import type { TransactionFilterSetter } from '@/pages/transactions/components/toolbar/types'
 
@@ -123,10 +125,14 @@ export function useTransactionFilterDraft({
   const amountCurrency = lockedCurrency ?? selections.currency[0] ?? baseCurrency
   const amountSymbol = currencies.find((currency) => currency.id === amountCurrency)?.symbol ?? ''
   const amountExponent = getCurrencyExponent(currencies, amountCurrency)
-  // The whole amount section is dead while its currency's decimal places are unknown, since neither
-  // the stored bounds nor a typed one means anything without them. Decided here rather than in the
-  // body, so the section the draft treats as locked is the section the user sees disabled
-  const isAmountLocked = isAmountRangeLocked(currencies, amountCurrency)
+  // Both fields refuse input while the decimal places are unknown, since a bound typed against the
+  // two-place fallback would be stored at the wrong scale. Decided here rather than in the body, so
+  // the fields the draft treats as locked are the fields the user sees disabled
+  const isAmountLocked = isAmountRangeLocked(filters, currencies, amountCurrency)
+  // The currency choice decides which minor units a bound is counted in, so it is held still only
+  // while an applied bound is waiting for that currency to arrive, which is the one case where
+  // changing it would leave the applied bounds counted in a currency nothing on screen names
+  const isAmountCurrencyLocked = isAppliedRangeWaitingOnCurrency(filters, currencies)
   const hasCrossedAmountBounds = isAmountRangeCrossed(amount, amountExponent)
   const amountCurrencyNote = currencyLocked
     ? `Amounts are matched in ${amountCurrency}, this account's currency`
@@ -166,9 +172,7 @@ export function useTransactionFilterDraft({
     return []
   }
 
-  // Whether the last seeding left the bounds blank because the decimal places were unknown, which is
-  // the only case with anything to fill in later
-  const seededWhileLockedRef = useRef(isAmountLocked)
+  const armAmountRestore = useRestoreAmountRange(filters, currencies, setAmount)
 
   /**
    * Reseeds the draft from the applied filters so opening starts clean and dismissing discards any
@@ -189,23 +193,12 @@ export function useTransactionFilterDraft({
     })
     setTagMatch(filters.tag_match ?? 'all')
     setDateRange({ from: filters.from_date ?? '', to: filters.to_date ?? '' })
-    // Stored bounds are in the minor units of the currency they were applied in, which is not
+    // Applied bounds are in the minor units of the currency they were applied in, which is not
     // necessarily the one the draft is now editing. They stay blank until that currency's decimal
-    // places are known, and the effect below fills them in once they are
-    const storedAmount = findAmountRangeDraft(filters, currencies)
-    seededWhileLockedRef.current = storedAmount === null
-    setAmount(storedAmount ?? EMPTY_AMOUNT)
-  }, [filters, currencies, showAccountFilter, currencyLocked])
-
-  // Fills the bounds in when the decimal places arrive, for a panel that opened before the currency
-  // table did and therefore seeded them blank. The whole section is disabled for as long as this is
-  // armed, so the fill can never land on an amount being typed
-  useEffect(() => {
-    if (isAmountLocked || !seededWhileLockedRef.current) return
-
-    seededWhileLockedRef.current = false
+    // places are known, and the restore above fills them in once they are
+    armAmountRestore()
     setAmount(findAmountRangeDraft(filters, currencies) ?? EMPTY_AMOUNT)
-  }, [isAmountLocked, filters, currencies])
+  }, [filters, currencies, showAccountFilter, currencyLocked, armAmountRestore])
 
   /**
    * Adds or removes a value from a facet draft, recording the label for server-searched facets
@@ -255,9 +248,9 @@ export function useTransactionFilterDraft({
 
   /**
    * Commits the draft to the applied filters, converting the amount bounds into the matched
-   * currency's minor units, then closes the panel. An amount or date range whose bounds exclude
-   * each other is refused, leaving the panel open on the message rather than closing on a list that
-   * cannot have results
+   * currency's minor units, then closes whichever presentation is open. An amount or date range
+   * whose bounds exclude each other is refused, staying open on the message rather than closing on
+   * a list that cannot have results
    */
   function applyFilters() {
     if (isApplyBlocked) return
@@ -296,6 +289,7 @@ export function useTransactionFilterDraft({
     amountExponent,
     amountCurrencyNote,
     isAmountLocked,
+    isAmountCurrencyLocked,
     currencyListState,
     hasCrossedAmountBounds,
     hasCrossedDateRange,

--- a/frontend/src/pages/transactions/components/toolbar/useTransactionFilterDraft.ts
+++ b/frontend/src/pages/transactions/components/toolbar/useTransactionFilterDraft.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Bookmark, Calendar, Coins, Store, Tag, Wallet } from 'lucide-react'
 import type { LucideIcon } from 'lucide-react'
 import type { OptionItem } from '@/components/filters/OptionList'
@@ -7,8 +7,15 @@ import { useCurrencies } from '@/api/currency'
 import { useMerchantDetails } from '@/api/merchants'
 import { useTagDetails } from '@/api/tags'
 import { useAuth } from '@/hooks/useAuth'
-import { fromMinorUnits, getCurrencyExponent, toMinorUnits } from '@/utils/moneyInput'
-import { isAmountRangeCrossed } from '@/pages/transactions/utils/amountRange'
+import { useCurrencyListState } from '@/hooks/useCurrencyListState'
+import { getCurrencyExponent } from '@/utils/moneyInput'
+import {
+  buildAmountFilterPatch,
+  findAmountRangeDraft,
+  isAmountRangeCrossed,
+  isAmountRangeLocked,
+  type AmountDraft,
+} from '@/pages/transactions/utils/amountRange'
 import { isDateRangeCrossed } from '@/pages/transactions/utils/dateRange'
 import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
 import type { TransactionFilterSetter } from '@/pages/transactions/components/toolbar/types'
@@ -37,7 +44,7 @@ export const FILTER_FACETS: FacetConfig[] = [
 
 export type MultiSelections = Record<string, string[]>
 
-export type AmountDraft = { min: string; max: string }
+const EMPTY_AMOUNT: AmountDraft = { min: '', max: '' }
 
 const EMPTY_SELECTIONS: MultiSelections = {
   accounts: [],
@@ -82,10 +89,11 @@ export function useTransactionFilterDraft({
   // Resolved names for selected merchants and tags, kept so the summary and the pinned rows stay
   // readable after the server search moves on
   const [referenceLabels, setReferenceLabels] = useState<Record<string, string>>({})
-  const [amount, setAmount] = useState<AmountDraft>({ min: '', max: '' })
+  const [amount, setAmount] = useState<AmountDraft>(EMPTY_AMOUNT)
   const [dateRange, setDateRange] = useState({ from: '', to: '' })
   const { user } = useAuth()
   const { data: currencies = [] } = useCurrencies()
+  const currencyListState = useCurrencyListState()
   const { data: accounts = [] } = useAccounts()
 
   // Merchant and tag names are only cached for the session they are picked in, so reopening the
@@ -115,6 +123,10 @@ export function useTransactionFilterDraft({
   const amountCurrency = lockedCurrency ?? selections.currency[0] ?? baseCurrency
   const amountSymbol = currencies.find((currency) => currency.id === amountCurrency)?.symbol ?? ''
   const amountExponent = getCurrencyExponent(currencies, amountCurrency)
+  // The whole amount section is dead while its currency's decimal places are unknown, since neither
+  // the stored bounds nor a typed one means anything without them. Decided here rather than in the
+  // body, so the section the draft treats as locked is the section the user sees disabled
+  const isAmountLocked = isAmountRangeLocked(currencies, amountCurrency)
   const hasCrossedAmountBounds = isAmountRangeCrossed(amount, amountExponent)
   const amountCurrencyNote = currencyLocked
     ? `Amounts are matched in ${amountCurrency}, this account's currency`
@@ -154,6 +166,10 @@ export function useTransactionFilterDraft({
     return []
   }
 
+  // Whether the last seeding left the bounds blank because the decimal places were unknown, which is
+  // the only case with anything to fill in later
+  const seededWhileLockedRef = useRef(isAmountLocked)
+
   /**
    * Reseeds the draft from the applied filters so opening starts clean and dismissing discards any
    * uncommitted edits
@@ -174,11 +190,22 @@ export function useTransactionFilterDraft({
     setTagMatch(filters.tag_match ?? 'all')
     setDateRange({ from: filters.from_date ?? '', to: filters.to_date ?? '' })
     // Stored bounds are in the minor units of the currency they were applied in, which is not
-    // necessarily the one the draft is now editing
-    const exponent = getCurrencyExponent(currencies, filters.amount_currency ?? '')
-    const toInput = (value?: number) => fromMinorUnits(value ?? null, exponent)
-    setAmount({ min: toInput(filters.min_amount), max: toInput(filters.max_amount) })
+    // necessarily the one the draft is now editing. They stay blank until that currency's decimal
+    // places are known, and the effect below fills them in once they are
+    const storedAmount = findAmountRangeDraft(filters, currencies)
+    seededWhileLockedRef.current = storedAmount === null
+    setAmount(storedAmount ?? EMPTY_AMOUNT)
   }, [filters, currencies, showAccountFilter, currencyLocked])
+
+  // Fills the bounds in when the decimal places arrive, for a panel that opened before the currency
+  // table did and therefore seeded them blank. The whole section is disabled for as long as this is
+  // armed, so the fill can never land on an amount being typed
+  useEffect(() => {
+    if (isAmountLocked || !seededWhileLockedRef.current) return
+
+    seededWhileLockedRef.current = false
+    setAmount(findAmountRangeDraft(filters, currencies) ?? EMPTY_AMOUNT)
+  }, [isAmountLocked, filters, currencies])
 
   /**
    * Adds or removes a value from a facet draft, recording the label for server-searched facets
@@ -208,7 +235,7 @@ export function useTransactionFilterDraft({
    */
   function clearAll() {
     setSelections(EMPTY_SELECTIONS)
-    setAmount({ min: '', max: '' })
+    setAmount(EMPTY_AMOUNT)
     setDateRange({ from: '', to: '' })
     setFilter({
       account_id: undefined,
@@ -228,17 +255,20 @@ export function useTransactionFilterDraft({
 
   /**
    * Commits the draft to the applied filters, converting the amount bounds into the matched
-   * currency's minor units, then closes the surface. An amount or date range whose bounds exclude
+   * currency's minor units, then closes the panel. An amount or date range whose bounds exclude
    * each other is refused, leaving the panel open on the message rather than closing on a list that
    * cannot have results
    */
   function applyFilters() {
     if (isApplyBlocked) return
 
-    // toMinorUnits returns null rather than undefined for a blank amount, so the setFilter payload
-    // below converts it back to keep min_amount and max_amount optional
-    const toMinor = (value: string) => toMinorUnits(value, amountExponent) ?? undefined
-    const hasAmount = Boolean(amount.min.trim() || amount.max.trim())
+    const appliedAmount = buildAmountFilterPatch({
+      amount,
+      amountCurrency,
+      exponent: amountExponent,
+      isLocked: isAmountLocked,
+      filters,
+    })
 
     setFilter({
       account_id: selections.accounts,
@@ -247,9 +277,7 @@ export function useTransactionFilterDraft({
       tag_id: selections.tags,
       tag_match: selections.tags.length > 0 ? tagMatch : undefined,
       currency: selections.currency[0],
-      min_amount: toMinor(amount.min),
-      max_amount: toMinor(amount.max),
-      amount_currency: hasAmount ? amountCurrency : undefined,
+      ...appliedAmount,
       from_date: dateRange.from || undefined,
       to_date: dateRange.to || undefined,
     })
@@ -267,6 +295,8 @@ export function useTransactionFilterDraft({
     amountSymbol,
     amountExponent,
     amountCurrencyNote,
+    isAmountLocked,
+    currencyListState,
     hasCrossedAmountBounds,
     hasCrossedDateRange,
     isApplyBlocked,

--- a/frontend/src/pages/transactions/utils/amountRange.ts
+++ b/frontend/src/pages/transactions/utils/amountRange.ts
@@ -1,4 +1,12 @@
-import { toMinorUnits } from '@/utils/moneyInput'
+import { findCurrencyExponent, fromMinorUnits, toMinorUnits } from '@/utils/moneyInput'
+import type { Currency } from '@/api/currency'
+import type { TransactionListFilters } from '@/pages/transactions/types/transactionList'
+
+/** The minimum and maximum as the fields hold them, in the plain format a money field takes */
+export type AmountDraft = { min: string; max: string }
+
+/** The applied bounds and the currency their minor units belong to */
+type AppliedAmountRange = Pick<TransactionListFilters, 'min_amount' | 'max_amount' | 'amount_currency'>
 
 /**
  * Reports whether the amount filter's bounds exclude each other, which no transaction can satisfy
@@ -10,9 +18,87 @@ import { toMinorUnits } from '@/utils/moneyInput'
  * @param amount - The minimum and maximum as the fields hold them
  * @param exponent - Decimal places of the currency the range matches in
  */
-export function isAmountRangeCrossed(amount: { min: string; max: string }, exponent: number): boolean {
+export function isAmountRangeCrossed(amount: AmountDraft, exponent: number): boolean {
   const min = toMinorUnits(amount.min, exponent)
   const max = toMinorUnits(amount.max, exponent)
 
   return min !== null && max !== null && min > max
+}
+
+/**
+ * Reports whether the amount range can be shown or edited at all, which it cannot while the decimal
+ * places of the currency it matches in are unknown
+ *
+ * @param currencies - The currency table, which is empty until it downloads
+ * @param amountCurrency - The currency the range matches in
+ */
+export function isAmountRangeLocked(currencies: Currency[], amountCurrency: string): boolean {
+  return findCurrencyExponent(currencies, amountCurrency) === null
+}
+
+/**
+ * Converts the applied bounds into the text the fields hold, or returns null when the decimal places
+ * of the currency they were applied in are unknown
+ *
+ * A stored bound can only be turned into text through the real decimal places, so a currency the
+ * table does not carry yields nothing rather than an amount scaled by the two-place fallback
+ *
+ * @param filters - The applied bounds and the currency their minor units belong to
+ * @param currencies - The currency table, which is empty until it downloads
+ */
+export function findAmountRangeDraft(filters: AppliedAmountRange, currencies: Currency[]): AmountDraft | null {
+  const exponent = findCurrencyExponent(currencies, filters.amount_currency ?? '')
+  if (exponent === null) return null
+
+  return {
+    min: fromMinorUnits(filters.min_amount ?? null, exponent),
+    max: fromMinorUnits(filters.max_amount ?? null, exponent),
+  }
+}
+
+/**
+ * Builds the amount part of the applied filters from the draft, handing back the bounds already
+ * applied while the range is locked
+ *
+ * The fields are blank for as long as they are locked, so converting them would clear a bound the
+ * user was never shown. Their currency is handed back with them, since bounds and the minor units
+ * they are counted in only mean anything together
+ *
+ * @param amount - The minimum and maximum as the fields hold them
+ * @param amountCurrency - The currency the range matches in
+ * @param exponent - Decimal places of that currency
+ * @param isLocked - Whether the range is locked, which is what makes the fields blank
+ * @param filters - The applied bounds, kept as they are while locked
+ */
+export function buildAmountFilterPatch({
+  amount,
+  amountCurrency,
+  exponent,
+  isLocked,
+  filters,
+}: {
+  amount: AmountDraft
+  amountCurrency: string
+  exponent: number
+  isLocked: boolean
+  filters: AppliedAmountRange
+}): AppliedAmountRange {
+  if (isLocked) {
+    return {
+      min_amount: filters.min_amount,
+      max_amount: filters.max_amount,
+      amount_currency: filters.amount_currency,
+    }
+  }
+
+  // toMinorUnits returns null rather than undefined for a blank amount, which the applied filters
+  // keep optional instead
+  const toMinor = (value: string) => toMinorUnits(value, exponent) ?? undefined
+  const hasAmount = Boolean(amount.min.trim() || amount.max.trim())
+
+  return {
+    min_amount: toMinor(amount.min),
+    max_amount: toMinor(amount.max),
+    amount_currency: hasAmount ? amountCurrency : undefined,
+  }
 }

--- a/frontend/src/pages/transactions/utils/amountRange.ts
+++ b/frontend/src/pages/transactions/utils/amountRange.ts
@@ -26,19 +26,42 @@ export function isAmountRangeCrossed(amount: AmountDraft, exponent: number): boo
 }
 
 /**
- * Reports whether the amount range can be shown or edited at all, which it cannot while the decimal
- * places of the currency it matches in are unknown
+ * Reports whether the fields have to refuse input, which they do while the decimal places they would
+ * be edited in are unknown, and while an applied bound cannot be shown
  *
+ * @param filters - The applied bounds and the currency their minor units belong to
  * @param currencies - The currency table, which is empty until it downloads
- * @param amountCurrency - The currency the range matches in
+ * @param amountCurrency - The currency the fields edit in, which is the one a typed bound is stored
+ * through and is not necessarily the one an applied bound was stored through
  */
-export function isAmountRangeLocked(currencies: Currency[], amountCurrency: string): boolean {
+export function isAmountRangeLocked(
+  filters: AppliedAmountRange,
+  currencies: Currency[],
+  amountCurrency: string,
+): boolean {
   return findCurrencyExponent(currencies, amountCurrency) === null
+    || isAppliedRangeWaitingOnCurrency(filters, currencies)
 }
 
 /**
- * Converts the applied bounds into the text the fields hold, or returns null when the decimal places
- * of the currency they were applied in are unknown
+ * Reports whether an applied bound exists that the fields cannot show yet, which is the only case
+ * with anything to fill in once the currency table arrives
+ *
+ * @param filters - The applied bounds and the currency their minor units belong to
+ * @param currencies - The currency table, which is empty until it downloads
+ */
+export function isAppliedRangeWaitingOnCurrency(
+  filters: AppliedAmountRange,
+  currencies: Currency[],
+): boolean {
+  const hasBound = filters.min_amount !== undefined || filters.max_amount !== undefined
+
+  return hasBound && findAmountRangeDraft(filters, currencies) === null
+}
+
+/**
+ * Converts the applied bounds into the text the fields hold, returning null when no currency was
+ * applied with them or when its decimal places are unknown
  *
  * A stored bound can only be turned into text through the real decimal places, so a currency the
  * table does not carry yields nothing rather than an amount scaled by the two-place fallback
@@ -60,14 +83,15 @@ export function findAmountRangeDraft(filters: AppliedAmountRange, currencies: Cu
  * Builds the amount part of the applied filters from the draft, handing back the bounds already
  * applied while the range is locked
  *
- * The fields are blank for as long as they are locked, so converting them would clear a bound the
- * user was never shown. Their currency is handed back with them, since bounds and the minor units
- * they are counted in only mean anything together
+ * A locked range is one whose decimal places are unknown, so converting what the fields hold would
+ * scale it by the two-place fallback, and a locked range that is blank would clear a bound the user
+ * was never shown. The applied currency is handed back with the applied bounds, since bounds and the
+ * minor units they are counted in only mean anything together
  *
  * @param amount - The minimum and maximum as the fields hold them
- * @param amountCurrency - The currency the range matches in
+ * @param amountCurrency - The currency the fields edit in
  * @param exponent - Decimal places of that currency
- * @param isLocked - Whether the range is locked, which is what makes the fields blank
+ * @param isLocked - Whether the fields are refusing input, which is what makes the draft unusable
  * @param filters - The applied bounds, kept as they are while locked
  */
 export function buildAmountFilterPatch({

--- a/frontend/src/utils/currencyStatus.ts
+++ b/frontend/src/utils/currencyStatus.ts
@@ -16,8 +16,11 @@ export const CURRENCY_AMOUNT_UNKNOWN = "We don't have the decimal places for thi
 /** Shown under a disabled minimum and maximum while the list is still on its way */
 export const CURRENCY_RANGE_LOADING = "The currency list is still loading, so the amount range can't be shown or changed yet."
 
-/** Shown under that pair once the list has failed */
-export const CURRENCY_RANGE_NOTICE = "We can't load the currency list right now, so the amount range can't be shown or changed. Refresh the page to try again."
+/** Shown under that pair once the list has failed, followed by the refresh offer below */
+export const CURRENCY_RANGE_NOTICE = "We can't load the currency list right now, so the amount range can't be shown or changed."
+
+/** The way out of a failed list, offered as a control that reloads rather than as an instruction */
+export const CURRENCY_REFRESH_ACTION = 'Refresh the page to try again'
 
 /** Shown under that pair when the list did load but does not carry the currency the range matches in */
 export const CURRENCY_RANGE_UNKNOWN = "We don't have the decimal places for the currency this range matches in, so it can't be shown or changed."

--- a/frontend/src/utils/currencyStatus.ts
+++ b/frontend/src/utils/currencyStatus.ts
@@ -7,11 +7,20 @@ export const CURRENCY_LIST_LOADING = 'Loading currencies...'
 /** Shown beside a currency field once the list has failed */
 export const CURRENCY_LIST_NOTICE = "We can't load the currency list right now. Refresh the page to try again."
 
-/** Shown beside an amount field standing down, which needs the currency's decimal places to say anything */
+/** Shown beside a disabled amount field, which needs the currency's decimal places to say anything */
 export const CURRENCY_AMOUNT_NOTICE = "We can't load the currency list right now, so this amount can't be shown or changed. Refresh the page to try again."
 
-/** Shown in that field's place when the list did load but does not carry that amount's own currency */
+/** Shown beside that field when the list did load but does not carry that amount's own currency */
 export const CURRENCY_AMOUNT_UNKNOWN = "We don't have the decimal places for this amount's currency, so it can't be shown or changed."
+
+/** Shown under a disabled minimum and maximum while the list is still on its way */
+export const CURRENCY_RANGE_LOADING = "The currency list is still loading, so the amount range can't be shown or changed yet."
+
+/** Shown under that pair once the list has failed */
+export const CURRENCY_RANGE_NOTICE = "We can't load the currency list right now, so the amount range can't be shown or changed. Refresh the page to try again."
+
+/** Shown under that pair when the list did load but does not carry the currency the range matches in */
+export const CURRENCY_RANGE_UNKNOWN = "We don't have the decimal places for the currency this range matches in, so it can't be shown or changed."
 
 /** Shown when a form that creates something with an amount is refused because the list failed */
 export const CURRENCY_LIST_REFUSAL = "We can't load the currency list right now. Refresh the page to try again."

--- a/frontend/src/utils/moneyInput.ts
+++ b/frontend/src/utils/moneyInput.ts
@@ -59,8 +59,8 @@ export function readMoneyInputChange(value: string, typed: string, exponent: num
  * in the table
  *
  * The fallback cannot tell an unrecognized code from a table that has not loaded yet, so a field
- * holding a stored amount should read its exponent through findCurrencyExponent below and stand down
- * when there is none, rather than displaying an amount scaled by this guess
+ * holding a stored amount should read its exponent through findCurrencyExponent below and lock when
+ * there is none, rather than displaying an amount scaled by this guess
  */
 export function getCurrencyExponent(currencies: Currency[], code: string): number {
   return currencies.find((currency) => currency.id === code)?.minor_unit_exponent ?? DEFAULT_MINOR_UNIT_EXPONENT
@@ -70,7 +70,7 @@ export function getCurrencyExponent(currencies: Currency[], code: string): numbe
  * Returns the number of decimal places a currency uses, or null when the code is not in the table
  *
  * A form holding a stored amount needs the difference the fallback above hides: without the real
- * exponent it can neither show that amount nor convert an edit to it, so the field has to stand down
+ * exponent it can neither show that amount nor convert an edit to it, so the field has to lock
  * rather than display a number scaled by a guess
  */
 export function findCurrencyExponent(currencies: Currency[], code: string): number | null {

--- a/frontend/tests/transactions/amountRange.test.ts
+++ b/frontend/tests/transactions/amountRange.test.ts
@@ -58,7 +58,7 @@ describe('the range while its currency has no known decimal places', () => {
     expect(isAmountRangeLocked({}, NO_CURRENCIES, 'JPY')).toBe(true)
     expect(isAmountRangeLocked({}, currencies, 'JPY')).toBe(false)
     expect(isAmountRangeLocked({}, currencies, 'KWD')).toBe(true)
-    // The base currency is blank until the signed-in user's profile arrives
+    // A user whose base currency is empty names no currency for the fields to edit in
     expect(isAmountRangeLocked({}, currencies, '')).toBe(true)
   })
 
@@ -119,7 +119,10 @@ describe('the range while its currency has no known decimal places', () => {
     })).toStrictEqual({ min_amount: 1000, max_amount: 5000, amount_currency: 'JPY' })
   })
 
-  it('commits what the fields hold once they are editable', () => {
+})
+
+describe('the range once its currency is known', () => {
+  it('commits what the fields hold', () => {
     expect(buildAmountFilterPatch({
       amount: { min: '25', max: '80' },
       amountCurrency: 'JPY',

--- a/frontend/tests/transactions/amountRange.test.ts
+++ b/frontend/tests/transactions/amountRange.test.ts
@@ -1,7 +1,7 @@
 /**
  * Tests the amount filter's bounds check, which keeps a minimum above the maximum from being
  * applied and coming back as an empty list with no reason given, and the rules that keep the bounds
- * off screen and out of the applied filters until the decimal places they are counted in are known
+ * off screen, and leave the applied ones alone, until the decimal places they are counted in are known
  */
 import { describe, expect, it } from 'vitest'
 import type { Currency } from '@/api/currency'
@@ -10,6 +10,7 @@ import {
   findAmountRangeDraft,
   isAmountRangeCrossed,
   isAmountRangeLocked,
+  isAppliedRangeWaitingOnCurrency,
 } from '@/pages/transactions/utils/amountRange'
 
 const CENTS = 2
@@ -52,49 +53,90 @@ describe('bounds that exclude each other', () => {
   })
 })
 
-describe('the range while the currency table is missing', () => {
-  it('locks until the matched currency is in the table', () => {
-    expect(isAmountRangeLocked(NO_CURRENCIES, 'JPY')).toBe(true)
-    expect(isAmountRangeLocked(currencies, 'JPY')).toBe(false)
-    expect(isAmountRangeLocked(currencies, 'KWD')).toBe(true)
+describe('the range while its currency has no known decimal places', () => {
+  it('locks the fields until the currency they edit in is in the table', () => {
+    expect(isAmountRangeLocked({}, NO_CURRENCIES, 'JPY')).toBe(true)
+    expect(isAmountRangeLocked({}, currencies, 'JPY')).toBe(false)
+    expect(isAmountRangeLocked({}, currencies, 'KWD')).toBe(true)
+    // The base currency is blank until the signed-in user's profile arrives
+    expect(isAmountRangeLocked({}, currencies, '')).toBe(true)
+  })
+
+  it('locks the fields over an applied bound it cannot show, whatever they edit in', () => {
+    const waiting = { min_amount: 1000, amount_currency: 'KWD' }
+
+    expect(isAppliedRangeWaitingOnCurrency(waiting, currencies)).toBe(true)
+    expect(isAmountRangeLocked(waiting, currencies, 'CAD')).toBe(true)
+  })
+
+  it('leaves the currency choice alone when no applied bound is waiting', () => {
+    expect(isAppliedRangeWaitingOnCurrency({}, NO_CURRENCIES)).toBe(false)
+    expect(isAppliedRangeWaitingOnCurrency({ amount_currency: 'JPY' }, NO_CURRENCIES)).toBe(false)
+    expect(isAppliedRangeWaitingOnCurrency({ min_amount: 1000, amount_currency: 'JPY' }, currencies)).toBe(false)
   })
 
   it('shows nothing rather than an amount scaled by the two-place fallback', () => {
     expect(findAmountRangeDraft({ min_amount: 1000, amount_currency: 'JPY' }, NO_CURRENCIES)).toBeNull()
-    expect(findAmountRangeDraft({ min_amount: 1000, amount_currency: 'JPY' }, currencies)).toEqual({
+    expect(findAmountRangeDraft({ min_amount: 1000, max_amount: 5000, amount_currency: 'JPY' }, currencies)).toStrictEqual({
       min: '1000',
-      max: '',
+      max: '5000',
     })
-    expect(findAmountRangeDraft({ min_amount: 1000, amount_currency: 'CAD' }, currencies)).toEqual({
+    expect(findAmountRangeDraft({ min_amount: 1000, max_amount: 5000, amount_currency: 'CAD' }, currencies)).toStrictEqual({
       min: '10.00',
+      max: '50.00',
+    })
+  })
+
+  it('shows a bound of zero rather than reading it as no bound', () => {
+    expect(findAmountRangeDraft({ min_amount: 0, amount_currency: 'CAD' }, currencies)).toStrictEqual({
+      min: '0.00',
       max: '',
     })
   })
 
-  it('leaves both bounds blank when none is applied', () => {
-    expect(findAmountRangeDraft({ amount_currency: 'CAD' }, currencies)).toEqual({ min: '', max: '' })
+  it('has nothing to show when no currency was applied with the bounds', () => {
+    expect(findAmountRangeDraft({}, currencies)).toBeNull()
+    expect(findAmountRangeDraft({ amount_currency: 'CAD' }, currencies)).toStrictEqual({ min: '', max: '' })
   })
 
-  it('keeps the applied bounds when the fields are locked and therefore blank', () => {
-    const applied = { min_amount: 1000, max_amount: 5000, amount_currency: 'JPY' }
-
+  it('keeps the applied bounds and their own currency while the fields are locked', () => {
     expect(buildAmountFilterPatch({
       amount: { min: '', max: '' },
+      amountCurrency: 'USD',
+      exponent: CENTS,
+      isLocked: true,
+      filters: { min_amount: 1000, max_amount: 5000, amount_currency: 'CAD' },
+    })).toStrictEqual({ min_amount: 1000, max_amount: 5000, amount_currency: 'CAD' })
+  })
+
+  it('refuses to convert text left in a locked field at the fallback scale', () => {
+    expect(buildAmountFilterPatch({
+      amount: { min: '7', max: '' },
       amountCurrency: 'JPY',
       exponent: CENTS,
       isLocked: true,
-      filters: applied,
-    })).toEqual(applied)
+      filters: { min_amount: 1000, max_amount: 5000, amount_currency: 'JPY' },
+    })).toStrictEqual({ min_amount: 1000, max_amount: 5000, amount_currency: 'JPY' })
   })
 
   it('commits what the fields hold once they are editable', () => {
     expect(buildAmountFilterPatch({
-      amount: { min: '1000', max: '' },
+      amount: { min: '25', max: '80' },
       amountCurrency: 'JPY',
       exponent: WHOLE_UNITS,
       isLocked: false,
-      filters: { min_amount: 1000, amount_currency: 'JPY' },
-    })).toEqual({ min_amount: 1000, max_amount: undefined, amount_currency: 'JPY' })
+      filters: { min_amount: 1000, max_amount: 5000, amount_currency: 'CAD' },
+    })).toStrictEqual({ min_amount: 25, max_amount: 80, amount_currency: 'JPY' })
+  })
+
+  it('keeps a bound of zero rather than dropping the range', () => {
+    expect(buildAmountFilterPatch({
+      amount: { min: '0', max: '' },
+      amountCurrency: 'CAD',
+      exponent: CENTS,
+      isLocked: false,
+      filters: {},
+    })).toStrictEqual({ min_amount: 0, max_amount: undefined, amount_currency: 'CAD' })
   })
 
   it('drops the currency along with the bounds when both are cleared', () => {
@@ -103,7 +145,7 @@ describe('the range while the currency table is missing', () => {
       amountCurrency: 'JPY',
       exponent: WHOLE_UNITS,
       isLocked: false,
-      filters: { min_amount: 1000, amount_currency: 'JPY' },
-    })).toEqual({ min_amount: undefined, max_amount: undefined, amount_currency: undefined })
+      filters: { min_amount: 1000, max_amount: 5000, amount_currency: 'JPY' },
+    })).toStrictEqual({ min_amount: undefined, max_amount: undefined, amount_currency: undefined })
   })
 })

--- a/frontend/tests/transactions/amountRange.test.ts
+++ b/frontend/tests/transactions/amountRange.test.ts
@@ -1,12 +1,27 @@
 /**
  * Tests the amount filter's bounds check, which keeps a minimum above the maximum from being
- * applied and coming back as an empty list with no reason given
+ * applied and coming back as an empty list with no reason given, and the rules that keep the bounds
+ * off screen and out of the applied filters until the decimal places they are counted in are known
  */
 import { describe, expect, it } from 'vitest'
-import { isAmountRangeCrossed } from '@/pages/transactions/utils/amountRange'
+import type { Currency } from '@/api/currency'
+import {
+  buildAmountFilterPatch,
+  findAmountRangeDraft,
+  isAmountRangeCrossed,
+  isAmountRangeLocked,
+} from '@/pages/transactions/utils/amountRange'
 
 const CENTS = 2
 const WHOLE_UNITS = 0
+
+const currencies: Currency[] = [
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+  { id: 'JPY', name: 'Japanese Yen', symbol: '¥', minor_unit_exponent: 0 },
+]
+
+// What the currency query holds until it resolves
+const NO_CURRENCIES: Currency[] = []
 
 describe('bounds that exclude each other', () => {
   it('reports a minimum above the maximum', () => {
@@ -34,5 +49,61 @@ describe('bounds that exclude each other', () => {
     expect(isAmountRangeCrossed({ min: '500', max: '' }, CENTS)).toBe(false)
     expect(isAmountRangeCrossed({ min: '', max: '5' }, CENTS)).toBe(false)
     expect(isAmountRangeCrossed({ min: '500', max: '.' }, CENTS)).toBe(false)
+  })
+})
+
+describe('the range while the currency table is missing', () => {
+  it('locks until the matched currency is in the table', () => {
+    expect(isAmountRangeLocked(NO_CURRENCIES, 'JPY')).toBe(true)
+    expect(isAmountRangeLocked(currencies, 'JPY')).toBe(false)
+    expect(isAmountRangeLocked(currencies, 'KWD')).toBe(true)
+  })
+
+  it('shows nothing rather than an amount scaled by the two-place fallback', () => {
+    expect(findAmountRangeDraft({ min_amount: 1000, amount_currency: 'JPY' }, NO_CURRENCIES)).toBeNull()
+    expect(findAmountRangeDraft({ min_amount: 1000, amount_currency: 'JPY' }, currencies)).toEqual({
+      min: '1000',
+      max: '',
+    })
+    expect(findAmountRangeDraft({ min_amount: 1000, amount_currency: 'CAD' }, currencies)).toEqual({
+      min: '10.00',
+      max: '',
+    })
+  })
+
+  it('leaves both bounds blank when none is applied', () => {
+    expect(findAmountRangeDraft({ amount_currency: 'CAD' }, currencies)).toEqual({ min: '', max: '' })
+  })
+
+  it('keeps the applied bounds when the fields are locked and therefore blank', () => {
+    const applied = { min_amount: 1000, max_amount: 5000, amount_currency: 'JPY' }
+
+    expect(buildAmountFilterPatch({
+      amount: { min: '', max: '' },
+      amountCurrency: 'JPY',
+      exponent: CENTS,
+      isLocked: true,
+      filters: applied,
+    })).toEqual(applied)
+  })
+
+  it('commits what the fields hold once they are editable', () => {
+    expect(buildAmountFilterPatch({
+      amount: { min: '1000', max: '' },
+      amountCurrency: 'JPY',
+      exponent: WHOLE_UNITS,
+      isLocked: false,
+      filters: { min_amount: 1000, amount_currency: 'JPY' },
+    })).toEqual({ min_amount: 1000, max_amount: undefined, amount_currency: 'JPY' })
+  })
+
+  it('drops the currency along with the bounds when both are cleared', () => {
+    expect(buildAmountFilterPatch({
+      amount: { min: '', max: '' },
+      amountCurrency: 'JPY',
+      exponent: WHOLE_UNITS,
+      isLocked: false,
+      filters: { min_amount: 1000, amount_currency: 'JPY' },
+    })).toEqual({ min_amount: undefined, max_amount: undefined, amount_currency: undefined })
   })
 })


### PR DESCRIPTION
Amounts typed into the transaction filter before the currency list arrived were read as having two decimal places, so in a currency that has none they were stored at the wrong scale and the list filtered on a range nobody had set. The minimum and maximum are now disabled until the decimal places they are counted in are known. A note underneath says why they cannot be used, and once the list has failed it offers a control that reloads the page.