### PR TITLE
fix: ship the four typefaces with the app

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -5,14 +5,6 @@
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>Lumina Finance</title>
-
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,500&family=DM+Mono:wght@400;500&family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300;1,9..40,400&family=Space+Grotesk:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,10 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource-variable/cormorant-garamond": "^5.3.0",
+        "@fontsource-variable/dm-sans": "^5.3.0",
+        "@fontsource-variable/space-grotesk": "^5.3.0",
+        "@fontsource/dm-mono": "^5.3.0",
         "@simplewebauthn/browser": "^13.3.0",
         "@tanstack/query-async-storage-persister": "^5.101.4",
         "@tanstack/react-query": "^5.101.4",
@@ -456,6 +460,42 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource-variable/cormorant-garamond": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/cormorant-garamond/-/cormorant-garamond-5.3.0.tgz",
+      "integrity": "sha512-rgZJ/5w3hi60swAPnrOXpZf5wEH6NTrvm4H8D9Y4b1QIFUqlX14eM3QTMU/eAznjfh0eXpO1QUqsFhiy58aoMg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/dm-sans": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/dm-sans/-/dm-sans-5.3.0.tgz",
+      "integrity": "sha512-BpUG5bqePiDFMBM4ZtLSlPdAIOM990uB1dlXzIf4aw21yQR7BmykedLXXXMqGWsR18aMLOsbWccwJNh3ztTQaA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/space-grotesk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/space-grotesk/-/space-grotesk-5.3.0.tgz",
+      "integrity": "sha512-2IxmvfB08i9vnGB3Ym/AXvhRE+8XOjWMXIyDum03c+tPwH0FUoMNQfGpU8NXPxjbws0Vvss3AH0Zqt4oJBBAdw==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/dm-mono": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-mono/-/dm-mono-5.3.0.tgz",
+      "integrity": "sha512-OINjI8C1S/wpchhQxl7njZdMn4+hnDCpQ4YtvvOpKNARo+0J8O1x1IcrChxNjHOhfVv1by8C/FQoy3hXK+C1Ug==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@humanfs/core": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@fontsource-variable/cormorant-garamond": "^5.3.0",
+    "@fontsource-variable/dm-sans": "^5.3.0",
+    "@fontsource-variable/space-grotesk": "^5.3.0",
+    "@fontsource/dm-mono": "^5.3.0",
     "@simplewebauthn/browser": "^13.3.0",
     "@tanstack/query-async-storage-persister": "^5.101.4",
     "@tanstack/react-query": "^5.101.4",

--- a/frontend/src/components/category-icon-selector/Selector.tsx
+++ b/frontend/src/components/category-icon-selector/Selector.tsx
@@ -285,7 +285,7 @@ function EmojiMartIconPicker({
       pickerElement = picker as unknown as HTMLElement
       const theme = EMOJI_MART_THEME[isDark ? 'dark' : 'light']
       pickerElement.style.width = '100%'
-      pickerElement.style.setProperty('--font-family', '"DM Sans", system-ui, sans-serif')
+      pickerElement.style.setProperty('--font-family', '"DM Sans Variable", system-ui, sans-serif')
       pickerElement.style.setProperty('--font-size', '14px')
       pickerElement.style.setProperty('--border-radius', '0.75rem')
       pickerElement.style.setProperty('--shadow', 'none')

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,14 @@ import { createRoot } from 'react-dom/client'
 import { defaultShouldDehydrateQuery, QueryClient, type Query } from '@tanstack/react-query'
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client'
 import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
+// Each import picks the narrowest build covering what the app renders. DM Sans varies by weight
+// only, giving up the letterform adjustment the third-party stylesheet carried, and italic ships
+// for it alone since no other family is ever set in italic. DM Mono ships the one weight in use
+import '@fontsource-variable/dm-sans/wght.css'
+import '@fontsource-variable/dm-sans/wght-italic.css'
+import '@fontsource-variable/cormorant-garamond/wght.css'
+import '@fontsource-variable/space-grotesk/wght.css'
+import '@fontsource/dm-mono/400.css'
 import '@/styles/tailwind.css'
 import App from '@/App.tsx'
 import ErrorBoundary from '@/components/errors/Boundary'

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -146,7 +146,7 @@
     overflow-x: clip;
     background-color: var(--app-bg);
     color: var(--app-text);
-    font-family: "DM Sans", system-ui, sans-serif;
+    font-family: "DM Sans Variable", system-ui, sans-serif;
   }
 
   button:not(:disabled),
@@ -2040,7 +2040,7 @@
   .app-page-title {
     font-size: var(--app-page-title-size);
     line-height: 1;
-    font-family: "Cormorant Garamond", Georgia, serif;
+    font-family: "Cormorant Garamond Variable", Georgia, serif;
     font-weight: 400;
     letter-spacing: -0.01em;
     color: var(--app-text);
@@ -2054,7 +2054,7 @@
 
   /* Financial figures — currency amounts, balances, percentages */
   .font-financial {
-    font-family: "Space Grotesk", "DM Sans", system-ui, sans-serif;
+    font-family: "Space Grotesk Variable", "DM Sans Variable", system-ui, sans-serif;
     font-variant-numeric: tabular-nums;
   }
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -7,11 +7,13 @@ export default {
   ],
   theme: {
     extend: {
+      // The "Variable" suffix is part of the family name the fontsource packages declare, rather
+      // than a typo. DM Mono has no variable build, so its package keeps the bare name
       fontFamily: {
-        sans: ['"DM Sans"', 'system-ui', 'sans-serif'],
-        serif: ['"Cormorant Garamond"', 'Georgia', 'serif'],
+        sans: ['"DM Sans Variable"', 'system-ui', 'sans-serif'],
+        serif: ['"Cormorant Garamond Variable"', 'Georgia', 'serif'],
         mono: ['"DM Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
-        display: ['"Cormorant Garamond"', 'Georgia', 'serif'],
+        display: ['"Cormorant Garamond Variable"', 'Georgia', 'serif'],
       },
       colors: {
         gold: '#C9A96A',


### PR DESCRIPTION
The four typefaces came from a Google Fonts stylesheet, so rendering any text in them meant a request to a remote host, and an instance that couldn't reach it fell back to Georgia and the system fonts. They now install as npm packages, so the app serves them itself. The family stacks match what those packages declare, and bold and italic text renders a little heavier.