### PR TITLE
test: check the shipped image in a real browser

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,4 +17,8 @@ frontend/.env
 frontend/dist
 frontend/node_modules
 
+e2e/node_modules
+e2e/test-results
+e2e/playwright-report
+
 internal-docs

--- a/.github/workflows/_docker-build-and-test.yml
+++ b/.github/workflows/_docker-build-and-test.yml
@@ -1,4 +1,4 @@
-name: Docker build and test
+name: Docker build and browser suite
 
 # Reusable step invoked by the pull request pipeline, it does not trigger on its own
 on:

--- a/.github/workflows/_docker-build-and-test.yml
+++ b/.github/workflows/_docker-build-and-test.yml
@@ -1,4 +1,4 @@
-name: Docker build and smoke test
+name: Docker build and test
 
 # Reusable step invoked by the pull request pipeline, it does not trigger on its own
 on:
@@ -8,12 +8,12 @@ permissions:
   contents: read
 
 env:
-  # Fixed local tag the smoke test reuses, it matches the image name in docker/compose.yml
+  # Fixed local tag the stack below reuses, it matches the image name in docker/compose.yml
   IMAGE_REF: luminahq/lumina-finance:ci
 
 jobs:
   build:
-    name: Build and smoke test Docker image (${{ matrix.platform }})
+    name: Build and test Docker image (${{ matrix.platform }})
     runs-on: ${{ matrix.runner }}
 
     # Each leg builds on a runner of its own architecture, so neither is emulated. One
@@ -47,8 +47,8 @@ jobs:
           registry-username: ${{ vars.DOCKERHUB_USERNAME }}
           registry-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      # Load the image into the local daemon rather than pushing, so the smoke test below
-      # can run the exact image this job just built without it leaving the runner
+      # Load the image into the local daemon rather than pushing, so the checks below run the
+      # exact image this job just built without it leaving the runner
       - name: Build image
         uses: docker/build-push-action@v7
         env:
@@ -76,6 +76,31 @@ jobs:
       - name: Start the stack
         run: docker compose -f docker/compose.yml up -d
 
+      # Installed while the container migrates, applies row-level security and seeds its
+      # currencies and categories, so the poll below usually passes on its first attempt
+      # rather than waiting out a boot that could have been overlapped
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "26.5"
+          cache: npm
+          cache-dependency-path: e2e/package-lock.json
+
+      - name: Install the browser suite
+        working-directory: e2e
+        run: npm ci
+
+      # Nothing else type-checks this package: there is no root tsconfig, and the frontend's
+      # covers its own source and tests alone. It runs here rather than beside the suite so a
+      # type error is reported before the browser download and the health poll it does not need
+      - name: Type-check the browser suite
+        working-directory: e2e
+        run: npm run typecheck
+
+      - name: Install the browser it drives
+        working-directory: e2e
+        run: npx playwright install --with-deps chromium
+
       # Caddy serves the backend health route under /api, poll until the app reports ready
       - name: Ping the health endpoint
         run: |
@@ -90,6 +115,24 @@ jobs:
           echo "Health check never succeeded, dumping logs"
           docker compose -f docker/compose.yml logs
           exit 1
+
+      - name: Run the browser suite
+        id: browser-suite
+        working-directory: e2e
+        env:
+          E2E_BASE_URL: http://localhost:8080
+        run: npm test
+
+      # Gated on the suite rather than on the job, because a report only exists when the suite
+      # itself ran. On an image that never boots the poll above fails first, and an upload
+      # gated on the job would then find nothing and pass with a warning
+      - name: Keep the report from a failed run
+        if: ${{ failure() && steps.browser-suite.outcome == 'failure' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: browser-suite-${{ matrix.platform }}
+          path: e2e/playwright-report
+          retention-days: 7
 
       - name: Tear down the stack
         if: always()

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -36,8 +36,12 @@ jobs:
             frontend:
               - 'frontend/**'
               - '.github/workflows/**'
+            # The browser suite runs inside the Docker job against the image it builds, so it
+            # belongs to this area rather than to one of its own. Without it here, a change to
+            # the suite is the one edit that merges without the suite having run
             docker:
               - 'docker/**'
+              - 'e2e/**'
               - '.github/workflows/**'
               - '.github/actions/**'
 

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+
+# Playwright writes both on a failing run, holding traces, screenshots and the HTML report
+test-results
+playwright-report

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -1,0 +1,109 @@
+{
+  "name": "e2e",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "e2e",
+      "devDependencies": {
+        "@playwright/test": "^1.62.1",
+        "@types/node": "^26.1.1",
+        "typescript": "^6.0.3"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "e2e",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.62.1",
+    "@types/node": "^26.1.1",
+    "typescript": "^6.0.3"
+  }
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,8 +4,8 @@ import { TEST_TIMEZONE } from './support/api'
 import { BASE_URL } from './support/target'
 
 // Above the 1050px breakpoint, so the desktop navigation and the desktop filter panel are the
-// ones rendered. The mobile filter sheet has no accessible name on the control that chooses
-// which filter to edit, so nothing drives it
+// ones rendered. In the mobile sheet the control that chooses which filter to edit is named by
+// whichever option it currently shows, so its name moves as it is used and nothing drives it
 const DESKTOP_VIEWPORT = { width: 1440, height: 900 }
 
 export default defineConfig({

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -3,10 +3,19 @@ import { defineConfig, devices } from '@playwright/test'
 import { TEST_TIMEZONE } from './support/api'
 import { BASE_URL } from './support/target'
 
-// Above the 1050px breakpoint, so the desktop navigation and the desktop filter panel are the
-// ones rendered. In the mobile sheet the control that chooses which filter to edit is named by
-// whichever option it currently shows, so its name moves as it is used and nothing drives it
-const DESKTOP_VIEWPORT = { width: 1440, height: 900 }
+// The three sizes the screenshot captures use, so the suite checks the layouts the captures
+// show. Copied by value from dev/demo/capture/shared.mjs rather than imported: that file is
+// JavaScript in the internal repository and this one is TypeScript in this one, so an import
+// would need a build step across the two
+const VIEWPORTS = {
+  desktop: { width: 2200, height: 1322 },
+
+  // Playwright's iPad Pro 11 landscape screen. Only the size is taken, because its full device
+  // entry also selects WebKit, and only Chromium is installed
+  tablet: { width: 1194, height: 834 },
+
+  phone: { width: 393, height: 852 },
+}
 
 export default defineConfig({
   testDir: './tests',
@@ -43,10 +52,25 @@ export default defineConfig({
     screenshot: 'only-on-failure',
   },
 
+  // Pinned rather than left to default, which is half the machine's cores and would serialise
+  // the three sizes on a two-core runner. The ceiling is not the runner but the one app
+  // container every test signs up against, which hashes each password with argon2id at 64 MiB
+  workers: 6,
+
   projects: [
     {
-      name: 'chromium',
-      use: { ...devices['Desktop Chrome'], viewport: DESKTOP_VIEWPORT },
+      name: 'desktop',
+      use: { ...devices['Desktop Chrome'], viewport: VIEWPORTS.desktop },
+    },
+    {
+      // Mobile devices, as the captures take them, so Chromium honours the page's own viewport
+      // meta tag and the layout width is the one written above rather than the screen's
+      name: 'tablet',
+      use: { ...devices['Desktop Chrome'], viewport: VIEWPORTS.tablet, isMobile: true, hasTouch: true },
+    },
+    {
+      name: 'phone',
+      use: { ...devices['Desktop Chrome'], viewport: VIEWPORTS.phone, isMobile: true, hasTouch: true },
     },
   ],
 })

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -58,8 +58,9 @@ export default defineConfig({
   },
 
   // Pinned rather than left to default, which is half the machine's cores and would serialise
-  // the three sizes on a two-core runner. The ceiling is not the runner but the one app
-  // container every test signs up against, which hashes each password with argon2id at 64 MiB
+  // the three sizes on a two-core runner. Raising it further buys little: every test signs up,
+  // and the app hashes each password on its single event loop, so those calls queue behind one
+  // another however many browsers are asking at once
   workers: 6,
 
   projects: [

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,6 +20,13 @@ export default defineConfig({
   // or in itself, and retrying would hide the one thing this suite exists to catch
   retries: 0,
 
+  // Both are raised above Playwright's defaults of 30 seconds and 5 seconds, because a spec
+  // can spend 20 seconds signing in and 20 more waiting for a modal against an instance that
+  // has just started, and every first assertion after a navigation waits on a cold query. With
+  // no retries, one slow query would otherwise be a failed run rather than a slow one
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+
   reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
 
   globalSetup: './support/global-setup.ts',

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,45 @@
+import { defineConfig, devices } from '@playwright/test'
+
+import { TEST_TIMEZONE } from './support/api'
+import { BASE_URL } from './support/target'
+
+// Above the 1050px breakpoint, so the desktop navigation and the desktop filter panel are the
+// ones rendered. The mobile filter sheet has no accessible name on the control that chooses
+// which filter to edit, so nothing drives it
+const DESKTOP_VIEWPORT = { width: 1440, height: 900 }
+
+export default defineConfig({
+  testDir: './tests',
+
+  // Every spec creates its own user, so nothing one spec writes is visible to another
+  fullyParallel: true,
+
+  forbidOnly: Boolean(process.env.CI),
+
+  // None anywhere. A spec that passes only on a second attempt is reporting a race in the app
+  // or in itself, and retrying would hide the one thing this suite exists to catch
+  retries: 0,
+
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+  globalSetup: './support/global-setup.ts',
+
+  use: {
+    baseURL: BASE_URL,
+    timezoneId: TEST_TIMEZONE,
+
+    // Amounts are formatted with the browser's own locale, so an unpinned runner renders a
+    // Canadian dollar amount as CA$42.50 where this one renders $42.50
+    locale: 'en-CA',
+
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'], viewport: DESKTOP_VIEWPORT },
+    },
+  ],
+})

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -50,6 +50,11 @@ export default defineConfig({
 
     trace: 'retain-on-failure',
     screenshot: 'only-on-failure',
+
+    // The captures pass this for the same reason: Chromium on Linux otherwise draws a classic
+    // scrollbar that takes fifteen pixels out of the page, so the widest project would lay out
+    // at 2185 and stop being the size it says it is
+    launchOptions: { args: ['--enable-features=OverlayScrollbar'] },
   },
 
   // Pinned rather than left to default, which is half the machine's cores and would serialise
@@ -63,8 +68,9 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'], viewport: VIEWPORTS.desktop },
     },
     {
-      // Mobile devices, as the captures take them, so Chromium honours the page's own viewport
-      // meta tag and the layout width is the one written above rather than the screen's
+      // Mobile devices, as the captures take them. What that changes here is the coarse-pointer
+      // media queries and the scrollbar, which is drawn over the page rather than taking width
+      // out of it, so these two lay out at exactly the width written above
       name: 'tablet',
       use: { ...devices['Desktop Chrome'], viewport: VIEWPORTS.tablet, isMobile: true, hasTouch: true },
     },

--- a/e2e/support/api.ts
+++ b/e2e/support/api.ts
@@ -18,6 +18,10 @@ export const TEST_TIMEZONE = 'America/Toronto'
 // in a currency other than its account's needs an exchange rate supplied with it
 export const TEST_CURRENCY = 'CAD'
 
+// The container seeds this one alongside the system categories, so every spec has a merchant to
+// name without creating one
+const SYSTEM_MERCHANT = 'Unknown'
+
 export interface TestUser {
   email: string
   password: string
@@ -57,4 +61,164 @@ export async function signUpUser(request: APIRequestContext): Promise<TestUser> 
 
   const body = (await response.json()) as { access_token: string }
   return { email, password: TEST_PASSWORD, firstName, accessToken: body.access_token }
+}
+
+/**
+ * Build the authorization header for calls made as a signed-up user.
+ */
+function asUser(user: TestUser): Record<string, string> {
+  return { Authorization: `Bearer ${user.accessToken}` }
+}
+
+/**
+ * Today's date where the browser and the seeded data agree it is.
+ *
+ * A transaction's date is a plain calendar date the API stores as given, so seeding "now" from
+ * the machine running the suite would put a transaction on tomorrow's date whenever that machine
+ * is east of the zone the browser is pinned to.
+ *
+ * @returns The date as YYYY-MM-DD
+ */
+export function todayInTestTimezone(): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: TEST_TIMEZONE }).format(new Date())
+}
+
+/**
+ * Look up a system record the container seeded, by its exact name.
+ *
+ * @param request - Playwright request context
+ * @param user - User whose view of the records is read
+ * @param kind - Which collection to search
+ * @param name - Exact name as seeded
+ * @returns The record's id
+ * @throws When the collection cannot be read, or holds no record of that name
+ */
+export async function findReferenceId(
+  request: APIRequestContext,
+  user: TestUser,
+  kind: 'categories' | 'merchants',
+  name: string,
+): Promise<string> {
+  const response = await request.get(`/api/${kind}`, { headers: asUser(user) })
+  if (!response.ok()) {
+    throw new Error(`reading ${kind} answered ${response.status()}: ${await response.text()}`)
+  }
+
+  const records = (await response.json()) as { id: string; name: string }[]
+  const match = records.find((record) => record.name === name)
+  if (match === undefined) {
+    throw new Error(`no ${kind} record named ${JSON.stringify(name)}`)
+  }
+  return match.id
+}
+
+export interface SeededAccount {
+  id: string
+  name: string
+  currency: string
+}
+
+export interface CreateAccountOptions {
+  name: string
+
+  /** Must agree with the type, as the API checks the pair rather than deriving one from the other */
+  accountKind?: string
+  accountType?: string
+  currency?: string
+
+  /** Signed opening balance in minor units */
+  startingBalance?: number
+}
+
+/**
+ * Create an account over the API.
+ *
+ * @param request - Playwright request context
+ * @param user - Account owner
+ * @param options - What to create, defaulting to a chequing account in the test currency
+ * @returns The account that was created
+ * @throws When creation does not answer 201
+ */
+export async function createAccount(
+  request: APIRequestContext,
+  user: TestUser,
+  options: CreateAccountOptions,
+): Promise<SeededAccount> {
+  const currency = options.currency ?? TEST_CURRENCY
+
+  const response = await request.post('/api/accounts', {
+    headers: asUser(user),
+    data: {
+      account_kind: options.accountKind ?? 'asset',
+      account_type: options.accountType ?? 'checking',
+      name: options.name,
+      currency,
+      starting_balance: options.startingBalance ?? null,
+    },
+  })
+
+  if (response.status() !== 201) {
+    throw new Error(`creating account ${options.name} answered ${response.status()}: ${await response.text()}`)
+  }
+
+  const body = (await response.json()) as { id: string }
+  return { id: body.id, name: options.name, currency }
+}
+
+export interface CreateTransactionOptions {
+  accountId: string
+
+  /** Exact name of a seeded system category, such as Groceries */
+  categoryName: string
+
+  /** Signed minor units, so -4250 is $42.50 going out and 4250 is $42.50 coming in */
+  amount: number
+
+  /** Plain calendar date as YYYY-MM-DD, defaulting to today in the pinned zone */
+  date?: string
+  currency?: string
+}
+
+/**
+ * Create a transaction over the API.
+ *
+ * The merchant is the seeded system record rather than one the spec makes, since every create
+ * requires one and no spec asserts on it.
+ *
+ * @param request - Playwright request context
+ * @param user - Transaction owner
+ * @param options - What to record
+ * @returns The transaction's id
+ * @throws When creation does not answer 201
+ */
+export async function createTransaction(
+  request: APIRequestContext,
+  user: TestUser,
+  options: CreateTransactionOptions,
+): Promise<string> {
+  const [categoryId, merchantId] = await Promise.all([
+    findReferenceId(request, user, 'categories', options.categoryName),
+    findReferenceId(request, user, 'merchants', SYSTEM_MERCHANT),
+  ])
+
+  const response = await request.post('/api/transactions', {
+    headers: asUser(user),
+    data: {
+      account_id: options.accountId,
+      dt: options.date ?? todayInTestTimezone(),
+      category_id: categoryId,
+      merchant_id: merchantId,
+      amount: options.amount,
+      currency: options.currency ?? TEST_CURRENCY,
+    },
+  })
+
+  if (response.status() !== 201) {
+    throw new Error(
+      `recording ${options.amount} in ${options.categoryName} answered ${response.status()}: ${await response.text()}`,
+    )
+  }
+
+  const body = (await response.json()) as { id: string }
+  return body.id
 }

--- a/e2e/support/api.ts
+++ b/e2e/support/api.ts
@@ -1,0 +1,60 @@
+/**
+ * Creating a user's data over the API, so a spec starts from the state it wants to test
+ * rather than clicking its way there through behaviour it is not testing.
+ */
+
+import type { APIRequestContext } from '@playwright/test'
+
+// Satisfies the backend's password policy: twelve to a hundred and twenty-eight characters,
+// with an uppercase letter, a digit and a special character
+export const TEST_PASSWORD = 'E2ePassw0rd!'
+
+// The browser runs in this zone too, set on the Playwright config, because the signup form
+// takes its default from the browser and a spec asserting on a date would otherwise depend
+// on where the machine running it happens to be
+export const TEST_TIMEZONE = 'America/Toronto'
+
+// Signup requires a base currency. Every seeded account uses it as well, since a transaction
+// in a currency other than its account's needs an exchange rate supplied with it
+export const TEST_CURRENCY = 'CAD'
+
+export interface TestUser {
+  email: string
+  password: string
+  firstName: string
+
+  /** Bearer token for calling the API as this user */
+  accessToken: string
+}
+
+/**
+ * Sign a new user up and return their credentials.
+ *
+ * Every call makes its own email address. That is what keeps one spec's data out of another's
+ * and lets them all run at once against a single instance.
+ *
+ * @param request - Playwright request context, which carries the base URL
+ * @returns The credentials of the user that was created
+ * @throws When signup does not answer 201
+ */
+export async function signUpUser(request: APIRequestContext): Promise<TestUser> {
+  const email = `e2e-${crypto.randomUUID()}@example.com`
+  const firstName = 'Test'
+
+  const response = await request.post('/api/auth/signup', {
+    data: {
+      email,
+      password: TEST_PASSWORD,
+      first_name: firstName,
+      tz: TEST_TIMEZONE,
+      base_currency: TEST_CURRENCY,
+    },
+  })
+
+  if (response.status() !== 201) {
+    throw new Error(`signup for ${email} answered ${response.status()}: ${await response.text()}`)
+  }
+
+  const body = (await response.json()) as { access_token: string }
+  return { email, password: TEST_PASSWORD, firstName, accessToken: body.access_token }
+}

--- a/e2e/support/api.ts
+++ b/e2e/support/api.ts
@@ -59,7 +59,11 @@ export async function signUpUser(request: APIRequestContext): Promise<TestUser> 
     throw new Error(`signup for ${email} answered ${response.status()}: ${await response.text()}`)
   }
 
-  const body = (await response.json()) as { access_token: string }
+  const body = (await response.json()) as { access_token?: string }
+  if (body.access_token === undefined) {
+    throw new Error(`signup for ${email} answered 201 without an access token`)
+  }
+
   return { email, password: TEST_PASSWORD, firstName, accessToken: body.access_token }
 }
 
@@ -247,6 +251,16 @@ export interface CreateMonthlyBudgetOptions {
 
   /** Spending limit for the period, in minor units */
   overallLimit: number
+
+  /**
+   * Where the period starts, as YYYY-MM-DD, which must be the first of a month.
+   *
+   * Passed in rather than worked out here so a spec can date its transactions to the same day
+   * it gave the budget. Left to default, a run crossing midnight into the first of a month
+   * anchors the period to one month and the spending to the next, and the card then reports
+   * nothing spent rather than failing.
+   */
+  periodStart?: string
   currency?: string
 }
 
@@ -283,7 +297,7 @@ export async function createMonthlyBudget(
       recurrence_freq: 'monthly',
       recurrence_dom: BUDGET_ANCHOR_DAY,
       category_ids: categoryIds,
-      period_start: budgetPeriodStart(),
+      period_start: options.periodStart ?? budgetPeriodStart(),
       overall_limit: options.overallLimit,
     },
   })

--- a/e2e/support/api.ts
+++ b/e2e/support/api.ts
@@ -83,6 +83,22 @@ export function todayInTestTimezone(): string {
   return new Intl.DateTimeFormat('en-CA', { timeZone: TEST_TIMEZONE }).format(new Date())
 }
 
+// A monthly budget's period has to start on the day its cadence is anchored to, and the API
+// refuses any other day rather than moving it
+const BUDGET_ANCHOR_DAY = 1
+
+/**
+ * The first of the current month, which is where a seeded budget's period starts.
+ *
+ * Dating a transaction here rather than at an arbitrary day keeps it inside the period whatever
+ * day the suite runs on, and never puts it in the future.
+ *
+ * @returns The date as YYYY-MM-DD
+ */
+export function budgetPeriodStart(): string {
+  return `${todayInTestTimezone().slice(0, 7)}-${String(BUDGET_ANCHOR_DAY).padStart(2, '0')}`
+}
+
 /**
  * Look up a system record the container seeded, by its exact name.
  *
@@ -217,6 +233,63 @@ export async function createTransaction(
     throw new Error(
       `recording ${options.amount} in ${options.categoryName} answered ${response.status()}: ${await response.text()}`,
     )
+  }
+
+  const body = (await response.json()) as { id: string }
+  return body.id
+}
+
+export interface CreateMonthlyBudgetOptions {
+  name: string
+
+  /** Exact names of the seeded system categories the budget tracks */
+  categoryNames: string[]
+
+  /** Spending limit for the period, in minor units */
+  overallLimit: number
+  currency?: string
+}
+
+/**
+ * Create a monthly budget with a period already running.
+ *
+ * Monthly is the only cadence here because it is the only one a spec needs. The others take
+ * different anchor fields, which the API checks rather than infers.
+ *
+ * The limit and the period start go together on purpose. Leaving them off is accepted and
+ * creates a base budget with no period at all, whose card then reads "Not set" and tracks
+ * nothing, so a spec seeded that way asserts against a budget that was never watching.
+ *
+ * @param request - Playwright request context
+ * @param user - Budget owner
+ * @param options - What to create
+ * @returns The base budget's id
+ * @throws When creation does not answer 201
+ */
+export async function createMonthlyBudget(
+  request: APIRequestContext,
+  user: TestUser,
+  options: CreateMonthlyBudgetOptions,
+): Promise<string> {
+  const categoryIds = await Promise.all(
+    options.categoryNames.map((name) => findReferenceId(request, user, 'categories', name)),
+  )
+
+  const response = await request.post('/api/base-budgets', {
+    headers: asUser(user),
+    data: {
+      name: options.name,
+      currency: options.currency ?? TEST_CURRENCY,
+      recurrence_freq: 'monthly',
+      recurrence_dom: BUDGET_ANCHOR_DAY,
+      category_ids: categoryIds,
+      period_start: budgetPeriodStart(),
+      overall_limit: options.overallLimit,
+    },
+  })
+
+  if (response.status() !== 201) {
+    throw new Error(`creating budget ${options.name} answered ${response.status()}: ${await response.text()}`)
   }
 
   const body = (await response.json()) as { id: string }

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -13,7 +13,7 @@ const CONTENT_TIMEOUT_MS = 20_000
 const MODAL_ATTEMPT_MS = 3_000
 
 // The app's own two breakpoints. Above the first the navigation is a sidebar and below it a
-// menu behind a button; above the second the list toolbars show their own controls inline and
+// menu behind a button. Above the second the list toolbars show their controls inline, and
 // below it a reduced set that opens filtering in a sheet
 const NAVIGATION_BREAKPOINT_PX = 1050
 const TOOLBAR_BREAKPOINT_PX = 750
@@ -117,7 +117,7 @@ export async function openModal(page: Page, buttonNames: string[], dialogName: s
   const dialog = page.getByRole('dialog', { name: dialogName })
 
   // Only one toolbar is ever displayed, so only one of these names is in the accessibility
-  // tree and the pair resolves to a single control at any width.
+  // tree and the pair resolves to a single control at any width
   //
   // Anything inside an open dialog is excluded, because the transaction modal's own submit
   // button carries the same name as the toolbar button that opened it. Without this the two

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -117,9 +117,14 @@ export async function openModal(page: Page, buttonNames: string[], dialogName: s
   const dialog = page.getByRole('dialog', { name: dialogName })
 
   // Only one toolbar is ever displayed, so only one of these names is in the accessibility
-  // tree and the pair resolves to a single control at any width
+  // tree and the pair resolves to a single control at any width.
+  //
+  // Anything inside an open dialog is excluded, because the transaction modal's own submit
+  // button carries the same name as the toolbar button that opened it. Without this the two
+  // match together in the moment between the check below and the click
+  const outsideDialogs = page.locator(':not([role="dialog"] *)')
   const opener = buttonNames
-    .map((name) => page.getByRole('button', { name, exact: true }))
+    .map((name) => page.getByRole('button', { name, exact: true }).and(outsideDialogs))
     .reduce((all, one) => all.or(one))
 
   await expect(async () => {

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -50,7 +50,10 @@ export async function openModal(page: Page, buttonName: string, dialogName: stri
 
   await expect(async () => {
     if (!(await dialog.isVisible())) {
-      await page.getByRole('button', { name: buttonName, exact: true }).click()
+      // Bounded, because a modal that opens between the check above and this click puts its
+      // backdrop over the button. Without a timeout that click waits out the whole test rather
+      // than failing and letting the next attempt see the dialog is already open
+      await page.getByRole('button', { name: buttonName, exact: true }).click({ timeout: MODAL_ATTEMPT_MS })
     }
     await expect(dialog).toBeVisible({ timeout: MODAL_ATTEMPT_MS })
   }).toPass({ timeout: CONTENT_TIMEOUT_MS })

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -2,12 +2,15 @@
  * Driving the parts of the app a spec passes through on its way to the behaviour it tests.
  */
 
-import type { Page } from '@playwright/test'
+import { expect, type Locator, type Page } from '@playwright/test'
 
 import type { TestUser } from './api'
 
 // Covers a cold API call against a container that has just started
 const CONTENT_TIMEOUT_MS = 20_000
+
+// How long one attempt at opening a modal is given before the click is made again
+const MODAL_ATTEMPT_MS = 3_000
 
 /**
  * Sign in through the login form and wait until the app leaves the login page.
@@ -27,4 +30,50 @@ export async function logIn(page: Page, user: TestUser): Promise<void> {
 
   await page.getByRole('button', { name: 'Log in' }).click()
   await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: CONTENT_TIMEOUT_MS })
+}
+
+/**
+ * Open a modal from a toolbar button, and answer with the dialog.
+ *
+ * The create buttons do nothing but raise a toast until the currency list has arrived, so a
+ * single click against a page that has just loaded opens nothing, and the wait that follows
+ * blames the modal for a cause that sits in a request. Clicking again until the dialog appears
+ * is what makes a spec independent of when that request settles.
+ *
+ * @param page - Page showing the toolbar
+ * @param buttonName - Accessible name of the button that opens the modal, matched exactly
+ * @param dialogName - Accessible name of the dialog it opens
+ * @returns The dialog, to scope every query inside it
+ */
+export async function openModal(page: Page, buttonName: string, dialogName: string): Promise<Locator> {
+  const dialog = page.getByRole('dialog', { name: dialogName })
+
+  await expect(async () => {
+    if (!(await dialog.isVisible())) {
+      await page.getByRole('button', { name: buttonName, exact: true }).click()
+    }
+    await expect(dialog).toBeVisible({ timeout: MODAL_ATTEMPT_MS })
+  }).toPass({ timeout: CONTENT_TIMEOUT_MS })
+
+  return dialog
+}
+
+/**
+ * Pick an option from one of the app's dropdowns.
+ *
+ * The dropdown is a button that opens a listbox rather than a native select, so this is two
+ * clicks. The listbox renders inside the dropdown rather than at the top of the document, which
+ * is why the options are found within the same scope.
+ *
+ * @param scope - Dialog or page holding the field
+ * @param fieldName - Accessible name of the dropdown
+ * @param optionName - Accessible name of the option to pick
+ */
+export async function chooseFromDropdown(
+  scope: Locator,
+  fieldName: string,
+  optionName: string | RegExp,
+): Promise<void> {
+  await scope.getByRole('combobox', { name: fieldName }).click()
+  await scope.getByRole('option', { name: optionName }).click()
 }

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -12,6 +12,27 @@ const CONTENT_TIMEOUT_MS = 20_000
 // How long one attempt at opening a modal is given before the click is made again
 const MODAL_ATTEMPT_MS = 3_000
 
+// The app's own two breakpoints. Above the first the navigation is a sidebar and below it a
+// menu behind a button; above the second the list toolbars show their own controls inline and
+// below it a reduced set that opens filtering in a sheet
+const NAVIGATION_BREAKPOINT_PX = 1050
+const TOOLBAR_BREAKPOINT_PX = 750
+
+/**
+ * Whether the page is at least this wide, as the app's own media queries see it.
+ *
+ * Asked of the page rather than worked out from the configured viewport, because a classic
+ * scrollbar takes its width out of the layout viewport, so the two numbers differ by fifteen
+ * on any project that draws one.
+ *
+ * @param page - Page to measure
+ * @param widthPx - Width to compare against
+ * @returns Whether the app's layout is at or above that width
+ */
+async function isAtLeast(page: Page, widthPx: number): Promise<boolean> {
+  return page.evaluate((px) => matchMedia(`(min-width: ${px}px)`).matches, widthPx)
+}
+
 /**
  * Sign in through the login form and wait until the app leaves the login page.
  *
@@ -33,6 +54,52 @@ export async function logIn(page: Page, user: TestUser): Promise<void> {
 }
 
 /**
+ * Assert the app is showing its signed-in shell.
+ *
+ * The navigation is the thing that says so, and it only renders for a signed-in user past the
+ * boot splash. Which half of it to read depends on the width: the sidebar carries the links
+ * themselves, while the menu keeps them behind a button and mounts them only once it is open.
+ *
+ * @param page - Page to assert on
+ */
+export async function expectSignedIn(page: Page): Promise<void> {
+  const signedIn = (await isAtLeast(page, NAVIGATION_BREAKPOINT_PX))
+    ? page.getByRole('link', { name: 'Accounts' })
+    : page.getByRole('button', { name: 'Open navigation menu' })
+
+  await expect(signedIn).toBeVisible()
+}
+
+/**
+ * Filter the transaction list down to one category, and apply it.
+ *
+ * Two different control sets do this job. Above the toolbar breakpoint it is a pill that opens
+ * a panel of tabs; below it a sheet whose first control is a dropdown rather than tabs, and
+ * that dropdown is named by whichever filter it currently shows rather than by what it is, so
+ * it is reached as the only one inside the sheet.
+ *
+ * @param page - Page showing the transaction list
+ * @param categoryName - Exact name of the category to keep
+ */
+export async function filterByCategory(page: Page, categoryName: string): Promise<void> {
+  if (await isAtLeast(page, TOOLBAR_BREAKPOINT_PX)) {
+    await page.getByRole('button', { name: 'Transaction filters' }).click()
+    await page.getByRole('tab', { name: 'Category' }).click()
+    await page.getByRole('checkbox', { name: categoryName }).click()
+    await page.getByRole('button', { name: 'Apply filters' }).click()
+    return
+  }
+
+  await page.getByRole('button', { name: 'Filters', exact: true }).click()
+
+  const sheet = page.getByRole('dialog', { name: 'Transaction filters' })
+  await sheet.getByRole('combobox').click()
+  await sheet.getByRole('option', { name: 'Category' }).click()
+  await sheet.getByRole('checkbox', { name: categoryName }).click()
+  await sheet.getByRole('button', { name: 'Apply filters' }).click()
+}
+
+/**
  * Open a modal from a toolbar button, and answer with the dialog.
  *
  * The create buttons do nothing but raise a toast until the currency list has arrived, so a
@@ -41,19 +108,26 @@ export async function logIn(page: Page, user: TestUser): Promise<void> {
  * is what makes a spec independent of when that request settles.
  *
  * @param page - Page showing the toolbar
- * @param buttonName - Accessible name of the button that opens the modal, matched exactly
+ * @param buttonNames - Accessible names of the button that opens the modal, one per toolbar,
+ *   since the reduced toolbar below the breakpoint calls the same control something else
  * @param dialogName - Accessible name of the dialog it opens
  * @returns The dialog, to scope every query inside it
  */
-export async function openModal(page: Page, buttonName: string, dialogName: string): Promise<Locator> {
+export async function openModal(page: Page, buttonNames: string[], dialogName: string): Promise<Locator> {
   const dialog = page.getByRole('dialog', { name: dialogName })
+
+  // Only one toolbar is ever displayed, so only one of these names is in the accessibility
+  // tree and the pair resolves to a single control at any width
+  const opener = buttonNames
+    .map((name) => page.getByRole('button', { name, exact: true }))
+    .reduce((all, one) => all.or(one))
 
   await expect(async () => {
     if (!(await dialog.isVisible())) {
       // Bounded, because a modal that opens between the check above and this click puts its
       // backdrop over the button. Without a timeout that click waits out the whole test rather
       // than failing and letting the next attempt see the dialog is already open
-      await page.getByRole('button', { name: buttonName, exact: true }).click({ timeout: MODAL_ATTEMPT_MS })
+      await opener.click({ timeout: MODAL_ATTEMPT_MS })
     }
     await expect(dialog).toBeVisible({ timeout: MODAL_ATTEMPT_MS })
   }).toPass({ timeout: CONTENT_TIMEOUT_MS })

--- a/e2e/support/app.ts
+++ b/e2e/support/app.ts
@@ -1,0 +1,30 @@
+/**
+ * Driving the parts of the app a spec passes through on its way to the behaviour it tests.
+ */
+
+import type { Page } from '@playwright/test'
+
+import type { TestUser } from './api'
+
+// Covers a cold API call against a container that has just started
+const CONTENT_TIMEOUT_MS = 20_000
+
+/**
+ * Sign in through the login form and wait until the app leaves the login page.
+ *
+ * Leaving the page is all this waits for. Whether the page it lands on has its data is for
+ * the spec to assert, since there is no signal in the app that would answer it generally.
+ *
+ * @param page - Page to drive, at any address in the app
+ * @param user - Credentials to sign in with
+ */
+export async function logIn(page: Page, user: TestUser): Promise<void> {
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(user.email)
+
+  // Exact, or it also matches the "Confirm password" field the signup form carries
+  await page.getByLabel('Password', { exact: true }).fill(user.password)
+
+  await page.getByRole('button', { name: 'Log in' }).click()
+  await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: CONTENT_TIMEOUT_MS })
+}

--- a/e2e/support/global-setup.ts
+++ b/e2e/support/global-setup.ts
@@ -1,0 +1,8 @@
+import { requireAppReachable } from './target'
+
+/**
+ * Confirm something is serving before the first spec opens a browser.
+ */
+export default async function globalSetup(): Promise<void> {
+  await requireAppReachable()
+}

--- a/e2e/support/target.ts
+++ b/e2e/support/target.ts
@@ -1,0 +1,58 @@
+/**
+ * The instance the suite runs against.
+ *
+ * The suite starts nothing and stops nothing. Something else brings an instance up and hands
+ * the address over, which is what lets the same specs run against a staging server, a
+ * container on a pipeline runner, or anything else already serving.
+ */
+
+// Required, with no default, so a run cannot quietly go at whatever happens to be on a
+// familiar port
+const configured = process.env.E2E_BASE_URL
+if (configured === undefined || configured === '') {
+  throw new Error('E2E_BASE_URL is required, as E2E_BASE_URL=http://127.0.0.1:8080 npx playwright test')
+}
+
+export const BASE_URL = configured.replace(/\/$/, '')
+
+// Long enough to cover a container that has just been started, short enough that pointing at
+// nothing fails while you are still watching
+const REACHABLE_TIMEOUT_MS = 60_000
+const REACHABLE_POLL_MS = 2_000
+
+/**
+ * Fail before any test runs when nothing is serving at the address.
+ *
+ * Without this, a wrong or unstarted address appears as a browser timeout inside whichever
+ * spec happened to run first, which reads as that spec being broken.
+ *
+ * @throws When the health route has not answered ok before the timeout expires
+ */
+export async function requireAppReachable(): Promise<void> {
+  const deadline = Date.now() + REACHABLE_TIMEOUT_MS
+  let lastAttempt = 'no response'
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetch(`${BASE_URL}/api/health`, {
+        signal: AbortSignal.timeout(REACHABLE_POLL_MS),
+      })
+      if (response.ok) {
+        const body = (await response.json()) as { status?: string }
+        if (body.status === 'ok') {
+          return
+        }
+        lastAttempt = `health answered ${JSON.stringify(body.status)}`
+      } else {
+        lastAttempt = `answered ${response.status}`
+      }
+    } catch (error) {
+      lastAttempt = error instanceof Error ? error.message : String(error)
+    }
+    await new Promise((settle) => setTimeout(settle, REACHABLE_POLL_MS))
+  }
+
+  throw new Error(
+    `nothing healthy at ${BASE_URL} after ${REACHABLE_TIMEOUT_MS / 1000}s, last attempt: ${lastAttempt}`,
+  )
+}

--- a/e2e/tests/accounts.spec.ts
+++ b/e2e/tests/accounts.spec.ts
@@ -1,0 +1,65 @@
+import { expect, test } from '@playwright/test'
+
+import { createAccount, createTransaction, signUpUser } from '../support/api'
+import { chooseFromDropdown, logIn, openModal } from '../support/app'
+
+const ACCOUNT_NAME = 'Everyday Chequing'
+
+test('starts a new user with no accounts and creates one through the modal', async ({ page, request }) => {
+  const user = await signUpUser(request)
+
+  await logIn(page, user)
+  await page.goto('/accounts')
+
+  // A fresh user sees this even against a database holding other people's records, so the
+  // assertion also fails if row-level security ever stops separating one user from another
+  await expect(page.getByText('No asset accounts')).toBeVisible()
+
+  const dialog = await openModal(page, 'Add Account', 'Add Account')
+  await chooseFromDropdown(dialog, 'Account Type', 'Checking')
+  await dialog.getByLabel('Account Name').fill(ACCOUNT_NAME)
+
+  // Currency is left alone: it already holds the base currency chosen at signup
+  await dialog.getByRole('button', { name: 'Create Account' }).click()
+
+  await expect(dialog).toBeHidden()
+  await expect(page.getByRole('link', { name: new RegExp(ACCOUNT_NAME) })).toBeVisible()
+})
+
+test('records an expense through the modal and shows it as money out', async ({ page, request }) => {
+  const user = await signUpUser(request)
+  const account = await createAccount(request, user, { name: ACCOUNT_NAME })
+
+  await logIn(page, user)
+  await page.goto('/transactions')
+
+  const dialog = await openModal(page, 'Add Transaction', 'Add Transaction')
+  await chooseFromDropdown(dialog, 'Account', new RegExp(account.name))
+  await chooseFromDropdown(dialog, 'Merchant', 'Unknown')
+  await chooseFromDropdown(dialog, 'Category', 'Groceries')
+  await dialog.getByLabel('Amount').fill('42.50')
+  await dialog.getByRole('button', { name: 'Add Transaction' }).click()
+
+  await expect(dialog).toBeHidden()
+
+  // The row is queried by role rather than by text because it renders its amount once per
+  // responsive layout and all of them sit in the DOM at once. Only the rendered one counts
+  // towards the accessible name. The leading minus is the assertion: an expense recorded with
+  // the wrong sign still reads $42.50, and would pass a check that only looked for the number
+  await expect(page.getByRole('button', { name: /-\$42\.50/ })).toBeVisible()
+})
+
+test('shows a transaction seeded over the API', async ({ page, request }) => {
+  const user = await signUpUser(request)
+  const account = await createAccount(request, user, { name: ACCOUNT_NAME })
+  await createTransaction(request, user, {
+    accountId: account.id,
+    categoryName: 'Groceries',
+    amount: -4250,
+  })
+
+  await logIn(page, user)
+  await page.goto('/transactions')
+
+  await expect(page.getByRole('button', { name: /-\$42\.50/ })).toBeVisible()
+})

--- a/e2e/tests/accounts.spec.ts
+++ b/e2e/tests/accounts.spec.ts
@@ -11,9 +11,11 @@ test('starts a new user with no accounts and creates one through the modal', asy
   await logIn(page, user)
   await page.goto('/accounts')
 
-  // Asserted together on purpose. The empty label alone also renders when the accounts request
-  // fails, since the list is given no error to show, so it would read the same on a broken page
-  // as on a new user's. The summary is the half that only appears once the request succeeded
+  // Both halves are needed before the empty state means anything. The list is given no error to
+  // show, so a failed accounts request renders the same empty label a new user sees. Waiting for
+  // the summary's placeholder to go says the request settled, and the summary label is there
+  // only when it settled without an error, since a failure replaces the whole summary
+  await expect(page.getByRole('status', { name: 'Loading net worth value' })).toBeHidden()
   await expect(page.getByText('Net Worth')).toBeVisible()
 
   // A fresh user sees this even against a database holding other people's records, so the

--- a/e2e/tests/accounts.spec.ts
+++ b/e2e/tests/accounts.spec.ts
@@ -11,6 +11,11 @@ test('starts a new user with no accounts and creates one through the modal', asy
   await logIn(page, user)
   await page.goto('/accounts')
 
+  // Asserted together on purpose. The empty label alone also renders when the accounts request
+  // fails, since the list is given no error to show, so it would read the same on a broken page
+  // as on a new user's. The summary is the half that only appears once the request succeeded
+  await expect(page.getByText('Net Worth')).toBeVisible()
+
   // A fresh user sees this even against a database holding other people's records, so the
   // assertion also fails if row-level security ever stops separating one user from another
   await expect(page.getByText('No asset accounts')).toBeVisible()

--- a/e2e/tests/accounts.spec.ts
+++ b/e2e/tests/accounts.spec.ts
@@ -22,7 +22,7 @@ test('starts a new user with no accounts and creates one through the modal', asy
   // assertion also fails if row-level security ever stops separating one user from another
   await expect(page.getByText('No asset accounts')).toBeVisible()
 
-  const dialog = await openModal(page, 'Add Account', 'Add Account')
+  const dialog = await openModal(page, ['Add Account', 'Add account'], 'Add Account')
   await chooseFromDropdown(dialog, 'Account Type', 'Checking')
   await dialog.getByLabel('Account Name').fill(ACCOUNT_NAME)
 
@@ -40,7 +40,7 @@ test('records an expense through the modal and shows it as money out', async ({ 
   await logIn(page, user)
   await page.goto('/transactions')
 
-  const dialog = await openModal(page, 'Add Transaction', 'Add Transaction')
+  const dialog = await openModal(page, ['Add Transaction', 'Add transaction'], 'Add Transaction')
   await chooseFromDropdown(dialog, 'Account', new RegExp(account.name))
   await chooseFromDropdown(dialog, 'Merchant', 'Unknown')
   await chooseFromDropdown(dialog, 'Category', 'Groceries')

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,12 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { signUpUser, TEST_PASSWORD } from '../support/api'
-import { logIn } from '../support/app'
-
-// Only the signed-in shell renders the primary navigation, so this is what says a spec reached
-// the app. The dashboard's own heading cannot say it: the greeting is one of five chosen by the
-// hour, and asserting on the heading role alone matches the auth page, which is also an h1
-const SIGNED_IN = { role: 'link' as const, name: 'Accounts' }
+import { expectSignedIn, logIn } from '../support/app'
 
 test('signs a new user up through the form', async ({ page }) => {
   const email = `e2e-${crypto.randomUUID()}@example.com`
@@ -30,7 +25,7 @@ test('signs a new user up through the form', async ({ page }) => {
   await page.getByRole('button', { name: 'Skip for now' }).click()
   await page.getByRole('button', { name: 'I still want to skip' }).click()
 
-  await expect(page.getByRole(SIGNED_IN.role, { name: SIGNED_IN.name })).toBeVisible()
+  await expectSignedIn(page)
 })
 
 test('signs an existing user in with their password', async ({ page, request }) => {
@@ -38,7 +33,7 @@ test('signs an existing user in with their password', async ({ page, request }) 
 
   await logIn(page, user)
 
-  await expect(page.getByRole(SIGNED_IN.role, { name: SIGNED_IN.name })).toBeVisible()
+  await expectSignedIn(page)
 })
 
 test('refuses a wrong password before accepting the right one', async ({ page, request }) => {
@@ -57,5 +52,5 @@ test('refuses a wrong password before accepting the right one', async ({ page, r
   await page.getByLabel('Password', { exact: true }).fill(user.password)
   await page.getByRole('button', { name: 'Log in' }).click()
 
-  await expect(page.getByRole(SIGNED_IN.role, { name: SIGNED_IN.name })).toBeVisible()
+  await expectSignedIn(page)
 })

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test'
+
+import { signUpUser, TEST_PASSWORD } from '../support/api'
+import { logIn } from '../support/app'
+
+// Only the signed-in shell renders the primary navigation, so this is what says a spec reached
+// the app. The dashboard's own heading cannot say it: the greeting is one of five chosen by the
+// hour, and asserting on the heading role alone matches the auth page, which is also an h1
+const SIGNED_IN = { role: 'link' as const, name: 'Accounts' }
+
+test('signs a new user up through the form', async ({ page }) => {
+  const email = `e2e-${crypto.randomUUID()}@example.com`
+
+  await page.goto('/signup')
+  await page.getByLabel('First name').fill('Test')
+  await page.getByLabel('Email').fill(email)
+  await page.getByLabel('Password', { exact: true }).fill(TEST_PASSWORD)
+  await page.getByLabel('Confirm password').fill(TEST_PASSWORD)
+
+  // Timezone and base currency keep the browser's own defaults, which the config pins, so the
+  // form needs no answer for either. Neither could be driven anyway: both are dropdowns with
+  // no accessible name
+
+  // Submit stays disabled until the currency list arrives, which Playwright waits out
+  await page.getByRole('button', { name: 'Sign up' }).click()
+
+  // The app offers a second factor before letting anyone in, a passkey where the origin
+  // supports one and an authenticator app otherwise. Both branches carry these same two
+  // controls, so one path works against a domain and against a bare address alike
+  await page.getByRole('button', { name: 'Skip for now' }).click()
+  await page.getByRole('button', { name: 'I still want to skip' }).click()
+
+  await expect(page.getByRole(SIGNED_IN.role, { name: SIGNED_IN.name })).toBeVisible()
+})
+
+test('signs an existing user in with their password', async ({ page, request }) => {
+  const user = await signUpUser(request)
+
+  await logIn(page, user)
+
+  await expect(page.getByRole(SIGNED_IN.role, { name: SIGNED_IN.name })).toBeVisible()
+})
+
+test('refuses a wrong password before accepting the right one', async ({ page, request }) => {
+  const user = await signUpUser(request)
+
+  await page.goto('/login')
+  await page.getByLabel('Email').fill(user.email)
+  await page.getByLabel('Password', { exact: true }).fill('WrongPassw0rd!')
+  await page.getByRole('button', { name: 'Log in' }).click()
+
+  // The backend answers "Invalid credentials" and the form shows this instead, so that a
+  // wrong address and a wrong password cannot be told apart
+  await expect(page.getByText('Incorrect email or password. Please try again.')).toBeVisible()
+  await expect(page).toHaveURL(/\/login$/)
+
+  await page.getByLabel('Password', { exact: true }).fill(user.password)
+  await page.getByRole('button', { name: 'Log in' }).click()
+
+  await expect(page.getByRole(SIGNED_IN.role, { name: SIGNED_IN.name })).toBeVisible()
+})

--- a/e2e/tests/budgets.spec.ts
+++ b/e2e/tests/budgets.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test'
+
+import {
+  budgetPeriodStart,
+  createAccount,
+  createMonthlyBudget,
+  createTransaction,
+  signUpUser,
+} from '../support/api'
+import { logIn } from '../support/app'
+
+test('counts seeded spending against the budget limit', async ({ page, request }) => {
+  const user = await signUpUser(request)
+  const account = await createAccount(request, user, { name: 'Everyday Chequing' })
+
+  await createMonthlyBudget(request, user, {
+    name: 'Monthly Food',
+    categoryNames: ['Groceries'],
+    overallLimit: 50_000,
+  })
+
+  // Dated where the period starts, so both fall inside it whatever day the suite runs. A
+  // transaction outside the period is not counted and not complained about, which would leave
+  // the card reading $0.00 used and the assertion below blaming the total
+  for (const amount of [-4250, -1000]) {
+    await createTransaction(request, user, {
+      accountId: account.id,
+      categoryName: 'Groceries',
+      amount,
+      date: budgetPeriodStart(),
+    })
+  }
+
+  await logIn(page, user)
+  await page.goto('/budgets')
+
+  await expect(page.getByRole('heading', { name: 'Monthly Food' })).toBeVisible()
+  await expect(page.getByText('$52.50 used of $500.00')).toBeVisible()
+})

--- a/e2e/tests/budgets.spec.ts
+++ b/e2e/tests/budgets.spec.ts
@@ -13,10 +13,15 @@ test('counts seeded spending against the budget limit', async ({ page, request }
   const user = await signUpUser(request)
   const account = await createAccount(request, user, { name: 'Everyday Chequing' })
 
+  // Read once and used for both, so a run that crosses midnight into the first of a month
+  // cannot anchor the period to one month and the spending to the next
+  const periodStart = budgetPeriodStart()
+
   await createMonthlyBudget(request, user, {
     name: 'Monthly Food',
     categoryNames: ['Groceries'],
     overallLimit: 50_000,
+    periodStart,
   })
 
   // Dated where the period starts, so both fall inside it whatever day the suite runs. A
@@ -27,7 +32,7 @@ test('counts seeded spending against the budget limit', async ({ page, request }
       accountId: account.id,
       categoryName: 'Groceries',
       amount,
-      date: budgetPeriodStart(),
+      date: periodStart,
     })
   }
 

--- a/e2e/tests/transactions.spec.ts
+++ b/e2e/tests/transactions.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test'
+
+import { createAccount, createTransaction, signUpUser } from '../support/api'
+import { logIn } from '../support/app'
+
+test('filters the list down to one category', async ({ page, request }) => {
+  const user = await signUpUser(request)
+  const account = await createAccount(request, user, { name: 'Everyday Chequing' })
+
+  for (const seed of [
+    { categoryName: 'Groceries', amount: -1000 },
+    { categoryName: 'Groceries', amount: -2000 },
+    { categoryName: 'Dining', amount: -3000 },
+  ]) {
+    await createTransaction(request, user, { accountId: account.id, ...seed })
+  }
+
+  await logIn(page, user)
+  await page.goto('/transactions')
+
+  // Each row is found by its own amount, which is what makes the assertions below say which
+  // transactions survived rather than only how many did
+  const groceries = [
+    page.getByRole('button', { name: /-\$10\.00/ }),
+    page.getByRole('button', { name: /-\$20\.00/ }),
+  ]
+  const dining = page.getByRole('button', { name: /-\$30\.00/ })
+
+  await expect(dining).toBeVisible()
+
+  await page.getByRole('button', { name: 'Transaction filters' }).click()
+  await page.getByRole('tab', { name: 'Category' }).click()
+  await page.getByRole('checkbox', { name: 'Groceries' }).click()
+  await page.getByRole('button', { name: 'Apply filters' }).click()
+
+  // Nothing here asserts on the filter controls themselves. A collapsed panel keeps its
+  // children in the DOM without inert or aria-hidden, so a check that the Groceries box is
+  // visible passes whether or not the panel ever opened
+  for (const row of groceries) {
+    await expect(row).toBeVisible()
+  }
+  await expect(dining).toBeHidden()
+})

--- a/e2e/tests/transactions.spec.ts
+++ b/e2e/tests/transactions.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '@playwright/test'
 
 import { createAccount, createTransaction, signUpUser } from '../support/api'
-import { logIn } from '../support/app'
+import { filterByCategory, logIn } from '../support/app'
 
 test('filters the list down to one category', async ({ page, request }) => {
   const user = await signUpUser(request)
@@ -31,10 +31,7 @@ test('filters the list down to one category', async ({ page, request }) => {
 
   await expect(rows).toHaveCount(3)
 
-  await page.getByRole('button', { name: 'Transaction filters' }).click()
-  await page.getByRole('tab', { name: 'Category' }).click()
-  await page.getByRole('checkbox', { name: 'Groceries' }).click()
-  await page.getByRole('button', { name: 'Apply filters' }).click()
+  await filterByCategory(page, 'Groceries')
 
   // The list holds the rows it had before Apply for a second, so anything asserted first would
   // be reading the unfiltered list. Waiting for the Dining row to go is what says the filtered

--- a/e2e/tests/transactions.spec.ts
+++ b/e2e/tests/transactions.spec.ts
@@ -26,18 +26,29 @@ test('filters the list down to one category', async ({ page, request }) => {
   ]
   const dining = page.getByRole('button', { name: /-\$30\.00/ })
 
-  await expect(dining).toBeVisible()
+  // Every row carries its amount in its own name, so this counts rows and nothing else
+  const rows = page.getByRole('button', { name: /-\$\d+\.\d\d/ })
+
+  await expect(rows).toHaveCount(3)
 
   await page.getByRole('button', { name: 'Transaction filters' }).click()
   await page.getByRole('tab', { name: 'Category' }).click()
   await page.getByRole('checkbox', { name: 'Groceries' }).click()
   await page.getByRole('button', { name: 'Apply filters' }).click()
 
-  // Nothing here asserts on the filter controls themselves. A collapsed panel keeps its
-  // children in the DOM without inert or aria-hidden, so a check that the Groceries box is
-  // visible passes whether or not the panel ever opened
+  // The list holds the rows it had before Apply for a second, so anything asserted first would
+  // be reading the unfiltered list. Waiting for the Dining row to go is what says the filtered
+  // result has arrived, and only then does what survived mean anything
+  await expect(dining).toBeHidden()
+
+  // Counted as well as named, or a filter that wrongly matched nothing would leave an empty
+  // list that satisfies every assertion about what should have gone
+  await expect(rows).toHaveCount(2)
   for (const row of groceries) {
     await expect(row).toBeVisible()
   }
-  await expect(dining).toBeHidden()
+
+  // Nothing here asserts on the filter controls themselves. A collapsed panel keeps its
+  // children in the DOM without inert or aria-hidden, so a check that the Groceries box is
+  // visible passes whether or not the panel ever opened
 })

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023", "DOM"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+    "skipLibCheck": true,
+
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["playwright.config.ts", "support", "tests"]
+}


### PR DESCRIPTION
The only check on the built image was that it answered a health request, which proves the container started, not that anything in it works. A Playwright suite now drives the image itself at the three sizes the screenshot captures use, signing up and signing in, creating an account and recording a transaction, filtering the list and reading a budget. It runs inside the existing Docker build job, so a failing test blocks the merge.