### PR TITLE
feat: start an import from a transaction list

### DIFF
--- a/frontend/src/components/filters/hooks/useDesktopToolbarLayout.ts
+++ b/frontend/src/components/filters/hooks/useDesktopToolbarLayout.ts
@@ -7,7 +7,10 @@ export type DesktopToolbarRefs = {
   toolbarRef: RefObject<HTMLDivElement | null>
   controlsRef: RefObject<HTMLDivElement | null>
   filterGroupRef: RefObject<HTMLDivElement | null>
-  createMeasureRef: RefObject<HTMLButtonElement | null>
+
+  // The whole run of actions after the filters, not the create button alone, since a list can offer
+  // a second one and the row has to be measured as it is drawn
+  createMeasureRef: RefObject<HTMLDivElement | null>
 }
 
 export type DesktopToolbarLayoutState = DesktopToolbarRefs & {
@@ -22,7 +25,7 @@ export function useDesktopToolbarLayout(): DesktopToolbarLayoutState {
   const toolbarRef = useRef<HTMLDivElement>(null)
   const controlsRef = useRef<HTMLDivElement>(null)
   const filterGroupRef = useRef<HTMLDivElement>(null)
-  const createMeasureRef = useRef<HTMLButtonElement>(null)
+  const createMeasureRef = useRef<HTMLDivElement>(null)
   const [desktopInlineLayout, setDesktopInlineLayout] = useState(false)
   const [desktopCreateStacked, setDesktopCreateStacked] = useState(false)
 

--- a/frontend/src/components/filters/hooks/useDesktopToolbarLayout.ts
+++ b/frontend/src/components/filters/hooks/useDesktopToolbarLayout.ts
@@ -7,10 +7,7 @@ export type DesktopToolbarRefs = {
   toolbarRef: RefObject<HTMLDivElement | null>
   controlsRef: RefObject<HTMLDivElement | null>
   filterGroupRef: RefObject<HTMLDivElement | null>
-
-  // The whole run of actions after the filters, not the create button alone, since a list can offer
-  // a second one and the row has to be measured as it is drawn
-  createMeasureRef: RefObject<HTMLDivElement | null>
+  createMeasureRef: RefObject<HTMLButtonElement | null>
 }
 
 export type DesktopToolbarLayoutState = DesktopToolbarRefs & {
@@ -25,7 +22,7 @@ export function useDesktopToolbarLayout(): DesktopToolbarLayoutState {
   const toolbarRef = useRef<HTMLDivElement>(null)
   const controlsRef = useRef<HTMLDivElement>(null)
   const filterGroupRef = useRef<HTMLDivElement>(null)
-  const createMeasureRef = useRef<HTMLDivElement>(null)
+  const createMeasureRef = useRef<HTMLButtonElement>(null)
   const [desktopInlineLayout, setDesktopInlineLayout] = useState(false)
   const [desktopCreateStacked, setDesktopCreateStacked] = useState(false)
 

--- a/frontend/src/components/list-controls/DesktopToolbarControls.tsx
+++ b/frontend/src/components/list-controls/DesktopToolbarControls.tsx
@@ -4,23 +4,24 @@ import { Plus } from 'lucide-react'
 type DesktopToolbarControlsProps = {
   controlsRef: RefObject<HTMLDivElement | null>
   filterGroupRef: RefObject<HTMLDivElement | null>
-  createMeasureRef: RefObject<HTMLDivElement | null>
+  createMeasureRef: RefObject<HTMLButtonElement | null>
   desktopInlineLayout: boolean
   desktopCreateStacked: boolean
-  // The domain-specific filter glass panel slotted into the filter group
+
+  // The domain-specific filter glass panel slotted into the filter group, alongside anything else
+  // the list puts on that side of the row. Everything in here is measured as it renders, since the
+  // hook reads the filter group's own children
   filterPanel: ReactNode
   createLabel: string
   onCreate: () => void
   createDisabled?: boolean
   createDisabledReason?: string
-
-  // An action shown ahead of the create button, for a list that has a second thing to offer
-  secondaryAction?: ReactNode
 }
 
 /**
  * Renders the desktop toolbar's filter slot and create action shared by the account and transaction
- * lists, plus the hidden measurement twin of both the layout hook reads to decide when the row wraps
+ * lists, plus the hidden measurement twin of the create button the toolbar layout hook reads to
+ * decide when the row wraps
  */
 export function DesktopToolbarControls({
   controlsRef,
@@ -33,7 +34,6 @@ export function DesktopToolbarControls({
   onCreate,
   createDisabled = false,
   createDisabledReason,
-  secondaryAction,
 }: DesktopToolbarControlsProps) {
   return (
     <div
@@ -47,8 +47,6 @@ export function DesktopToolbarControls({
         {filterPanel}
       </div>
 
-      {secondaryAction}
-
       <button
         type="button"
         className={`app-glass-button-primary h-10 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
@@ -59,26 +57,16 @@ export function DesktopToolbarControls({
         <Plus size={18} aria-hidden />
         <span>{createLabel}</span>
       </button>
-
-      {/* What the layout hook measures, so it has to hold everything the row actually draws after
-          the filters, at the same gap. Measuring the create button alone once a second button sat
-          beside it would report a row narrower than it renders, and the row would stay on one line
-          where it no longer fits rather than wrapping. Hidden on the wrapper rather than on each
-          copy inside it, which also takes the whole subtree out of the tab order and off the
-          accessibility tree, so the copy of a real action in here is neither clickable nor
-          reachable. Rendered whether or not there is a secondary action, since the hook gives up
-          for good when it finds no element on its first pass */}
-      <div
+      <button
         ref={createMeasureRef}
-        className="pointer-events-none invisible absolute flex shrink-0 items-center gap-3"
+        type="button"
+        className="app-glass-button-primary pointer-events-none invisible absolute h-10 w-auto shrink-0"
+        tabIndex={-1}
         aria-hidden
       >
-        {secondaryAction}
-        <button type="button" className="app-glass-button-primary h-10 w-auto shrink-0" tabIndex={-1}>
-          <Plus size={18} aria-hidden />
-          <span>{createLabel}</span>
-        </button>
-      </div>
+        <Plus size={18} aria-hidden />
+        <span>{createLabel}</span>
+      </button>
     </div>
   )
 }

--- a/frontend/src/components/list-controls/DesktopToolbarControls.tsx
+++ b/frontend/src/components/list-controls/DesktopToolbarControls.tsx
@@ -4,7 +4,7 @@ import { Plus } from 'lucide-react'
 type DesktopToolbarControlsProps = {
   controlsRef: RefObject<HTMLDivElement | null>
   filterGroupRef: RefObject<HTMLDivElement | null>
-  createMeasureRef: RefObject<HTMLButtonElement | null>
+  createMeasureRef: RefObject<HTMLDivElement | null>
   desktopInlineLayout: boolean
   desktopCreateStacked: boolean
   // The domain-specific filter glass panel slotted into the filter group
@@ -13,12 +13,14 @@ type DesktopToolbarControlsProps = {
   onCreate: () => void
   createDisabled?: boolean
   createDisabledReason?: string
+
+  // An action shown ahead of the create button, for a list that has a second thing to offer
+  secondaryAction?: ReactNode
 }
 
 /**
  * Renders the desktop toolbar's filter slot and create action shared by the account and transaction
- * lists, plus the hidden measurement twin of the create button the toolbar layout hook reads to
- * decide when the row wraps
+ * lists, plus the hidden measurement twin of both the layout hook reads to decide when the row wraps
  */
 export function DesktopToolbarControls({
   controlsRef,
@@ -31,6 +33,7 @@ export function DesktopToolbarControls({
   onCreate,
   createDisabled = false,
   createDisabledReason,
+  secondaryAction,
 }: DesktopToolbarControlsProps) {
   return (
     <div
@@ -44,6 +47,8 @@ export function DesktopToolbarControls({
         {filterPanel}
       </div>
 
+      {secondaryAction}
+
       <button
         type="button"
         className={`app-glass-button-primary h-10 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}
@@ -54,16 +59,26 @@ export function DesktopToolbarControls({
         <Plus size={18} aria-hidden />
         <span>{createLabel}</span>
       </button>
-      <button
+
+      {/* What the layout hook measures, so it has to hold everything the row actually draws after
+          the filters, at the same gap. Measuring the create button alone once a second button sat
+          beside it would report a row narrower than it renders, and the row would stay on one line
+          where it no longer fits rather than wrapping. Hidden on the wrapper rather than on each
+          copy inside it, which also takes the whole subtree out of the tab order and off the
+          accessibility tree, so the copy of a real action in here is neither clickable nor
+          reachable. Rendered whether or not there is a secondary action, since the hook gives up
+          for good when it finds no element on its first pass */}
+      <div
         ref={createMeasureRef}
-        type="button"
-        className="app-glass-button-primary pointer-events-none invisible absolute h-10 w-auto shrink-0"
-        tabIndex={-1}
+        className="pointer-events-none invisible absolute flex shrink-0 items-center gap-3"
         aria-hidden
       >
-        <Plus size={18} aria-hidden />
-        <span>{createLabel}</span>
-      </button>
+        {secondaryAction}
+        <button type="button" className="app-glass-button-primary h-10 w-auto shrink-0" tabIndex={-1}>
+          <Plus size={18} aria-hidden />
+          <span>{createLabel}</span>
+        </button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/list-controls/MobileToolbarActions.tsx
+++ b/frontend/src/components/list-controls/MobileToolbarActions.tsx
@@ -11,7 +11,7 @@ type MobileToolbarActionsProps = {
   // Shown as the button's title and accessible name in place of primaryLabel while disabled
   primaryDisabledReason?: string
 
-  // An action shown ahead of the primary one, for a list that has a second thing to offer
+  // An action shown ahead of the filters, for a list that has a second thing to offer
   secondaryAction?: ReactNode
 }
 
@@ -30,6 +30,8 @@ export function MobileToolbarActions({
 }: MobileToolbarActionsProps) {
   return (
     <div className="flex w-full items-center gap-3 min-[750px]:hidden">
+      {secondaryAction}
+
       <button
         type="button"
         className="app-glass-button h-11 min-w-0 flex-1 justify-between"
@@ -51,8 +53,6 @@ export function MobileToolbarActions({
           </span>
         )}
       </button>
-
-      {secondaryAction}
 
       <button
         type="button"

--- a/frontend/src/components/list-controls/MobileToolbarActions.tsx
+++ b/frontend/src/components/list-controls/MobileToolbarActions.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import { Plus, SlidersHorizontal } from 'lucide-react'
 
 type MobileToolbarActionsProps = {
@@ -9,6 +10,9 @@ type MobileToolbarActionsProps = {
   primaryDisabled?: boolean
   // Shown as the button's title and accessible name in place of primaryLabel while disabled
   primaryDisabledReason?: string
+
+  // An action shown ahead of the primary one, for a list that has a second thing to offer
+  secondaryAction?: ReactNode
 }
 
 /**
@@ -22,6 +26,7 @@ export function MobileToolbarActions({
   primaryLabel,
   primaryDisabled = false,
   primaryDisabledReason,
+  secondaryAction,
 }: MobileToolbarActionsProps) {
   return (
     <div className="flex w-full items-center gap-3 min-[750px]:hidden">
@@ -46,6 +51,8 @@ export function MobileToolbarActions({
           </span>
         )}
       </button>
+
+      {secondaryAction}
 
       <button
         type="button"

--- a/frontend/src/components/list-controls/MobileToolbarActions.tsx
+++ b/frontend/src/components/list-controls/MobileToolbarActions.tsx
@@ -11,7 +11,7 @@ type MobileToolbarActionsProps = {
   // Shown as the button's title and accessible name in place of primaryLabel while disabled
   primaryDisabledReason?: string
 
-  // An action shown ahead of the filters, for a list that has a second thing to offer
+  // An action shown beside the primary one, for a list that has a second thing to offer
   secondaryAction?: ReactNode
 }
 
@@ -30,8 +30,6 @@ export function MobileToolbarActions({
 }: MobileToolbarActionsProps) {
   return (
     <div className="flex w-full items-center gap-3 min-[750px]:hidden">
-      {secondaryAction}
-
       <button
         type="button"
         className="app-glass-button h-11 min-w-0 flex-1 justify-between"
@@ -53,6 +51,8 @@ export function MobileToolbarActions({
           </span>
         )}
       </button>
+
+      {secondaryAction}
 
       <button
         type="button"

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -13,6 +13,7 @@ import MonthlyCashFlowCard from '@/pages/accounts/detail/components/monthly-cash
 import { TopCategoriesBySpendingCard } from '@/pages/accounts/detail/components/spending-breakdown/TopCategoriesCard'
 import { TopMerchantsBySpendingCard } from '@/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard'
 import { ACCOUNT_SKELETON_FADE_MS, EASE } from '@/pages/accounts/detail/constants/accountDetail'
+import { IMPORT_ACCOUNT_PARAM } from '@/pages/imports/constants'
 import TransactionListSection from '@/pages/transactions/components/ListSection'
 import { toTransactionListAccount } from '@/pages/transactions/types/transactionList'
 import CreateTransactionModal from '@/pages/transactions/components/transaction-modal/Modal'
@@ -106,6 +107,13 @@ export default function AccountDetailPage() {
     setShowAccountEditModal(true)
   }
 
+  // The account rides in the address rather than in router state, so the import survives a reload
+  // and can be shared, and the import page settles for itself whether it may write to that account
+  const openImport = () => {
+    if (!visibleAccount) return
+    navigate(`/settings/imports?${IMPORT_ACCOUNT_PARAM}=${visibleAccount.id}`)
+  }
+
   const handleAccountDeleteStarted = (deletingAccount: Account) => {
     setDeletedAccountSnapshot(deletingAccount)
     setDeleteExitPhase('pending')
@@ -193,6 +201,7 @@ export default function AccountDetailPage() {
               linkedTaxAdvantagedCategory={linkedTaxAdvantagedCategory}
               linkedTaxAdvantagedCategoryError={linkedTaxAdvantagedCategoryError}
               onEdit={openAccountEditModal}
+              onImport={openImport}
             />
 
             <BalanceChartCard account={visibleAccount} />

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -218,14 +218,11 @@ export default function AccountDetailPage() {
             <h2 className="mb-4 font-serif text-4xl font-medium leading-none">Transactions</h2>
             <TransactionListSection
               key={visibleAccount.id}
-              fixedAccount={{
-                id: visibleAccount.id,
-                name: visibleAccount.name,
-                currency: visibleAccount.currency,
-                institution: visibleAccount.institution,
-                is_archived: visibleAccount.is_archived,
-                closed_at: visibleAccount.closed_at,
-              }}
+              // The same narrowing the counterparty accounts go through, rather than a second list
+              // of fields to keep in step with it. A field this page forgot to copy is one the
+              // toolbar reads as absent, and whether an import may be written here is read from two
+              // of them
+              fixedAccount={toTransactionListAccount(visibleAccount)}
               accounts={(accounts ?? []).map(toTransactionListAccount)}
               currency={visibleAccount.currency}
               onCreateTransaction={openCreateTransaction}

--- a/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
+++ b/frontend/src/pages/accounts/detail/AccountDetailPage.tsx
@@ -201,7 +201,6 @@ export default function AccountDetailPage() {
               linkedTaxAdvantagedCategory={linkedTaxAdvantagedCategory}
               linkedTaxAdvantagedCategoryError={linkedTaxAdvantagedCategoryError}
               onEdit={openAccountEditModal}
-              onImport={openImport}
             />
 
             <BalanceChartCard account={visibleAccount} />
@@ -225,11 +224,13 @@ export default function AccountDetailPage() {
                 currency: visibleAccount.currency,
                 institution: visibleAccount.institution,
                 is_archived: visibleAccount.is_archived,
+                closed_at: visibleAccount.closed_at,
               }}
               accounts={(accounts ?? []).map(toTransactionListAccount)}
               currency={visibleAccount.currency}
               onCreateTransaction={openCreateTransaction}
               onEditTransaction={openEditTransaction}
+              onImport={openImport}
             />
           </div>
 

--- a/frontend/src/pages/accounts/detail/components/identity/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/identity/Card.tsx
@@ -14,9 +14,11 @@ import { TaxAdvantagedCategoryBand } from './TaxAdvantagedBand'
 /**
  * Renders account identity, static account facts, and tax-advantaged context
  *
- * @param onImport - Opens an import that files every row into this account. Offered only while the
- *   account can take new transactions, which an archived or closed one cannot, so the import is
- *   absent rather than disabled on those, the way the edit button already is on a closed account
+ * @param onImport - Opens an import that files every row into this account. Absent rather than
+ *   disabled on an archived or closed account, the way the edit button already is on a closed one,
+ *   since the API refuses an import written to either. It is still offered on an account the user
+ *   may only read, which the API also refuses, because nothing the account list carries says which
+ *   of them those are
  */
 export default function AccountIdentityCard({
   account,

--- a/frontend/src/pages/accounts/detail/components/identity/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/identity/Card.tsx
@@ -1,4 +1,4 @@
-import { Pencil } from 'lucide-react'
+import { Pencil, Upload } from 'lucide-react'
 import type { Account } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import { formatCurrency } from '@/utils/formatCurrency'
@@ -13,17 +13,23 @@ import { TaxAdvantagedCategoryBand } from './TaxAdvantagedBand'
 
 /**
  * Renders account identity, static account facts, and tax-advantaged context
+ *
+ * @param onImport - Opens an import that files every row into this account. Offered only while the
+ *   account can take new transactions, which an archived or closed one cannot, so the import is
+ *   absent rather than disabled on those, the way the edit button already is on a closed account
  */
 export default function AccountIdentityCard({
   account,
   linkedTaxAdvantagedCategory,
   linkedTaxAdvantagedCategoryError,
   onEdit,
+  onImport,
 }: {
   account: Account
   linkedTaxAdvantagedCategory: TaxAdvantagedCategory | undefined
   linkedTaxAdvantagedCategoryError: unknown
   onEdit: () => void
+  onImport: () => void
 }) {
   const { user } = useAuth()
   const linkedTaxAdvantagedCategoryId = account.group_id === null ? account.tax_advantaged_category_id : null
@@ -45,14 +51,27 @@ export default function AccountIdentityCard({
   return (
     <section className="app-card relative flex flex-col min-[750px]:min-h-[440px]">
       {!account.closed_at && (
-        <button
-          type="button"
-          aria-label="Edit account"
-          className="app-icon-button absolute right-2 top-2"
-          onClick={onEdit}
-        >
-          <Pencil size={14} aria-hidden />
-        </button>
+        <div className="absolute right-2 top-2 flex items-center gap-1">
+          {!account.is_archived && (
+            <button
+              type="button"
+              aria-label="Import transactions into this account"
+              className="app-icon-button"
+              onClick={onImport}
+            >
+              <Upload size={14} aria-hidden />
+            </button>
+          )}
+
+          <button
+            type="button"
+            aria-label="Edit account"
+            className="app-icon-button"
+            onClick={onEdit}
+          >
+            <Pencil size={14} aria-hidden />
+          </button>
+        </div>
       )}
 
       <InstitutionLogo institution={account.institution} variant="detail" />

--- a/frontend/src/pages/accounts/detail/components/identity/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/identity/Card.tsx
@@ -1,4 +1,4 @@
-import { Pencil, Upload } from 'lucide-react'
+import { Pencil } from 'lucide-react'
 import type { Account } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import { formatCurrency } from '@/utils/formatCurrency'
@@ -13,25 +13,17 @@ import { TaxAdvantagedCategoryBand } from './TaxAdvantagedBand'
 
 /**
  * Renders account identity, static account facts, and tax-advantaged context
- *
- * @param onImport - Opens an import that files every row into this account. Absent rather than
- *   disabled on an archived or closed account, the way the edit button already is on a closed one,
- *   since the API refuses an import written to either. It is still offered on an account the user
- *   may only read, which the API also refuses, because nothing the account list carries says which
- *   of them those are
  */
 export default function AccountIdentityCard({
   account,
   linkedTaxAdvantagedCategory,
   linkedTaxAdvantagedCategoryError,
   onEdit,
-  onImport,
 }: {
   account: Account
   linkedTaxAdvantagedCategory: TaxAdvantagedCategory | undefined
   linkedTaxAdvantagedCategoryError: unknown
   onEdit: () => void
-  onImport: () => void
 }) {
   const { user } = useAuth()
   const linkedTaxAdvantagedCategoryId = account.group_id === null ? account.tax_advantaged_category_id : null
@@ -53,27 +45,14 @@ export default function AccountIdentityCard({
   return (
     <section className="app-card relative flex flex-col min-[750px]:min-h-[440px]">
       {!account.closed_at && (
-        <div className="absolute right-2 top-2 flex items-center gap-1">
-          {!account.is_archived && (
-            <button
-              type="button"
-              aria-label="Import transactions into this account"
-              className="app-icon-button"
-              onClick={onImport}
-            >
-              <Upload size={14} aria-hidden />
-            </button>
-          )}
-
-          <button
-            type="button"
-            aria-label="Edit account"
-            className="app-icon-button"
-            onClick={onEdit}
-          >
-            <Pencil size={14} aria-hidden />
-          </button>
-        </div>
+        <button
+          type="button"
+          aria-label="Edit account"
+          className="app-icon-button absolute right-2 top-2"
+          onClick={onEdit}
+        >
+          <Pencil size={14} aria-hidden />
+        </button>
       )}
 
       <InstitutionLogo institution={account.institution} variant="detail" />

--- a/frontend/src/pages/imports/ImportsPage.tsx
+++ b/frontend/src/pages/imports/ImportsPage.tsx
@@ -55,14 +55,17 @@ export default function ImportsPage() {
   // what the user had. Leaving the scope gives that export back
   const isScopedToAccount = accountScope.state === 'ready'
 
-  // A Firefly import that is already running keeps its own flow on screen even if a scope arrives
-  // over it, which the browser's Back button can do without remounting the page. Swapping the flow
-  // under a commit would replace the overlay reporting it with an idle one and leave the page
-  // looking finished while the write was still going
+  // Whichever flow is working keeps the page, whatever the scope and the stored choice say. The
+  // address can gain or lose the account without remounting the page, through the link out of the
+  // scope and the browser's Back button, and swapping the flow under a commit would replace the
+  // overlay reporting it with an idle one and leave the page looking finished while the write was
+  // still going. Read from each workflow rather than from the flow on screen, so neither can be
+  // swapped away while it is the busy one
   const isFireflyBusy = fireflyWorkflow.importOverlayOpen
     || fireflyWorkflow.processingFileKind !== null
     || fireflyWorkflow.isImportingBudgets
-  const isFirefly = dataSource === 'firefly' && (!isScopedToAccount || isFireflyBusy)
+  const isGenericBusy = workflow.importOverlayOpen || workflow.isProcessingFiles || workflow.isImportInFlight
+  const isFirefly = isFireflyBusy || (!isGenericBusy && dataSource === 'firefly' && !isScopedToAccount)
   const importOverlayOpen = isFirefly ? fireflyWorkflow.importOverlayOpen : workflow.importOverlayOpen
 
   // Where the page came from, which is also where its two exits go while the scope holds
@@ -76,9 +79,7 @@ export default function ImportsPage() {
 
   // Switching source resets the flow being left, so a file still being read or an import still
   // being written would finish into a flow the user has already discarded
-  const isImportBusy = overlayOnScreen || (isFirefly
-    ? fireflyWorkflow.processingFileKind !== null || fireflyWorkflow.isImportingBudgets
-    : workflow.isProcessingFiles || workflow.isImportInFlight)
+  const isImportBusy = overlayOnScreen || isFireflyBusy || isGenericBusy
 
   // Every mapping answer is made against these three lists, and one of them going stale sends the
   // import at a category or account that has since been renamed or deleted elsewhere. Categories in
@@ -117,13 +118,9 @@ export default function ImportsPage() {
 
   // The scope is settled against the accounts list, so the page holds until that answer arrives and
   // shows no import flow at all where the answer is no. Settings is the way out of all three, since
-  // none of them has an account worth returning to
-  //
-  // An import already under way keeps the page it is running on. The commit refetches the accounts
-  // list as it finishes, so an account archived elsewhere during the import would otherwise replace
-  // the overlay reporting what was written with a refusal screen, and the user would never learn
-  // whether the import wrote anything
-  if (accountScope.state !== 'unscoped' && accountScope.state !== 'ready' && !isImportBusy) {
+  // none of them has an account worth returning to. None of the three can interrupt an import that
+  // has already started, because the scope settles once per account and is then held
+  if (accountScope.state !== 'unscoped' && accountScope.state !== 'ready') {
     return (
       <div
         className="relative flex h-screen min-h-screen flex-col items-center justify-center px-5"

--- a/frontend/src/pages/imports/ImportsPage.tsx
+++ b/frontend/src/pages/imports/ImportsPage.tsx
@@ -3,7 +3,13 @@ import { useNavigate } from 'react-router'
 import { useQueryClient } from '@tanstack/react-query'
 import { Upload, X } from 'lucide-react'
 import { accountKeys, categoryKeys, institutionKeys, merchantKeys } from '@/api/cache/queryKeys'
-import { ImportProgressOverlay } from './components'
+import {
+  ACCOUNTS_LOAD_FAILURE_EXPLANATION,
+  ACCOUNTS_LOAD_FAILURE_TITLE,
+  IMPORT_NOT_PERMITTED_EXPLANATION,
+  IMPORT_NOT_PERMITTED_TITLE,
+} from './constants'
+import { ImportLoadFailure, ImportProgressOverlay } from './components'
 import { useFireflyImportWorkflow } from './firefly/hooks'
 import {
   FireflyAccountMappingStep,
@@ -13,7 +19,7 @@ import {
   FireflyFilesStep,
   FireflyPreviewStep,
 } from './firefly/sections'
-import { useTransactionImportWorkflow } from './hooks'
+import { useImportAccountScope, useTransactionImportWorkflow } from './hooks'
 import {
   ImportAccountMappingStep,
   ImportAutoCreateStep,
@@ -38,10 +44,21 @@ export default function ImportsPage() {
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const [dataSource, setDataSource] = useState<ImportDataSource>('generic')
+  const accountScope = useImportAccountScope()
   const workflow = useTransactionImportWorkflow()
   const fireflyWorkflow = useFireflyImportWorkflow()
-  const isFirefly = dataSource === 'firefly'
+
+  // An import started from an account is the generic flow and nothing else, since the account it
+  // fixes has no meaning to the Firefly one. Read from the scope rather than from the stored choice,
+  // because that choice is page state and a change of query string leaves the page mounted, so a
+  // scope arriving over a staged Firefly export has to render the generic flow without disturbing
+  // what the user had. Leaving the scope gives that export back
+  const isScopedToAccount = accountScope.state === 'ready'
+  const isFirefly = !isScopedToAccount && dataSource === 'firefly'
   const importOverlayOpen = isFirefly ? fireflyWorkflow.importOverlayOpen : workflow.importOverlayOpen
+
+  // Where the page came from, which is also where its two exits go while the scope holds
+  const scopedAccountPath = accountScope.accountId ? `/accounts/${accountScope.accountId}` : null
 
   // The overlay covers the page for as long as it takes to fade, which is after the import it was
   // showing has already ended, so the page under it is held until it has actually gone rather than
@@ -87,7 +104,47 @@ export default function ImportsPage() {
   }
 
   const handleDone = () => {
-    navigate('/')
+    navigate(isScopedToAccount && scopedAccountPath ? scopedAccountPath : '/')
+  }
+
+  // The scope is settled against the accounts list, so the page holds until that answer arrives and
+  // shows no import flow at all where the answer is no. Settings is the way out of all three, since
+  // none of them has an account worth returning to
+  if (accountScope.state !== 'unscoped' && accountScope.state !== 'ready') {
+    return (
+      <div
+        className="relative flex h-screen min-h-screen flex-col items-center justify-center px-5"
+        style={{ background: 'var(--app-bg)', color: 'var(--app-text)' }}
+      >
+        <button
+          type="button"
+          className="app-icon-button absolute right-5 top-5 z-20 shrink-0 sm:right-8 sm:top-6"
+          onClick={() => navigate('/settings')}
+          aria-label="Close import workflow"
+        >
+          <X size={20} aria-hidden />
+        </button>
+
+        {accountScope.state === 'loading' && <div className="app-spinner" role="status" aria-label="Loading" />}
+
+        {accountScope.state === 'failed' && (
+          <div className="w-full max-w-md">
+            <ImportLoadFailure
+              title={ACCOUNTS_LOAD_FAILURE_TITLE}
+              description={ACCOUNTS_LOAD_FAILURE_EXPLANATION}
+              onRetry={accountScope.refetchAccounts}
+            />
+          </div>
+        )}
+
+        {accountScope.state === 'unavailable' && (
+          <div className="max-w-md text-center">
+            <h1 className="app-page-title">{IMPORT_NOT_PERMITTED_TITLE}</h1>
+            <p className="app-page-description">{IMPORT_NOT_PERMITTED_EXPLANATION}</p>
+          </div>
+        )}
+      </div>
+    )
   }
 
   return (
@@ -107,7 +164,7 @@ export default function ImportsPage() {
         <button
           type="button"
           className="app-icon-button absolute right-5 top-5 z-20 shrink-0 sm:right-8 sm:top-6"
-          onClick={() => navigate('/settings')}
+          onClick={() => navigate(isScopedToAccount && scopedAccountPath ? scopedAccountPath : '/settings')}
           aria-label="Close import workflow"
         >
           <X size={20} aria-hidden />
@@ -149,7 +206,8 @@ export default function ImportsPage() {
           <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5 pt-3 sm:px-8 xl:overflow-hidden">
             <div className="flex min-h-full flex-col gap-8 xl:h-full xl:min-h-0 xl:flex-row">
               <aside className="flex flex-col gap-8 xl:h-full xl:w-[340px] xl:shrink-0">
-                <ImportSourceStep value={dataSource} onChange={handleDataSourceChange} />
+                {/* An import started from an account has one source, so the choice is not offered */}
+                {!isScopedToAccount && <ImportSourceStep value={dataSource} onChange={handleDataSourceChange} />}
                 <div className="min-h-0 xl:flex-1">
                   {isFirefly ? <FireflyFilesStep {...fireflyWorkflow} /> : <ImportFilesStep {...workflow} />}
                 </div>

--- a/frontend/src/pages/imports/ImportsPage.tsx
+++ b/frontend/src/pages/imports/ImportsPage.tsx
@@ -4,10 +4,10 @@ import { useQueryClient } from '@tanstack/react-query'
 import { Upload, X } from 'lucide-react'
 import { accountKeys, categoryKeys, institutionKeys, merchantKeys } from '@/api/cache/queryKeys'
 import {
-  ACCOUNTS_LOAD_FAILURE_EXPLANATION,
-  ACCOUNTS_LOAD_FAILURE_TITLE,
   IMPORT_NOT_PERMITTED_EXPLANATION,
   IMPORT_NOT_PERMITTED_TITLE,
+  IMPORT_SCOPE_FAILURE_EXPLANATION,
+  IMPORT_SCOPE_FAILURE_TITLE,
 } from './constants'
 import { ImportLoadFailure, ImportProgressOverlay } from './components'
 import { useFireflyImportWorkflow } from './firefly/hooks'
@@ -54,7 +54,15 @@ export default function ImportsPage() {
   // scope arriving over a staged Firefly export has to render the generic flow without disturbing
   // what the user had. Leaving the scope gives that export back
   const isScopedToAccount = accountScope.state === 'ready'
-  const isFirefly = !isScopedToAccount && dataSource === 'firefly'
+
+  // A Firefly import that is already running keeps its own flow on screen even if a scope arrives
+  // over it, which the browser's Back button can do without remounting the page. Swapping the flow
+  // under a commit would replace the overlay reporting it with an idle one and leave the page
+  // looking finished while the write was still going
+  const isFireflyBusy = fireflyWorkflow.importOverlayOpen
+    || fireflyWorkflow.processingFileKind !== null
+    || fireflyWorkflow.isImportingBudgets
+  const isFirefly = dataSource === 'firefly' && (!isScopedToAccount || isFireflyBusy)
   const importOverlayOpen = isFirefly ? fireflyWorkflow.importOverlayOpen : workflow.importOverlayOpen
 
   // Where the page came from, which is also where its two exits go while the scope holds
@@ -110,7 +118,12 @@ export default function ImportsPage() {
   // The scope is settled against the accounts list, so the page holds until that answer arrives and
   // shows no import flow at all where the answer is no. Settings is the way out of all three, since
   // none of them has an account worth returning to
-  if (accountScope.state !== 'unscoped' && accountScope.state !== 'ready') {
+  //
+  // An import already under way keeps the page it is running on. The commit refetches the accounts
+  // list as it finishes, so an account archived elsewhere during the import would otherwise replace
+  // the overlay reporting what was written with a refusal screen, and the user would never learn
+  // whether the import wrote anything
+  if (accountScope.state !== 'unscoped' && accountScope.state !== 'ready' && !isImportBusy) {
     return (
       <div
         className="relative flex h-screen min-h-screen flex-col items-center justify-center px-5"
@@ -130,8 +143,8 @@ export default function ImportsPage() {
         {accountScope.state === 'failed' && (
           <div className="w-full max-w-md">
             <ImportLoadFailure
-              title={ACCOUNTS_LOAD_FAILURE_TITLE}
-              description={ACCOUNTS_LOAD_FAILURE_EXPLANATION}
+              title={IMPORT_SCOPE_FAILURE_TITLE}
+              description={IMPORT_SCOPE_FAILURE_EXPLANATION}
               onRetry={accountScope.refetchAccounts}
             />
           </div>

--- a/frontend/src/pages/imports/ImportsPage.tsx
+++ b/frontend/src/pages/imports/ImportsPage.tsx
@@ -45,7 +45,7 @@ export default function ImportsPage() {
   const queryClient = useQueryClient()
   const [dataSource, setDataSource] = useState<ImportDataSource>('generic')
   const accountScope = useImportAccountScope()
-  const workflow = useTransactionImportWorkflow()
+  const workflow = useTransactionImportWorkflow(accountScope.account)
   const fireflyWorkflow = useFireflyImportWorkflow()
 
   // An import started from an account is the generic flow and nothing else, since the account it

--- a/frontend/src/pages/imports/ImportsPage.tsx
+++ b/frontend/src/pages/imports/ImportsPage.tsx
@@ -65,7 +65,13 @@ export default function ImportsPage() {
     || fireflyWorkflow.processingFileKind !== null
     || fireflyWorkflow.isImportingBudgets
   const isGenericBusy = workflow.importOverlayOpen || workflow.isProcessingFiles || workflow.isImportInFlight
-  const isFirefly = isFireflyBusy || (!isGenericBusy && dataSource === 'firefly' && !isScopedToAccount)
+
+  // A staged CSV holds the page as well as a running import, or dismissing a failed commit would
+  // drop the user on an empty Firefly flow with their file still staged behind it. Kept apart from
+  // the busy flag, which decides whether the source may be changed at all, and a staged file has
+  // never stopped that: changing the source resets the flow being left
+  const isGenericHoldingPage = isGenericBusy || workflow.files.length > 0
+  const isFirefly = isFireflyBusy || (!isGenericHoldingPage && dataSource === 'firefly' && !isScopedToAccount)
   const importOverlayOpen = isFirefly ? fireflyWorkflow.importOverlayOpen : workflow.importOverlayOpen
 
   // Where the page came from, which is also where its two exits go while the scope holds

--- a/frontend/src/pages/imports/ImportsPage.tsx
+++ b/frontend/src/pages/imports/ImportsPage.tsx
@@ -65,13 +65,7 @@ export default function ImportsPage() {
     || fireflyWorkflow.processingFileKind !== null
     || fireflyWorkflow.isImportingBudgets
   const isGenericBusy = workflow.importOverlayOpen || workflow.isProcessingFiles || workflow.isImportInFlight
-
-  // A staged CSV holds the page as well as a running import, or dismissing a failed commit would
-  // drop the user on an empty Firefly flow with their file still staged behind it. Kept apart from
-  // the busy flag, which decides whether the source may be changed at all, and a staged file has
-  // never stopped that: changing the source resets the flow being left
-  const isGenericHoldingPage = isGenericBusy || workflow.files.length > 0
-  const isFirefly = isFireflyBusy || (!isGenericHoldingPage && dataSource === 'firefly' && !isScopedToAccount)
+  const isFirefly = isFireflyBusy || (!isGenericBusy && dataSource === 'firefly' && !isScopedToAccount)
   const importOverlayOpen = isFirefly ? fireflyWorkflow.importOverlayOpen : workflow.importOverlayOpen
 
   // Where the page came from, which is also where its two exits go while the scope holds
@@ -124,9 +118,14 @@ export default function ImportsPage() {
 
   // The scope is settled against the accounts list, so the page holds until that answer arrives and
   // shows no import flow at all where the answer is no. Settings is the way out of all three, since
-  // none of them has an account worth returning to. None of the three can interrupt an import that
-  // has already started, because the scope settles once per account and is then held
-  if (accountScope.state !== 'unscoped' && accountScope.state !== 'ready') {
+  // none of them has an account worth returning to
+  //
+  // None of the three may take the page from an import that is already working. The scope holds its
+  // answer once a current list has given one, but a list that has not managed to arrive settles
+  // nothing, and a refetch landing during a commit would otherwise replace the overlay reporting
+  // what was written. That also strands the page: the overlay is taken off screen without the exit
+  // that would clear the flag dimming and disabling everything under it
+  if (accountScope.state !== 'unscoped' && accountScope.state !== 'ready' && !isImportBusy) {
     return (
       <div
         className="relative flex h-screen min-h-screen flex-col items-center justify-center px-5"

--- a/frontend/src/pages/imports/components/Primitives.tsx
+++ b/frontend/src/pages/imports/components/Primitives.tsx
@@ -178,25 +178,47 @@ export function ImportLoadFailure({
  *   browser rearranges on its own, and gives every notice that lists something the same shape. The
  *   marker is set back on, since Tailwind's reset takes it off. A notice with nothing to list omits
  *   the list and renders as it always did
+ * @param tone - How much the notice is asking of the reader. The danger tone is for the one a user
+ *   has to act on before importing, rather than the ordinary ones saying what the import will do,
+ *   and it takes the same colours the load failure already uses
  */
-export function ImportNotice({ title, children, items }: { title: string; children: ReactNode; items?: ReactNode[] }) {
+export function ImportNotice({
+  title,
+  children,
+  items,
+  tone = 'warning',
+}: {
+  title: string
+  children: ReactNode
+  items?: ReactNode[]
+  tone?: 'warning' | 'danger'
+}) {
+  const isDanger = tone === 'danger'
+
   return (
     <div
       className="flex items-start gap-3 rounded-lg px-4 py-3"
       style={{
         ...IMPORT_INSET_STYLE,
+        // The inset style carries a background and no border, so the danger tone brings its own
+        ...(isDanger
+          ? { border: '1px solid var(--app-negative-border)', background: 'var(--app-negative-soft)' }
+          : {}),
         color: 'var(--app-text-muted)',
       }}
     >
       <span
         className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center"
-        style={{ color: 'var(--app-warning-text)' }}
+        style={{ color: isDanger ? 'var(--app-negative)' : 'var(--app-warning-text)' }}
         aria-hidden
       >
         <TriangleAlert size={16} strokeWidth={2.25} />
       </span>
       <div className="min-w-0">
-        <p className="text-[0.9375rem] font-semibold leading-5" style={{ color: 'var(--app-text)' }}>
+        <p
+          className="text-[0.9375rem] font-semibold leading-5"
+          style={{ color: isDanger ? 'var(--app-negative)' : 'var(--app-text)' }}
+        >
           {title}
         </p>
         <p className="mt-1 text-sm leading-5">

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -245,25 +245,6 @@ export const IMPORT_NOT_PERMITTED_EXPLANATION = 'Transactions can only be import
 export const IMPORT_SCOPE_FAILURE_TITLE = 'Your accounts could not be loaded'
 export const IMPORT_SCOPE_FAILURE_EXPLANATION = 'Without them this import cannot tell whether it may write to the account it was started from.'
 
-// Shown in place of the imported-account table when the import was started from an account, since
-// every row goes to that account and there is nothing left to answer
-export const FIXED_ACCOUNT_EMPTY_TITLE = 'No file staged'
-export const FIXED_ACCOUNT_EMPTY_DESCRIPTION = 'Upload a CSV file to import it into this account.'
-
-/**
- * Says which account every row of a scoped import is written to
- *
- * Where the file states a counterparty, the second half points at the table that answers it rather
- * than promising the transfer lands in an account of the user's, since an unanswered counterparty
- * records the transfer as money going outside this app. A file stating none gets the first half
- * alone
- */
-export function getFixedAccountStatement(accountName: string, hasCounterpartySources: boolean) {
-  return hasCounterpartySources
-    ? `All transactions will be imported into ${accountName}. Where a row is a transfer, the counterparty it names is answered in the table below.`
-    : `All transactions will be imported into ${accountName}.`
-}
-
 /**
  * Says what a scoped import does with the currency of the account it writes to
  *
@@ -285,9 +266,12 @@ export const FIXED_ACCOUNT_WARNING_LINK_LABEL = 'Open the full import page'
 
 /**
  * Says what a scoped import will do with a file it is the wrong page for
+ *
+ * Shown before a file is staged as well as after, so it speaks of the import rather than of a file
+ * on screen, and it is the one place the step says which account the rows are going to
  */
 export function getFixedAccountWarning(accountName: string) {
-  return `Every row in this file will be written to ${accountName}. A file covering more than one account, or holding amounts in a currency this account is not kept in, has to go through the full import page.`
+  return `Every transaction imported here will be written to ${accountName}. A file covering more than one account, or holding amounts in a currency this account is not kept in, has to go through the full import page.`
 }
 
 // Shown over the accounts that appear only as a counterparty, which the import writes nothing to

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -226,6 +226,16 @@ export const CLEARED_ACCOUNT_SOURCES_EXPLANATION = 'An account these sources wer
 export const CLEARED_CATEGORY_SOURCES_TITLE = 'Answers cleared'
 export const CLEARED_CATEGORY_SOURCES_EXPLANATION = 'A category these values were matched to no longer exists, so their answers were cleared. Choose a category for each one, or queue a new one for it:'
 
+// Carries the account an import was started from, as a query parameter rather than router state so
+// the scope survives a reload and a shared address
+export const IMPORT_ACCOUNT_PARAM = 'account'
+
+// Shown in place of the whole import page when the address points at an account no import can be
+// written to, which the button on the account's own card never offers and only a typed or shared
+// address reaches
+export const IMPORT_NOT_PERMITTED_TITLE = 'This action is not permitted'
+export const IMPORT_NOT_PERMITTED_EXPLANATION = 'Transactions can only be imported into an account that is open and not archived. This account is archived, closed, or no longer exists.'
+
 // Shown over the accounts that appear only as a counterparty, which the import writes nothing to
 export const COUNTERPARTY_ONLY_TABLE_TITLE = 'Counterparty accounts'
 export const COUNTERPARTY_ONLY_EXPLANATION = 'These accounts only ever appeared as the counterparty of a transfer. Matching one to an account of your own records where the money came from or went to and writes no transaction into that account, which is why an account you have archived can be chosen here and stays archived. Leaving one unmatched records the transfer as going outside this app. To bring a name in as an account of your own instead, select Create New Account in its Existing Account column.'

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -253,12 +253,14 @@ export const FIXED_ACCOUNT_EMPTY_DESCRIPTION = 'Upload a CSV file to import it i
 /**
  * Says which account every row of a scoped import is written to
  *
- * The counterparty clause is only true where the file states one, so a file with no such column
- * gets the first half alone rather than a promise about transfers it does not carry
+ * Where the file states a counterparty, the second half points at the table that answers it rather
+ * than promising the transfer lands in an account of the user's, since an unanswered counterparty
+ * records the transfer as money going outside this app. A file stating none gets the first half
+ * alone
  */
 export function getFixedAccountStatement(accountName: string, hasCounterpartySources: boolean) {
   return hasCounterpartySources
-    ? `All transactions will be imported into ${accountName}, with the appropriate transfers recorded in the counterparty account.`
+    ? `All transactions will be imported into ${accountName}. Where a row is a transfer, the counterparty it names is answered in the table below.`
     : `All transactions will be imported into ${accountName}.`
 }
 
@@ -266,10 +268,12 @@ export function getFixedAccountStatement(accountName: string, hasCounterpartySou
  * Says what a scoped import does with the currency of the account it writes to
  *
  * Replaces the ordinary currency note, which speaks of the account each source is mapped to and of
- * changing a currency on a row, neither of which a scoped import has
+ * changing a currency on a row, neither of which a scoped import has. A row stating another currency
+ * stops the whole import rather than being dropped from it, since one unimportable row leaves the
+ * commit with no payload at all
  */
 export function getFixedAccountCurrencyNote(accountName: string, currency: string) {
-  return `Imported amounts are treated as raw values. Every row will be assigned ${currency}, the currency ${accountName} is kept in, and a row stating a different currency is left out of the import.`
+  return `Imported amounts are treated as raw values. Every row will be assigned ${currency}, the currency ${accountName} is kept in, and a row stating a different currency stops the import until the file is corrected or its currency column is set to Do not import.`
 }
 
 // The file cannot be checked for covering more than one account, since the column that would say so

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -236,6 +236,32 @@ export const IMPORT_ACCOUNT_PARAM = 'account'
 export const IMPORT_NOT_PERMITTED_TITLE = 'This action is not permitted'
 export const IMPORT_NOT_PERMITTED_EXPLANATION = 'Transactions can only be imported into an account that is open and not archived. This account is archived, closed, or no longer exists.'
 
+// Shown in place of the imported-account table when the import was started from an account, since
+// every row goes to that account and there is nothing left to answer
+export const FIXED_ACCOUNT_EMPTY_TITLE = 'No file staged'
+export const FIXED_ACCOUNT_EMPTY_DESCRIPTION = 'Upload a CSV file to import it into this account.'
+
+/**
+ * Says which account every row of a scoped import is written to
+ */
+export function getFixedAccountStatement(accountName: string) {
+  return `All transactions will be imported into ${accountName}, with the appropriate transfers recorded in the counterparty account.`
+}
+
+// The file cannot be checked for covering more than one account, since the column that would say so
+// is not offered here, so the notice says what the import will do and offers the way out. The
+// currency is named alongside it because a file the account's currency refuses is the other reason
+// to leave, and both are answered by the same page
+export const FIXED_ACCOUNT_WARNING_TITLE = 'One account only'
+export const FIXED_ACCOUNT_WARNING_LINK_LABEL = 'Open the full import page'
+
+/**
+ * Says what a scoped import will do with a file it is the wrong page for
+ */
+export function getFixedAccountWarning(accountName: string) {
+  return `Every row in this file will be written to ${accountName}. A file covering more than one account, or holding amounts in a currency this account is not kept in, has to go through the full import page.`
+}
+
 // Shown over the accounts that appear only as a counterparty, which the import writes nothing to
 export const COUNTERPARTY_ONLY_TABLE_TITLE = 'Counterparty accounts'
 export const COUNTERPARTY_ONLY_EXPLANATION = 'These accounts only ever appeared as the counterparty of a transfer. Matching one to an account of your own records where the money came from or went to and writes no transaction into that account, which is why an account you have archived can be chosen here and stays archived. Leaving one unmatched records the transfer as going outside this app. To bring a name in as an account of your own instead, select Create New Account in its Existing Account column.'

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -233,8 +233,17 @@ export const IMPORT_ACCOUNT_PARAM = 'account'
 // Shown in place of the whole import page when the address points at an account no import can be
 // written to, which the button on the account's own card never offers and only a typed or shared
 // address reaches
+// The account is only ever missing from the list, archived or closed, and the list leaves out both
+// an account that has gone and one belonging to someone else, so the wording covers being unable to
+// import into it rather than claiming to know which of those it is
 export const IMPORT_NOT_PERMITTED_TITLE = 'This action is not permitted'
-export const IMPORT_NOT_PERMITTED_EXPLANATION = 'Transactions can only be imported into an account that is open and not archived. This account is archived, closed, or no longer exists.'
+export const IMPORT_NOT_PERMITTED_EXPLANATION = 'Transactions can only be imported into an account that is open and not archived. This one is archived, closed, or not an account you can import into.'
+
+// Shown in place of the whole page where the accounts list cannot say whether this account takes an
+// import. The mapping step's own failure text is about mapping sources onto a list, which is a
+// question this page never reaches
+export const IMPORT_SCOPE_FAILURE_TITLE = 'Your accounts could not be loaded'
+export const IMPORT_SCOPE_FAILURE_EXPLANATION = 'Without them this import cannot tell whether it may write to the account it was started from.'
 
 // Shown in place of the imported-account table when the import was started from an account, since
 // every row goes to that account and there is nothing left to answer
@@ -243,9 +252,24 @@ export const FIXED_ACCOUNT_EMPTY_DESCRIPTION = 'Upload a CSV file to import it i
 
 /**
  * Says which account every row of a scoped import is written to
+ *
+ * The counterparty clause is only true where the file states one, so a file with no such column
+ * gets the first half alone rather than a promise about transfers it does not carry
  */
-export function getFixedAccountStatement(accountName: string) {
-  return `All transactions will be imported into ${accountName}, with the appropriate transfers recorded in the counterparty account.`
+export function getFixedAccountStatement(accountName: string, hasCounterpartySources: boolean) {
+  return hasCounterpartySources
+    ? `All transactions will be imported into ${accountName}, with the appropriate transfers recorded in the counterparty account.`
+    : `All transactions will be imported into ${accountName}.`
+}
+
+/**
+ * Says what a scoped import does with the currency of the account it writes to
+ *
+ * Replaces the ordinary currency note, which speaks of the account each source is mapped to and of
+ * changing a currency on a row, neither of which a scoped import has
+ */
+export function getFixedAccountCurrencyNote(accountName: string, currency: string) {
+  return `Imported amounts are treated as raw values. Every row will be assigned ${currency}, the currency ${accountName} is kept in, and a row stating a different currency is left out of the import.`
 }
 
 // The file cannot be checked for covering more than one account, since the column that would say so

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -231,8 +231,8 @@ export const CLEARED_CATEGORY_SOURCES_EXPLANATION = 'A category these values wer
 export const IMPORT_ACCOUNT_PARAM = 'account'
 
 // Shown in place of the whole import page when the address points at an account no import can be
-// written to, which the button on the account's own card never offers and only a typed or shared
-// address reaches
+// written to. The button offering the import is disabled in those states, so this is reached by a
+// typed or shared address, or by an account whose state changed after the address was made
 // The account is only ever missing from the list, archived or closed, and the list leaves out both
 // an account that has gone and one belonging to someone else, so the wording covers being unable to
 // import into it rather than claiming to know which of those it is

--- a/frontend/src/pages/imports/hooks/index.ts
+++ b/frontend/src/pages/imports/hooks/index.ts
@@ -1,4 +1,5 @@
 export * from './useImportAccountCreateState'
+export * from './useImportAccountScope'
 export * from './useImportMerchantMatches'
 export * from './useImportReferenceData'
 export * from './useTransactionImportWorkflow'

--- a/frontend/src/pages/imports/hooks/useImportAccountScope.ts
+++ b/frontend/src/pages/imports/hooks/useImportAccountScope.ts
@@ -28,8 +28,9 @@ export interface ImportAccountScope {
  * The answer is settled once per account and then held. The question this asks is whether an import
  * may be started here, and an account archived elsewhere while one is already under way must not
  * take the running import off the screen, nor quietly turn the staged file back into an ordinary
- * import whose rows rest on creating an account. The API refuses the commit in that case, which is
- * where a change made elsewhere belongs. Pointing the address at a different account asks again
+ * import whose rows rest on creating an account. The commit refuses to write rows to an archived
+ * account anyway, which is where a change made elsewhere belongs. Pointing the address at a
+ * different account asks again
  */
 export function useImportAccountScope(): ImportAccountScope {
   const [searchParams] = useSearchParams()
@@ -47,18 +48,27 @@ export function useImportAccountScope(): ImportAccountScope {
     [accountId, accounts],
   )
 
+  const accountsCurrent = dataUpdatedAt > 0 && !isFetching && !isError
+
   const liveState = getImportAccountScopeState({
     accountId,
     account,
-    accountsCurrent: dataUpdatedAt > 0 && !isFetching && !isError,
+    accountsCurrent,
     accountsError: isError,
   })
 
+  // Settled only on an answer a current list gave. `ready` is deliberately optimistic about a list
+  // that may be months old, which is right while the fresh one is still on its way and wrong to
+  // hold for the rest of the page: an account archived before this page was ever opened would then
+  // never be corrected, and the import would run to a commit that refuses every row
+  //
   // The account carries on being read from the list while it is settled, so a rename shows, and it
   // is only replaced wholesale when the address points somewhere else
   const [settledAccount, setSettledAccount] = useState<AccountsOverview | null>(null)
   const isSettled = Boolean(accountId) && settledAccount?.id === accountId
-  if (liveState === 'ready' && account && settledAccount !== account) setSettledAccount(account)
+  if (liveState === 'ready' && accountsCurrent && account && settledAccount !== account) {
+    setSettledAccount(account)
+  }
 
   const state = isSettled ? 'ready' : liveState
 

--- a/frontend/src/pages/imports/hooks/useImportAccountScope.ts
+++ b/frontend/src/pages/imports/hooks/useImportAccountScope.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react'
+import { useSearchParams } from 'react-router'
+import { useAccounts, type AccountsOverview } from '@/api/accounts'
+import { IMPORT_ACCOUNT_PARAM } from '@/pages/imports/constants'
+import { getImportAccountScopeState, type ImportAccountScopeState } from '@/pages/imports/utils'
+
+/**
+ * The account an import was started from, and what the page should do about it
+ */
+export interface ImportAccountScope {
+  /** The account the address points at, null on an ordinary import started from Settings */
+  accountId: string | null
+
+  /** The account itself, only once it is settled that an import may be written to it */
+  account: AccountsOverview | null
+
+  state: ImportAccountScopeState
+  refetchAccounts: () => void
+}
+
+/**
+ * Reads the account an import was started from and settles whether the page may import into it
+ *
+ * The same accounts query both import flows already read, so this costs no extra request, and the
+ * three flags it derives are the ones `useImportReferenceData` derives from the same query
+ */
+export function useImportAccountScope(): ImportAccountScope {
+  const [searchParams] = useSearchParams()
+  const accountId = searchParams.get(IMPORT_ACCOUNT_PARAM)
+  const {
+    data: accounts = [],
+    isError,
+    isFetching,
+    dataUpdatedAt,
+    refetch,
+  } = useAccounts()
+
+  const account = useMemo(
+    () => (accountId ? accounts.find((candidate) => candidate.id === accountId) : undefined),
+    [accountId, accounts],
+  )
+
+  const state = getImportAccountScopeState({
+    accountId,
+    account,
+    accountsCurrent: dataUpdatedAt > 0 && !isFetching && !isError,
+    accountsError: isError,
+  })
+
+  return {
+    accountId,
+    // Held back until the state settles, so nothing downstream can file rows into an account that
+    // is archived, closed or still being judged
+    account: state === 'ready' && account ? account : null,
+    state,
+    refetchAccounts: refetch,
+  }
+}

--- a/frontend/src/pages/imports/hooks/useImportAccountScope.ts
+++ b/frontend/src/pages/imports/hooks/useImportAccountScope.ts
@@ -1,6 +1,7 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { useSearchParams } from 'react-router'
-import { useAccounts, type AccountsOverview } from '@/api/accounts'
+import { useAccounts } from '@/api/accounts'
+import type { AccountsOverview } from '@/api/accounts'
 import { IMPORT_ACCOUNT_PARAM } from '@/pages/imports/constants'
 import { getImportAccountScopeState, type ImportAccountScopeState } from '@/pages/imports/utils'
 
@@ -23,6 +24,12 @@ export interface ImportAccountScope {
  *
  * The same accounts query both import flows already read, so this costs no extra request, and the
  * three flags it derives are the ones `useImportReferenceData` derives from the same query
+ *
+ * The answer is settled once per account and then held. The question this asks is whether an import
+ * may be started here, and an account archived elsewhere while one is already under way must not
+ * take the running import off the screen, nor quietly turn the staged file back into an ordinary
+ * import whose rows rest on creating an account. The API refuses the commit in that case, which is
+ * where a change made elsewhere belongs. Pointing the address at a different account asks again
  */
 export function useImportAccountScope(): ImportAccountScope {
   const [searchParams] = useSearchParams()
@@ -40,18 +47,26 @@ export function useImportAccountScope(): ImportAccountScope {
     [accountId, accounts],
   )
 
-  const state = getImportAccountScopeState({
+  const liveState = getImportAccountScopeState({
     accountId,
     account,
     accountsCurrent: dataUpdatedAt > 0 && !isFetching && !isError,
     accountsError: isError,
   })
 
+  // The account carries on being read from the list while it is settled, so a rename shows, and it
+  // is only replaced wholesale when the address points somewhere else
+  const [settledAccount, setSettledAccount] = useState<AccountsOverview | null>(null)
+  const isSettled = Boolean(accountId) && settledAccount?.id === accountId
+  if (liveState === 'ready' && account && settledAccount !== account) setSettledAccount(account)
+
+  const state = isSettled ? 'ready' : liveState
+
   return {
     accountId,
     // Held back until the state settles, so nothing downstream can file rows into an account that
     // is archived, closed or still being judged
-    account: state === 'ready' && account ? account : null,
+    account: state === 'ready' ? settledAccount ?? account ?? null : null,
     state,
     refetchAccounts: refetch,
   }

--- a/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
@@ -104,13 +104,15 @@ export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | nu
   const isAccountFixed = fixedAccount !== null
 
   // The account an import was started from answers for every row, so nothing downstream may read a
-  // mapped account column while that holds. Emptied here rather than cleared from what is stored,
-  // because the column mapping is only inferred when a file is staged: a user who leaves the scope,
-  // maps the account column by hand and comes back would otherwise arrive with it mapped, the row
-  // sources would go back to being that column's values, and every row with a blank account cell
-  // would be refused on a page where the column is meant not to matter. Their answer is still there
-  // when they leave the scope again, until they map another column here, which writes the emptied
-  // map back
+  // mapped account column while that holds. Emptied here rather than cleared outright, because the
+  // column mapping is only inferred when a file is staged: a user who leaves the scope, maps the
+  // account column by hand and comes back would otherwise arrive with it mapped, the row sources
+  // would go back to being that column's values, and every row with a blank account cell would be
+  // refused on a page where the column is meant not to matter
+  //
+  // What is stored keeps that answer only until the next file is staged or the next column is
+  // answered here, both of which write this emptied map back. So leaving the scope leaves the
+  // account column unmapped in the ordinary case, for the user to answer on the page they went to
   const columnMap = useMemo(
     () => (isAccountFixed ? { ...storedColumnMap, account_id: '' } : storedColumnMap),
     [isAccountFixed, storedColumnMap],
@@ -377,8 +379,13 @@ export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | nu
     [allAccounts],
   )
 
+  // Read against the stored map rather than the emptied one, because that is the map the key was
+  // written from. The scope can turn on and off without a file being staged or a column answered,
+  // which is what writes the key, so comparing against the emptied map would call the key stale on
+  // a scope change alone. The match would then never run and every counterparty the file names
+  // would quietly record its transfer as money leaving the app
   const canInferAccountMappings = Boolean(accountAutoMatchKey)
-    && accountAutoMatchKey === (columnMap.account_id || FILE_ACCOUNT_MATCH_KEY)
+    && accountAutoMatchKey === (storedColumnMap.account_id || FILE_ACCOUNT_MATCH_KEY)
 
   const { mappings: liveAccountMappings, clearedSources: clearedAccountSources } = useMemo(
     () => (accountsResolved
@@ -463,9 +470,23 @@ export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | nu
 
   // Read before the name match and any of the defaults are layered on, so the batch bar can tell an
   // answer the user gave from one the step filled in for them
+  //
+  // A source rows are written to is left out while the account is fixed. Its answer is that account
+  // whatever the user picked earlier, so reporting it as theirs would offer a later reader an answer
+  // the step is ignoring
   const handAnsweredAccountSources = useMemo(
-    () => new Set(Object.entries(liveAccountMappings).filter(([, choice]) => choice).map(([source]) => source)),
-    [liveAccountMappings],
+    () => {
+      const counterpartyOnly = new Set(
+        accountMappingSources.filter((source) => source.isCounterpartyOnly).map((source) => source.id),
+      )
+
+      return new Set(
+        Object.entries(liveAccountMappings)
+          .filter(([source, choice]) => choice && !(isAccountFixed && !counterpartyOnly.has(source)))
+          .map(([source]) => source),
+      )
+    },
+    [accountMappingSources, isAccountFixed, liveAccountMappings],
   )
 
   // Read before the create-new fallback, which answers every row source and would therefore leave

--- a/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
@@ -11,6 +11,7 @@ import { OUTSIDE_ACCOUNT_LABEL, OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
 import type { ColumnMap, ColumnTarget, ColumnValidationErrors, ImportCategoryKind, ImportFileDraft, ImportOverlayPhase, PreviewTransactionRow } from '@/pages/imports/types'
 import {
   applyCreateAccountFallback,
+  applyFixedImportAccount,
   buildColumnTargetOptions,
   buildImportAnswerScope,
   buildImportAccountMappingSources,
@@ -392,12 +393,17 @@ export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | nu
       // since the worst that answer can do is offer a new account the user still has to fill in
       const answerableSources = accountMappingSources.filter((source) => !clearedAccountSources.has(source.id))
 
+      // The account an import was started from answers every source rows are written to, over every
+      // source rather than only the answerable ones, so a cleared source cannot slip past it into
+      // the create-new fallback and quietly create an account the step says nothing about
+      const answered = applyFixedImportAccount(accountMappingSources, liveAccountMappings, fixedAccount?.id ?? null)
+
       const resolved = canInferAccountMappings
-        ? inferAccountMappings(answerableSources, liveAccountMappings, {
+        ? inferAccountMappings(answerableSources, answered, {
           rowAccounts: selectableAccounts,
           counterpartyAccounts: allAccounts,
         })
-        : { ...liveAccountMappings }
+        : { ...answered }
 
       // No row is written to these, so the import creates nothing for them unless the user asks for
       // an account by hand, and the transfers pointing at them say the money left the app
@@ -406,7 +412,7 @@ export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | nu
       }
       return resolved
     },
-    [accountMappingSources, allAccounts, canInferAccountMappings, clearedAccountSources, liveAccountMappings, selectableAccounts],
+    [accountMappingSources, allAccounts, canInferAccountMappings, clearedAccountSources, fixedAccount, liveAccountMappings, selectableAccounts],
   )
 
   // Every row source the match could not place rests on creating an account, so the step asks for
@@ -906,6 +912,7 @@ export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | nu
     isProcessingFiles,
     autoFilledColumnHeaders,
     columnMap,
+    fixedAccount,
     accountMappings: resolvedAccountMappings,
     archivedAccountMatches,
     autoFilledAccountSources,

--- a/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
@@ -87,7 +87,8 @@ const IMPORT_OVERLAY_MIN_MS = 2000
  *
  * @param fixedAccount - The account this import was started from, null for an ordinary import. It
  *   answers the account question outright, so the column mapping neither offers nor keeps an account
- *   column while it holds
+ *   column while it holds, and every source rows are written to is that account rather than anything
+ *   resolved from the file. A transfer's counterparty is resolved as it always is
  */
 export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | null = null) {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -477,14 +478,20 @@ export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | nu
   const autoFilledAccountSources = useMemo(
     () => new Set(
       accountMappingSources
-        .filter((source) => isAutoFilledAccountSource(
-          liveAccountMappings[source.id] ?? '',
-          resolvedAccountMappings[source.id] ?? '',
-          source.isCounterpartyOnly,
-        ))
+        .filter((source) => {
+          // The highlight means an account was recognised from what the file says, and the account
+          // an import was started from is neither recognised nor shown in a row of its own
+          if (isAccountFixed && !source.isCounterpartyOnly) return false
+
+          return isAutoFilledAccountSource(
+            liveAccountMappings[source.id] ?? '',
+            resolvedAccountMappings[source.id] ?? '',
+            source.isCounterpartyOnly,
+          )
+        })
         .map((source) => source.id),
     ),
-    [accountMappingSources, liveAccountMappings, resolvedAccountMappings],
+    [accountMappingSources, isAccountFixed, liveAccountMappings, resolvedAccountMappings],
   )
 
   const importedCategories = useMemo(

--- a/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent, type Dispatch, type SetStateAction } from 'react'
+import type { AccountsOverview } from '@/api/accounts'
 import {
   discardStagedRun,
   useCommitStagedImport,
@@ -82,8 +83,12 @@ const IMPORT_OVERLAY_MIN_MS = 2000
  * Account and category matches are only inferred automatically while the required columns stay
  * mapped to the same headers; changing a required column's mapping clears the matching auto-fill key
  * so a stale inference is never carried into a different set of source values
+ *
+ * @param fixedAccount - The account this import was started from, null for an ordinary import. It
+ *   answers the account question outright, so the column mapping neither offers nor keeps an account
+ *   column while it holds
  */
-export function useTransactionImportWorkflow() {
+export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | null = null) {
   const inputRef = useRef<HTMLInputElement>(null)
   const [files, setFiles] = useState<ImportFileDraft[]>([])
   const [isProcessingFiles, setIsProcessingFiles] = useState(false)
@@ -93,7 +98,21 @@ export function useTransactionImportWorkflow() {
   // leaves their answers alone instead of guessing over them. A column set to Do not import counts
   // as answered, which is the case an empty mapping cannot tell apart on its own
   const [decidedColumnHeaders, setDecidedColumnHeaders] = useState<Set<string>>(() => new Set())
-  const [columnMap, setColumnMap] = useState<ColumnMap>(EMPTY_COLUMN_MAP)
+  const [storedColumnMap, setStoredColumnMap] = useState<ColumnMap>(EMPTY_COLUMN_MAP)
+  const isAccountFixed = fixedAccount !== null
+
+  // The account an import was started from answers for every row, so nothing downstream may read a
+  // mapped account column while that holds. Emptied here rather than cleared from what is stored,
+  // because the column mapping is only inferred when a file is staged: a user who leaves the scope,
+  // maps the account column by hand and comes back would otherwise arrive with it mapped, the row
+  // sources would go back to being that column's values, and every row with a blank account cell
+  // would be refused on a page where the column is meant not to matter. Their answer is still there
+  // when they leave the scope again, until they map another column here, which writes the emptied
+  // map back
+  const columnMap = useMemo(
+    () => (isAccountFixed ? { ...storedColumnMap, account_id: '' } : storedColumnMap),
+    [isAccountFixed, storedColumnMap],
+  )
 
   const [scopedAccountMappings, setScopedAccountMappings] = useState<ScopedImportAnswers<string>>(emptyScopedImportAnswers)
   const [accountAutoMatchKey, setAccountAutoMatchKey] = useState('')
@@ -296,8 +315,8 @@ export function useTransactionImportWorkflow() {
   )
 
   const columnTargetOptions = useMemo(
-    () => buildColumnTargetOptions(),
-    [],
+    () => buildColumnTargetOptions({ omitAccountColumn: isAccountFixed }),
+    [isAccountFixed],
   )
 
   // Counted off the files and the merchant column alone, so the mapping step can say how many rows
@@ -657,10 +676,12 @@ export function useTransactionImportWorkflow() {
    * none of them has to be re-run to reach the same state
    */
   const applyStagedFiles = (nextFiles: ImportFileDraft[]) => {
-    const result = inferColumnMap(columnMap, nextFiles, supportedCurrencyCodes, decidedColumnHeaders)
+    const result = inferColumnMap(columnMap, nextFiles, supportedCurrencyCodes, decidedColumnHeaders, {
+      omitAccountColumn: isAccountFixed,
+    })
 
     setFiles(nextFiles)
-    setColumnMap(result.map)
+    setStoredColumnMap(result.map)
     setColumnValidationErrors(result.errors)
     setAutoFilledColumnHeaders((current) => getNextAutoFilledColumnHeaders(current, columnMap, result.map))
     syncAutoMatchKeys(result.map, result.errors, nextFiles)
@@ -747,7 +768,7 @@ export function useTransactionImportWorkflow() {
     }
 
     setColumnValidationErrors(nextColumnValidationErrors)
-    setColumnMap(nextColumnMap)
+    setStoredColumnMap(nextColumnMap)
 
     // The mapping the last refusal was about has changed, so the message stops being true
     setImportError(null)
@@ -855,7 +876,7 @@ export function useTransactionImportWorkflow() {
     setIsProcessingFiles(false)
     setAutoFilledColumnHeaders(new Set())
     setDecidedColumnHeaders(new Set())
-    setColumnMap(EMPTY_COLUMN_MAP)
+    setStoredColumnMap(EMPTY_COLUMN_MAP)
     setScopedAccountMappings(emptyScopedImportAnswers)
     setAccountAutoMatchKey('')
     resetAccountCreateState()

--- a/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
@@ -15,7 +15,14 @@ import {
   CREATED_ACCOUNT_CREDIT_LIMIT_NOTE,
   CREATED_ACCOUNT_EXPLANATION,
   CREATED_ACCOUNT_TITLE,
+  FIXED_ACCOUNT_EMPTY_DESCRIPTION,
+  FIXED_ACCOUNT_EMPTY_TITLE,
+  FIXED_ACCOUNT_WARNING_LINK_LABEL,
+  FIXED_ACCOUNT_WARNING_TITLE,
+  IMPORT_INSET_STYLE,
   UNSET_BATCH_INSTITUTION,
+  getFixedAccountStatement,
+  getFixedAccountWarning,
 } from '@/pages/imports/constants'
 import type { ImportAccountSource } from '@/pages/imports/types'
 import { isCreatingImportAccount } from '@/pages/imports/utils'
@@ -31,6 +38,7 @@ type ImportAccountMappingStepProps = Pick<
   TransactionImportWorkflow,
   | 'accountMappingSources'
   | 'accountMappings'
+  | 'fixedAccount'
   | 'archivedAccountMatches'
   | 'autoFilledAccountSources'
   | 'handAnsweredAccountSources'
@@ -65,10 +73,15 @@ type ImportAccountMappingStepProps = Pick<
 /**
  * Account mapping step of the generic CSV import flow, wrapping the shared mapping table with the
  * modal used to create an institution from a row or from the batch bar
+ *
+ * An import started from an account has no imported-account table at all: every row goes to that
+ * account, so the step says so and warns about the one file this page is wrong for. The counterparty
+ * table is unaffected, since a transfer still has to say where its money came from or went to
  */
 export function ImportAccountMappingStep({
   accountMappingSources,
   accountMappings,
+  fixedAccount,
   archivedAccountMatches,
   autoFilledAccountSources,
   handAnsweredAccountSources,
@@ -198,9 +211,10 @@ export function ImportAccountMappingStep({
           onRetry={refetchAccounts}
         />
       ) : accountMappingSources.length === 0 ? (
+        // A fixed account has no column to check, so the empty state asks only for the file
         <EmptyState
-          title="No account sources detected"
-          description="Upload a file or check the mapped account column."
+          title={fixedAccount ? FIXED_ACCOUNT_EMPTY_TITLE : 'No account sources detected'}
+          description={fixedAccount ? FIXED_ACCOUNT_EMPTY_DESCRIPTION : 'Upload a file or check the mapped account column.'}
         />
       ) : (
         <>
@@ -238,18 +252,40 @@ export function ImportAccountMappingStep({
               {CREATED_ACCOUNT_EXPLANATION}
             </ImportNotice>
           )}
-          <ImportAccountMappingTable
-            rows={importedRows}
-            options={accountOptions}
-            batchAccountType={batchAccountType}
-            batchAccountCurrency={batchAccountCurrency}
-            batchAccountInstitution={batchAccountInstitution}
-            onBatchAccountTypeChange={setBatchAccountType}
-            onBatchAccountCurrencyChange={setBatchAccountCurrency}
-            onBatchAccountInstitutionChange={setBatchAccountInstitution}
-            onBatchCreateInstitution={(query) => openInstitutionModal(query, IMPORTED_BATCH_TARGET)}
-            {...sharedTableProps}
-          />
+          {fixedAccount ? (
+            <div className="space-y-3">
+              <p
+                className="px-4 py-6 text-center text-sm leading-6"
+                style={{ ...IMPORT_INSET_STYLE, color: 'var(--app-text-muted)' }}
+              >
+                {getFixedAccountStatement(fixedAccount.name)}
+              </p>
+              <ImportNotice tone="danger" title={FIXED_ACCOUNT_WARNING_TITLE}>
+                {getFixedAccountWarning(fixedAccount.name)}
+                {' '}
+                <Link
+                  to="/settings/imports"
+                  className="font-medium underline underline-offset-2 transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+                  style={{ color: 'var(--app-accent)' }}
+                >
+                  {FIXED_ACCOUNT_WARNING_LINK_LABEL}
+                </Link>
+              </ImportNotice>
+            </div>
+          ) : (
+            <ImportAccountMappingTable
+              rows={importedRows}
+              options={accountOptions}
+              batchAccountType={batchAccountType}
+              batchAccountCurrency={batchAccountCurrency}
+              batchAccountInstitution={batchAccountInstitution}
+              onBatchAccountTypeChange={setBatchAccountType}
+              onBatchAccountCurrencyChange={setBatchAccountCurrency}
+              onBatchAccountInstitutionChange={setBatchAccountInstitution}
+              onBatchCreateInstitution={(query) => openInstitutionModal(query, IMPORTED_BATCH_TARGET)}
+              {...sharedTableProps}
+            />
+          )}
           {counterpartySources.length > 0 && (
             <div className="space-y-3 pt-8">
               <div className="space-y-1">

--- a/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
@@ -21,6 +21,7 @@ import {
   FIXED_ACCOUNT_WARNING_TITLE,
   IMPORT_INSET_STYLE,
   UNSET_BATCH_INSTITUTION,
+  getFixedAccountCurrencyNote,
   getFixedAccountStatement,
   getFixedAccountWarning,
 } from '@/pages/imports/constants'
@@ -201,7 +202,9 @@ export function ImportAccountMappingStep({
     <ImportStep index="03" title="Account Mapping">
       {!accountsFailed && (
         <ImportNotice title="Currency Handling">
-          Imported amounts are treated as raw values. During import, each amount will be assigned the base currency of the mapped account, or the currency shown against a new account, which is taken from the file where it states one and can be changed on any row.
+          {fixedAccount
+            ? getFixedAccountCurrencyNote(fixedAccount.name, fixedAccount.currency)
+            : 'Imported amounts are treated as raw values. During import, each amount will be assigned the base currency of the mapped account, or the currency shown against a new account, which is taken from the file where it states one and can be changed on any row.'}
         </ImportNotice>
       )}
       {accountsFailed ? (
@@ -258,7 +261,7 @@ export function ImportAccountMappingStep({
                 className="px-4 py-6 text-center text-sm leading-6"
                 style={{ ...IMPORT_INSET_STYLE, color: 'var(--app-text-muted)' }}
               >
-                {getFixedAccountStatement(fixedAccount.name)}
+                {getFixedAccountStatement(fixedAccount.name, counterpartySources.length > 0)}
               </p>
               <ImportNotice tone="danger" title={FIXED_ACCOUNT_WARNING_TITLE}>
                 {getFixedAccountWarning(fixedAccount.name)}

--- a/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
@@ -15,14 +15,10 @@ import {
   CREATED_ACCOUNT_CREDIT_LIMIT_NOTE,
   CREATED_ACCOUNT_EXPLANATION,
   CREATED_ACCOUNT_TITLE,
-  FIXED_ACCOUNT_EMPTY_DESCRIPTION,
-  FIXED_ACCOUNT_EMPTY_TITLE,
   FIXED_ACCOUNT_WARNING_LINK_LABEL,
   FIXED_ACCOUNT_WARNING_TITLE,
-  IMPORT_INSET_STYLE,
   UNSET_BATCH_INSTITUTION,
   getFixedAccountCurrencyNote,
-  getFixedAccountStatement,
   getFixedAccountWarning,
 } from '@/pages/imports/constants'
 import type { ImportAccountSource } from '@/pages/imports/types'
@@ -207,6 +203,21 @@ export function ImportAccountMappingStep({
             : 'Imported amounts are treated as raw values. During import, each amount will be assigned the base currency of the mapped account, or the currency shown against a new account, which is taken from the file where it states one and can be changed on any row.'}
         </ImportNotice>
       )}
+      {/* Says what this page will do with a file whether or not one is staged, since a file covering
+          more than one account has to be sent elsewhere before it is uploaded rather than after */}
+      {fixedAccount && (
+        <ImportNotice tone="danger" title={FIXED_ACCOUNT_WARNING_TITLE}>
+          {getFixedAccountWarning(fixedAccount.name)}
+          {' '}
+          <Link
+            to="/settings/imports"
+            className="font-medium underline underline-offset-2 transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+            style={{ color: 'var(--app-accent)' }}
+          >
+            {FIXED_ACCOUNT_WARNING_LINK_LABEL}
+          </Link>
+        </ImportNotice>
+      )}
       {accountsFailed ? (
         <ImportLoadFailure
           title={ACCOUNTS_LOAD_FAILURE_TITLE}
@@ -214,11 +225,14 @@ export function ImportAccountMappingStep({
           onRetry={refetchAccounts}
         />
       ) : accountMappingSources.length === 0 ? (
-        // A fixed account has no column to check, so the empty state asks only for the file
-        <EmptyState
-          title={fixedAccount ? FIXED_ACCOUNT_EMPTY_TITLE : 'No account sources detected'}
-          description={fixedAccount ? FIXED_ACCOUNT_EMPTY_DESCRIPTION : 'Upload a file or check the mapped account column.'}
-        />
+        // A fixed account has already been told what will happen, by the notice above, so nothing
+        // asks it for a file a second time
+        fixedAccount ? null : (
+          <EmptyState
+            title="No account sources detected"
+            description="Upload a file or check the mapped account column."
+          />
+        )
       ) : (
         <>
           {clearedAccountSourceLabels.length > 0 && (
@@ -255,27 +269,9 @@ export function ImportAccountMappingStep({
               {CREATED_ACCOUNT_EXPLANATION}
             </ImportNotice>
           )}
-          {fixedAccount ? (
-            <div className="space-y-3">
-              <p
-                className="px-4 py-6 text-center text-sm leading-6"
-                style={{ ...IMPORT_INSET_STYLE, color: 'var(--app-text-muted)' }}
-              >
-                {getFixedAccountStatement(fixedAccount.name, counterpartySources.length > 0)}
-              </p>
-              <ImportNotice tone="danger" title={FIXED_ACCOUNT_WARNING_TITLE}>
-                {getFixedAccountWarning(fixedAccount.name)}
-                {' '}
-                <Link
-                  to="/settings/imports"
-                  className="font-medium underline underline-offset-2 transition-colors duration-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
-                  style={{ color: 'var(--app-accent)' }}
-                >
-                  {FIXED_ACCOUNT_WARNING_LINK_LABEL}
-                </Link>
-              </ImportNotice>
-            </div>
-          ) : (
+          {/* The scope answers every source rows are written to, so there is no table to show for
+              them. The counterparty table below still asks about a transfer's other side */}
+          {fixedAccount ? null : (
             <ImportAccountMappingTable
               rows={importedRows}
               options={accountOptions}

--- a/frontend/src/pages/imports/utils/accountMapping.ts
+++ b/frontend/src/pages/imports/utils/accountMapping.ts
@@ -132,6 +132,10 @@ export function dropVanishedAccountMappings(
  * creating an account, since `applyCreateAccountFallback` covers every row source with no answer,
  * so a tie between two of the user's accounts ends up creating a third one carrying that name
  *
+ * An import started from an account reaches neither of those. `applyFixedImportAccount` has already
+ * answered every source rows are written to, so this only ever settles a transfer's counterparty
+ * there
+ *
  * The two lists differ by which accounts each kind of source can be offered: a source no row is
  * written to can record an archived account, so matching it against the list the dropdown does not
  * offer would fill in a choice the user cannot see or change
@@ -196,6 +200,9 @@ export function applyFixedImportAccount(
  *
  * Kept out of `inferAccountMappings`, which the Firefly flow shares and which answers a different
  * question: which existing account a source is, with no answer being a legitimate result
+ *
+ * An import started from an account leaves nothing here to rest on create, since every source rows
+ * are written to is answered before this runs
  *
  * @param sources - Every mapping source, cleared ones included, since a cleared row still has to be
  *   answerable and this fallback can only ever offer it a new account

--- a/frontend/src/pages/imports/utils/accountMapping.ts
+++ b/frontend/src/pages/imports/utils/accountMapping.ts
@@ -154,6 +154,39 @@ export function inferAccountMappings(
 }
 
 /**
+ * Files every source rows are written to into the one account an import was started from
+ *
+ * That account is the user's own answer rather than a guess, so it goes on before the name match,
+ * which leaves an answered source alone, and before the create-new fallback, which then finds
+ * nothing left to rest on create. It answers a source whose stored answer was cleared as well, since
+ * the step shows no dropdown to answer one with while the account is fixed
+ *
+ * A counterparty-only source is left alone. No row is written to it, so it still asks which account
+ * a transfer's money came from or went to, which may be any account or none
+ *
+ * @param sources - Every mapping source, cleared ones included
+ * @param mappings - The answers as stored, before any match or default is layered on
+ * @param accountId - The account the import was started from, null for an ordinary import, which
+ *   returns the answers untouched
+ */
+export function applyFixedImportAccount(
+  sources: ImportAccountSource[],
+  mappings: Record<string, string>,
+  accountId: string | null,
+): Record<string, string> {
+  if (!accountId) return mappings
+
+  const next = { ...mappings }
+
+  for (const source of sources) {
+    if (source.isCounterpartyOnly) continue
+    next[source.id] = accountId
+  }
+
+  return next
+}
+
+/**
  * Rests every row source the match could not place on creating an account
  *
  * A source rows are written to has to end up as some account, so creating one is the only answer

--- a/frontend/src/pages/imports/utils/accountScope.ts
+++ b/frontend/src/pages/imports/utils/accountScope.ts
@@ -1,0 +1,50 @@
+import type { AccountsOverview } from '@/api/accounts'
+
+/**
+ * What the import page does with the account its address points at
+ *
+ * `unscoped` is an ordinary import started from Settings, and `ready` is one started from an
+ * account, which fixes every row to that account. The other three are what the page shows instead
+ * of the flow
+ */
+export type ImportAccountScopeState = 'unscoped' | 'loading' | 'failed' | 'unavailable' | 'ready'
+
+/**
+ * Settles what the import page does with the account in its address
+ *
+ * An account is only importable while it is open and not archived, which is what the API asks of
+ * every account an import writes rows to.
+ *
+ * Both stale readings of the accounts list wait for a current one: a list that predates the account
+ * and a list that still calls it archived would each otherwise refuse an account that is fine on the
+ * server, and that list is kept in local storage for months. An account the list holds as open is
+ * taken at its word even while a refetch is in flight, so a background refresh never takes a staged
+ * import off the screen
+ *
+ * @param accountId - The account the address points at, null on an ordinary import
+ * @param account - That account as the loaded list holds it, undefined where the list has no such id
+ * @param accountsCurrent - Whether the list is in hand, with no request in flight and none failed
+ * @param accountsError - Whether the last request for the list failed, whatever is in hand
+ */
+export function getImportAccountScopeState({
+  accountId,
+  account,
+  accountsCurrent,
+  accountsError,
+}: {
+  accountId: string | null
+  account: AccountsOverview | undefined
+  accountsCurrent: boolean
+  accountsError: boolean
+}): ImportAccountScopeState {
+  if (!accountId) return 'unscoped'
+
+  if (account && !account.is_archived && !account.closed_at) return 'ready'
+  if (accountsCurrent) return 'unavailable'
+
+  // Reached where the list in hand cannot answer the question and the request that would have has
+  // failed, which nothing retries on its own, so the page offers the retry rather than waiting
+  if (accountsError) return 'failed'
+
+  return 'loading'
+}

--- a/frontend/src/pages/imports/utils/accountScope.ts
+++ b/frontend/src/pages/imports/utils/accountScope.ts
@@ -10,6 +10,25 @@ import type { AccountsOverview } from '@/api/accounts'
 export type ImportAccountScopeState = 'unscoped' | 'loading' | 'failed' | 'unavailable' | 'ready'
 
 /**
+ * Whether an import may write rows to this account
+ *
+ * The rule the API applies to every account an import writes to, which refuses an archived one and
+ * an account that has been closed. Read both by the page that offers the import and by the page that
+ * carries it out, so the control offering it and the screen refusing it cannot drift apart
+ *
+ * Asked of the two fields rather than of a whole account, since the transaction list is handed a
+ * summary carrying only what it reads. A summary stating neither field is taken as an open account,
+ * which is how the Add Transaction button beside it already reads a missing `is_archived`
+ *
+ * @param account - The account, or null where none has been loaded, which is not importable either
+ */
+export function isImportableAccount(
+  account: { is_archived?: boolean; closed_at?: string | null } | null | undefined,
+): boolean {
+  return Boolean(account) && !account?.is_archived && !account?.closed_at
+}
+
+/**
  * Settles what the import page does with the account in its address
  *
  * An account is only importable while it is open and not archived, which is what the API asks of
@@ -39,7 +58,7 @@ export function getImportAccountScopeState({
 }): ImportAccountScopeState {
   if (!accountId) return 'unscoped'
 
-  if (account && !account.is_archived && !account.closed_at) return 'ready'
+  if (isImportableAccount(account)) return 'ready'
   if (accountsCurrent) return 'unavailable'
 
   // Reached where the list in hand cannot answer the question and the request that would have has

--- a/frontend/src/pages/imports/utils/accountScope.ts
+++ b/frontend/src/pages/imports/utils/accountScope.ts
@@ -9,12 +9,19 @@ import type { AccountsOverview } from '@/api/accounts'
  */
 export type ImportAccountScopeState = 'unscoped' | 'loading' | 'failed' | 'unavailable' | 'ready'
 
+/** One mapping row's answer, and the facts that decide whether an import may be written to it */
+export interface ImportableAccountFacts {
+  is_archived?: boolean
+  closed_at?: string | null
+}
+
 /**
  * Whether an import may write rows to this account
  *
- * The rule the API applies to every account an import writes to, which refuses an archived one and
- * an account that has been closed. Read both by the page that offers the import and by the page that
- * carries it out, so the control offering it and the screen refusing it cannot drift apart
+ * The two states the app can see that stop an import: an archived account and a closed one. The API
+ * refuses a third the accounts list says nothing about, which is an account shared with the user at
+ * read level, so a true answer here means only that nothing on this side objects. Read both by the
+ * control offering the import and by the page carrying it out, so the two cannot drift apart
  *
  * Asked of the two fields rather than of a whole account, since the transaction list is handed a
  * summary carrying only what it reads. A summary stating neither field is taken as an open account,
@@ -22,10 +29,22 @@ export type ImportAccountScopeState = 'unscoped' | 'loading' | 'failed' | 'unava
  *
  * @param account - The account, or null where none has been loaded, which is not importable either
  */
-export function isImportableAccount(
-  account: { is_archived?: boolean; closed_at?: string | null } | null | undefined,
-): boolean {
+export function isImportableAccount(account: ImportableAccountFacts | null | undefined): boolean {
   return Boolean(account) && !account?.is_archived && !account?.closed_at
+}
+
+/**
+ * Says why an import cannot be written to this account, or nothing where it can
+ *
+ * Both states are read-only, and an account in both is described as archived, since that is the one
+ * a user put it in and the one they can take it out of
+ *
+ * @param account - The account, or null where the control has no one account to import into, which
+ *   has no reason to give
+ */
+export function getImportBlockReason(account: ImportableAccountFacts | null | undefined): string | undefined {
+  if (!account || isImportableAccount(account)) return undefined
+  return account.is_archived ? 'Archived accounts are read-only' : 'Closed accounts are read-only'
 }
 
 /**

--- a/frontend/src/pages/imports/utils/autoColumnMapping.ts
+++ b/frontend/src/pages/imports/utils/autoColumnMapping.ts
@@ -173,9 +173,11 @@ const MIN_CATEGORY_DISTINCT_VALUES = 4
  * it used to hold
  * @param omitAccountColumn - Whether the finished map may hold an account column, which an import
  * started from an account may not, since that account is the answer. The account column is still
- * detected and only dropped at the end, so the column it found stays claimed and no other field can
- * take it. Skipping the detection instead would hand a column of account names to the merchant
- * field, which scores on the shape of a short repeated text column
+ * detected and only dropped at the end, so a column it claims is not left for another field to take.
+ * Skipping the detection instead would hand a column of account names to the merchant field, which
+ * scores on the shape of a short repeated text column. This only covers a column the account field
+ * would accept: one with a blank cell fails its required-values check, is refused there, and can
+ * still be claimed as a merchant, which is what happens on an ordinary import as well
  */
 export function inferColumnMap(
   columnMap: ColumnMap,

--- a/frontend/src/pages/imports/utils/autoColumnMapping.ts
+++ b/frontend/src/pages/imports/utils/autoColumnMapping.ts
@@ -171,12 +171,18 @@ const MIN_CATEGORY_DISTINCT_VALUES = 4
  * headings does not undo the answer. The decision is remembered about the column rather than about
  * the field, so ignoring a column keeps it ignored while a different column can still fill the field
  * it used to hold
+ * @param omitAccountColumn - Whether the finished map may hold an account column, which an import
+ * started from an account may not, since that account is the answer. The account column is still
+ * detected and only dropped at the end, so the column it found stays claimed and no other field can
+ * take it. Skipping the detection instead would hand a column of account names to the merchant
+ * field, which scores on the shape of a short repeated text column
  */
 export function inferColumnMap(
   columnMap: ColumnMap,
   files: ImportFileDraft[],
   supportedCurrencyCodes: Set<string>,
   decidedHeaders: Set<string> = new Set(),
+  { omitAccountColumn = false } = {},
 ) {
   const result = validateColumnMap(columnMap, files, supportedCurrencyCodes)
   if (files.length === 0) return result
@@ -200,6 +206,8 @@ export function inferColumnMap(
       usedHeaders.add(header)
     }
   }
+
+  if (omitAccountColumn) inferredMap.account_id = ''
 
   return validateColumnMap(inferredMap, files, supportedCurrencyCodes)
 }

--- a/frontend/src/pages/imports/utils/index.ts
+++ b/frontend/src/pages/imports/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './accountMapping'
+export * from './accountScope'
 export * from './autoColumnMapping'
 export * from './categoryMatching'
 export * from './merchantMatching'

--- a/frontend/src/pages/imports/utils/workflowOptions.ts
+++ b/frontend/src/pages/imports/utils/workflowOptions.ts
@@ -136,9 +136,15 @@ export function buildImportCategoryMatchOptions(categories: Category[] = []): Dr
  *
  * Each field's hint rides along as the option's description, which is where a user decides what a
  * column means. Ignoring a column needs no explanation, so that entry carries none
+ *
+ * @param omitAccountColumn - Whether the account field is left out, which is what an import started
+ *   from an account does, since that account is the answer and no column may contradict it
  */
-export function buildColumnTargetOptions(): DropdownOption[] {
-  const targetsByGroup = [...COLUMN_TARGETS].sort((a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)))
+export function buildColumnTargetOptions({ omitAccountColumn = false } = {}): DropdownOption[] {
+  const offeredTargets = omitAccountColumn
+    ? COLUMN_TARGETS.filter((target) => target.id !== 'account_id')
+    : COLUMN_TARGETS
+  const targetsByGroup = [...offeredTargets].sort((a, b) => Number(Boolean(b.required)) - Number(Boolean(a.required)))
 
   return [
     { value: '', label: 'Do not import' },

--- a/frontend/src/pages/transactions/TransactionsPage.tsx
+++ b/frontend/src/pages/transactions/TransactionsPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useReducedMotion } from 'motion/react'
+import { useNavigate } from 'react-router'
 import { useAuth } from '@/hooks/useAuth'
 import { useAccounts } from '@/api/accounts'
 import {
@@ -22,6 +23,7 @@ import {
  * Renders the transactions page overview, filters, list, and transaction modal workflows
  */
 export default function TransactionsPage() {
+  const navigate = useNavigate()
   const prefersReducedMotion = useReducedMotion()
   const loadTransaction = useLoadTransaction()
   const { user } = useAuth()
@@ -46,6 +48,16 @@ export default function TransactionsPage() {
       setCreateModalKey((key) => key + 1)
       setShowCreateModal(true)
     })
+  }
+
+  /**
+   * Opens the import page, which asks which account each row belongs to
+   *
+   * This list spans every account, so the import is not fixed to one the way it is from an account's
+   * own page, and the address carries none
+   */
+  const openImport = () => {
+    navigate('/settings/imports')
   }
 
   /**
@@ -162,6 +174,7 @@ export default function TransactionsPage() {
           onSettledTransactionsChange={handleSettledTransactionsChange}
           onCreateTransaction={openCreateModal}
           onEditTransaction={openEditModal}
+          onImport={openImport}
         />
       </div>
 

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -5,7 +5,7 @@ import {
   useInfiniteTransactions,
   type Transaction,
 } from '@/api/transactions'
-import { isImportableAccount } from '@/pages/imports/utils'
+import { getImportBlockReason, isImportableAccount } from '@/pages/imports/utils'
 import { TRANSACTION_FILTER_KEYS, TRANSACTION_LIST_EASE } from '@/pages/transactions/constants/transactionList'
 import TransactionDateGroupList from '@/pages/transactions/components/DateGroupList'
 import TransactionFilterLoadingOverlay from '@/pages/transactions/components/FilterLoadingOverlay'
@@ -137,13 +137,12 @@ export default function TransactionListSection({
   const createDisabled = Boolean(fixedAccount?.is_archived)
   const createDisabledReason = createDisabled ? 'Archived accounts are read-only' : undefined
 
-  // Offered only where the list is fixed to one account, since an import written from here goes to
-  // that account and the list of every account has none. It stays on the row in the two states an
-  // import cannot be written to, greyed out with the reason, rather than coming and going
-  const importDisabled = !isImportableAccount(fixedAccount)
-  const importDisabledReason = fixedAccount?.is_archived
-    ? 'Archived accounts are read-only'
-    : fixedAccount?.closed_at ? 'Closed accounts are read-only' : undefined
+  // Only a list fixed to one account can be blocked, since only that one writes rows to an account
+  // of its own. On the list of every account the button is the way to the import page and is always
+  // offered. Where it is blocked it stays on the row, greyed out with the reason, rather than
+  // coming and going
+  const importDisabled = Boolean(fixedAccount) && !isImportableAccount(fixedAccount)
+  const importDisabledReason = getImportBlockReason(fixedAccount)
 
   const { sentinelRef, showPendingFetch } = useInfiniteScrollTrigger({
     hasNextPage,
@@ -184,7 +183,7 @@ export default function TransactionListSection({
         onCreateTransaction={onCreateTransaction}
         createDisabled={createDisabled}
         createDisabledReason={createDisabledReason}
-        onImport={fixedAccount && onImport ? onImport : undefined}
+        onImport={onImport}
         importDisabled={importDisabled}
         importDisabledReason={importDisabledReason}
         onStickyOffsetChange={setDateHeaderStickyTop}

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -5,6 +5,7 @@ import {
   useInfiniteTransactions,
   type Transaction,
 } from '@/api/transactions'
+import { isImportableAccount } from '@/pages/imports/utils'
 import { TRANSACTION_FILTER_KEYS, TRANSACTION_LIST_EASE } from '@/pages/transactions/constants/transactionList'
 import TransactionDateGroupList from '@/pages/transactions/components/DateGroupList'
 import TransactionFilterLoadingOverlay from '@/pages/transactions/components/FilterLoadingOverlay'
@@ -44,6 +45,7 @@ export default function TransactionListSection({
   onSettledTransactionsChange,
   onCreateTransaction,
   onEditTransaction,
+  onImport,
 }: {
   fixedAccount?: TransactionListAccount
   accounts?: TransactionListAccount[]
@@ -54,6 +56,9 @@ export default function TransactionListSection({
   onSettledTransactionsChange?: (transactions: Transaction[]) => void
   onCreateTransaction: () => void
   onEditTransaction: (transaction: Transaction) => void
+
+  // Opens an import filed into the account this list is fixed to, offered only alongside one
+  onImport?: () => void
 }) {
   const prefersReducedMotion = useReducedMotion()
   const { search, setSearch, activeSearch, submitSearch } = useTransactionSearch()
@@ -132,6 +137,14 @@ export default function TransactionListSection({
   const createDisabled = Boolean(fixedAccount?.is_archived)
   const createDisabledReason = createDisabled ? 'Archived accounts are read-only' : undefined
 
+  // Offered only where the list is fixed to one account, since an import written from here goes to
+  // that account and the list of every account has none. It stays on the row in the two states an
+  // import cannot be written to, greyed out with the reason, rather than coming and going
+  const importDisabled = !isImportableAccount(fixedAccount)
+  const importDisabledReason = fixedAccount?.is_archived
+    ? 'Archived accounts are read-only'
+    : fixedAccount?.closed_at ? 'Closed accounts are read-only' : undefined
+
   const { sentinelRef, showPendingFetch } = useInfiniteScrollTrigger({
     hasNextPage,
     isFetchingNextPage,
@@ -171,6 +184,9 @@ export default function TransactionListSection({
         onCreateTransaction={onCreateTransaction}
         createDisabled={createDisabled}
         createDisabledReason={createDisabledReason}
+        onImport={fixedAccount && onImport ? onImport : undefined}
+        importDisabled={importDisabled}
+        importDisabledReason={importDisabledReason}
         onStickyOffsetChange={setDateHeaderStickyTop}
       />
 

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -48,14 +48,17 @@ export default function TransactionListToolbar({
   const importAction = onImport ? (
     <button
       type="button"
-      className="app-glass-button h-11 shrink-0 min-[750px]:h-10"
+      className="app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:h-10 min-[750px]:w-auto min-[750px]:px-4"
       onClick={onImport}
       disabled={importDisabled}
       title={importDisabledReason}
       aria-label={showAccountFilter ? 'Import transactions' : 'Import transactions into this account'}
     >
       <Upload size={18} aria-hidden />
-      <span>Import</span>
+
+      {/* The word is dropped on a phone, where the row is three controls wide and the filters button
+          needs the space it would take. The accessible name carries it at both widths */}
+      <span className="hidden min-[750px]:inline">Import</span>
     </button>
   ) : undefined
 

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -40,18 +40,22 @@ export default function TransactionListToolbar({
   const shell = useToolbarShellState()
   useToolbarStickyOffset(shell.toolbarRef, onStickyOffsetChange)
 
-  // One node for both widths and for the hidden copy the desktop row measures itself by, sized to
-  // match whichever primary button it stands beside, which is taller on a phone than on a desktop
+  // One node for both widths, sized to match the buttons it stands beside, which are taller on a
+  // phone than on a desktop. The accessible name says which import this is, since the word on the
+  // button cannot: on a list fixed to one account it files every row into that account, and on the
+  // list of every account it is the way to the import page. The reason it is blocked rides on the
+  // title alone, the way the create button's does, so the name still says what the control is
   const importAction = onImport ? (
     <button
       type="button"
-      className="app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:h-10 min-[750px]:w-10"
+      className="app-glass-button h-11 shrink-0 min-[750px]:h-10"
       onClick={onImport}
       disabled={importDisabled}
       title={importDisabledReason}
-      aria-label={importDisabledReason ?? 'Import transactions into this account'}
+      aria-label={showAccountFilter ? 'Import transactions' : 'Import transactions into this account'}
     >
       <Upload size={18} aria-hidden />
+      <span>Import</span>
     </button>
   ) : undefined
 
@@ -99,20 +103,27 @@ export default function TransactionListToolbar({
           desktopInlineLayout={shell.desktopInlineLayout}
           desktopCreateStacked={shell.desktopCreateStacked}
           filterPanel={
-            <TransactionFilterPanel
-              accountOptions={accountOptions}
-              categoryOptions={categoryOptions}
-              filters={filters}
-              setFilter={setFilter}
-              showAccountFilter={showAccountFilter}
-              lockedCurrency={lockedCurrency}
-            />
+            // Both go in the filter slot rather than beside the create button, because the layout
+            // hook measures this group's own children as they render. A button placed after the
+            // group instead would need its own measured twin, or the row would report itself
+            // narrower than it draws and stay on one line where it no longer fits. Wrapped as one
+            // child, since the group spreads its children apart once the create button stacks
+            <div className="flex min-w-0 items-center gap-3">
+              {importAction}
+              <TransactionFilterPanel
+                accountOptions={accountOptions}
+                categoryOptions={categoryOptions}
+                filters={filters}
+                setFilter={setFilter}
+                showAccountFilter={showAccountFilter}
+                lockedCurrency={lockedCurrency}
+              />
+            </div>
           }
           createLabel="Add Transaction"
           onCreate={onCreateTransaction}
           createDisabled={createDisabled}
           createDisabledReason={createDisabledReason}
-          secondaryAction={importAction}
         />
       </ToolbarStickyShell>
 

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { Upload } from 'lucide-react'
 import { DesktopToolbarControls } from '@/components/list-controls/DesktopToolbarControls'
 import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { MobileToolbarActions } from '@/components/list-controls/MobileToolbarActions'
@@ -31,10 +32,28 @@ export default function TransactionListToolbar({
   onCreateTransaction,
   createDisabled = false,
   createDisabledReason,
+  onImport,
+  importDisabled = false,
+  importDisabledReason,
   onStickyOffsetChange,
 }: TransactionListToolbarProps) {
   const shell = useToolbarShellState()
   useToolbarStickyOffset(shell.toolbarRef, onStickyOffsetChange)
+
+  // One node for both widths and for the hidden copy the desktop row measures itself by, sized to
+  // match whichever primary button it stands beside, which is taller on a phone than on a desktop
+  const importAction = onImport ? (
+    <button
+      type="button"
+      className="app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:h-10 min-[750px]:w-10"
+      onClick={onImport}
+      disabled={importDisabled}
+      title={importDisabledReason}
+      aria-label={importDisabledReason ?? 'Import transactions into this account'}
+    >
+      <Upload size={18} aria-hidden />
+    </button>
+  ) : undefined
 
   const accountOptions = useMemo(
     () => getAccountOptions(accounts),
@@ -70,6 +89,7 @@ export default function TransactionListToolbar({
           primaryLabel="Add transaction"
           primaryDisabled={createDisabled}
           primaryDisabledReason={createDisabledReason}
+          secondaryAction={importAction}
         />
 
         <DesktopToolbarControls
@@ -92,6 +112,7 @@ export default function TransactionListToolbar({
           onCreate={onCreateTransaction}
           createDisabled={createDisabled}
           createDisabledReason={createDisabledReason}
+          secondaryAction={importAction}
         />
       </ToolbarStickyShell>
 

--- a/frontend/src/pages/transactions/components/toolbar/types.ts
+++ b/frontend/src/pages/transactions/components/toolbar/types.ts
@@ -17,5 +17,11 @@ export type TransactionListToolbarProps = {
   onCreateTransaction: () => void
   createDisabled?: boolean
   createDisabledReason?: string
+
+  // Opens an import that files every row into the one account this list is fixed to. Absent on the
+  // list of every account, which has no one account to import into
+  onImport?: () => void
+  importDisabled?: boolean
+  importDisabledReason?: string
   onStickyOffsetChange?: (offset: number) => void
 }

--- a/frontend/src/pages/transactions/types/transactionList.ts
+++ b/frontend/src/pages/transactions/types/transactionList.ts
@@ -25,6 +25,9 @@ export interface TransactionListAccount {
   currency?: string
   institution?: AccountsOverview['institution']
   is_archived?: boolean
+
+  /** When the account was closed, which is a second state that takes no new transactions */
+  closed_at?: string | null
 }
 
 /**
@@ -40,6 +43,7 @@ export function toTransactionListAccount(account: AccountsOverview): Transaction
     currency: account.currency,
     institution: account.institution,
     is_archived: account.is_archived,
+    closed_at: account.closed_at,
   }
 }
 

--- a/frontend/tests/pages/imports/utils/accountMapping.fixedAccount.test.ts
+++ b/frontend/tests/pages/imports/utils/accountMapping.fixedAccount.test.ts
@@ -57,6 +57,22 @@ describe('filing every row into the account an import was started from', () => {
     expect(applyFixedImportAccount(sources, {}, 'acct-1')).toEqual({ 'file-1': 'acct-1' })
   })
 
+  // Every source rows are written to rather than the first of them, so answering one and stopping
+  // would leave the rest to the create-new fallback while the step says every row goes to one
+  // account
+  it('answers every source rows are written to', () => {
+    const sources = [
+      createSource('Everyday'),
+      createSource('Travel Card'),
+      COUNTERPARTY_SOURCE,
+    ]
+
+    expect(applyFixedImportAccount(sources, {}, 'acct-1')).toEqual({
+      Everyday: 'acct-1',
+      'Travel Card': 'acct-1',
+    })
+  })
+
   // The step shows no dropdown to answer a row source with while the account is fixed, so an answer
   // stored under an earlier scope cannot be corrected by hand and has to give way here
   it('overrides an answer stored for that source', () => {

--- a/frontend/tests/pages/imports/utils/accountMapping.fixedAccount.test.ts
+++ b/frontend/tests/pages/imports/utils/accountMapping.fixedAccount.test.ts
@@ -1,0 +1,104 @@
+/**
+ * Tests what an import started from an account does to the mapping answers: every source rows are
+ * written to takes that account, and the two things layered after it, the name match and the
+ * create-new fallback, both find nothing left to answer
+ */
+import { describe, expect, it } from 'vitest'
+import { CREATE_ACCOUNT_VALUE } from '@/pages/imports/constants'
+import type { AccountsOverview } from '@/api/accounts'
+import type { ImportAccountSource } from '@/pages/imports/types'
+import { OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
+import {
+  applyCreateAccountFallback,
+  applyFixedImportAccount,
+  inferAccountMappings,
+} from '@/pages/imports/utils'
+
+/**
+ * Creates a mapping source, defaulting to one rows are written to
+ */
+function createSource(id: string, overrides: Partial<ImportAccountSource> = {}): ImportAccountSource {
+  return { id, label: id, matchText: id, isCounterpartyOnly: false, ...overrides }
+}
+
+/**
+ * Creates an account overview, carrying only the fields these rules read
+ */
+function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverview {
+  return {
+    id: 'acct-1',
+    owner_id: null,
+    group_id: null,
+    account_kind: 'asset',
+    account_type: 'checking',
+    tax_advantaged_category_id: null,
+    name: 'Everyday',
+    institution: null,
+    currency: 'CAD',
+    current_balance: 0,
+    base_currency_current_balance: 0,
+    current_balance_fx_status: { state: 'complete', missing_pairs: [] },
+    credit_limit: null,
+    is_archived: false,
+    closed_at: null,
+    ...overrides,
+  }
+}
+
+// With no account column mapped the file itself is the one source rows are written to, which is
+// what a scoped import always has
+const FILE_SOURCE = createSource('file-1')
+const COUNTERPARTY_SOURCE = createSource('Mum', { isCounterpartyOnly: true })
+
+describe('filing every row into the account an import was started from', () => {
+  it('answers the file source and leaves a counterparty source alone', () => {
+    const sources = [FILE_SOURCE, COUNTERPARTY_SOURCE]
+
+    expect(applyFixedImportAccount(sources, {}, 'acct-1')).toEqual({ 'file-1': 'acct-1' })
+  })
+
+  // The step shows no dropdown to answer a row source with while the account is fixed, so an answer
+  // stored under an earlier scope cannot be corrected by hand and has to give way here
+  it('overrides an answer stored for that source', () => {
+    expect(applyFixedImportAccount([FILE_SOURCE], { 'file-1': 'acct-9' }, 'acct-1')).toEqual({
+      'file-1': 'acct-1',
+    })
+  })
+
+  it('leaves a counterparty answer alone', () => {
+    expect(applyFixedImportAccount([COUNTERPARTY_SOURCE], { Mum: OUTSIDE_ACCOUNT_VALUE }, 'acct-1')).toEqual({
+      Mum: OUTSIDE_ACCOUNT_VALUE,
+    })
+  })
+
+  // Which is what the page holds the moment the user follows the link out of the scope
+  it('changes nothing at all for an ordinary import', () => {
+    expect(applyFixedImportAccount([FILE_SOURCE], { 'file-1': 'acct-9' }, null)).toEqual({
+      'file-1': 'acct-9',
+    })
+  })
+})
+
+describe('what the layers after it do with an answered source', () => {
+  const accounts = [createAccount()]
+
+  // The file is called Everyday.csv, which the match would otherwise read as the account of that
+  // name, so this is the case where the two disagree
+  const namedLikeAnAccount = createSource('file-1', { label: 'Everyday', matchText: 'Everyday.csv' })
+
+  it('leaves the name match nothing to change', () => {
+    const answered = applyFixedImportAccount([namedLikeAnAccount], {}, 'acct-2')
+
+    expect(inferAccountMappings([namedLikeAnAccount], answered, {
+      rowAccounts: accounts,
+      counterpartyAccounts: accounts,
+    })).toEqual({ 'file-1': 'acct-2' })
+  })
+
+  it('leaves the create-new fallback nothing to rest on create', () => {
+    const answered = applyFixedImportAccount([FILE_SOURCE], {}, 'acct-1')
+
+    expect(applyCreateAccountFallback([FILE_SOURCE], answered)).toEqual({ 'file-1': 'acct-1' })
+    expect(applyCreateAccountFallback([FILE_SOURCE], {})).toEqual({ 'file-1': CREATE_ACCOUNT_VALUE })
+  })
+})

--- a/frontend/tests/pages/imports/utils/autoColumnMapping.test.ts
+++ b/frontend/tests/pages/imports/utils/autoColumnMapping.test.ts
@@ -176,6 +176,48 @@ describe('import column inference', () => {
     expect(Object.values(map)).not.toContain('Type')
   })
 
+  // An import started from an account has no account field to fill, and the column that would have
+  // filled it must not fall to another field instead. Three rows over two distinct values is what
+  // the merchant field scores on, so this fails if the account field is skipped rather than filled
+  // in and then dropped
+  it('leaves an account column unmapped rather than passing it to another field when the account is fixed', () => {
+    const files = [createFile(
+      ['Date', 'Account', 'Amount', 'Category'],
+      [
+        { Date: '2026-04-11', Account: 'Everyday', Amount: '-12.00', Category: 'Groceries' },
+        { Date: '2026-04-12', Account: 'Everyday', Amount: '-8.00', Category: 'Transit' },
+        { Date: '2026-04-13', Account: 'Travel Card', Amount: '-20.00', Category: 'Dining' },
+      ],
+    )]
+
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES, new Set(), {
+      omitAccountColumn: true,
+    })
+
+    expect(map.account_id).toBe('')
+    expect(Object.values(map)).not.toContain('Account')
+
+    // The rest of the file still maps as it always did
+    expect(map.dt).toBe('Date')
+    expect(map.amount).toBe('Amount')
+    expect(map.category_id).toBe('Category')
+  })
+
+  it('maps the same account column as usual when the account is not fixed', () => {
+    const files = [createFile(
+      ['Date', 'Account', 'Amount', 'Category'],
+      [
+        { Date: '2026-04-11', Account: 'Everyday', Amount: '-12.00', Category: 'Groceries' },
+        { Date: '2026-04-12', Account: 'Everyday', Amount: '-8.00', Category: 'Transit' },
+        { Date: '2026-04-13', Account: 'Travel Card', Amount: '-20.00', Category: 'Dining' },
+      ],
+    )]
+
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(map.account_id).toBe('Account')
+  })
+
   // Reading the alias table by property returned the function every object inherits for this one
   // name, which is truthy, and comparing scores against it left a value nothing could beat: the
   // column claimed whichever field reached it first, and no later column could displace it

--- a/frontend/tests/pages/imports/utils/importAccountScope.test.ts
+++ b/frontend/tests/pages/imports/utils/importAccountScope.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests what the import page does with the account its address points at, which decides between
+ * running the flow, holding, offering a retry, and refusing the import outright
+ */
+import { describe, expect, it } from 'vitest'
+import type { AccountsOverview } from '@/api/accounts'
+import { getImportAccountScopeState } from '@/pages/imports/utils'
+
+/**
+ * Creates an account overview, carrying only the fields this rule reads
+ */
+function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverview {
+  return {
+    id: 'acct-1',
+    owner_id: null,
+    group_id: null,
+    account_kind: 'asset',
+    account_type: 'checking',
+    tax_advantaged_category_id: null,
+    name: 'Everyday Chequing',
+    institution: null,
+    currency: 'CAD',
+    current_balance: 0,
+    base_currency_current_balance: 0,
+    current_balance_fx_status: { state: 'complete', missing_pairs: [] },
+    credit_limit: null,
+    is_archived: false,
+    closed_at: null,
+    ...overrides,
+  }
+}
+
+describe('what the import page does with the account in its address', () => {
+  it('runs the ordinary flow when the address carries no account', () => {
+    expect(getImportAccountScopeState({
+      accountId: null,
+      account: undefined,
+      accountsCurrent: true,
+      accountsError: false,
+    })).toBe('unscoped')
+  })
+
+  // The list being refreshed in the background is not a reason to take a staged import off the
+  // screen, so an account the list already holds as open is taken at its word
+  it('imports into an open account even while the list is being refreshed', () => {
+    expect(getImportAccountScopeState({
+      accountId: 'acct-1',
+      account: createAccount(),
+      accountsCurrent: false,
+      accountsError: false,
+    })).toBe('ready')
+  })
+
+  it('refuses an archived account', () => {
+    expect(getImportAccountScopeState({
+      accountId: 'acct-1',
+      account: createAccount({ is_archived: true }),
+      accountsCurrent: true,
+      accountsError: false,
+    })).toBe('unavailable')
+  })
+
+  // The API asks for an open account on every row it writes, so a closed one is refused here rather
+  // than at the commit
+  it('refuses a closed account', () => {
+    expect(getImportAccountScopeState({
+      accountId: 'acct-1',
+      account: createAccount({ closed_at: '2026-01-31T12:00:00Z' }),
+      accountsCurrent: true,
+      accountsError: false,
+    })).toBe('unavailable')
+  })
+
+  it('refuses an account a current list does not hold', () => {
+    expect(getImportAccountScopeState({
+      accountId: 'acct-missing',
+      account: undefined,
+      accountsCurrent: true,
+      accountsError: false,
+    })).toBe('unavailable')
+  })
+
+  // The list is kept in local storage for months, so one that predates the account is no reason to
+  // refuse it. The page holds until a current list answers
+  it('holds when the list in hand does not have the account and a request is still in flight', () => {
+    expect(getImportAccountScopeState({
+      accountId: 'acct-missing',
+      account: undefined,
+      accountsCurrent: false,
+      accountsError: false,
+    })).toBe('loading')
+  })
+
+  // Nothing retries on its own, so holding here would be a wait that never ends
+  it('offers the retry when the list cannot answer and the last request failed', () => {
+    expect(getImportAccountScopeState({
+      accountId: 'acct-missing',
+      account: undefined,
+      accountsCurrent: false,
+      accountsError: true,
+    })).toBe('failed')
+  })
+
+  // A stale list calling an account archived is the same kind of wrong answer as one that has never
+  // heard of it, so both wait rather than one waiting and the other refusing
+  it('refuses an archived account only once the list is current', () => {
+    expect(getImportAccountScopeState({
+      accountId: 'acct-1',
+      account: createAccount({ is_archived: true }),
+      accountsCurrent: false,
+      accountsError: false,
+    })).toBe('loading')
+  })
+})

--- a/frontend/tests/pages/imports/utils/importAccountScope.test.ts
+++ b/frontend/tests/pages/imports/utils/importAccountScope.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import type { AccountsOverview } from '@/api/accounts'
-import { getImportAccountScopeState, isImportableAccount } from '@/pages/imports/utils'
+import { getImportAccountScopeState, getImportBlockReason, isImportableAccount } from '@/pages/imports/utils'
 
 /**
  * Creates an account overview, carrying only the fields this rule reads
@@ -50,6 +50,38 @@ describe('which accounts an import may be written to', () => {
   it('refuses an account that is not there at all', () => {
     expect(isImportableAccount(undefined)).toBe(false)
     expect(isImportableAccount(null)).toBe(false)
+  })
+
+  // The transaction list is handed a summary of an account rather than the whole thing, so the rule
+  // has to answer for one stating neither field, and it answers the way the Add Transaction button
+  // beside it already reads a missing archived flag
+  it('takes a summary stating neither field as an open account', () => {
+    expect(isImportableAccount({})).toBe(true)
+  })
+})
+
+describe('why an import cannot be written to an account', () => {
+  it('says nothing about an open account', () => {
+    expect(getImportBlockReason(createAccount())).toBeUndefined()
+  })
+
+  it('says nothing where there is no account to speak of', () => {
+    expect(getImportBlockReason(undefined)).toBeUndefined()
+  })
+
+  it('says an archived account is read-only', () => {
+    expect(getImportBlockReason(createAccount({ is_archived: true }))).toBe('Archived accounts are read-only')
+  })
+
+  it('says a closed account is read-only', () => {
+    expect(getImportBlockReason(createAccount({ closed_at: '2026-03-01T14:00:00Z' }))).toBe('Closed accounts are read-only')
+  })
+
+  // Both are true of an account in both states, and archiving is the one the user did and can undo
+  it('describes an account in both states as archived', () => {
+    const account = createAccount({ is_archived: true, closed_at: '2026-03-01T14:00:00Z' })
+
+    expect(getImportBlockReason(account)).toBe('Archived accounts are read-only')
   })
 })
 

--- a/frontend/tests/pages/imports/utils/importAccountScope.test.ts
+++ b/frontend/tests/pages/imports/utils/importAccountScope.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import type { AccountsOverview } from '@/api/accounts'
-import { getImportAccountScopeState } from '@/pages/imports/utils'
+import { getImportAccountScopeState, isImportableAccount } from '@/pages/imports/utils'
 
 /**
  * Creates an account overview, carrying only the fields this rule reads
@@ -29,6 +29,29 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     ...overrides,
   }
 }
+
+// Read both by the control offering the import and by the page carrying it out, so a state one of
+// them accepts and the other refuses cannot exist
+describe('which accounts an import may be written to', () => {
+  it('accepts an open account', () => {
+    expect(isImportableAccount(createAccount())).toBe(true)
+  })
+
+  it('refuses an archived account', () => {
+    expect(isImportableAccount(createAccount({ is_archived: true }))).toBe(false)
+  })
+
+  // The state the account summary the transaction list receives used to drop, so the control
+  // offering the import could not tell it apart from an open account
+  it('refuses a closed account that is not archived', () => {
+    expect(isImportableAccount(createAccount({ closed_at: '2026-03-01T14:00:00Z' }))).toBe(false)
+  })
+
+  it('refuses an account that is not there at all', () => {
+    expect(isImportableAccount(undefined)).toBe(false)
+    expect(isImportableAccount(null)).toBe(false)
+  })
+})
 
 describe('what the import page does with the account in its address', () => {
   it('runs the ordinary flow when the address carries no account', () => {

--- a/frontend/tests/pages/imports/utils/workflowOptions.test.ts
+++ b/frontend/tests/pages/imports/utils/workflowOptions.test.ts
@@ -187,6 +187,21 @@ describe('import workflow option helpers', () => {
     expect(groups.indexOf('Optional fields')).toBeGreaterThan(groups.lastIndexOf('Required fields'))
   })
 
+  // An import started from an account has its answer already, so no column may contradict it
+  it('leaves the account field out of the column targets when the account is fixed', () => {
+    const options = buildColumnTargetOptions({ omitAccountColumn: true })
+    const values = options.map((option) => option.value)
+
+    expect(values).not.toContain('account_id')
+    expect(values).toEqual(expect.arrayContaining([
+      '',
+      'dt',
+      'amount',
+      'category_id',
+      'counterparty_account_id',
+    ]))
+  })
+
 
   it('marks an archived account wherever it is offered', () => {
     const options = buildImportAccountOptions([

--- a/frontend/tests/pages/transactions/types/transactionList.test.ts
+++ b/frontend/tests/pages/transactions/types/transactionList.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests the narrowing that hands an account to the transaction list, which is what the list reads
+ * to decide whether the account can take new transactions and whether an import may be written to it
+ */
+import { describe, expect, it } from 'vitest'
+import type { AccountsOverview } from '@/api/accounts'
+import { toTransactionListAccount } from '@/pages/transactions/types/transactionList'
+
+/**
+ * Creates an account overview, carrying only the fields this narrowing reads
+ */
+function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverview {
+  return {
+    id: 'acct-1',
+    owner_id: null,
+    group_id: null,
+    account_kind: 'asset',
+    account_type: 'checking',
+    tax_advantaged_category_id: null,
+    name: 'Everyday Chequing',
+    institution: null,
+    currency: 'CAD',
+    current_balance: 0,
+    base_currency_current_balance: 0,
+    current_balance_fx_status: { state: 'complete', missing_pairs: [] },
+    credit_limit: null,
+    is_archived: false,
+    closed_at: null,
+    ...overrides,
+  }
+}
+
+describe('the account the transaction list is handed', () => {
+  it('carries the fields the list renders and answers with', () => {
+    expect(toTransactionListAccount(createAccount())).toEqual({
+      id: 'acct-1',
+      name: 'Everyday Chequing',
+      currency: 'CAD',
+      institution: null,
+      is_archived: false,
+      closed_at: null,
+    })
+  })
+
+  // Dropped here, the toolbar cannot tell a closed account from an open one, and offers an import
+  // the API would refuse
+  it('carries the closing date through', () => {
+    const account = createAccount({ closed_at: '2026-03-01T14:00:00Z' })
+
+    expect(toTransactionListAccount(account).closed_at).toBe('2026-03-01T14:00:00Z')
+  })
+
+  it('carries the archived state through', () => {
+    expect(toTransactionListAccount(createAccount({ is_archived: true })).is_archived).toBe(true)
+  })
+})


### PR DESCRIPTION
To import a statement into an account, you used to have to go to settings, import, then match the imported transactions to the account. Now, you can start the import process directly from an account, and those transactions will be matched automatically to that account. There is also an import button on the transactions list on the transactions page for convenience as well, so you don't have to click several times to start the import process.