### PR TITLE
fix: read currency decimal places from the seeded list

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -44,8 +44,10 @@ export default defineConfig({
     baseURL: BASE_URL,
     timezoneId: TEST_TIMEZONE,
 
-    // Amounts are formatted with the browser's own locale, so an unpinned runner renders a
-    // Canadian dollar amount as CA$42.50 where this one renders $42.50
+    // Money no longer follows this, since the app pins its own locale for currency, so an amount
+    // reads the same here whatever this is set to. It still decides what the browser reports to
+    // anything reading the locale directly, and matching the app's pinned convention keeps the two
+    // from telling a test different stories
     locale: 'en-CA',
 
     trace: 'retain-on-failure',

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -44,10 +44,10 @@ export default defineConfig({
     baseURL: BASE_URL,
     timezoneId: TEST_TIMEZONE,
 
-    // Money no longer follows this, since the app pins its own locale for currency, so an amount
-    // reads the same here whatever this is set to. It still decides what the browser reports to
-    // anything reading the locale directly, and matching the app's pinned convention keeps the two
-    // from telling a test different stories
+    // Money is written the way the reader's own region writes it, so this decides how the currency
+    // symbols in these tests render and cannot be removed without rewriting their expectations. The
+    // suite spends Canadian dollars, which this renders as $42.50. Dropped, a runner set to the
+    // United States renders the same amount CA$42.50 and every assertion naming a symbol fails
     locale: 'en-CA',
 
     trace: 'retain-on-failure',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,8 +9,8 @@
     "build:app": "tsc -b tsconfig.app.json tsconfig.node.json && vite build",
     "lint": "eslint .",
     "preview": "vite preview",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "LC_ALL=en-US vitest run",
+    "test:watch": "LC_ALL=en-US vitest"
   },
   "dependencies": {
     "@fontsource-variable/cormorant-garamond": "^5.3.0",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,7 +72,6 @@ function scrollDocumentToTop() {
 // Module-level flag so the loading screen only shows once per app session
 let hasShownLoadingScreen = false;
 
-
 /** Redirect to /login if unauthenticated. Show loading screen on first visit. */
 function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, isInitialLoad }: { displayLocation: Location; onContentReady: () => void; pageTransitionPhase: PageTransitionPhase; isInitialLoad: boolean }) {
   const { user, loading } = useAuth();
@@ -102,9 +101,16 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   const ready = !loading && minTimePassed && !currenciesPending;
 
   // Failing means the recovery screen rather than the app, because every screen below shows money and
-  // none can show it correctly without the list. Gated on the session being known, so a visitor whose
-  // session turns out to be stale is sent to log in rather than shown an error on the way there
-  const currencyListUnavailable = !loading && currenciesFailed;
+  // none can show it correctly without the list
+  //
+  // Deliberately not held back until the session is known. Doing that reads better for a visitor whose
+  // stored session turns out to be stale, who would otherwise see the error for the moment before
+  // being sent to log in, but it costs more than it buys: the session request carries no timeout of
+  // its own, so a network that swallows packets leaves it pending forever, and waiting on it would
+  // leave that user on the loading screen with no reload button instead of on this screen with one.
+  // Both cases mean the server is unreachable, and the screen that says so is the better answer to
+  // both. Once the session does resolve without one, the redirect above wins on the next render
+  const currencyListUnavailable = currenciesFailed;
 
   // The loading phase runs after the switch while the new route's chunk mounts
   const routeLoading = pageTransitionPhase === 'loading';
@@ -155,8 +161,9 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // A recovery-code login holds the account to re-enrolment before any route renders
   if (user?.second_factor_reenrollment_required) return <ForcedReenrollScreen />;
 
-  // Nothing here retries on its own, so this stands until the user reloads, which is what the screen
-  // asks them to do. It says so in its own words when the reason is that the server cannot be reached
+  // Nothing retries this on its own, not a refocus, a reconnect, or the remount every navigation
+  // performs, so it stands until the user reloads, which is what the screen asks them to do. It says
+  // so in its own words when the reason is that the server cannot be reached
   if (currencyListUnavailable) {
     return <Fallback componentStack={null} error={currencyError} preserveStoredData variant="screen" />;
   }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useLayoutEffect, useCallback, startTransition, lazy, Suspense } from 'react'
 import { BrowserRouter, Routes, Route, Navigate, Outlet, useLocation, type Location } from 'react-router'
 import { AnimatePresence, motion } from 'motion/react'
+import { useCurrencies } from '@/api/currency'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { NavCollapseProvider } from '@/contexts/NavCollapseContext'
 import { ToastProvider } from '@/contexts/ToastContext'
@@ -88,7 +89,13 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // Only show loading screen if there's a session being restored or user just authenticated
   const shouldShowLoading = loading || (!hasShownLoadingScreen && user);
   const [minTimePassed, setMinTimePassed] = useState(hasShownLoadingScreen);
-  const ready = !loading && minTimePassed;
+  // No amount can be rendered before the currency list arrives, since each currency's decimal places
+  // live in it and the browser's own figures disagree with it for 16 codes. Holding the app behind the
+  // loading screen it is already showing means every screen below paints its amounts once and
+  // correctly, rather than at a guessed scale that then jumps. A list that fails to arrive stops
+  // being pending, so an outage costs the wrong decimals rather than locking anyone out
+  const { isPending: currenciesPending } = useCurrencies();
+  const ready = !loading && minTimePassed && !currenciesPending;
 
   // The loading phase runs after the switch while the new route's chunk mounts
   const routeLoading = pageTransitionPhase === 'loading';

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -103,13 +103,17 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // Failing means the recovery screen rather than the app, because every screen below shows money and
   // none can show it correctly without the list
   //
-  // Deliberately not held back until the session is known. Doing that reads better for a visitor whose
-  // stored session turns out to be stale, who would otherwise see the error for the moment before
-  // being sent to log in, but it costs more than it buys: the session request carries no timeout of
-  // its own, so a network that swallows packets leaves it pending forever, and waiting on it would
-  // leave that user on the loading screen with no reload button instead of on this screen with one.
-  // Both cases mean the server is unreachable, and the screen that says so is the better answer to
-  // both. Once the session does resolve without one, the redirect above wins on the next render
+  // Deliberately not held back until the session is known, though that does cost something. A visitor
+  // whose stored session turns out to be stale sees this screen until the session request answers and
+  // the redirect above wins, which is immediate on a fresh load but at least 750ms after a browser
+  // reload, since the session restore is held back that long, and longer again behind a slow server.
+  // A valid session that answers slowly can see it too, cutting the minimum loading screen short
+  //
+  // It buys more than it costs. The session request carries no timeout of its own, so a network that
+  // swallows packets leaves it pending forever, and waiting on it would strand that user on the
+  // loading screen with no reload button rather than on this screen with one. Every one of these
+  // cases means the server is unreachable, and the screen saying so is the better answer to all of
+  // them
   const currencyListUnavailable = currenciesFailed;
 
   // The loading phase runs after the switch while the new route's chunk mounts

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,6 +71,13 @@ function scrollDocumentToTop() {
 // Module-level flag so the loading screen only shows once per app session
 let hasShownLoadingScreen = false;
 
+// How long the app waits for the currency list before rendering money without it. The list normally
+// arrives with the session, so this is not the expected path. It exists because the request can stay
+// pending rather than fail: a browser that reports itself offline leaves the query paused, and one
+// that black-holes the connection runs out its own timeout and its retry first. Without a deadline
+// either state leaves the whole authenticated app on a loading screen with no way even to sign out
+const CURRENCY_WAIT_LIMIT_MS = 3000;
+
 /** Redirect to /login if unauthenticated. Show loading screen on first visit. */
 function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, isInitialLoad }: { displayLocation: Location; onContentReady: () => void; pageTransitionPhase: PageTransitionPhase; isInitialLoad: boolean }) {
   const { user, loading } = useAuth();
@@ -92,10 +99,11 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // No amount can be rendered before the currency list arrives, since each currency's decimal places
   // live in it and the browser's own figures disagree with it for 16 codes. Holding the app behind the
   // loading screen it is already showing means every screen below paints its amounts once and
-  // correctly, rather than at a guessed scale that then jumps. A list that fails to arrive stops
-  // being pending, so an outage costs the wrong decimals rather than locking anyone out
+  // correctly, rather than at a guessed scale that then jumps. Past the deadline the app renders
+  // anyway, falling back to what the browser reports, which is right for 139 of the 155 codes
   const { isPending: currenciesPending } = useCurrencies();
-  const ready = !loading && minTimePassed && !currenciesPending;
+  const [currencyWaitElapsed, setCurrencyWaitElapsed] = useState(false);
+  const ready = !loading && minTimePassed && (!currenciesPending || currencyWaitElapsed);
 
   // The loading phase runs after the switch while the new route's chunk mounts
   const routeLoading = pageTransitionPhase === 'loading';
@@ -115,6 +123,14 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
     });
     return () => cancelAnimationFrame(frame);
   }, [ready]);
+
+  // Give up waiting on the currency list once the deadline passes, so a request that never resolves
+  // either way cannot hold the app on its loading screen
+  useEffect(() => {
+    if (!currenciesPending) return;
+    const timer = setTimeout(() => setCurrencyWaitElapsed(true), CURRENCY_WAIT_LIMIT_MS);
+    return () => clearTimeout(timer);
+  }, [currenciesPending]);
 
   useCacheValidation(user?.id, Boolean(user && ready));
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -78,6 +78,12 @@ let hasShownLoadingScreen = false;
 // either state leaves the whole authenticated app on a loading screen with no way even to sign out
 const CURRENCY_WAIT_LIMIT_MS = 3000;
 
+// Whether that wait has already been served. Module-level for the same reason hasShownLoadingScreen
+// above is: the protected subtree remounts on every navigation, so a flag held in component state
+// would start the wait again on each one, and a list that never arrives would put the loading screen
+// back between every page for as long as the session lasted
+let hasWaitedForCurrencies = false;
+
 /** Redirect to /login if unauthenticated. Show loading screen on first visit. */
 function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, isInitialLoad }: { displayLocation: Location; onContentReady: () => void; pageTransitionPhase: PageTransitionPhase; isInitialLoad: boolean }) {
   const { user, loading } = useAuth();
@@ -102,7 +108,7 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // correctly, rather than at a guessed scale that then jumps. Past the deadline the app renders
   // anyway, falling back to what the browser reports, which is right for 139 of the 155 codes
   const { isPending: currenciesPending } = useCurrencies();
-  const [currencyWaitElapsed, setCurrencyWaitElapsed] = useState(false);
+  const [currencyWaitElapsed, setCurrencyWaitElapsed] = useState(hasWaitedForCurrencies);
   const ready = !loading && minTimePassed && (!currenciesPending || currencyWaitElapsed);
 
   // The loading phase runs after the switch while the new route's chunk mounts
@@ -127,8 +133,11 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // Give up waiting on the currency list once the deadline passes, so a request that never resolves
   // either way cannot hold the app on its loading screen
   useEffect(() => {
-    if (!currenciesPending) return;
-    const timer = setTimeout(() => setCurrencyWaitElapsed(true), CURRENCY_WAIT_LIMIT_MS);
+    if (!currenciesPending || hasWaitedForCurrencies) return;
+    const timer = setTimeout(() => {
+      hasWaitedForCurrencies = true;
+      setCurrencyWaitElapsed(true);
+    }, CURRENCY_WAIT_LIMIT_MS);
     return () => clearTimeout(timer);
   }, [currenciesPending]);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { useCacheValidation } from '@/hooks/useCacheValidation'
 import { useTheme } from '@/hooks/useTheme'
 import Navigation from '@/components/navigation/Navigation'
 import ErrorBoundary from '@/components/errors/Boundary'
+import Fallback from '@/components/errors/Fallback'
 import LoadingScreen from '@/components/loading/Screen'
 import ForcedReenrollScreen from '@/components/two-factor/ForcedReenrollScreen'
 
@@ -71,18 +72,10 @@ function scrollDocumentToTop() {
 // Module-level flag so the loading screen only shows once per app session
 let hasShownLoadingScreen = false;
 
-// How long the app waits for the currency list before rendering money without it. The list normally
-// arrives with the session, so this is not the expected path. It exists because the request can stay
-// pending rather than fail: a browser that reports itself offline leaves the query paused, and one
-// that black-holes the connection runs out its own timeout and its retry first. Without a deadline
-// either state leaves the whole authenticated app on a loading screen with no way even to sign out
-const CURRENCY_WAIT_LIMIT_MS = 3000;
-
-// Whether that wait has already been served. Module-level for the same reason hasShownLoadingScreen
-// above is: the protected subtree remounts on every navigation, so a flag held in component state
-// would start the wait again on each one, and a list that never arrives would put the loading screen
-// back between every page for as long as the session lasted
-let hasWaitedForCurrencies = false;
+// How long the app waits for the currency list before giving up on it. A request that fails says so
+// on its own, but one can also stay pending indefinitely: a browser that reports itself offline
+// leaves the query paused rather than failed. Waiting needs an end either way
+const CURRENCY_WAIT_LIMIT_MS = 5000;
 
 /** Redirect to /login if unauthenticated. Show loading screen on first visit. */
 function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, isInitialLoad }: { displayLocation: Location; onContentReady: () => void; pageTransitionPhase: PageTransitionPhase; isInitialLoad: boolean }) {
@@ -105,11 +98,15 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // No amount can be rendered before the currency list arrives, since each currency's decimal places
   // live in it and the browser's own figures disagree with it for 16 codes. Holding the app behind the
   // loading screen it is already showing means every screen below paints its amounts once and
-  // correctly, rather than at a guessed scale that then jumps. Past the deadline the app renders
-  // anyway, falling back to what the browser reports, which is right for 139 of the 155 codes
-  const { isPending: currenciesPending } = useCurrencies();
-  const [currencyWaitElapsed, setCurrencyWaitElapsed] = useState(hasWaitedForCurrencies);
-  const ready = !loading && minTimePassed && (!currenciesPending || currencyWaitElapsed);
+  // correctly, rather than at a guessed scale that then jumps
+  const { isPending: currenciesPending, isError: currenciesFailed, error: currencyError } = useCurrencies();
+  const [currencyWaitExpired, setCurrencyWaitExpired] = useState(false);
+  const ready = !loading && minTimePassed && !currenciesPending;
+
+  // Giving up means the recovery screen rather than the app, because every screen below this one
+  // shows money and none of them can show it correctly without the list. A slow list that arrives
+  // after the deadline clears this on its own, since the wait only counts while the query is pending
+  const currencyListUnavailable = currenciesFailed || (currenciesPending && currencyWaitExpired);
 
   // The loading phase runs after the switch while the new route's chunk mounts
   const routeLoading = pageTransitionPhase === 'loading';
@@ -133,11 +130,8 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // Give up waiting on the currency list once the deadline passes, so a request that never resolves
   // either way cannot hold the app on its loading screen
   useEffect(() => {
-    if (!currenciesPending || hasWaitedForCurrencies) return;
-    const timer = setTimeout(() => {
-      hasWaitedForCurrencies = true;
-      setCurrencyWaitElapsed(true);
-    }, CURRENCY_WAIT_LIMIT_MS);
+    if (!currenciesPending) return;
+    const timer = setTimeout(() => setCurrencyWaitExpired(true), CURRENCY_WAIT_LIMIT_MS);
     return () => clearTimeout(timer);
   }, [currenciesPending]);
 
@@ -170,6 +164,20 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
 
   // A recovery-code login holds the account to re-enrolment before any route renders
   if (user?.second_factor_reenrollment_required) return <ForcedReenrollScreen />;
+
+  // Every screen below this one shows money, and none of them can show it correctly without the
+  // currency list, so a list that never arrived is a dead end rather than something to render
+  // around. The recovery screen offers the reload that fixes it, and says so itself when what went
+  // wrong is that the server cannot be reached
+  if (currencyListUnavailable) {
+    return (
+      <Fallback
+        componentStack={null}
+        error={currencyError ?? new Error('The currency list did not arrive')}
+        variant="screen"
+      />
+    );
+  }
 
   // The Routes subtree remounts on each path change, so this wrapper is recreated
   // per navigation and must start hidden through both loading and entering, otherwise

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,10 +72,6 @@ function scrollDocumentToTop() {
 // Module-level flag so the loading screen only shows once per app session
 let hasShownLoadingScreen = false;
 
-// How long the app waits for the currency list before giving up on it. A request that fails says so
-// on its own, but one can also stay pending indefinitely: a browser that reports itself offline
-// leaves the query paused rather than failed. Waiting needs an end either way
-const CURRENCY_WAIT_LIMIT_MS = 5000;
 
 /** Redirect to /login if unauthenticated. Show loading screen on first visit. */
 function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, isInitialLoad }: { displayLocation: Location; onContentReady: () => void; pageTransitionPhase: PageTransitionPhase; isInitialLoad: boolean }) {
@@ -96,17 +92,19 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   const shouldShowLoading = loading || (!hasShownLoadingScreen && user);
   const [minTimePassed, setMinTimePassed] = useState(hasShownLoadingScreen);
   // No amount can be rendered before the currency list arrives, since each currency's decimal places
-  // live in it and the browser's own figures disagree with it for 16 codes. Holding the app behind the
-  // loading screen it is already showing means every screen below paints its amounts once and
-  // correctly, rather than at a guessed scale that then jumps
+  // live in it and the browser's own figures disagree with it for 16 codes. Waiting here means every
+  // screen below paints its amounts once and correctly, rather than at a guessed scale that then jumps
+  //
+  // The wait is bounded by the request rather than by a timer here, so it survives this component
+  // remounting on every navigation and needs nothing reset. useCurrencies aborts at five seconds and
+  // does not retry, so this is pending for at most that long and then either has the list or has failed
   const { isPending: currenciesPending, isError: currenciesFailed, error: currencyError } = useCurrencies();
-  const [currencyWaitExpired, setCurrencyWaitExpired] = useState(false);
   const ready = !loading && minTimePassed && !currenciesPending;
 
-  // Giving up means the recovery screen rather than the app, because every screen below this one
-  // shows money and none of them can show it correctly without the list. A slow list that arrives
-  // after the deadline clears this on its own, since the wait only counts while the query is pending
-  const currencyListUnavailable = currenciesFailed || (currenciesPending && currencyWaitExpired);
+  // Failing means the recovery screen rather than the app, because every screen below shows money and
+  // none can show it correctly without the list. Gated on the session being known, so a visitor whose
+  // session turns out to be stale is sent to log in rather than shown an error on the way there
+  const currencyListUnavailable = !loading && currenciesFailed;
 
   // The loading phase runs after the switch while the new route's chunk mounts
   const routeLoading = pageTransitionPhase === 'loading';
@@ -127,15 +125,7 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
     return () => cancelAnimationFrame(frame);
   }, [ready]);
 
-  // Give up waiting on the currency list once the deadline passes, so a request that never resolves
-  // either way cannot hold the app on its loading screen
-  useEffect(() => {
-    if (!currenciesPending) return;
-    const timer = setTimeout(() => setCurrencyWaitExpired(true), CURRENCY_WAIT_LIMIT_MS);
-    return () => clearTimeout(timer);
-  }, [currenciesPending]);
-
-  useCacheValidation(user?.id, Boolean(user && ready));
+  useCacheValidation(user?.id, Boolean(user && ready && !currencyListUnavailable));
 
   // Hold the route loader back until the chunk has stayed pending past the delay so
   // cached or fast navigations never flash the spinner, and clear the flag on
@@ -165,18 +155,10 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
   // A recovery-code login holds the account to re-enrolment before any route renders
   if (user?.second_factor_reenrollment_required) return <ForcedReenrollScreen />;
 
-  // Every screen below this one shows money, and none of them can show it correctly without the
-  // currency list, so a list that never arrived is a dead end rather than something to render
-  // around. The recovery screen offers the reload that fixes it, and says so itself when what went
-  // wrong is that the server cannot be reached
+  // Nothing here retries on its own, so this stands until the user reloads, which is what the screen
+  // asks them to do. It says so in its own words when the reason is that the server cannot be reached
   if (currencyListUnavailable) {
-    return (
-      <Fallback
-        componentStack={null}
-        error={currencyError ?? new Error('The currency list did not arrive')}
-        variant="screen"
-      />
-    );
+    return <Fallback componentStack={null} error={currencyError} preserveStoredData variant="screen" />;
   }
 
   // The Routes subtree remounts on each path change, so this wrapper is recreated

--- a/frontend/src/api/currency/hooks.ts
+++ b/frontend/src/api/currency/hooks.ts
@@ -3,20 +3,32 @@ import { fetchCurrencies } from '@/api/currency/requests';
 import { currencyKeys } from '@/api/cache/queryKeys';
 
 /**
- * Reads currencies with session-long caching because ISO 4217 metadata is effectively static
+ * How the currency list is fetched and held
  *
- * This query has to settle, and quickly, because the app renders nothing until it does. Both options
- * below exist for that and are deliberately narrower than the defaults: the shared retry would put a
- * second full timeout in front of the failure, and the shared network mode leaves a query paused
- * rather than failed while the browser reports itself offline, which never settles at all
+ * Exported so a test can assert on these rather than restate them, because three of them exist to
+ * keep the app out of a state it took five review rounds to stop reaching, and a test that spelled
+ * them out itself would keep passing after someone changed the real ones.
+ *
+ * The app renders no screen until this query settles, so it has to settle and settle quickly. Each
+ * option below is deliberately narrower than the shared default: the shared retry would put a second
+ * full request timeout in front of the failure, the shared network mode leaves the query paused
+ * rather than failed while the browser reports itself offline, which never settles at all, and
+ * retryOnMount would send a query that already failed back to pending every time a component
+ * remounted, which the navigation sidebar does on every click
+ */
+export const currencyQueryOptions = {
+  queryKey: currencyKeys.list(),
+  queryFn: fetchCurrencies,
+  staleTime: Infinity,
+  gcTime: Infinity,
+  retry: false,
+  retryOnMount: false,
+  networkMode: 'always',
+} as const;
+
+/**
+ * Reads currencies with session-long caching because ISO 4217 metadata is effectively static
  */
 export function useCurrencies() {
-  return useQuery({
-    queryKey: currencyKeys.list(),
-    queryFn: fetchCurrencies,
-    staleTime: Infinity,
-    gcTime: Infinity,
-    retry: false,
-    networkMode: 'always',
-  });
+  return useQuery(currencyQueryOptions);
 }

--- a/frontend/src/api/currency/hooks.ts
+++ b/frontend/src/api/currency/hooks.ts
@@ -1,20 +1,26 @@
-import { useQuery } from '@tanstack/react-query';
+import { type UseQueryOptions, useQuery } from '@tanstack/react-query';
+import type { Currency } from '@/api/currency/types';
 import { fetchCurrencies } from '@/api/currency/requests';
 import { currencyKeys } from '@/api/cache/queryKeys';
 
 /**
  * How the currency list is fetched and held
  *
- * Exported so a test can assert on these rather than restate them, because three of them exist to
- * keep the app out of a state it took five review rounds to stop reaching, and a test that spelled
- * them out itself would keep passing after someone changed the real ones.
+ * Exported so a test can assert on these rather than restate them, since a test spelling them out
+ * itself would keep passing after someone changed the real ones.
  *
- * The app renders no screen until this query settles, so it has to settle and settle quickly. Each
- * option below is deliberately narrower than the shared default: the shared retry would put a second
- * full request timeout in front of the failure, the shared network mode leaves the query paused
- * rather than failed while the browser reports itself offline, which never settles at all, and
- * retryOnMount would send a query that already failed back to pending every time a component
- * remounted, which the navigation sidebar does on every click
+ * The app renders no screen until this query settles, so it has to settle, and quickly. The last four
+ * options are what make that true, and each is set here rather than left to the shared default: the
+ * shared retry would put a second full request timeout in front of the failure; the shared network
+ * mode leaves the query paused rather than failed while the browser reports itself offline, which
+ * never settles at all; retryOnMount would send a query that already failed back to pending whenever
+ * the route subtree remounts, which is on most navigations; and a refetch on window focus would do
+ * the same when the user came back to the tab. The last of those does follow the shared default
+ * today, and is repeated here because the app depends on it and a change made in one place should
+ * not quietly reach this
+ *
+ * The satisfies clause is what keeps a mistyped option name an error. Written inline at the useQuery
+ * call the compiler would reject an unknown key on its own, but a shared object is checked loosely
  */
 export const currencyQueryOptions = {
   queryKey: currencyKeys.list(),
@@ -24,7 +30,8 @@ export const currencyQueryOptions = {
   retry: false,
   retryOnMount: false,
   networkMode: 'always',
-} as const;
+  refetchOnWindowFocus: false,
+} as const satisfies UseQueryOptions<Currency[], Error>;
 
 /**
  * Reads currencies with session-long caching because ISO 4217 metadata is effectively static

--- a/frontend/src/api/currency/hooks.ts
+++ b/frontend/src/api/currency/hooks.ts
@@ -4,6 +4,11 @@ import { currencyKeys } from '@/api/cache/queryKeys';
 
 /**
  * Reads currencies with session-long caching because ISO 4217 metadata is effectively static
+ *
+ * This query has to settle, and quickly, because the app renders nothing until it does. Both options
+ * below exist for that and are deliberately narrower than the defaults: the shared retry would put a
+ * second full timeout in front of the failure, and the shared network mode leaves a query paused
+ * rather than failed while the browser reports itself offline, which never settles at all
  */
 export function useCurrencies() {
   return useQuery({
@@ -11,5 +16,7 @@ export function useCurrencies() {
     queryFn: fetchCurrencies,
     staleTime: Infinity,
     gcTime: Infinity,
+    retry: false,
+    networkMode: 'always',
   });
 }

--- a/frontend/src/api/currency/requests.ts
+++ b/frontend/src/api/currency/requests.ts
@@ -1,14 +1,13 @@
 import { API_BASE } from '@/api/config';
 import type { Currency } from '@/api/currency/types';
 
-// A request left hanging is worse here than one that fails, since every form waiting on the list shows
-// that it is still loading and would say so forever. Aborting turns that into a failure the forms can
-// report and the user can act on
+// How long the app itself waits, since no screen can render an amount before this list arrives.
+// App.tsx holds everything behind its loading screen until this settles one way or the other, and
+// shows the recovery screen when it fails. The bound lives here rather than in a timer beside that
+// loading screen, where it would have to be reset every time a component remounted
 //
-// It is also how long the app itself waits: no screen can render an amount before this list arrives,
-// so App.tsx holds everything behind its loading screen until this settles one way or the other, and
-// shows the recovery screen when it fails. That is why the bound lives here rather than in a timer
-// beside the loading screen, where it would have to be reset every time a component remounted
+// The sign-up and provider-callback pages read the list outside that gate, to fill a currency picker
+// rather than to format an amount, and this is also what stops those waiting on it forever
 const CURRENCY_REQUEST_TIMEOUT_MS = 5_000;
 
 /**

--- a/frontend/src/api/currency/requests.ts
+++ b/frontend/src/api/currency/requests.ts
@@ -1,13 +1,16 @@
 import { API_BASE } from '@/api/config';
 import type { Currency } from '@/api/currency/types';
 
-// How long the app itself waits, since no screen can render an amount before this list arrives.
-// App.tsx holds everything behind its loading screen until this settles one way or the other, and
-// shows the recovery screen when it fails. The bound lives here rather than in a timer beside that
-// loading screen, where it would have to be reset every time a component remounted
+// A request left hanging is worse here than one that fails, since everything waiting on the list can
+// only say it is still loading and would say so forever. Aborting turns that into a failure the app
+// can report and the user can act on
 //
-// The sign-up and provider-callback pages read the list outside that gate, to fill a currency picker
-// rather than to format an amount, and this is also what stops those waiting on it forever
+// It is also how long the app itself waits, since no screen can render an amount before this list
+// arrives: App.tsx holds everything behind its loading screen until this settles one way or the
+// other, and shows the recovery screen when it fails. That is why the bound lives here rather than in
+// a timer beside that loading screen, where it would have to be reset every time a component
+// remounted. The sign-up and provider-callback pages sit outside that gate and read the list to fill
+// a currency picker rather than to format an amount, and this is what stops those hanging too
 const CURRENCY_REQUEST_TIMEOUT_MS = 5_000;
 
 /**

--- a/frontend/src/api/currency/requests.ts
+++ b/frontend/src/api/currency/requests.ts
@@ -4,7 +4,12 @@ import type { Currency } from '@/api/currency/types';
 // A request left hanging is worse here than one that fails, since every form waiting on the list shows
 // that it is still loading and would say so forever. Aborting turns that into a failure the forms can
 // report and the user can act on
-const CURRENCY_REQUEST_TIMEOUT_MS = 10_000;
+//
+// It is also how long the app itself waits: no screen can render an amount before this list arrives,
+// so App.tsx holds everything behind its loading screen until this settles one way or the other, and
+// shows the recovery screen when it fails. That is why the bound lives here rather than in a timer
+// beside the loading screen, where it would have to be reset every time a component remounted
+const CURRENCY_REQUEST_TIMEOUT_MS = 5_000;
 
 /**
  * Fetches static ISO currency metadata used by money inputs and displays

--- a/frontend/src/components/errors/Fallback.tsx
+++ b/frontend/src/components/errors/Fallback.tsx
@@ -25,6 +25,12 @@ const COPY_CONFIRMATION_MS = 2000;
 interface FallbackProps {
   componentStack: string | null;
   error: unknown;
+
+  // Keeps the reload from emptying this browser's storage. Set it where the failure is known to be a
+  // network one, since the wipe exists to clear state that could have caused a render error and it
+  // costs the theme and the sidebar width to no purpose when that is not what went wrong
+  preserveStoredData?: boolean;
+
   variant: FallbackVariant;
 }
 
@@ -35,7 +41,7 @@ interface FallbackProps {
  * stands alone when there is no app left around it. Both carry the same message and actions, since
  * from the user's side the difference is only how much of the app is still there
  */
-export default function Fallback({ componentStack, error, variant }: FallbackProps) {
+export default function Fallback({ componentStack, error, preserveStoredData = false, variant }: FallbackProps) {
   const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
   const copyResetTimer = useRef<number | null>(null);
   // Until the probe comes back the message assumes a bug, since that is the only thing the user
@@ -47,11 +53,14 @@ export default function Fallback({ componentStack, error, variant }: FallbackPro
   }, []);
 
   /**
-   * Reloads onto empty storage, because state saved in this browser can be what broke the render
-   * and a plain reload would restore it
+   * Reloads, by default onto empty storage, because state saved in this browser can be what broke the
+   * render and a plain reload would restore it
+   *
+   * A caller that knows the failure was a network one keeps the storage, since wiping it then only
+   * costs the user their theme and sidebar width without making the reload any likelier to work
    */
   const handleReload = () => {
-    clearStoredData();
+    if (!preserveStoredData) clearStoredData();
     window.location.reload();
   };
 

--- a/frontend/src/components/errors/Fallback.tsx
+++ b/frontend/src/components/errors/Fallback.tsx
@@ -27,8 +27,8 @@ interface FallbackProps {
   error: unknown;
 
   // Keeps the reload from emptying this browser's storage. Set it where the failure is known to be a
-  // network one, since the wipe exists to clear state that could have caused a render error and it
-  // costs the theme and the sidebar width to no purpose when that is not what went wrong
+  // network one, since the wipe exists to clear state that could have caused a render error, and it
+  // otherwise takes the theme, the sidebar width and the whole cached query data with it for nothing
   preserveStoredData?: boolean;
 
   variant: FallbackVariant;
@@ -56,8 +56,9 @@ export default function Fallback({ componentStack, error, preserveStoredData = f
    * Reloads, by default onto empty storage, because state saved in this browser can be what broke the
    * render and a plain reload would restore it
    *
-   * A caller that knows the failure was a network one keeps the storage, since wiping it then only
-   * costs the user their theme and sidebar width without making the reload any likelier to work
+   * A caller that knows the failure was a network one keeps the storage, since wiping it then costs
+   * the user their theme, their sidebar width and every cached response without making the reload any
+   * likelier to work
    */
   const handleReload = () => {
     if (!preserveStoredData) clearStoredData();

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -4,7 +4,7 @@ import { StickyNote, Tag as TagIcon } from 'lucide-react'
 import type { Institution } from '@/api/institutions'
 import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { resolveInstitutionLogoUrl } from '@/utils/institutionLogo'
 
 const MAX_VISIBLE_TAGS = 1
@@ -155,6 +155,7 @@ export default function TransactionRow({
   // The row clips its content only while the height animates, so the grow and collapse read cleanly
   // while the resting row still lets a tag tooltip overflow past its edges
   const [isAnimatingHeight, setIsAnimatingHeight] = useState(false)
+  const { formatCurrency } = useMoneyFormatters()
   const categoryName = category?.name ?? 'Uncategorized'
   const categoryIcon = category?.icon ?? DEFAULT_CATEGORY_ICON
   const fallbackTitle = category?.kind === 'transfer' ? 'Transfer' : 'Transaction'

--- a/frontend/src/hooks/useMoneyFormatters.ts
+++ b/frontend/src/hooks/useMoneyFormatters.ts
@@ -1,0 +1,42 @@
+import { useMemo } from 'react'
+import { useCurrencies } from '@/api/currency'
+import type { Currency } from '@/api/currency'
+import { type CompactMoneyRule, formatCompactMoney } from '@/utils/formatCompactMoney'
+import { formatCurrency } from '@/utils/formatCurrency'
+
+// A stable empty list, so the memo below does not rebuild the formatters on every render while the
+// currency list is still on its way
+const NO_CURRENCIES: Currency[] = []
+
+type CompactMoneyOptions = Parameters<typeof formatCompactMoney>[4]
+
+/**
+ * Reads the currency list and returns the money formatters already bound to it
+ *
+ * Each currency's decimal places live in that list rather than in the browser, whose own figures
+ * disagree with it for 16 codes, so a formatter cannot render an amount correctly without it. The
+ * list is returned alongside the bound formatters for passing into the modules that format money
+ * outside a component and so cannot call this
+ *
+ * Every authenticated screen renders below a gate that waits for the list, so the two-place fallback
+ * inside the formatters only ever covers a code genuinely absent from a list that did arrive
+ */
+export function useMoneyFormatters() {
+  const { data } = useCurrencies()
+  const currencies = data ?? NO_CURRENCIES
+
+  return useMemo(
+    () => ({
+      currencies,
+      formatCurrency: (minorUnits: number, currency: string) =>
+        formatCurrency(minorUnits, currency, currencies),
+      formatCompactMoney: (
+        minorUnits: number,
+        currency: string,
+        rules: CompactMoneyRule[],
+        options?: CompactMoneyOptions,
+      ) => formatCompactMoney(minorUnits, currency, rules, currencies, options),
+    }),
+    [currencies],
+  )
+}

--- a/frontend/src/hooks/useMoneyFormatters.ts
+++ b/frontend/src/hooks/useMoneyFormatters.ts
@@ -1,25 +1,19 @@
 import { useMemo } from 'react'
 import { useCurrencies } from '@/api/currency'
 import type { Currency } from '@/api/currency'
-import { type CompactMoneyRule, formatCompactMoney } from '@/utils/formatCompactMoney'
 import { formatCurrency } from '@/utils/formatCurrency'
 
-// A stable empty list, so the memo below does not rebuild the formatters on every render while the
+// A stable empty list, so the memo below does not rebuild the formatter on every render while the
 // currency list is still on its way
 const NO_CURRENCIES: Currency[] = []
 
-type CompactMoneyOptions = Parameters<typeof formatCompactMoney>[4]
-
 /**
- * Reads the currency list and returns the money formatters already bound to it
+ * Reads the currency list and returns the money formatter already bound to it
  *
  * Each currency's decimal places live in that list rather than in the browser, whose own figures
  * disagree with it for 16 codes, so a formatter cannot render an amount correctly without it. The
- * list is returned alongside the bound formatters for passing into the modules that format money
- * outside a component and so cannot call this
- *
- * Every authenticated screen renders below a gate that waits for the list, so the two-place fallback
- * inside the formatters only ever covers a code genuinely absent from a list that did arrive
+ * list is returned alongside the bound formatter for passing into the modules that format money
+ * outside a component and so cannot call this, which is how every compact amount is reached
  */
 export function useMoneyFormatters() {
   const { data } = useCurrencies()
@@ -30,12 +24,6 @@ export function useMoneyFormatters() {
       currencies,
       formatCurrency: (minorUnits: number, currency: string) =>
         formatCurrency(minorUnits, currency, currencies),
-      formatCompactMoney: (
-        minorUnits: number,
-        currency: string,
-        rules: CompactMoneyRule[],
-        options?: CompactMoneyOptions,
-      ) => formatCompactMoney(minorUnits, currency, rules, currencies, options),
     }),
     [currencies],
   )

--- a/frontend/src/hooks/useMoneyFormatters.ts
+++ b/frontend/src/hooks/useMoneyFormatters.ts
@@ -3,8 +3,9 @@ import { useCurrencies } from '@/api/currency'
 import type { Currency } from '@/api/currency'
 import { formatCurrency } from '@/utils/formatCurrency'
 
-// A stable empty list, so the memo below does not rebuild the formatter on every render while the
-// currency list is still on its way
+// Only reached if this is somehow called above the gate in App.tsx that waits for the list, since no
+// screen below that gate renders before the list is in hand. It is a stable reference rather than a
+// fresh array so that, if it ever is reached, the memo below does not rebuild on every render
 const NO_CURRENCIES: Currency[] = []
 
 /**

--- a/frontend/src/pages/accounts/components/ListSection.tsx
+++ b/frontend/src/pages/accounts/components/ListSection.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import type { AccountsOverview } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import AccountRow from '@/pages/accounts/components/Row'
 import type { AccountAccent } from '@/pages/accounts/types/accounts'
 
@@ -32,6 +32,7 @@ export default function AccountListSection({
   loading?: boolean
 }) {
   const prefersReducedMotion = useReducedMotion()
+  const { formatCurrency } = useMoneyFormatters()
   const titleColor = accent === 'positive' ? 'var(--app-positive)' : 'var(--app-negative)'
   const subtotalColor = accent === 'positive'
     ? subtotal >= 0 ? 'var(--app-positive)' : 'var(--app-negative)'

--- a/frontend/src/pages/accounts/components/Row.tsx
+++ b/frontend/src/pages/accounts/components/Row.tsx
@@ -3,7 +3,7 @@ import { EyeOff } from 'lucide-react'
 import type { AccountsOverview } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { InstitutionLogo } from '@/pages/accounts/components/InstitutionLogo'
 import { humanizeAccountType } from '@/pages/accounts/detail/utils/formatAccountType'
 import type { AccountAccent } from '@/pages/accounts/types/accounts'
@@ -34,6 +34,7 @@ export default function AccountRow({
   displayCurrency: string
   isArchived?: boolean
 }) {
+  const { formatCurrency } = useMoneyFormatters()
   const barColor = isArchived
     ? 'var(--app-text-muted)'
     : accent === 'positive' ? 'var(--app-positive)' : 'var(--app-negative)'

--- a/frontend/src/pages/accounts/components/metrics/Band.tsx
+++ b/frontend/src/pages/accounts/components/metrics/Band.tsx
@@ -1,4 +1,5 @@
 import { RunwayHelpTooltip } from '@/components/tooltips/RunwayHelpTooltip'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { AccountsMetricsViewModel } from '@/pages/accounts/types/accounts'
 import {
   getCreditUsageDisplay,
@@ -23,9 +24,10 @@ export default function MetricsBand({
   metrics,
   displayCurrency,
 }: MetricsBandProps) {
+  const { currencies } = useMoneyFormatters()
   const { savingsRate, creditUsage, runway } = metrics
-  const savingsRateDisplay = getSavingsRateDisplay(savingsRate, displayCurrency)
-  const creditUsageDisplay = getCreditUsageDisplay(creditUsage, displayCurrency)
+  const savingsRateDisplay = getSavingsRateDisplay(savingsRate, displayCurrency, currencies)
+  const creditUsageDisplay = getCreditUsageDisplay(creditUsage, displayCurrency, currencies)
 
   return (
     <section>

--- a/frontend/src/pages/accounts/components/summary/Statement.tsx
+++ b/frontend/src/pages/accounts/components/summary/Statement.tsx
@@ -1,4 +1,4 @@
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { FxStatus } from '@/api/shared/fx'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import { getAccountSummaryFxStatusMessage } from '@/pages/accounts/utils/fxTooltipMessages'
@@ -31,6 +31,8 @@ export default function SummaryStatement({
   displayCurrency,
   fxStatus,
 }: SummaryStatementProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   if (error) {
     return (
       <p className="py-2 font-medium" style={{ color: 'var(--app-negative)' }}>

--- a/frontend/src/pages/accounts/components/tax-advantaged-limits/CompactLimitMeter.tsx
+++ b/frontend/src/pages/accounts/components/tax-advantaged-limits/CompactLimitMeter.tsx
@@ -6,6 +6,7 @@ import {
   DeferredChartTooltipOverlay,
   type DeferredChartTooltipOverlayHandle,
 } from '@/components/charts/DeferredTooltipOverlay'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import {
   clampTaxAdvantagedPercent,
   formatTaxAdvantagedMeterMoney,
@@ -47,6 +48,7 @@ export function TaxAdvantagedCompactLimitMeter({
 }: TaxAdvantagedCompactLimitMeterProps) {
   const meterRef = useRef<HTMLDivElement | null>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<LimitMeterTooltipData>>(null)
+  const { currencies } = useMoneyFormatters()
 
   if (limit === null) {
     return (
@@ -66,12 +68,12 @@ export function TaxAdvantagedCompactLimitMeter({
 
   const color = getTaxAdvantagedUsageColor(used, limit)
   const barWidth = getTaxAdvantagedUsagePercent(used, limit)
-  const usageLabel = `${formatTaxAdvantagedMeterMoney(used, currency)} / ${formatTaxAdvantagedMeterMoney(limit, currency)}`
+  const usageLabel = `${formatTaxAdvantagedMeterMoney(used, currency, currencies)} / ${formatTaxAdvantagedMeterMoney(limit, currency, currencies)}`
   const remaining = limit - used
   const remainingLabel =
     remaining < 0
-      ? `${formatTaxAdvantagedMeterMoney(Math.abs(remaining), currency)} over`
-      : formatTaxAdvantagedMeterMoney(remaining, currency)
+      ? `${formatTaxAdvantagedMeterMoney(Math.abs(remaining), currency, currencies)} over`
+      : formatTaxAdvantagedMeterMoney(remaining, currency, currencies)
   const valueLabel = valueMode === 'remaining' ? remainingLabel : usageLabel
   const availablePercent =
     availableBoundary === null ? 0 : getTaxAdvantagedUsagePercent(availableBoundary, limit)

--- a/frontend/src/pages/accounts/components/tax-advantaged-limits/LimitMeterTooltipContent.tsx
+++ b/frontend/src/pages/accounts/components/tax-advantaged-limits/LimitMeterTooltipContent.tsx
@@ -2,6 +2,7 @@ import {
   ChartTooltipRow,
   ChartTooltipTitle,
 } from '@/components/charts/TooltipContent'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { formatTaxAdvantagedRawMoney } from '@/pages/accounts/utils/taxAdvantagedLimits'
 
 type TaxAdvantagedLimitMeterTooltipContentProps = {
@@ -20,18 +21,20 @@ export function TaxAdvantagedLimitMeterTooltipContent({
   remaining,
   currency,
 }: TaxAdvantagedLimitMeterTooltipContentProps) {
+  const { currencies } = useMoneyFormatters()
+
   return (
     <>
       <ChartTooltipTitle className="font-medium">{label}</ChartTooltipTitle>
       <ChartTooltipRow
         label="Used"
-        value={formatTaxAdvantagedRawMoney(used, currency)}
+        value={formatTaxAdvantagedRawMoney(used, currency, currencies)}
         valueClassName="text-right"
         financialValue
       />
       <ChartTooltipRow
         label="Remaining"
-        value={formatTaxAdvantagedRawMoney(remaining, currency)}
+        value={formatTaxAdvantagedRawMoney(remaining, currency, currencies)}
         valueClassName="text-right"
         valueStyle={remaining < 0 ? { color: 'var(--app-negative)' } : undefined}
         financialValue

--- a/frontend/src/pages/accounts/detail/components/balance-chart/TooltipContent.tsx
+++ b/frontend/src/pages/accounts/detail/components/balance-chart/TooltipContent.tsx
@@ -2,7 +2,7 @@ import {
   ChartTooltipRow,
   ChartTooltipTitle,
 } from '@/components/charts/TooltipContent'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { BalanceChartMode } from '@/pages/accounts/detail/constants/accountDetail'
 import { formatSignedBalanceCurrency } from '@/pages/accounts/detail/utils/balanceChartAxis'
 import type { BalanceChartDataPoint } from '@/pages/accounts/detail/utils/balanceChartViewModel'
@@ -21,10 +21,11 @@ export function BalanceChartTooltipContent({
   chartMode,
   currency,
 }: BalanceChartTooltipContentProps) {
+  const { currencies, formatCurrency } = useMoneyFormatters()
   const label = chartMode === 'balance' ? 'Balance' : 'Change'
   const value = chartMode === 'balance'
     ? formatCurrency(point.balance, currency)
-    : formatSignedBalanceCurrency(point.periodBalance ?? 0, currency)
+    : formatSignedBalanceCurrency(point.periodBalance ?? 0, currency, currencies)
 
   return (
     <>

--- a/frontend/src/pages/accounts/detail/components/balance-chart/ValueSummary.tsx
+++ b/frontend/src/pages/accounts/detail/components/balance-chart/ValueSummary.tsx
@@ -1,5 +1,5 @@
 import { TrendingDown, TrendingUp } from 'lucide-react'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { BalanceChartSnapshot } from '@/pages/accounts/detail/utils/balanceChartViewModel'
 
 type BalanceValueSummaryProps = {
@@ -10,6 +10,8 @@ type BalanceValueSummaryProps = {
  * Renders the current balance and selected-range movement summary above the chart
  */
 export function BalanceValueSummary({ snapshot }: BalanceValueSummaryProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <div className="mb-4">
       <p

--- a/frontend/src/pages/accounts/detail/components/edit-identity/controls/ArchiveBalanceWarning.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/controls/ArchiveBalanceWarning.tsx
@@ -1,5 +1,5 @@
 import { AlertTriangle } from 'lucide-react'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type ArchiveBalanceWarningProps = {
   balance: number
@@ -13,6 +13,7 @@ export function ArchiveBalanceWarning({
   balance,
   currency,
 }: ArchiveBalanceWarningProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const adjustmentAmount = -balance
   const hasBalance = balance !== 0
 

--- a/frontend/src/pages/accounts/detail/components/identity/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/identity/Card.tsx
@@ -1,7 +1,7 @@
 import { Pencil } from 'lucide-react'
 import type { Account } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { InstitutionLogo } from '@/pages/accounts/components/InstitutionLogo'
 import { ACCOUNT_KIND_LABEL } from '@/pages/accounts/detail/constants/accountDetail'
 import { humanizeAccountType } from '@/pages/accounts/detail/utils/formatAccountType'
@@ -26,6 +26,7 @@ export default function AccountIdentityCard({
   onEdit: () => void
 }) {
   const { user } = useAuth()
+  const { formatCurrency } = useMoneyFormatters()
   const linkedTaxAdvantagedCategoryId = account.group_id === null ? account.tax_advantaged_category_id : null
 
   // closed_at is an instant rather than a calendar day, so it is read in the user's own zone

--- a/frontend/src/pages/accounts/detail/components/identity/LimitUsage.tsx
+++ b/frontend/src/pages/accounts/detail/components/identity/LimitUsage.tsx
@@ -1,4 +1,4 @@
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import {
   getTaxAdvantagedUsageColor,
   getTaxAdvantagedUsagePercent,
@@ -20,6 +20,8 @@ export function DetailLimitUsage({
   limit,
   currency,
 }: DetailLimitUsageProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   if (limit === null) {
     return (
       <div>

--- a/frontend/src/pages/accounts/detail/components/monthly-cash-flow/TooltipContent.tsx
+++ b/frontend/src/pages/accounts/detail/components/monthly-cash-flow/TooltipContent.tsx
@@ -2,7 +2,7 @@ import {
   ChartTooltipRow,
   ChartTooltipTitle,
 } from '@/components/charts/TooltipContent'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { CashFlowBar } from '@/pages/accounts/detail/utils/cashFlowChartViewModel'
 
 type MonthlyCashFlowTooltipContentProps = {
@@ -19,6 +19,8 @@ export function MonthlyCashFlowTooltipContent({
   currency,
   title,
 }: MonthlyCashFlowTooltipContentProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <>
       <ChartTooltipTitle>{title}</ChartTooltipTitle>

--- a/frontend/src/pages/accounts/detail/components/spending-breakdown/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/spending-breakdown/Card.tsx
@@ -3,7 +3,7 @@ import type { SpendingRange } from '@/api/accounts'
 import { LoadingContent, LoadingOverlay } from '@/components/loading/Transition'
 import { TimeRangeSelector } from '@/components/time-range/Selector'
 import { useLoadingSnapshot } from '@/hooks/useLoadingSnapshot'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { getDeterministicChartColor } from '@/utils/chartColor'
 import {
   BREAKDOWN_CARD_LIST_MIN_HEIGHT,
@@ -42,6 +42,7 @@ export function SpendingBreakdownCard({
   loading,
   transitionKey,
 }: SpendingBreakdownCardProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const incomingSnapshot = useMemo<BreakdownSnapshot>(() => ({
     rows,
     grandTotal,

--- a/frontend/src/pages/accounts/detail/utils/balanceChartAxis.ts
+++ b/frontend/src/pages/accounts/detail/utils/balanceChartAxis.ts
@@ -1,4 +1,5 @@
 import type { BalanceRange } from '@/pages/accounts/detail/constants/accountDetail'
+import type { Currency } from '@/api/currency'
 import { formatCurrency } from '@/utils/formatCurrency'
 import { calendarDateMs } from './calendarDate'
 import { DATE_FORMATS, formatDate } from '@/utils/date'
@@ -45,7 +46,7 @@ export function formatUtcAxisDate(value: number): string {
  * Formats a change in balance with an explicit plus or minus in front of it, leaving an unchanged
  * balance with no sign at all
  */
-export function formatSignedBalanceCurrency(amount: number, currency: string): string {
-  if (amount === 0) return formatCurrency(amount, currency)
-  return `${amount > 0 ? '+' : '−'}${formatCurrency(Math.abs(amount), currency)}`
+export function formatSignedBalanceCurrency(amount: number, currency: string, currencies: Currency[]): string {
+  if (amount === 0) return formatCurrency(amount, currency, currencies)
+  return `${amount > 0 ? '+' : '−'}${formatCurrency(Math.abs(amount), currency, currencies)}`
 }

--- a/frontend/src/pages/accounts/hooks/useAccountsMetrics.ts
+++ b/frontend/src/pages/accounts/hooks/useAccountsMetrics.ts
@@ -1,6 +1,7 @@
 import type { AccountsOverview } from '@/api/accounts'
 import { useDashboardCredit, useDashboardSavingsRate } from '@/api/dashboard'
 import { useRunway } from '@/api/user'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { AccountsMetricsViewModel } from '@/pages/accounts/types/accounts'
 import {
   getCreditUsageMetric,
@@ -18,10 +19,11 @@ export function useAccountsMetrics(
   const { data: dashboardCredit, isFetching: dashboardCreditLoading } = useDashboardCredit()
   const { data: dashboardSavingsRate, isFetching: dashboardSavingsRateLoading } = useDashboardSavingsRate()
   const { data: runway, isFetching: runwayLoading } = useRunway()
+  const { currencies } = useMoneyFormatters()
 
   return {
     savingsRate: getSavingsRateMetric(dashboardSavingsRate, dashboardSavingsRateLoading),
     creditUsage: getCreditUsageMetric(rows, dashboardCredit, dashboardCreditLoading),
-    runway: getRunwayMetric(runway, runwayLoading, displayCurrency),
+    runway: getRunwayMetric(runway, runwayLoading, displayCurrency, currencies),
   }
 }

--- a/frontend/src/pages/accounts/utils/accountMetrics.ts
+++ b/frontend/src/pages/accounts/utils/accountMetrics.ts
@@ -4,6 +4,7 @@ import type {
   SavingsRateWidgetResponse,
 } from '@/api/dashboard'
 import type { RunwayResult } from '@/api/user'
+import type { Currency } from '@/api/currency'
 import type { AccountsMetricsViewModel } from '@/pages/accounts/types/accounts'
 import { formatCurrency } from '@/utils/formatCurrency'
 import {
@@ -102,6 +103,7 @@ export function getRunwayMetric(
   runway: RunwayResult | undefined,
   isLoading: boolean,
   displayCurrency: string,
+  currencies: Currency[],
 ): AccountsMetricsViewModel['runway'] {
   const months = runway?.months ?? null
   const bandKey = runwayBand(months, runway?.thresholds)
@@ -114,7 +116,7 @@ export function getRunwayMetric(
         ? 'Choose accounts in Settings'
         : runway.reason === 'insufficient_history'
           ? 'Need 1+ month of net expense data'
-          : `${formatCurrency(runway.avg_monthly_expense, displayCurrency)}/mth · ${formatRunwayBasis(runway.months_covered)}`
+          : `${formatCurrency(runway.avg_monthly_expense, displayCurrency, currencies)}/mth · ${formatRunwayBasis(runway.months_covered)}`
 
   return {
     label: formatCompactRunway(months),

--- a/frontend/src/pages/accounts/utils/metricDisplay.ts
+++ b/frontend/src/pages/accounts/utils/metricDisplay.ts
@@ -1,4 +1,5 @@
 import type { AccountsMetricsViewModel } from '@/pages/accounts/types/accounts'
+import type { Currency } from '@/api/currency'
 import { formatCurrency } from '@/utils/formatCurrency'
 
 export type MetricDisplay = {
@@ -12,6 +13,7 @@ export type MetricDisplay = {
 export function getSavingsRateDisplay(
   savingsRate: AccountsMetricsViewModel['savingsRate'],
   displayCurrency: string,
+  currencies: Currency[],
 ): MetricDisplay {
   const value =
     !savingsRate.isLoading && savingsRate.value !== null
@@ -22,7 +24,7 @@ export function getSavingsRateDisplay(
   const caption = savingsRate.isLoading
     ? 'Loading savings rate'
     : savingsRate.value !== null
-      ? `${formatCurrency(savingsRate.net, displayCurrency)} of ${formatCurrency(savingsRate.income, displayCurrency)} this month`
+      ? `${formatCurrency(savingsRate.net, displayCurrency, currencies)} of ${formatCurrency(savingsRate.income, displayCurrency, currencies)} this month`
       : savingsRate.hasExpenses
         ? 'No income this month'
         : 'No data this month'
@@ -36,13 +38,14 @@ export function getSavingsRateDisplay(
 export function getCreditUsageDisplay(
   creditUsage: AccountsMetricsViewModel['creditUsage'],
   displayCurrency: string,
+  currencies: Currency[],
 ): MetricDisplay {
   const value =
     !creditUsage.isLoading && creditUsage.hasCreditData ? `${creditUsage.utilization}%` : 'N/A'
   const caption = creditUsage.isLoading
     ? 'Loading credit totals'
     : creditUsage.hasCreditData
-      ? `${formatCurrency(creditUsage.totalUsed, displayCurrency)} of ${formatCurrency(creditUsage.totalLimit, displayCurrency)}`
+      ? `${formatCurrency(creditUsage.totalUsed, displayCurrency, currencies)} of ${formatCurrency(creditUsage.totalLimit, displayCurrency, currencies)}`
       : creditUsage.hasCreditLimits && creditUsage.fxStatus?.state !== 'none'
         ? 'FX unavailable'
         : creditUsage.hasCreditAccounts

--- a/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
+++ b/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
@@ -3,7 +3,7 @@ import type { Currency } from '@/api/currency'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import type { TaxAdvantagedLimitSummary } from '@/pages/accounts/types/accounts'
 import { type CompactMoneyRule, formatCompactMoney } from '@/utils/formatCompactMoney'
-import { createMoneyFormatter, toMajorUnits } from '@/utils/formatCurrency'
+import { formatMajorUnits, toMajorUnits } from '@/utils/formatCurrency'
 
 /**
  * Chooses the usage colour for tax-advantaged contribution and withdrawal meters
@@ -73,7 +73,7 @@ export function formatTaxAdvantagedRawMoney(
   currency: string,
   currencies: Currency[],
 ): string {
-  return createMoneyFormatter(currency, 0).format(toMajorUnits(amount, currency, currencies))
+  return formatMajorUnits(toMajorUnits(amount, currency, currencies), currency, 0)
 }
 
 /**

--- a/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
+++ b/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
@@ -1,6 +1,7 @@
 import type { AccountsOverview } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import type { TaxAdvantagedLimitSummary } from '@/pages/accounts/types/accounts'
+import { MONEY_LOCALE } from '@/utils/formatCurrency'
 
 /**
  * Chooses the usage colour for tax-advantaged contribution and withdrawal meters
@@ -38,13 +39,13 @@ export function getTaxAdvantagedRemainingColor(remaining: number): string {
 }
 
 function getMajorCurrencyAmount(minorUnits: number, currency: string): number {
-  const formatter = new Intl.NumberFormat(undefined, { style: 'currency', currency })
+  const formatter = new Intl.NumberFormat(MONEY_LOCALE, { style: 'currency', currency })
   const exponent = formatter.resolvedOptions().maximumFractionDigits ?? 2
   return minorUnits / Math.pow(10, exponent) || 0
 }
 
 function formatNoDecimalCurrency(value: number, currency: string): string {
-  return new Intl.NumberFormat(undefined, {
+  return new Intl.NumberFormat(MONEY_LOCALE, {
     style: 'currency',
     currency,
     currencySign: 'accounting',
@@ -61,7 +62,7 @@ function formatNoDecimalCurrencyWithSuffix(
   currency: string,
   suffix: 'K' | 'M',
 ): string {
-  const formatter = new Intl.NumberFormat(undefined, {
+  const formatter = new Intl.NumberFormat(MONEY_LOCALE, {
     style: 'currency',
     currency,
     currencySign: 'accounting',

--- a/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
+++ b/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
@@ -1,7 +1,9 @@
 import type { AccountsOverview } from '@/api/accounts'
+import type { Currency } from '@/api/currency'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import type { TaxAdvantagedLimitSummary } from '@/pages/accounts/types/accounts'
-import { MONEY_LOCALE } from '@/utils/formatCurrency'
+import { type CompactMoneyRule, formatCompactMoney } from '@/utils/formatCompactMoney'
+import { createMoneyFormatter, toMajorUnits } from '@/utils/formatCurrency'
 
 /**
  * Chooses the usage colour for tax-advantaged contribution and withdrawal meters
@@ -38,66 +40,40 @@ export function getTaxAdvantagedRemainingColor(remaining: number): string {
   return 'var(--app-accent)'
 }
 
-function getMajorCurrencyAmount(minorUnits: number, currency: string): number {
-  const formatter = new Intl.NumberFormat(MONEY_LOCALE, { style: 'currency', currency })
-  const exponent = formatter.resolvedOptions().maximumFractionDigits ?? 2
-  return minorUnits / Math.pow(10, exponent) || 0
-}
-
-function formatNoDecimalCurrency(value: number, currency: string): string {
-  return new Intl.NumberFormat(MONEY_LOCALE, {
-    style: 'currency',
-    currency,
-    currencySign: 'accounting',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  }).format(value)
-}
-
-/**
- * Adds a compact suffix after the final numeric part of a currency amount
- */
-function formatNoDecimalCurrencyWithSuffix(
-  value: number,
-  currency: string,
-  suffix: 'K' | 'M',
-): string {
-  const formatter = new Intl.NumberFormat(MONEY_LOCALE, {
-    style: 'currency',
-    currency,
-    currencySign: 'accounting',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
-  })
-  const parts = formatter.formatToParts(value)
-  const numberPartTypes = new Set(['integer', 'group'])
-  const suffixIndex = parts.findLastIndex((part) => numberPartTypes.has(part.type))
-
-  return parts
-    .map((part, index) => `${part.value}${index === suffixIndex ? suffix : ''}`)
-    .join('')
-}
+// The meters read at a glance beside a progress bar, so every amount on them is whole, both the
+// compacted ones and the ones small enough to render in full
+const METER_MONEY_RULES: CompactMoneyRule[] = [
+  { threshold: 1_000_000, divisor: 1_000_000, suffix: 'M', fractionDigits: 0 },
+  { threshold: 1_000, divisor: 1_000, suffix: 'K', fractionDigits: 0 },
+]
 
 /**
  * Formats compact meter amounts without decimals while preserving currency symbols
+ *
+ * No "≈" prefix, unlike the dashboard's compact amounts: the meter shows the figure beside the limit
+ * it is measured against, where a marker of approximation on one and not the other would read as a
+ * difference between them
  */
-export function formatTaxAdvantagedMeterMoney(amount: number, currency: string): string {
-  const majorUnits = getMajorCurrencyAmount(amount, currency)
-  const absoluteMajorUnits = Math.abs(majorUnits)
-  if (absoluteMajorUnits >= 1_000_000) {
-    return formatNoDecimalCurrencyWithSuffix(majorUnits / 1_000_000, currency, 'M')
-  }
-  if (absoluteMajorUnits >= 1_000) {
-    return formatNoDecimalCurrencyWithSuffix(majorUnits / 1_000, currency, 'K')
-  }
-  return formatNoDecimalCurrency(majorUnits, currency)
+export function formatTaxAdvantagedMeterMoney(
+  amount: number,
+  currency: string,
+  currencies: Currency[],
+): string {
+  return formatCompactMoney(amount, currency, METER_MONEY_RULES, currencies, {
+    prefix: '',
+    plainFractionDigits: 0,
+  })
 }
 
 /**
  * Formats full tax-advantaged limit amounts for tooltip rows
  */
-export function formatTaxAdvantagedRawMoney(amount: number, currency: string): string {
-  return formatNoDecimalCurrency(getMajorCurrencyAmount(amount, currency), currency)
+export function formatTaxAdvantagedRawMoney(
+  amount: number,
+  currency: string,
+  currencies: Currency[],
+): string {
+  return createMoneyFormatter(currency, 0).format(toMajorUnits(amount, currency, currencies))
 }
 
 /**

--- a/frontend/src/pages/budgets/components/budget-card/Card.tsx
+++ b/frontend/src/pages/budgets/components/budget-card/Card.tsx
@@ -1,5 +1,5 @@
 import type { BaseBudget, Budget, BudgetUtilization } from '@/api/budgets'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import BudgetCategoryRow from '@/pages/budgets/components/budget-card/CategoryRow'
 import ArchivedPill from '@/pages/budgets/components/shared/ArchivedPill'
 import BudgetAttentionIcon from '@/pages/budgets/components/shared/AttentionIcon'
@@ -26,6 +26,7 @@ export default function BudgetCard({
   isArchived?: boolean
   onOpen: () => void
 }) {
+  const { formatCurrency } = useMoneyFormatters()
   const shownCategories = categoryNames.length > 3 ? categoryNames.slice(0, 2) : categoryNames.slice(0, 3)
   const extraCategoryCount = Math.max(categoryNames.length - shownCategories.length, 0)
   const spent = utilization?.total_spent ?? 0

--- a/frontend/src/pages/budgets/components/budget-details-modal/ChartTooltip.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/ChartTooltip.tsx
@@ -1,4 +1,4 @@
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import {
   ChartTooltipRow,
   ChartTooltipTitle,
@@ -47,6 +47,7 @@ export default function BudgetChartTooltip({
   point: BudgetChartPoint
   currency: string
 }) {
+  const { formatCurrency } = useMoneyFormatters()
   const categoryBreakdown = point.categories ?? []
 
   return (

--- a/frontend/src/pages/budgets/components/budget-details-modal/PeriodHistory.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/PeriodHistory.tsx
@@ -1,4 +1,4 @@
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { formatBudgetPeriod } from '@/pages/budgets/utils/budgetPeriods'
 import type { BudgetPeriodHistoryEntry } from '@/pages/budgets/utils/budgetDetails'
 
@@ -18,6 +18,8 @@ export default function BudgetPeriodHistory({
   loading,
   error,
 }: BudgetPeriodHistoryProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <section className="min-[1050px]:flex min-[1050px]:min-h-0 min-[1050px]:flex-1 min-[1050px]:flex-col">
       <h3 className="text-base font-semibold" style={{ color: 'var(--app-text)' }}>Period history</h3>

--- a/frontend/src/pages/budgets/components/budget-details-modal/Sidebar.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState, type UIEvent } from 'react'
 import { Pencil, Trash2, X } from 'lucide-react'
 import type { BaseBudget, Budget, BudgetUtilization } from '@/api/budgets'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import MarqueeText from '@/components/display/MarqueeText'
 import ScrollableListMoreButton from '@/components/list-controls/MoreButton'
 import ArchivedPill from '@/pages/budgets/components/shared/ArchivedPill'
@@ -62,6 +62,7 @@ export default function BudgetDetailsSidebar({
   onDelete,
 }: BudgetDetailsSidebarProps) {
   const trackedCategoryListRef = useRef<HTMLDivElement | null>(null)
+  const { formatCurrency } = useMoneyFormatters()
   const [trackedCategoryListScrollable, setTrackedCategoryListScrollable] = useState(false)
   const [trackedCategoryListAtBottom, setTrackedCategoryListAtBottom] = useState(false)
   const showTrackedCategoryListMoreIndicator = trackedCategoryListScrollable && !trackedCategoryListAtBottom

--- a/frontend/src/pages/dashboard/utils/formatDashboardMoney.ts
+++ b/frontend/src/pages/dashboard/utils/formatDashboardMoney.ts
@@ -1,3 +1,4 @@
+import type { Currency } from '@/api/currency'
 import { formatCurrency } from '@/utils/formatCurrency'
 import { DASHBOARD_MONEY_RULES } from '@/pages/dashboard/constants/moneyRules'
 import { formatCompactMoney } from '@/utils/formatCompactMoney'
@@ -11,8 +12,9 @@ export function formatDashboardMoney(
   minorUnits: number,
   currency: string,
   format: DashboardMoneyFormat,
+  currencies: Currency[],
 ) {
-  if (format === 'raw') return formatCurrency(minorUnits, currency)
+  if (format === 'raw') return formatCurrency(minorUnits, currency, currencies)
 
-  return formatCompactMoney(minorUnits, currency, DASHBOARD_MONEY_RULES[format])
+  return formatCompactMoney(minorUnits, currency, DASHBOARD_MONEY_RULES[format], currencies)
 }

--- a/frontend/src/pages/dashboard/utils/getRunwayCaption.ts
+++ b/frontend/src/pages/dashboard/utils/getRunwayCaption.ts
@@ -1,4 +1,5 @@
 import type { RunwayResult } from '@/api/user'
+import type { Currency } from '@/api/currency'
 import { formatCurrency } from '@/utils/formatCurrency'
 import { formatRunwayBasis } from '@/utils/runway'
 
@@ -8,11 +9,12 @@ import { formatRunwayBasis } from '@/utils/runway'
 export function getRunwayCaption(
   runway: RunwayResult | undefined,
   displayCurrency: string,
+  currencies: Currency[],
 ) {
   if (!runway) return ''
 
   if (runway.reason === 'no_accounts') return 'Choose accounts in Settings'
   if (runway.reason === 'insufficient_history') return 'Need 1+ month of net expense data'
 
-  return `${formatCurrency(runway.avg_monthly_expense, displayCurrency)}/mth \u00B7 ${formatRunwayBasis(runway.months_covered)}`
+  return `${formatCurrency(runway.avg_monthly_expense, displayCurrency, currencies)}/mth \u00B7 ${formatRunwayBasis(runway.months_covered)}`
 }

--- a/frontend/src/pages/dashboard/widgets/credit/UsageBody.tsx
+++ b/frontend/src/pages/dashboard/widgets/credit/UsageBody.tsx
@@ -1,4 +1,5 @@
 import { AppScrambledNumber } from '@/components/display/ScrambledNumber'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { formatDashboardMoney } from '@/pages/dashboard/utils/formatDashboardMoney'
 import type { CreditUsageSummary } from '@/pages/dashboard/utils/getCreditUsageSummary'
 
@@ -21,6 +22,7 @@ export function CreditUsageBody({
     hasCredit,
     tierColor,
   } = summary
+  const { currencies } = useMoneyFormatters()
 
   const size = 120
   const strokeWidth = 10
@@ -68,10 +70,10 @@ export function CreditUsageBody({
       </div>
       <div className="min-w-0">
         <p className="font-financial text-3xl font-normal leading-none tracking-tight max-[1000px]:text-[1.6875rem]">
-          <AppScrambledNumber text={formatDashboardMoney(displayAmount, displayCurrency, 'credit')} />
+          <AppScrambledNumber text={formatDashboardMoney(displayAmount, displayCurrency, 'credit', currencies)} />
         </p>
         <p className="font-financial mt-1.5 text-sm max-[1000px]:text-[0.7875rem]" style={{ color: 'var(--app-text-muted)' }}>
-          of <AppScrambledNumber text={formatDashboardMoney(creditAvailable, displayCurrency, 'credit')} />
+          of <AppScrambledNumber text={formatDashboardMoney(creditAvailable, displayCurrency, 'credit', currencies)} />
         </p>
       </div>
     </div>

--- a/frontend/src/pages/dashboard/widgets/net-worth/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/net-worth/Chart.tsx
@@ -29,7 +29,7 @@ import {
   getRechartsTooltipPointer,
   type RechartsTooltipState,
 } from '@/components/charts/rechartsTooltip'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type NetWorthChartProps = {
   data: NetWorthSeriesPoint[]
@@ -66,6 +66,8 @@ function NetWorthTooltipContent({
   point: NetWorthSeriesPoint
   displayCurrency: string
 }) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <>
       <ChartTooltipTitle>{point.date}</ChartTooltipTitle>

--- a/frontend/src/pages/dashboard/widgets/net-worth/Metric.tsx
+++ b/frontend/src/pages/dashboard/widgets/net-worth/Metric.tsx
@@ -1,3 +1,5 @@
+import type { Currency } from '@/api/currency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { formatDashboardMoney } from '@/pages/dashboard/utils/formatDashboardMoney'
 
 type NetWorthMetricProps = {
@@ -9,9 +11,9 @@ type NetWorthMetricProps = {
 /**
  * Formats dashboard net worth movement with an explicit positive or negative sign
  */
-function formatNetWorthChange(amount: number, currency: string) {
-  if (amount === 0) return formatDashboardMoney(0, currency, 'netWorth')
-  return `${amount > 0 ? '+' : '-'}${formatDashboardMoney(Math.abs(amount), currency, 'netWorth')}`
+function formatNetWorthChange(amount: number, currency: string, currencies: Currency[]) {
+  if (amount === 0) return formatDashboardMoney(0, currency, 'netWorth', currencies)
+  return `${amount > 0 ? '+' : '-'}${formatDashboardMoney(Math.abs(amount), currency, 'netWorth', currencies)}`
 }
 
 /**
@@ -22,6 +24,7 @@ export function NetWorthMetric({
   netWorthChange,
   displayCurrency,
 }: NetWorthMetricProps) {
+  const { currencies } = useMoneyFormatters()
   const netWorthColor = netWorth < 0 ? 'var(--app-negative)' : 'var(--app-text)'
   const netWorthChangeColor =
     netWorthChange == null || netWorthChange === 0
@@ -36,15 +39,15 @@ export function NetWorthMetric({
         className="min-w-0 font-financial font-normal tracking-tight leading-none text-3xl max-[1000px]:text-[1.6875rem]"
         style={{ color: netWorthColor }}
       >
-        {formatDashboardMoney(netWorth, displayCurrency, 'netWorth')}
+        {formatDashboardMoney(netWorth, displayCurrency, 'netWorth', currencies)}
       </p>
       {netWorthChange != null && (
         <p
           className="shrink-0 pb-0.5 font-financial text-sm font-medium leading-none max-[1000px]:text-xs"
           style={{ color: netWorthChangeColor }}
-          aria-label={`Net worth change ${formatNetWorthChange(netWorthChange, displayCurrency)}`}
+          aria-label={`Net worth change ${formatNetWorthChange(netWorthChange, displayCurrency, currencies)}`}
         >
-          {formatNetWorthChange(netWorthChange, displayCurrency)}
+          {formatNetWorthChange(netWorthChange, displayCurrency, currencies)}
         </p>
       )}
     </div>

--- a/frontend/src/pages/dashboard/widgets/recent-activity/List.tsx
+++ b/frontend/src/pages/dashboard/widgets/recent-activity/List.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router'
 import { formatDashboardShortDate } from '@/pages/dashboard/utils/formatDashboardShortDate'
 import type { RecentActivityRow } from '@/pages/dashboard/utils/getRecentActivityRows'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type RecentActivityListProps = {
   rows: RecentActivityRow[]
@@ -16,6 +16,7 @@ type RecentActivityRowProps = {
  * Renders one recent transaction row with category metadata and signed amount
  */
 function RecentActivityRowItem({ row, showDivider }: RecentActivityRowProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const { transaction, category, title, isIncome } = row
 
   return (

--- a/frontend/src/pages/dashboard/widgets/runway/SegmentsBar.tsx
+++ b/frontend/src/pages/dashboard/widgets/runway/SegmentsBar.tsx
@@ -9,7 +9,7 @@ import {
 import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import type { RunwaySegment } from '@/pages/dashboard/types/dashboard'
 import { useCursorTooltip } from '@/hooks/useCursorTooltip'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type RunwaySegmentsBarProps = {
   segments: RunwaySegment[]
@@ -42,6 +42,7 @@ export function RunwaySegmentsBar({
   displayCurrency,
   tooltipOriginRef,
 }: RunwaySegmentsBarProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const {
     tooltipRef,
     tooltipItem: hoveredSegment,

--- a/frontend/src/pages/dashboard/widgets/runway/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/runway/Widget.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef } from 'react'
 import { useAccounts } from '@/api/accounts'
 import { useRunway, useRunwayAccounts } from '@/api/user'
 import { useLoadingSnapshot } from '@/hooks/useLoadingSnapshot'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import {
   RUNWAY_BAND_STYLE,
   formatCompactRunway,
@@ -22,6 +23,7 @@ type RunwayWidgetProps = {
  */
 export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
   const runwayCardRef = useRef<HTMLDivElement>(null)
+  const { currencies } = useMoneyFormatters()
   const { data: incomingRunway, isFetching: runwayLoading } = useRunway()
   const { data: incomingRunwayAccountIds, isFetching: runwayAccountsLoading } = useRunwayAccounts()
   const { data: incomingAccounts, isFetching: accountsLoading } = useAccounts()
@@ -47,7 +49,7 @@ export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
   const runwayMonths = runway?.months ?? null
   const runwayBandKey = runwayBand(runwayMonths, runway?.thresholds)
   const runwayStyle = runwayBandKey ? RUNWAY_BAND_STYLE[runwayBandKey] : null
-  const runwayCaption = getRunwayCaption(runway, displayCurrency)
+  const runwayCaption = getRunwayCaption(runway, displayCurrency, currencies)
   const fxStatus = runway?.fx_status
   const runwaySegments = useMemo(
     () => getRunwaySegments(accounts, runwayAccountIds, runway),

--- a/frontend/src/pages/dashboard/widgets/spending-breakdown/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-breakdown/Chart.tsx
@@ -18,6 +18,7 @@ import {
   BREAKDOWN_PIE_ANIMATION_MS,
 } from '@/pages/dashboard/constants/animation'
 import { useCursorTooltip, type CursorTooltipPointer } from '@/hooks/useCursorTooltip'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { formatDashboardMoney } from '@/pages/dashboard/utils/formatDashboardMoney'
 import {
   getSpendingBreakdownEntryColor,
@@ -111,6 +112,7 @@ export function SpendingBreakdownChart({
   shouldReduceMotion,
 }: SpendingBreakdownChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
+  const { currencies } = useMoneyFormatters()
   const {
     tooltipRef,
     tooltipItem: hoveredEntry,
@@ -136,7 +138,7 @@ export function SpendingBreakdownChart({
           Total {breakdownMode === 'spending' ? 'Expense' : 'Income'}
         </span>
         <span className="font-financial mt-1 text-3xl font-normal tracking-tight max-[1000px]:text-[1.6875rem]">
-          <AppScrambledNumber text={formatDashboardMoney(total, displayCurrency, 'breakdown')} />
+          <AppScrambledNumber text={formatDashboardMoney(total, displayCurrency, 'breakdown', currencies)} />
         </span>
       </div>
       <AnimatePresence initial={false}>

--- a/frontend/src/pages/dashboard/widgets/spending-breakdown/TooltipContent.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-breakdown/TooltipContent.tsx
@@ -4,7 +4,7 @@ import {
   ChartTooltipValue,
 } from '@/components/charts/TooltipContent'
 import type { BreakdownMode } from '@/pages/dashboard/utils/getSpendingBreakdownSummary'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { SpendingBreakdownCrossoverBadge } from './CrossoverBadge'
 
 type SpendingBreakdownTooltipContentProps = {
@@ -21,6 +21,8 @@ export function SpendingBreakdownTooltipContent({
   breakdownMode,
   displayCurrency,
 }: SpendingBreakdownTooltipContentProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <>
       <div className="flex items-center gap-2">

--- a/frontend/src/pages/dashboard/widgets/spending-comparison/Metric.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-comparison/Metric.tsx
@@ -3,7 +3,7 @@ import {
   ArrowUpRight,
 } from 'lucide-react'
 import { AppScrambledNumber } from '@/components/display/ScrambledNumber'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type SpendingComparisonMetricProps = {
   spentToDate: number
@@ -21,6 +21,8 @@ export function SpendingComparisonMetric({
   spendingDeltaText,
   displayCurrency,
 }: SpendingComparisonMetricProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <div className="flex items-baseline gap-2">
       <p className="font-financial text-3xl font-normal leading-none tracking-tight max-[1000px]:text-[1.6875rem]">

--- a/frontend/src/pages/dashboard/widgets/spending-comparison/TooltipContent.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-comparison/TooltipContent.tsx
@@ -8,7 +8,7 @@ import {
   PREVIOUS_LABEL_BY_RANGE,
 } from '@/pages/dashboard/constants/ranges'
 import type { SpendingComparisonSeriesPoint } from '@/pages/dashboard/types/dashboard'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type SpendingComparisonTooltipContentProps = {
   point: SpendingComparisonSeriesPoint
@@ -24,6 +24,7 @@ export function SpendingComparisonTooltipContent({
   displayCurrency,
   spendingRange,
 }: SpendingComparisonTooltipContentProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const rows = [
     {
       key: 'current',

--- a/frontend/src/pages/dashboard/widgets/top-budgets/List.tsx
+++ b/frontend/src/pages/dashboard/widgets/top-budgets/List.tsx
@@ -2,7 +2,7 @@ import { Link } from 'react-router'
 import type { TopBudget } from '@/pages/dashboard/types/dashboard'
 import { formatDashboardShortDate } from '@/pages/dashboard/utils/formatDashboardShortDate'
 import { getTopBudgetAttentionState } from '@/pages/dashboard/utils/getTopBudgetAttentionState'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type TopBudgetsListProps = {
   budgets: TopBudget[]
@@ -24,6 +24,7 @@ function getBudgetProgressWidth(usagePct: number) {
  * Renders a linked top budget row with its usage status and progress bar
  */
 function TopBudgetRow({ budget, showDivider }: TopBudgetRowProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const attention = getTopBudgetAttentionState(budget.usagePct)
   const barPct = getBudgetProgressWidth(budget.usagePct)
 

--- a/frontend/src/pages/insights/components/cash-flow-card/BarChart.tsx
+++ b/frontend/src/pages/insights/components/cash-flow-card/BarChart.tsx
@@ -22,6 +22,8 @@ import {
   getChartDataSignature,
   useChartEntranceAnimation,
 } from '@/components/charts/useChartEntranceAnimation'
+import type { Currency } from '@/api/currency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { DASHBOARD_X_AXIS_TICK_FONT_SIZE } from '@/pages/dashboard/constants/chart'
 import type { CashFlowBarBucket } from '@/pages/insights/types/cashFlow'
 import { formatSignedCurrency, getSignedAmountColor } from '@/pages/insights/utils/money'
@@ -61,17 +63,22 @@ function getCashFlowTooltipPointer(
   }
 }
 
+// Wide enough for the longest label the pinned format produces, which is two characters longer than
+// it used to be: a currency whose symbol carries a region prefix renders as US$1,234,567.89 rather
+// than $1,234,567.89, and the label clips at the old bound
+const MAX_Y_AXIS_WIDTH_PX = 104
+
 /**
  * Sizes the Y axis from formatted currency labels so large values do not clip
  */
-function getCashFlowYAxisWidth(buckets: CashFlowBarBucket[], currency: string) {
+function getCashFlowYAxisWidth(buckets: CashFlowBarBucket[], currency: string, currencies: Currency[]) {
   const values = buckets.flatMap((bucket) => [bucket.net, 0])
   const longestLabel = values.reduce((longest, value) => {
-    const label = formatCurrency(value, currency)
+    const label = formatCurrency(value, currency, currencies)
     return label.length > longest.length ? label : longest
   }, '')
 
-  return Math.min(92, Math.max(52, longestLabel.length * 6 + 10))
+  return Math.min(MAX_Y_AXIS_WIDTH_PX, Math.max(52, longestLabel.length * 6 + 10))
 }
 
 /**
@@ -84,12 +91,14 @@ function CashFlowBarTooltipContent({
   bucket: CashFlowBarBucket
   displayCurrency: string
 }) {
+  const { currencies, formatCurrency } = useMoneyFormatters()
+
   return (
     <>
       <ChartTooltipTitle>{bucket.rangeLabel}</ChartTooltipTitle>
       <ChartTooltipRow
         label="Net"
-        value={formatSignedCurrency(bucket.net, displayCurrency)}
+        value={formatSignedCurrency(bucket.net, displayCurrency, currencies)}
         valueStyle={{ color: getSignedAmountColor(bucket.net) }}
         financialValue
       />
@@ -119,8 +128,9 @@ export function CashFlowBarChart({
 }: CashFlowBarChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<CashFlowBarBucket>>(null)
+  const { currencies, formatCurrency } = useMoneyFormatters()
   const hasActivity = buckets.some((bucket) => bucket.inflow > 0 || bucket.outflow > 0)
-  const yAxisWidth = getCashFlowYAxisWidth(buckets, displayCurrency)
+  const yAxisWidth = getCashFlowYAxisWidth(buckets, displayCurrency, currencies)
   const dataSignature = useMemo(
     () => getChartDataSignature(buckets, (bucket) => bucket.net),
     [buckets],

--- a/frontend/src/pages/insights/components/cash-flow-card/BarChart.tsx
+++ b/frontend/src/pages/insights/components/cash-flow-card/BarChart.tsx
@@ -63,11 +63,12 @@ function getCashFlowTooltipPointer(
   }
 }
 
-// Wide enough for the longest label this can produce, which is a negative amount in a currency whose
-// symbol carries a region prefix: (US$1,234,567.89) is seventeen characters, four more than the
-// $1,234,567.89 the old bound was set for, since accounting style wraps a negative in parentheses
-// and the net figure plotted here is negative in any month that spent more than it earned
-const MAX_Y_AXIS_WIDTH_PX = 112
+// Wide enough for the longest label this can produce across the seeded currencies, measured rather
+// than assumed: a negative three-decimal amount written with its code instead of a symbol, such as
+// (BHD 1,234,567.890) at nineteen characters. Most codes render that way rather than with a symbol,
+// accounting style wraps a negative in parentheses, and the net figure plotted here is negative in
+// any month that spent more than it earned, so all three apply at once
+const MAX_Y_AXIS_WIDTH_PX = 124
 
 /**
  * Sizes the Y axis from formatted currency labels so large values do not clip

--- a/frontend/src/pages/insights/components/cash-flow-card/BarChart.tsx
+++ b/frontend/src/pages/insights/components/cash-flow-card/BarChart.tsx
@@ -63,10 +63,11 @@ function getCashFlowTooltipPointer(
   }
 }
 
-// Wide enough for the longest label the pinned format produces, which is two characters longer than
-// it used to be: a currency whose symbol carries a region prefix renders as US$1,234,567.89 rather
-// than $1,234,567.89, and the label clips at the old bound
-const MAX_Y_AXIS_WIDTH_PX = 104
+// Wide enough for the longest label this can produce, which is a negative amount in a currency whose
+// symbol carries a region prefix: (US$1,234,567.89) is seventeen characters, four more than the
+// $1,234,567.89 the old bound was set for, since accounting style wraps a negative in parentheses
+// and the net figure plotted here is negative in any month that spent more than it earned
+const MAX_Y_AXIS_WIDTH_PX = 112
 
 /**
  * Sizes the Y axis from formatted currency labels so large values do not clip

--- a/frontend/src/pages/insights/components/cash-flow-card/Card.tsx
+++ b/frontend/src/pages/insights/components/cash-flow-card/Card.tsx
@@ -6,6 +6,7 @@ import {
   LoadingOverlay,
 } from '@/components/loading/Transition'
 import { useLoadingSnapshot } from '@/hooks/useLoadingSnapshot'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { CashFlowBarChart } from './BarChart'
 import type { CashFlowBarBucket, CashFlowGranularity } from '@/pages/insights/types/cashFlow'
 import { getInsightsCashFlowFxStatusMessage } from '@/pages/insights/utils/fxTooltipMessages'
@@ -44,6 +45,7 @@ export function CashFlowCard({
   loading = false,
   transitionKey,
 }: CashFlowCardProps) {
+  const { currencies } = useMoneyFormatters()
   const incomingSnapshot = useMemo<CashFlowSnapshot>(() => ({
     granularity,
     buckets,
@@ -101,7 +103,7 @@ export function CashFlowCard({
                 className="mt-1 font-financial text-3xl leading-none tracking-tight"
                 style={{ color: getSignedAmountColor(totalNet) }}
               >
-                {formatSignedCurrency(totalNet, displaySnapshot.displayCurrency)}
+                {formatSignedCurrency(totalNet, displaySnapshot.displayCurrency, currencies)}
               </p>
             </div>
             <CashFlowBarChart

--- a/frontend/src/pages/insights/components/fund-flow-card/CategoryList.tsx
+++ b/frontend/src/pages/insights/components/fund-flow-card/CategoryList.tsx
@@ -4,7 +4,7 @@ import { ChevronDown } from 'lucide-react'
 import { InsightCalculationTooltip } from '@/pages/insights/components/CalculationTooltip'
 import type { InsightsFlowEntry } from '@/api/insights'
 import { joinClassNames } from '@/utils/classNames'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type FundFlowCategoryListProps = {
   title: string
@@ -36,6 +36,7 @@ export function FundFlowCategoryList({
 }: FundFlowCategoryListProps) {
   const listId = useId()
   const shouldReduceMotion = useReducedMotion()
+  const { formatCurrency } = useMoneyFormatters()
   const totalCount = normalEntries.length + flippedEntries.length
   const displayCount = flippedEntries.length > 0
     ? `${normalEntries.length} + ${flippedEntries.length}`

--- a/frontend/src/pages/insights/components/fund-flow-card/Chart.tsx
+++ b/frontend/src/pages/insights/components/fund-flow-card/Chart.tsx
@@ -13,8 +13,8 @@ import {
 import { ChartTooltipTitle, ChartTooltipValue } from '@/components/charts/TooltipContent'
 import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import { useCursorTooltip } from '@/hooks/useCursorTooltip'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { FundFlowData, FundFlowNode, FundFlowNodeKind } from '@/pages/insights/types/fundFlow'
-import { formatCurrency } from '@/utils/formatCurrency'
 import {
   LoadingContent,
   LoadingOverlay,
@@ -158,6 +158,8 @@ function SankeyFlowTooltipContent({
   tooltip: SankeyFlowTooltipData
   displayCurrency: string
 }) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <div className="min-w-44 max-w-64">
       <div className="flex justify-between gap-4">

--- a/frontend/src/pages/insights/components/income-expense-breakdown-card/PieChart.tsx
+++ b/frontend/src/pages/insights/components/income-expense-breakdown-card/PieChart.tsx
@@ -18,6 +18,7 @@ import {
   useChartEntranceAnimation,
 } from '@/components/charts/useChartEntranceAnimation'
 import { useCursorTooltip } from '@/hooks/useCursorTooltip'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { BreakdownEntry } from '@/pages/insights/types/incomeExpenseBreakdown'
 import {
   getBreakdownCrossoverKind,
@@ -27,7 +28,6 @@ import {
   getBreakdownTotal,
 } from '@/pages/insights/utils/incomeExpenseBreakdownDisplay'
 import { getCategoryColor, getCategoryColorMap } from '@/utils/chartColor'
-import { formatCurrency } from '@/utils/formatCurrency'
 
 type IncomeExpensePieChartProps = {
   mode: InsightsBreakdownCategoryKind
@@ -69,6 +69,7 @@ export function IncomeExpensePieChart({
   shouldReduceMotion,
 }: IncomeExpensePieChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
+  const { formatCurrency } = useMoneyFormatters()
   const {
     tooltipRef,
     tooltipItem: hoveredEntry,

--- a/frontend/src/pages/insights/components/income-expense-breakdown-card/TrendSections.tsx
+++ b/frontend/src/pages/insights/components/income-expense-breakdown-card/TrendSections.tsx
@@ -1,5 +1,6 @@
 import { AnimatePresence, motion } from 'motion/react'
 import type { InsightsBreakdownCategoryKind } from '@/api/insights'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { InsightCalculationTooltip } from '@/pages/insights/components/CalculationTooltip'
 import type { CategoryTrendSection } from '@/pages/insights/types/incomeExpenseBreakdown'
 import {
@@ -9,7 +10,6 @@ import {
   getTransactionCountLabel,
   getTrendSectionCalculation,
 } from '@/pages/insights/utils/incomeExpenseBreakdownDisplay'
-import { formatCurrency } from '@/utils/formatCurrency'
 
 type IncomeExpenseTrendSectionsProps = {
   mode: InsightsBreakdownCategoryKind
@@ -43,6 +43,8 @@ export function IncomeExpenseTrendSections({
   animationKey,
   shouldReduceMotion,
 }: IncomeExpenseTrendSectionsProps) {
+  const { currencies, formatCurrency } = useMoneyFormatters()
+
   return (
     <div className="flex flex-col border-t border-[var(--app-border)] pt-4 min-[1350px]:min-h-[620px] min-[1350px]:border-t-0 min-[1350px]:pt-0">
       <div className="grid gap-5 min-[1350px]:min-h-0 min-[1350px]:flex-1 min-[1350px]:grid-rows-2 min-[1350px]:gap-4">
@@ -117,7 +119,7 @@ export function IncomeExpenseTrendSections({
                             {formatCurrency(driver.amount, displayCurrency)}
                           </p>
                           <p className="font-financial text-sm min-[750px]:mt-1" style={{ color: driverColor }}>
-                            {formatSignedBreakdownCurrency(changeAmount, displayCurrency)}
+                            {formatSignedBreakdownCurrency(changeAmount, displayCurrency, currencies)}
                             {changePctLabel && (
                               <>
                                 {' '}

--- a/frontend/src/pages/insights/components/merchant-distribution-card/MarketMap.tsx
+++ b/frontend/src/pages/insights/components/merchant-distribution-card/MarketMap.tsx
@@ -7,6 +7,7 @@ import {
 import { ChartTooltipRow, ChartTooltipTitle } from '@/components/charts/TooltipContent'
 import CursorTooltipPortal from '@/components/charts/CursorTooltipPortal'
 import { useCursorTooltip } from '@/hooks/useCursorTooltip'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type {
   MerchantMarketMerchant,
   MerchantMarketTile,
@@ -16,7 +17,6 @@ import {
   splitMerchantTreemapItems,
 } from '@/pages/insights/utils/merchantDistributionMap'
 import { formatSignedCurrency } from '@/pages/insights/utils/money'
-import { formatCurrency } from '@/utils/formatCurrency'
 
 type MerchantMarketMapProps = {
   merchants: MerchantMarketMerchant[]
@@ -36,6 +36,7 @@ export function MerchantMarketMap({
   currency,
 }: MerchantMarketMapProps) {
   const mapRef = useRef<HTMLDivElement | null>(null)
+  const { currencies, formatCurrency } = useMoneyFormatters()
   const {
     tooltipRef,
     tooltipItem: hoveredMerchant,
@@ -205,7 +206,7 @@ export function MerchantMarketMap({
                 label="Change"
                 value={(
                   <>
-                    {formatSignedCurrency(hoveredMerchant.changeAmount, currency)}
+                    {formatSignedCurrency(hoveredMerchant.changeAmount, currency, currencies)}
                     {hoveredMerchant.changePct === null
                       ? ''
                       : ` (${hoveredMerchant.changePct > 0 ? '+' : ''}${hoveredMerchant.changePct}%)`}

--- a/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
+++ b/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
@@ -6,9 +6,9 @@ import {
   LoadingOverlay,
 } from '@/components/loading/Transition'
 import { useLoadingSnapshot } from '@/hooks/useLoadingSnapshot'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { MerchantRankingRow } from '@/pages/insights/types/merchantRanking'
 import { getMerchantSpendingFxStatusMessage } from '@/pages/insights/utils/fxTooltipMessages'
-import { formatCurrency } from '@/utils/formatCurrency'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import { InsightCalculationTooltip } from '@/pages/insights/components/CalculationTooltip'
 import { InsightSectionHeader } from '@/pages/insights/components/SectionHeader'
@@ -51,6 +51,7 @@ export function MerchantRankingCard({
   loading = false,
   transitionKey,
 }: MerchantRankingCardProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const incomingSnapshot = useMemo<MerchantRankingSnapshot>(() => ({
     merchants,
     fxStatus,

--- a/frontend/src/pages/insights/components/net-worth-card/Card.tsx
+++ b/frontend/src/pages/insights/components/net-worth-card/Card.tsx
@@ -6,8 +6,8 @@ import {
   LoadingOverlay,
 } from '@/components/loading/Transition'
 import { useLoadingSnapshot } from '@/hooks/useLoadingSnapshot'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { getInsightsNetWorthFxStatusMessage } from '@/pages/insights/utils/fxTooltipMessages'
-import { formatCurrency } from '@/utils/formatCurrency'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import { InsightCalculationTooltip } from '@/pages/insights/components/CalculationTooltip'
 import { InsightActionButton } from '@/pages/insights/components/ActionButton'
@@ -69,6 +69,7 @@ export function NetWorthCard({
   loading = false,
   transitionKey,
 }: NetWorthCardProps) {
+  const { currencies, formatCurrency } = useMoneyFormatters()
   const incomingSnapshot = useMemo<NetWorthSnapshot>(() => ({
     mode,
     groups,
@@ -153,7 +154,7 @@ export function NetWorthCard({
                   </p>
                   <div className="flex items-center gap-1.5 text-sm font-medium leading-none" style={{ color: netWorthTrendColor }}>
                     <NetWorthTrendIcon size={14} aria-hidden />
-                    <span className="font-financial">{formatSignedNetWorthCurrency(latestChange, displaySnapshot.displayCurrency)}</span>
+                    <span className="font-financial">{formatSignedNetWorthCurrency(latestChange, displaySnapshot.displayCurrency, currencies)}</span>
                     <span style={{ color: 'var(--app-text-subtle)' }}>since start</span>
                   </div>
                 </div>

--- a/frontend/src/pages/insights/components/net-worth-card/Chart.tsx
+++ b/frontend/src/pages/insights/components/net-worth-card/Chart.tsx
@@ -25,8 +25,8 @@ import {
   getChartDataSignature,
   useChartEntranceAnimation,
 } from '@/components/charts/useChartEntranceAnimation'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { DASHBOARD_X_AXIS_TICK_FONT_SIZE } from '@/pages/dashboard/constants/chart'
-import { formatCurrency } from '@/utils/formatCurrency'
 import {
   NET_WORTH_AXIS_TICK_COUNT,
   formatNetWorthAxisDate,
@@ -159,6 +159,7 @@ function NetWorthChartTooltipContent({
   displayCurrency: string
   mode: NetWorthViewMode
 }) {
+  const { currencies, formatCurrency } = useMoneyFormatters()
   const detailItems = items.map((item, index) => ({ item, index }))
   const displayedNetWorth = mode === 'composition'
     ? detailItems.reduce((sum, { index }) => sum + Number(point[getValueKey(index)] ?? 0), 0)
@@ -175,7 +176,7 @@ function NetWorthChartTooltipContent({
       {mode === 'overview' && (
         <ChartTooltipRow
           label="Change"
-          value={formatSignedNetWorthCurrency(point.totalChange, displayCurrency)}
+          value={formatSignedNetWorthCurrency(point.totalChange, displayCurrency, currencies)}
           financialValue
         />
       )}
@@ -195,7 +196,7 @@ function NetWorthChartTooltipContent({
                   {mode === 'overview' && (
                     <>
                       {' '}
-                      ({formatSignedNetWorthCurrency(change, displayCurrency)})
+                      ({formatSignedNetWorthCurrency(change, displayCurrency, currencies)})
                     </>
                   )}
                 </>
@@ -223,6 +224,7 @@ export function NetWorthChart({
 }: NetWorthChartProps) {
   const chartRef = useRef<HTMLDivElement>(null)
   const tooltipRef = useRef<DeferredChartTooltipOverlayHandle<NetWorthDeltaPoint>>(null)
+  const { currencies } = useMoneyFormatters()
   const hasChartData = groups.length > 0 && deltaSeries.length > 0
   const dateAxisStartMs = deltaSeries[0]?.dateMs ?? 0
   const dateAxisEndMs = deltaSeries.at(-1)?.dateMs ?? dateAxisStartMs
@@ -238,7 +240,7 @@ export function NetWorthChart({
     () => new Map(deltaSeries.map((point) => [point.dateMs, point])),
     [deltaSeries],
   )
-  const startNetWorthAxisLabel = formatNetWorthAxisMoney(deltaSeries[0]?.startTotal ?? 0, displayCurrency)
+  const startNetWorthAxisLabel = formatNetWorthAxisMoney(deltaSeries[0]?.startTotal ?? 0, displayCurrency, currencies)
   const startNetWorthLabelPoint = mode === 'overview' ? deltaSeries[0] : undefined
   const startNetWorthLabelY = startNetWorthLabelPoint
     ? getNetWorthFirstBarLabelY(startNetWorthLabelPoint, chartItems)

--- a/frontend/src/pages/insights/components/period-glance-card/PrimaryPanel.tsx
+++ b/frontend/src/pages/insights/components/period-glance-card/PrimaryPanel.tsx
@@ -3,7 +3,7 @@ import type { FxStatus } from '@/api/shared/fx'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import type { PeriodGlancePrimaryMetric } from '@/pages/insights/types/periodGlance'
 import { getPeriodIncomeExpenseFxStatusMessage } from '@/pages/insights/utils/fxTooltipMessages'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { InsightCalculationTooltip } from '@/pages/insights/components/CalculationTooltip'
 import { getPeriodGlanceToneClass } from './display'
 import { useFittedPrimaryAmount } from './useFittedPrimaryAmount'
@@ -26,6 +26,7 @@ export function PeriodGlancePrimaryPanel({
   incomeExpenseFxStatus,
   displayCurrency,
 }: PeriodGlancePrimaryPanelProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const [primaryAmountRef, primaryAmountFontSizeRem, primaryAmountMaxRem] = useFittedPrimaryAmount(primaryMetric.value)
   const primaryAmountStyle: CSSProperties | undefined =
     primaryAmountFontSizeRem < primaryAmountMaxRem ? { fontSize: `${primaryAmountFontSizeRem}rem` } : undefined

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Chart.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Chart.tsx
@@ -29,7 +29,7 @@ import {
   type SavingsRateTier,
 } from '@/pages/insights/utils/savingsRateChart'
 import { formatSavingsRateValue } from '@/pages/insights/utils/money'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 type SavingsRateTooltipState = {
   activeLabel?: string | number
@@ -91,6 +91,8 @@ function SavingsRateHistoryTooltipContent({
   point: SavingsRateHistoryPoint
   displayCurrency: string
 }) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <>
       <ChartTooltipTitle>{point.fullLabel}</ChartTooltipTitle>

--- a/frontend/src/pages/insights/hooks/useInsightsCardData.ts
+++ b/frontend/src/pages/insights/hooks/useInsightsCardData.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import type { InsightsBreakdownCategoryKind } from '@/api/insights'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import type { InsightsCardQueries } from '@/pages/insights/hooks/useInsightsCardQueries'
 import type { InsightsRangeInputDates } from '@/pages/insights/types/range'
 import { getCashFlowBarData } from '@/pages/insights/utils/cashFlow'
@@ -31,6 +32,7 @@ export function useInsightsCardData({
   rangeInputDates,
   breakdownMode,
 }: UseInsightsCardDataParams) {
+  const { currencies } = useMoneyFormatters()
   const selectedBreakdown = useMemo(
     () => getBreakdownEntriesForMode(queries.incomeExpenseBreakdown.data, breakdownMode),
     [breakdownMode, queries.incomeExpenseBreakdown.data],
@@ -44,8 +46,8 @@ export function useInsightsCardData({
     [breakdownMode, queries.incomeExpenseBreakdown.data],
   )
   const periodGlanceData = useMemo(
-    () => getPeriodGlanceCardData(queries.periodGlance.data, displayCurrency),
-    [displayCurrency, queries.periodGlance.data],
+    () => getPeriodGlanceCardData(queries.periodGlance.data, displayCurrency, currencies),
+    [currencies, displayCurrency, queries.periodGlance.data],
   )
   const fundFlowData = useMemo(
     () => getFundFlowCardData(queries.fundFlow.data),

--- a/frontend/src/pages/insights/utils/incomeExpenseBreakdownDisplay.ts
+++ b/frontend/src/pages/insights/utils/incomeExpenseBreakdownDisplay.ts
@@ -1,4 +1,5 @@
 import type { InsightsBreakdownCategoryKind } from '@/api/insights'
+import type { Currency } from '@/api/currency'
 import type {
   BreakdownEntry,
   CategoryTrendSection,
@@ -30,9 +31,9 @@ export function getBreakdownPercent(amount: number, total: number) {
 /**
  * Formats signed currency changes without showing a sign for unchanged values
  */
-export function formatSignedBreakdownCurrency(amount: number, currency: string) {
-  if (amount === 0) return formatCurrency(amount, currency)
-  return `${amount > 0 ? '+' : '-'}${formatCurrency(Math.abs(amount), currency)}`
+export function formatSignedBreakdownCurrency(amount: number, currency: string, currencies: Currency[]) {
+  if (amount === 0) return formatCurrency(amount, currency, currencies)
+  return `${amount > 0 ? '+' : '-'}${formatCurrency(Math.abs(amount), currency, currencies)}`
 }
 
 /**

--- a/frontend/src/pages/insights/utils/money.ts
+++ b/frontend/src/pages/insights/utils/money.ts
@@ -1,3 +1,4 @@
+import type { Currency } from '@/api/currency'
 import { formatCurrency } from '@/utils/formatCurrency'
 
 /**
@@ -26,9 +27,9 @@ export function formatSavingsRateValue(rate: number | null) {
  * Formats an amount with a leading plus or minus so a movement reads as a direction, while zero
  * is shown plainly with no sign at all
  */
-export function formatSignedCurrency(amount: number, currency: string) {
-  if (amount === 0) return formatCurrency(amount, currency)
-  return `${amount > 0 ? '+' : '-'}${formatCurrency(Math.abs(amount), currency)}`
+export function formatSignedCurrency(amount: number, currency: string, currencies: Currency[]) {
+  if (amount === 0) return formatCurrency(amount, currency, currencies)
+  return `${amount > 0 ? '+' : '-'}${formatCurrency(Math.abs(amount), currency, currencies)}`
 }
 
 /**

--- a/frontend/src/pages/insights/utils/netWorthChart.ts
+++ b/frontend/src/pages/insights/utils/netWorthChart.ts
@@ -1,3 +1,4 @@
+import type { Currency } from '@/api/currency'
 import { formatCurrency } from '@/utils/formatCurrency'
 import { formatCompactMoney, type CompactMoneyRule } from '@/utils/formatCompactMoney'
 import { DATE_FORMATS, formatDate, parseYmd } from '@/utils/date'
@@ -66,16 +67,16 @@ const netWorthAxisMoneyRules: CompactMoneyRule[] = [
 /**
  * Formats signed currency changes without showing a sign for unchanged values
  */
-export function formatSignedNetWorthCurrency(amount: number, currency: string) {
-  if (amount === 0) return formatCurrency(amount, currency)
-  return `${amount > 0 ? '+' : '-'}${formatCurrency(Math.abs(amount), currency)}`
+export function formatSignedNetWorthCurrency(amount: number, currency: string, currencies: Currency[]) {
+  if (amount === 0) return formatCurrency(amount, currency, currencies)
+  return `${amount > 0 ? '+' : '-'}${formatCurrency(Math.abs(amount), currency, currencies)}`
 }
 
 /**
  * Formats a net worth chart axis value with K/M compaction rules and no currency prefix
  */
-export function formatNetWorthAxisMoney(value: number, currency: string) {
-  return formatCompactMoney(value, currency, netWorthAxisMoneyRules, { prefix: '' })
+export function formatNetWorthAxisMoney(value: number, currency: string, currencies: Currency[]) {
+  return formatCompactMoney(value, currency, netWorthAxisMoneyRules, currencies, { prefix: '' })
 }
 
 /**

--- a/frontend/src/pages/insights/utils/periodGlance.ts
+++ b/frontend/src/pages/insights/utils/periodGlance.ts
@@ -1,4 +1,5 @@
 import type { InsightsPeriodGlanceResponse } from '@/api/insights'
+import type { Currency } from '@/api/currency'
 import { formatCurrency } from '@/utils/formatCurrency'
 import type {
   PeriodGlancePrimaryMetric,
@@ -58,15 +59,20 @@ function getPeriodGlanceChangeDetail(
   changeAmount: number,
   changePct: number | undefined,
   displayCurrency: string,
+  currencies: Currency[],
 ) {
-  const amount = formatSignedCurrency(changeAmount, displayCurrency)
+  const amount = formatSignedCurrency(changeAmount, displayCurrency, currencies)
   if (changePct === undefined) {
     return `${amount} vs previous matching period`
   }
   return `${amount} (${changePct > 0 ? '+' : ''}${changePct}%) vs previous matching period`
 }
 
-function getPeriodGlanceBrief(data: InsightsPeriodGlanceResponse, displayCurrency: string): PeriodBrief {
+function getPeriodGlanceBrief(
+  data: InsightsPeriodGlanceResponse,
+  displayCurrency: string,
+  currencies: Currency[],
+): PeriodBrief {
   const netSavings = data.income - data.expenses
   const savingsRate = getSavingsRate(data.income, data.expenses)
 
@@ -97,7 +103,7 @@ function getPeriodGlanceBrief(data: InsightsPeriodGlanceResponse, displayCurrenc
         label: 'Biggest Change',
         value: data.biggest_change_name ?? 'N/A',
         detail: data.biggest_change_name && data.biggest_change_amount !== undefined
-          ? getPeriodGlanceChangeDetail(data.biggest_change_amount, data.biggest_change_pct, displayCurrency)
+          ? getPeriodGlanceChangeDetail(data.biggest_change_amount, data.biggest_change_pct, displayCurrency, currencies)
           : 'No comparable category movement in this range',
         calculation: 'Category with the largest dollar change from the previous matching period',
         fxStatus: data.biggest_change_fx_status,
@@ -167,16 +173,22 @@ function getLoadingPeriodGlanceBrief(): PeriodBrief {
 function formatBriefMetricValue(
   metric: PeriodBrief['metrics'][number],
   displayCurrency: string,
+  currencies: Currency[],
 ) {
   return metric.signed
-    ? formatSignedCurrency(metric.value, displayCurrency)
-    : formatCurrency(metric.value, displayCurrency)
+    ? formatSignedCurrency(metric.value, displayCurrency, currencies)
+    : formatCurrency(metric.value, displayCurrency, currencies)
 }
 
-function getSupportItems(secondaryMetric: PeriodBrief['metrics'][number], signals: PeriodBrief['signals'], displayCurrency: string) {
+function getSupportItems(
+  secondaryMetric: PeriodBrief['metrics'][number],
+  signals: PeriodBrief['signals'],
+  displayCurrency: string,
+  currencies: Currency[],
+) {
   const secondarySignal: InsightSignal = {
     label: secondaryMetric.label,
-    value: formatBriefMetricValue(secondaryMetric, displayCurrency),
+    value: formatBriefMetricValue(secondaryMetric, displayCurrency, currencies),
     detail: secondaryMetric.detail,
     calculation: secondaryMetric.calculation,
     tone: secondaryMetric.tone,
@@ -205,9 +217,10 @@ function getSupportItems(secondaryMetric: PeriodBrief['metrics'][number], signal
 export function getPeriodGlanceCardData(
   data: InsightsPeriodGlanceResponse | undefined,
   displayCurrency: string,
+  currencies: Currency[],
 ): PeriodGlanceCardData {
   const brief = data
-    ? getPeriodGlanceBrief(data, displayCurrency)
+    ? getPeriodGlanceBrief(data, displayCurrency, currencies)
     : getLoadingPeriodGlanceBrief()
   const primaryMetric = brief.metrics[0]
   const secondaryMetric = brief.metrics[1]
@@ -215,12 +228,12 @@ export function getPeriodGlanceCardData(
   return {
     primaryMetric: {
       label: primaryMetric.label,
-      value: formatBriefMetricValue(primaryMetric, displayCurrency),
+      value: formatBriefMetricValue(primaryMetric, displayCurrency, currencies),
       detail: primaryMetric.detail,
       calculation: primaryMetric.calculation,
       tone: primaryMetric.tone,
     },
-    supportItems: getSupportItems(secondaryMetric, brief.signals, displayCurrency),
+    supportItems: getSupportItems(secondaryMetric, brief.signals, displayCurrency, currencies),
     income: data?.income ?? 0,
     expenses: data?.expenses ?? 0,
   }

--- a/frontend/src/pages/settings/components/runway-section/AccountTiles.tsx
+++ b/frontend/src/pages/settings/components/runway-section/AccountTiles.tsx
@@ -1,7 +1,7 @@
 import { Archive, Check } from 'lucide-react'
 import type { AccountsOverview } from '@/api/accounts'
 import MarqueeText from '@/components/display/MarqueeText'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 interface ArchivedRunwayAccountTileProps {
   account: AccountsOverview
@@ -17,6 +17,7 @@ interface RunwayAccountTileProps {
  * Shows an archived account that was previously included in runway settings
  */
 export function ArchivedRunwayAccountTile({ account }: ArchivedRunwayAccountTileProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const institutionName = account.institution?.name ?? 'Cash'
 
   return (
@@ -57,6 +58,7 @@ export function ArchivedRunwayAccountTile({ account }: ArchivedRunwayAccountTile
  * Renders an eligible runway account as a selectable settings row
  */
 export function RunwayAccountTile({ account, selected, onToggle }: RunwayAccountTileProps) {
+  const { formatCurrency } = useMoneyFormatters()
   const institutionName = account.institution?.name ?? 'Cash'
 
   return (

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/panels/AccountLinksPanel.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/panels/AccountLinksPanel.tsx
@@ -1,6 +1,6 @@
 import type { AccountsOverview } from '@/api/accounts'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 interface TaxAdvantagedAccountLinksPanelProps {
   accountError: string | null
@@ -22,6 +22,8 @@ export default function TaxAdvantagedAccountLinksPanel({
   pendingAccountId,
   plan,
 }: TaxAdvantagedAccountLinksPanelProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <div className="flex h-full min-h-0 flex-col gap-4">
       <div className="shrink-0">

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/panels/LimitsPanel.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/panels/LimitsPanel.tsx
@@ -5,7 +5,7 @@ import type {
   TaxAdvantagedCategory,
   TaxAdvantagedCategoryLimit,
 } from '@/api/tax-advantaged-categories'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { LIMIT_DELETE_BUTTON_TRANSITION } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/constants'
 import TaxAdvantagedOpeningUsageLabel from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/controls/OpeningUsageLabel'
 
@@ -51,6 +51,8 @@ export default function TaxAdvantagedLimitsPanel({
   showAddTaxYear,
   sortedLimits,
 }: TaxAdvantagedLimitsPanelProps) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <div className="space-y-5">
       <div className="space-y-2 border-b pb-4" style={{ borderColor: 'var(--app-border)' }}>

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -1,7 +1,7 @@
 import { AnimatePresence, motion } from 'motion/react'
 import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import TransactionRow from '@/components/transactions/Row'
 import { TRANSACTION_LIST_EASE } from '@/pages/transactions/constants/transactionList'
 import type { TransactionDateGroup, TransactionListAccount } from '@/pages/transactions/types/transactionList'
@@ -34,6 +34,8 @@ export default function TransactionDateGroupList({
   skipEnterAnimation?: boolean
   onEditTransaction: (transaction: Transaction) => void
 }) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <div className="min-[1300px]:grid min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content] min-[1300px]:gap-x-3">
       {/* initial={false} suppresses the first render and the whole-list swap on filter changes, so a

--- a/frontend/src/pages/transactions/components/top-band/DailyCashFlowChart.tsx
+++ b/frontend/src/pages/transactions/components/top-band/DailyCashFlowChart.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/components/charts/rechartsTooltip'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import IconTooltip from '@/components/tooltips/IconTooltip'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { useDeferredMount } from '@/hooks/useDeferredMount'
 import { PLACEHOLDER_DAILY_FLOW } from '@/pages/transactions/components/top-band/constants'
 import {
@@ -82,6 +82,8 @@ function DailyCashFlowTooltipContent({
   displayCurrency: string
   mode: DailyCashFlowChartMode
 }) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <>
       <ChartTooltipTitle>{point.rangeLabel}</ChartTooltipTitle>

--- a/frontend/src/pages/transactions/components/top-band/MostExpensiveTransactionsPanel.tsx
+++ b/frontend/src/pages/transactions/components/top-band/MostExpensiveTransactionsPanel.tsx
@@ -3,7 +3,7 @@ import type { FxStatus } from '@/api/shared/fx'
 import type { OutlierTransaction } from '@/api/transactions'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import IconTooltip from '@/components/tooltips/IconTooltip'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import {
   OUTLIER_TRANSACTION_LIMIT,
   OUTLIER_TRANSACTION_ROW_GAP,
@@ -35,6 +35,7 @@ export default function MostExpensiveTransactionsPanel({
   onOpenOutlierTransaction: (transactionId: string) => void
   className?: string
 }) {
+  const { formatCurrency } = useMoneyFormatters()
   const contentTransition = { duration: prefersReducedMotion ? 0 : 0.24, ease: [0.25, 0.1, 0.25, 1] } as const
 
   return (

--- a/frontend/src/pages/transactions/components/top-band/NetFlowSummary.tsx
+++ b/frontend/src/pages/transactions/components/top-band/NetFlowSummary.tsx
@@ -4,7 +4,7 @@ import type { FxStatus } from '@/api/shared/fx'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { getCashFlowFxStatusMessage } from '@/pages/transactions/utils/fxTooltipMessages'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
 const MAX_NET_FLOW_FONT_SIZE = 60
 const netFlowCalculation =
@@ -29,6 +29,7 @@ export default function NetFlowSummary({
   const containerRef = useRef<HTMLDivElement>(null)
   const measurementRef = useRef<HTMLSpanElement>(null)
   const [netFlowFontSize, setNetFlowFontSize] = useState(MAX_NET_FLOW_FONT_SIZE)
+  const { formatCurrency } = useMoneyFormatters()
   const netFlow = inflow + outflow
   const netColor = netFlow >= 0 ? 'var(--app-positive)' : 'var(--app-negative)'
   const formattedNetFlow = `${netFlow >= 0 ? '+' : ''}${formatCurrency(netFlow, displayCurrency)}`

--- a/frontend/src/pages/transactions/components/top-band/TopCategoriesChart.tsx
+++ b/frontend/src/pages/transactions/components/top-band/TopCategoriesChart.tsx
@@ -32,7 +32,7 @@ import {
 } from '@/components/charts/useChartEntranceAnimation'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import IconTooltip from '@/components/tooltips/IconTooltip'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { useDeferredMount } from '@/hooks/useDeferredMount'
 import {
   TOP_CATEGORY_AXIS_AVG_CHAR_WIDTH,
@@ -64,6 +64,8 @@ function TopCategoryTooltipContent({
   point: OverviewCategorySpend
   displayCurrency: string
 }) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <>
       <ChartTooltipTitle>{point.name}</ChartTooltipTitle>

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -14,7 +14,7 @@ import type {
   TransactionDirection,
   TransactionModalKind,
 } from '@/pages/transactions/components/transaction-modal/types'
-import { formatCurrency } from '@/utils/formatCurrency'
+import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { getFieldLabelId } from '@/utils/fieldLabel'
 
 type SelectedTransactionTag = {
@@ -103,6 +103,8 @@ interface TransactionReferencesSectionProps {
  * two account dropdowns is currently holding that account
  */
 function RunningBalanceRow({ runningBalance }: { runningBalance?: { amount: number; currency: string } }) {
+  const { formatCurrency } = useMoneyFormatters()
+
   return (
     <AnimatePresence initial={false}>
       {runningBalance && (

--- a/frontend/src/utils/formatCompactMoney.ts
+++ b/frontend/src/utils/formatCompactMoney.ts
@@ -24,10 +24,7 @@ function formatCurrencyWithSuffix(
   suffix: CompactMoneyRule['suffix'],
   fractionDigits: number,
 ) {
-  // Same reason formatMajorUnits normalizes: accounting style wraps a negative before rounding it,
-  // so a compacted amount too small to show would come back as ($0K)
-  const roundsToZero = Math.abs(value) < 0.5 / 10 ** fractionDigits
-  const parts = createMoneyFormatter(currency, fractionDigits).formatToParts(roundsToZero ? 0 : value)
+  const parts = createMoneyFormatter(currency, fractionDigits).formatToParts(value)
   const numberPartTypes = new Set(['integer', 'group', 'decimal', 'fraction'])
   const suffixIndex = parts.findLastIndex((part) => numberPartTypes.has(part.type))
 

--- a/frontend/src/utils/formatCompactMoney.ts
+++ b/frontend/src/utils/formatCompactMoney.ts
@@ -1,4 +1,4 @@
-import { formatCurrency } from '@/utils/formatCurrency'
+import { MONEY_LOCALE, formatCurrency } from '@/utils/formatCurrency'
 
 export type CompactMoneyRule = {
   threshold: number
@@ -13,7 +13,7 @@ type CompactMoneyOptions = {
 }
 
 function getCurrencyExponent(currency: string) {
-  return new Intl.NumberFormat(undefined, { style: 'currency', currency })
+  return new Intl.NumberFormat(MONEY_LOCALE, { style: 'currency', currency })
     .resolvedOptions()
     .maximumFractionDigits ?? 2
 }
@@ -24,7 +24,7 @@ function formatCurrencyWithSuffix(
   suffix: CompactMoneyRule['suffix'],
   fractionDigits: number,
 ) {
-  const formatter = new Intl.NumberFormat(undefined, {
+  const formatter = new Intl.NumberFormat(MONEY_LOCALE, {
     style: 'currency',
     currency,
     currencySign: 'accounting',

--- a/frontend/src/utils/formatCompactMoney.ts
+++ b/frontend/src/utils/formatCompactMoney.ts
@@ -1,4 +1,5 @@
-import { MONEY_LOCALE, formatCurrency } from '@/utils/formatCurrency'
+import type { Currency } from '@/api/currency'
+import { createMoneyFormatter, formatCurrency, toMajorUnits } from '@/utils/formatCurrency'
 
 export type CompactMoneyRule = {
   threshold: number
@@ -10,12 +11,11 @@ export type CompactMoneyRule = {
 
 type CompactMoneyOptions = {
   prefix?: string
-}
 
-function getCurrencyExponent(currency: string) {
-  return new Intl.NumberFormat(MONEY_LOCALE, { style: 'currency', currency })
-    .resolvedOptions()
-    .maximumFractionDigits ?? 2
+  // Decimal places for an amount below every threshold, which renders in full rather than compacted.
+  // Left unset it follows the currency's own, so a caller showing whole amounts when compacted has
+  // to say so here or a small amount comes back carrying cents the rest of its scale does not show
+  plainFractionDigits?: number
 }
 
 function formatCurrencyWithSuffix(
@@ -24,14 +24,7 @@ function formatCurrencyWithSuffix(
   suffix: CompactMoneyRule['suffix'],
   fractionDigits: number,
 ) {
-  const formatter = new Intl.NumberFormat(MONEY_LOCALE, {
-    style: 'currency',
-    currency,
-    currencySign: 'accounting',
-    minimumFractionDigits: fractionDigits,
-    maximumFractionDigits: fractionDigits,
-  })
-  const parts = formatter.formatToParts(value)
+  const parts = createMoneyFormatter(currency, fractionDigits).formatToParts(value)
   const numberPartTypes = new Set(['integer', 'group', 'decimal', 'fraction'])
   const suffixIndex = parts.findLastIndex((part) => numberPartTypes.has(part.type))
 
@@ -51,22 +44,26 @@ function applyCompactRule(value: number, rule: CompactMoneyRule) {
 
 /**
  * Formats an amount in a currency's minor units as compact text once it crosses one of the given
- * thresholds, such as showing "≈$1.2M" instead of the full number, falling back to `formatCurrency`
- * when no rule applies
+ * thresholds, such as showing "≈$1.2M" instead of the full number, and in full when no rule applies
  *
  * Rules are checked in order and the first whose threshold the absolute value meets is used, so callers
  * should list rules from largest threshold to smallest
+ *
+ * @param currencies - The fetched currency list, which carries each code's decimal places
  */
 export function formatCompactMoney(
   minorUnits: number,
   currency: string,
   rules: CompactMoneyRule[],
-  { prefix = '≈' }: CompactMoneyOptions = {},
+  currencies: Currency[],
+  { prefix = '≈', plainFractionDigits }: CompactMoneyOptions = {},
 ) {
-  const exponent = getCurrencyExponent(currency)
-  const majorUnits = minorUnits / Math.pow(10, exponent) || 0
+  const majorUnits = toMajorUnits(minorUnits, currency, currencies)
   const rule = rules.find(({ threshold }) => Math.abs(majorUnits) >= threshold)
-  if (!rule) return formatCurrency(minorUnits, currency)
+  if (!rule) {
+    if (plainFractionDigits === undefined) return formatCurrency(minorUnits, currency, currencies)
+    return createMoneyFormatter(currency, plainFractionDigits).format(majorUnits)
+  }
 
   return `${prefix}${formatCurrencyWithSuffix(
     applyCompactRule(majorUnits, rule),

--- a/frontend/src/utils/formatCompactMoney.ts
+++ b/frontend/src/utils/formatCompactMoney.ts
@@ -1,5 +1,5 @@
 import type { Currency } from '@/api/currency'
-import { createMoneyFormatter, formatCurrency, toMajorUnits } from '@/utils/formatCurrency'
+import { createMoneyFormatter, formatCurrency, formatMajorUnits, toMajorUnits } from '@/utils/formatCurrency'
 
 export type CompactMoneyRule = {
   threshold: number
@@ -24,7 +24,10 @@ function formatCurrencyWithSuffix(
   suffix: CompactMoneyRule['suffix'],
   fractionDigits: number,
 ) {
-  const parts = createMoneyFormatter(currency, fractionDigits).formatToParts(value)
+  // Same reason formatMajorUnits normalizes: accounting style wraps a negative before rounding it,
+  // so a compacted amount too small to show would come back as ($0K)
+  const roundsToZero = Math.abs(value) < 0.5 / 10 ** fractionDigits
+  const parts = createMoneyFormatter(currency, fractionDigits).formatToParts(roundsToZero ? 0 : value)
   const numberPartTypes = new Set(['integer', 'group', 'decimal', 'fraction'])
   const suffixIndex = parts.findLastIndex((part) => numberPartTypes.has(part.type))
 
@@ -62,7 +65,7 @@ export function formatCompactMoney(
   const rule = rules.find(({ threshold }) => Math.abs(majorUnits) >= threshold)
   if (!rule) {
     if (plainFractionDigits === undefined) return formatCurrency(minorUnits, currency, currencies)
-    return createMoneyFormatter(currency, plainFractionDigits).format(majorUnits)
+    return formatMajorUnits(majorUnits, currency, plainFractionDigits)
   }
 
   return `${prefix}${formatCurrencyWithSuffix(

--- a/frontend/src/utils/formatCurrency.ts
+++ b/frontend/src/utils/formatCurrency.ts
@@ -1,7 +1,7 @@
 import type { Currency } from '@/api/currency'
-import { getCurrencyExponent } from '@/utils/moneyInput'
+import { DEFAULT_MINOR_UNIT_EXPONENT, findCurrencyExponent } from '@/utils/moneyInput'
 
-// Every amount the product renders goes through this locale, so a browser configured for another
+// Every amount rendered as money goes through this locale, so a browser configured for another
 // region still sees one currency convention. Under it CAD is "$" and USD is "US$", which keeps the
 // two apart on a screen holding both. Kept separate from DATE_LOCALE in utils/date.ts, since the
 // date convention and the currency convention could diverge later
@@ -28,14 +28,42 @@ export function createMoneyFormatter(currency: string, fractionDigits: number): 
 }
 
 /**
+ * Returns the decimal places to render a currency at
+ *
+ * The seeded list is the authority, since the browser's own figures disagree with it for 16 of the
+ * 155 seeded codes. A code the list does not carry falls back to the browser rather than to a flat
+ * two, because two is wrong by a factor of a hundred for a currency with no decimal places at all:
+ * a list that failed to load would otherwise render a ¥500,000 balance as JP¥5,000.00. The browser
+ * is right for 139 of the 155 and is what the app rendered before the list was read at all, so an
+ * unreachable currency service costs the decimals of 16 currencies rather than a hundredfold error
+ */
+function resolveDisplayExponent(currency: string, currencies: Currency[]): number {
+  const seeded = findCurrencyExponent(currencies, currency)
+  if (seeded !== null) return seeded
+
+  return new Intl.NumberFormat(MONEY_LOCALE, { style: 'currency', currency })
+    .resolvedOptions()
+    .maximumFractionDigits ?? DEFAULT_MINOR_UNIT_EXPONENT
+}
+
+/**
+ * Formats an amount already in major units at a fixed number of decimal places
+ *
+ * An amount too small to show at those places is rendered as zero rather than as a signed value.
+ * Accounting style decides to wrap a negative in parentheses before rounding it, so without this a
+ * balance 40 cents over its limit comes back as ($0) on a meter that shows no decimals
+ */
+export function formatMajorUnits(value: number, currency: string, fractionDigits: number): string {
+  const roundsToZero = Math.abs(value) < 0.5 / 10 ** fractionDigits
+  return createMoneyFormatter(currency, fractionDigits).format(roundsToZero ? 0 : value)
+}
+
+/**
  * Converts an amount in a currency's minor units into its major units, using the decimal places
  * recorded for that currency
- *
- * -0 is normalized to 0, so an amount that divides to negative zero never reaches accounting style
- * and comes back wrapped in parentheses
  */
 export function toMajorUnits(minorUnits: number, currency: string, currencies: Currency[]): number {
-  return minorUnits / Math.pow(10, getCurrencyExponent(currencies, currency)) || 0
+  return minorUnits / Math.pow(10, resolveDisplayExponent(currency, currencies))
 }
 
 /**
@@ -43,13 +71,11 @@ export function toMajorUnits(minorUnits: number, currency: string, currencies: C
  * convention, rather than the reader's
  *
  * Negative amounts render in accounting style, wrapped in parentheses instead of a leading minus sign,
- * and -0 is normalized to 0 so a zero amount never appears wrapped in parentheses
+ * and an amount that rounds to zero never appears wrapped that way
  *
- * @param currencies - The fetched currency list, which carries each code's decimal places. A code
- *   missing from it falls back to two places, so a list that has not arrived scales every amount by
- *   a guess
+ * @param currencies - The fetched currency list, which carries each code's decimal places
  */
 export function formatCurrency(minorUnits: number, currency: string, currencies: Currency[]): string {
-  const exponent = getCurrencyExponent(currencies, currency)
-  return createMoneyFormatter(currency, exponent).format(toMajorUnits(minorUnits, currency, currencies))
+  const exponent = resolveDisplayExponent(currency, currencies)
+  return formatMajorUnits(minorUnits / Math.pow(10, exponent), currency, exponent)
 }

--- a/frontend/src/utils/formatCurrency.ts
+++ b/frontend/src/utils/formatCurrency.ts
@@ -1,15 +1,21 @@
-// Format an integer amount in a currency's minor units (e.g. cents) as a
-// localized currency string. Intl.NumberFormat knows the exponent for each
-// ISO 4217 code, so we divide by 10^exponent before formatting
-// currencySign: 'accounting' renders negatives in parentheses — e.g. -100 → ($100.00)
+// Every amount the product renders goes through this locale, so a browser configured for another
+// region still sees one currency convention. Under it CAD is "$" and USD is "US$", which keeps the
+// two apart on a screen holding both. Kept separate from DATE_LOCALE in utils/date.ts, since the
+// date convention and the currency convention could diverge later
+export const MONEY_LOCALE = 'en-CA'
+
+// Format an integer amount in a currency's minor units (e.g. cents) as a currency string.
+// Intl.NumberFormat knows the exponent for each ISO 4217 code, so we divide by 10^exponent before
+// formatting. currencySign: 'accounting' renders negatives in parentheses, so -100 gives ($100.00)
 /**
- * Formats an integer amount in a currency's minor units as a localized currency string
+ * Formats an integer amount in a currency's minor units as a currency string in the app's own
+ * convention, rather than the reader's
  *
  * Negative amounts render in accounting style, wrapped in parentheses instead of a leading minus sign,
  * and -0 is normalized to 0 so a zero amount never appears wrapped in parentheses
  */
 export function formatCurrency(minorUnits: number, currency: string): string {
-  const fmt = new Intl.NumberFormat(undefined, {
+  const fmt = new Intl.NumberFormat(MONEY_LOCALE, {
     style: 'currency',
     currency,
     currencySign: 'accounting',

--- a/frontend/src/utils/formatCurrency.ts
+++ b/frontend/src/utils/formatCurrency.ts
@@ -5,11 +5,13 @@ import { DEFAULT_MINOR_UNIT_EXPONENT, findCurrencyExponent } from '@/utils/money
  * Builds the money formatter for a currency, fixed at the decimal places given
  *
  * The locale is left to the reader's own, which is what decides how a currency's symbol is written.
- * Every region writes its own currency bare and marks the rest: to a reader in Canada, Canadian
- * dollars are "$" and US dollars are "US$", and to a reader in the United States it is the other way
- * round. Both are right for the person looking at them, so this follows the browser rather than
- * naming a region. Note this is not what utils/date.ts does, which pins one date convention, because
- * a date has no home country to be read as foreign from
+ * Where two currencies would otherwise share a symbol, a region writes its own plain and marks the
+ * others: read from Canada, Canadian dollars are "$" and US dollars are "US$", and read from the
+ * United States, US dollars are "$" and Canadian dollars are "CA$". A currency whose symbol collides
+ * with nothing, such as the euro, is written plain everywhere. Each of those is right for the person
+ * looking at it, so this follows the browser rather than naming a region. Note this is not what
+ * utils/date.ts does, which pins one date convention, because a date has no home country to be read
+ * as foreign from
  *
  * Both fraction-digit options are set rather than left to Intl, whose own tables disagree with the
  * seeded currency list for 16 codes. Dividing by the seeded exponent without also fixing the places
@@ -34,9 +36,10 @@ export function createMoneyFormatter(currency: string, fractionDigits: number): 
  * The seeded list is the authority, since the browser's own figures disagree with it for 16 of the
  * 155 seeded codes. The fallback covers a code that list does not carry, such as one added to the
  * standard after the seed last ran, and it reads the browser rather than assuming a flat two, because
- * two is wrong by a factor of a hundred for a currency with no decimal places at all: it would render
- * a ¥500,000 balance as JP¥5,000.00. A list that fails to load never reaches here, since the app shows
- * its recovery screen instead of rendering any amount at all
+ * two is wrong by a factor of a hundred for a currency with no decimal places at all: a yen balance of
+ * 500000 minor units would render as five thousand rather than five hundred thousand. A list that
+ * fails to load never reaches here, since the app shows its recovery screen instead of rendering any
+ * amount at all
  */
 function resolveDisplayExponent(currency: string, currencies: Currency[]): number {
   const seeded = findCurrencyExponent(currencies, currency)
@@ -68,8 +71,8 @@ export function toMajorUnits(minorUnits: number, currency: string, currencies: C
 }
 
 /**
- * Formats an integer amount in a currency's minor units as a currency string in the app's own
- * convention, rather than the reader's
+ * Formats an integer amount in a currency's minor units as a currency string, written the way the
+ * reader's own region writes it
  *
  * Negative amounts render in accounting style, wrapped in parentheses instead of a leading minus sign,
  * and an amount that rounds to zero never appears wrapped that way

--- a/frontend/src/utils/formatCurrency.ts
+++ b/frontend/src/utils/formatCurrency.ts
@@ -1,14 +1,15 @@
 import type { Currency } from '@/api/currency'
 import { DEFAULT_MINOR_UNIT_EXPONENT, findCurrencyExponent } from '@/utils/moneyInput'
 
-// Every amount rendered as money goes through this locale, so a browser configured for another
-// region still sees one currency convention. Under it CAD is "$" and USD is "US$", which keeps the
-// two apart on a screen holding both. Kept separate from DATE_LOCALE in utils/date.ts, since the
-// date convention and the currency convention could diverge later
-export const MONEY_LOCALE = 'en-CA'
-
 /**
- * Builds the pinned money formatter for a currency, fixed at the decimal places given
+ * Builds the money formatter for a currency, fixed at the decimal places given
+ *
+ * The locale is left to the reader's own, which is what decides how a currency's symbol is written.
+ * Every region writes its own currency bare and marks the rest: to a reader in Canada, Canadian
+ * dollars are "$" and US dollars are "US$", and to a reader in the United States it is the other way
+ * round. Both are right for the person looking at them, so this follows the browser rather than
+ * naming a region. Note this is not what utils/date.ts does, which pins one date convention, because
+ * a date has no home country to be read as foreign from
  *
  * Both fraction-digit options are set rather than left to Intl, whose own tables disagree with the
  * seeded currency list for 16 codes. Dividing by the seeded exponent without also fixing the places
@@ -18,7 +19,7 @@ export const MONEY_LOCALE = 'en-CA'
  * currencySign: 'accounting' renders negatives in parentheses, so -100 gives ($100.00)
  */
 export function createMoneyFormatter(currency: string, fractionDigits: number): Intl.NumberFormat {
-  return new Intl.NumberFormat(MONEY_LOCALE, {
+  return new Intl.NumberFormat(undefined, {
     style: 'currency',
     currency,
     currencySign: 'accounting',
@@ -41,7 +42,7 @@ function resolveDisplayExponent(currency: string, currencies: Currency[]): numbe
   const seeded = findCurrencyExponent(currencies, currency)
   if (seeded !== null) return seeded
 
-  return new Intl.NumberFormat(MONEY_LOCALE, { style: 'currency', currency })
+  return new Intl.NumberFormat(undefined, { style: 'currency', currency })
     .resolvedOptions()
     .maximumFractionDigits ?? DEFAULT_MINOR_UNIT_EXPONENT
 }

--- a/frontend/src/utils/formatCurrency.ts
+++ b/frontend/src/utils/formatCurrency.ts
@@ -1,27 +1,55 @@
+import type { Currency } from '@/api/currency'
+import { getCurrencyExponent } from '@/utils/moneyInput'
+
 // Every amount the product renders goes through this locale, so a browser configured for another
 // region still sees one currency convention. Under it CAD is "$" and USD is "US$", which keeps the
 // two apart on a screen holding both. Kept separate from DATE_LOCALE in utils/date.ts, since the
 // date convention and the currency convention could diverge later
 export const MONEY_LOCALE = 'en-CA'
 
-// Format an integer amount in a currency's minor units (e.g. cents) as a currency string.
-// Intl.NumberFormat knows the exponent for each ISO 4217 code, so we divide by 10^exponent before
-// formatting. currencySign: 'accounting' renders negatives in parentheses, so -100 gives ($100.00)
+/**
+ * Builds the pinned money formatter for a currency, fixed at the decimal places given
+ *
+ * Both fraction-digit options are set rather than left to Intl, whose own tables disagree with the
+ * seeded currency list for 16 codes. Dividing by the seeded exponent without also fixing the places
+ * rendered produces a wrong number: 123456 minor units of PKR divides to 1234.56, which Intl then
+ * renders as "PKR 1,235" because it believes PKR has no decimals
+ *
+ * currencySign: 'accounting' renders negatives in parentheses, so -100 gives ($100.00)
+ */
+export function createMoneyFormatter(currency: string, fractionDigits: number): Intl.NumberFormat {
+  return new Intl.NumberFormat(MONEY_LOCALE, {
+    style: 'currency',
+    currency,
+    currencySign: 'accounting',
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })
+}
+
+/**
+ * Converts an amount in a currency's minor units into its major units, using the decimal places
+ * recorded for that currency
+ *
+ * -0 is normalized to 0, so an amount that divides to negative zero never reaches accounting style
+ * and comes back wrapped in parentheses
+ */
+export function toMajorUnits(minorUnits: number, currency: string, currencies: Currency[]): number {
+  return minorUnits / Math.pow(10, getCurrencyExponent(currencies, currency)) || 0
+}
+
 /**
  * Formats an integer amount in a currency's minor units as a currency string in the app's own
  * convention, rather than the reader's
  *
  * Negative amounts render in accounting style, wrapped in parentheses instead of a leading minus sign,
  * and -0 is normalized to 0 so a zero amount never appears wrapped in parentheses
+ *
+ * @param currencies - The fetched currency list, which carries each code's decimal places. A code
+ *   missing from it falls back to two places, so a list that has not arrived scales every amount by
+ *   a guess
  */
-export function formatCurrency(minorUnits: number, currency: string): string {
-  const fmt = new Intl.NumberFormat(MONEY_LOCALE, {
-    style: 'currency',
-    currency,
-    currencySign: 'accounting',
-  })
-  const exponent = fmt.resolvedOptions().maximumFractionDigits ?? 2
-  // Normalize -0 to 0 so accounting sign doesn't wrap zero in parentheses
-  const value = minorUnits / Math.pow(10, exponent) || 0
-  return fmt.format(value)
+export function formatCurrency(minorUnits: number, currency: string, currencies: Currency[]): string {
+  const exponent = getCurrencyExponent(currencies, currency)
+  return createMoneyFormatter(currency, exponent).format(toMajorUnits(minorUnits, currency, currencies))
 }

--- a/frontend/src/utils/formatCurrency.ts
+++ b/frontend/src/utils/formatCurrency.ts
@@ -31,11 +31,11 @@ export function createMoneyFormatter(currency: string, fractionDigits: number): 
  * Returns the decimal places to render a currency at
  *
  * The seeded list is the authority, since the browser's own figures disagree with it for 16 of the
- * 155 seeded codes. A code the list does not carry falls back to the browser rather than to a flat
- * two, because two is wrong by a factor of a hundred for a currency with no decimal places at all:
- * a list that failed to load would otherwise render a ¥500,000 balance as JP¥5,000.00. The browser
- * is right for 139 of the 155 and is what the app rendered before the list was read at all, so an
- * unreachable currency service costs the decimals of 16 currencies rather than a hundredfold error
+ * 155 seeded codes. The fallback covers a code that list does not carry, such as one added to the
+ * standard after the seed last ran, and it reads the browser rather than assuming a flat two, because
+ * two is wrong by a factor of a hundred for a currency with no decimal places at all: it would render
+ * a ¥500,000 balance as JP¥5,000.00. A list that fails to load never reaches here, since the app shows
+ * its recovery screen instead of rendering any amount at all
  */
 function resolveDisplayExponent(currency: string, currencies: Currency[]): number {
   const seeded = findCurrencyExponent(currencies, currency)

--- a/frontend/tests/api/currency.test.ts
+++ b/frontend/tests/api/currency.test.ts
@@ -4,7 +4,7 @@
  * These tests catch regressions where currency metadata requests call the wrong
  * endpoint or ignore backend load failures
  */
-import { QueryClient, QueryObserver } from '@tanstack/react-query';
+import { QueryClient, QueryObserver, onlineManager } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { API_BASE } from '@/api/config';
 import { fetchCurrencies } from '@/api/currency';
@@ -52,10 +52,10 @@ describe('currency API functions', () => {
 
 /**
  * The app renders no screen until this query settles, and shows its recovery screen when it fails, so
- * a failure that quietly returns to pending puts the whole app back on its loading screen. Every
- * navigation remounts the component holding this query, so that has to survive a remount
+ * a failure that quietly returns to pending puts the whole app back on its loading screen. Most
+ * navigations remount the component holding this query, so that has to survive a remount
  */
-describe('the currency query once it has failed', () => {
+describe('the currency query when it cannot load', () => {
   /** Subscribes an observer the way a mounting component does, and returns its unsubscribe */
   function mount(client: QueryClient) {
     const observer = new QueryObserver(client, currencyQueryOptions);
@@ -80,8 +80,20 @@ describe('the currency query once it has failed', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
-  it('fails rather than pausing while the browser reports itself offline', () => {
-    // A paused query keeps its pending status and never settles, so the app would wait on it forever
-    expect(currencyQueryOptions.networkMode).toBe('always');
+  it('fails rather than pausing while the browser reports itself offline', async () => {
+    // A paused query keeps its pending status and never settles, so the app would hold its loading
+    // screen forever rather than reaching the recovery screen that offers a way out
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    onlineManager.setOnline(false);
+
+    try {
+      const client = new QueryClient();
+      const { observer, unsubscribe } = mount(client);
+      await vi.waitFor(() => expect(observer.getCurrentResult().isError).toBe(true));
+      expect(observer.getCurrentResult().fetchStatus).not.toBe('paused');
+      unsubscribe();
+    } finally {
+      onlineManager.setOnline(true);
+    }
   });
 });

--- a/frontend/tests/api/currency.test.ts
+++ b/frontend/tests/api/currency.test.ts
@@ -4,9 +4,11 @@
  * These tests catch regressions where currency metadata requests call the wrong
  * endpoint or ignore backend load failures
  */
+import { QueryClient, QueryObserver } from '@tanstack/react-query';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { API_BASE } from '@/api/config';
 import { fetchCurrencies } from '@/api/currency';
+import { currencyQueryOptions } from '@/api/currency/hooks';
 
 const fetchMock = vi.fn();
 
@@ -45,5 +47,41 @@ describe('currency API functions', () => {
     });
 
     await expect(fetchCurrencies()).rejects.toThrow('Failed to load currencies (500)');
+  });
+});
+
+/**
+ * The app renders no screen until this query settles, and shows its recovery screen when it fails, so
+ * a failure that quietly returns to pending puts the whole app back on its loading screen. Every
+ * navigation remounts the component holding this query, so that has to survive a remount
+ */
+describe('the currency query once it has failed', () => {
+  /** Subscribes an observer the way a mounting component does, and returns its unsubscribe */
+  function mount(client: QueryClient) {
+    const observer = new QueryObserver(client, currencyQueryOptions);
+    return { observer, unsubscribe: observer.subscribe(() => {}) };
+  }
+
+  it('stays failed across a remount rather than fetching again', async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 500 });
+    const client = new QueryClient();
+
+    const first = mount(client);
+    await vi.waitFor(() => expect(first.observer.getCurrentResult().isError).toBe(true));
+    first.unsubscribe();
+
+    const second = mount(client);
+    const result = second.observer.getCurrentResult();
+    second.unsubscribe();
+
+    expect(result.isError).toBe(true);
+    expect(result.isPending).toBe(false);
+    // One call for the whole sequence: no retry on the failure, and none on the remount either
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails rather than pausing while the browser reports itself offline', () => {
+    // A paused query keeps its pending status and never settles, so the app would wait on it forever
+    expect(currencyQueryOptions.networkMode).toBe('always');
   });
 });

--- a/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
+++ b/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
@@ -96,7 +96,7 @@ describe('account metric helpers', () => {
     })
     expect(getRunwayMetric(runway, false, 'USD', testCurrencies)).toMatchObject({
       months: 7.4,
-      caption: 'US$1,234.56/mth · 6 mths basis',
+      caption: '$1,234.56/mth · 6 mths basis',
       progress: 100,
     })
   })

--- a/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
+++ b/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
@@ -1,6 +1,10 @@
 /**
  * Tests the account metrics themselves, so the savings rate, credit usage and runway figures cannot
  * drift from the history and balances they are calculated from
+ *
+ * A currency's symbol is written the reader's way, so the amounts below assume the region the suite
+ * pins through LC_ALL in its package script: read from the United States, where US dollars are the
+ * plain ones and Canadian dollars are marked CA$
  */
 import { describe, expect, it } from 'vitest'
 import type { RunwayResult } from '@/api/user'

--- a/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
+++ b/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
@@ -96,7 +96,7 @@ describe('account metric helpers', () => {
     })
     expect(getRunwayMetric(runway, false, 'USD')).toMatchObject({
       months: 7.4,
-      caption: '$1,234.56/mth · 6 mths basis',
+      caption: 'US$1,234.56/mth · 6 mths basis',
       progress: 100,
     })
   })

--- a/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
+++ b/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
@@ -9,7 +9,7 @@ import {
   getRunwayMetric,
   getSavingsRateMetric,
 } from '@/pages/accounts/utils/accountMetrics'
-import { createAccount } from './fixtures'
+import { createAccount, testCurrencies } from './fixtures'
 
 describe('account metric helpers', () => {
   it('uses the latest savings period and handles no-income expense months', () => {
@@ -86,15 +86,15 @@ describe('account metric helpers', () => {
       fx_status: { state: 'complete', missing_pairs: [] },
     }
 
-    expect(getRunwayMetric(undefined, false, 'USD')).toMatchObject({
+    expect(getRunwayMetric(undefined, false, 'USD', testCurrencies)).toMatchObject({
       months: null,
       progress: 0,
       caption: '',
     })
-    expect(getRunwayMetric({ ...runway, months: null, reason: 'no_accounts' }, false, 'USD')).toMatchObject({
+    expect(getRunwayMetric({ ...runway, months: null, reason: 'no_accounts' }, false, 'USD', testCurrencies)).toMatchObject({
       caption: 'Choose accounts in Settings',
     })
-    expect(getRunwayMetric(runway, false, 'USD')).toMatchObject({
+    expect(getRunwayMetric(runway, false, 'USD', testCurrencies)).toMatchObject({
       months: 7.4,
       caption: 'US$1,234.56/mth · 6 mths basis',
       progress: 100,

--- a/frontend/tests/pages/accounts/utils/fixtures.ts
+++ b/frontend/tests/pages/accounts/utils/fixtures.ts
@@ -5,8 +5,14 @@
  * unremarkable, so an assertion only ever turns on what its own test set
  */
 import type { AccountsOverview } from '@/api/accounts'
+import type { Currency } from '@/api/currency'
 import type { Institution } from '@/api/institutions'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
+
+export const testCurrencies: Currency[] = [
+  { id: 'USD', name: 'US Dollar', symbol: 'US$', minor_unit_exponent: 2 },
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+]
 
 export function createAccount(overrides: Partial<AccountsOverview>): AccountsOverview {
   return {

--- a/frontend/tests/pages/accounts/utils/metricDisplay.test.ts
+++ b/frontend/tests/pages/accounts/utils/metricDisplay.test.ts
@@ -8,6 +8,7 @@ import {
   getCreditUsageDisplay,
   getSavingsRateDisplay,
 } from '@/pages/accounts/utils/metricDisplay'
+import { testCurrencies } from './fixtures'
 
 describe('account metric display helpers', () => {
   it('formats savings rate empty states for accounts with expenses and no income', () => {
@@ -22,7 +23,7 @@ describe('account metric display helpers', () => {
       fxStatus: undefined,
     }
 
-    expect(getSavingsRateDisplay(savingsRate, 'USD')).toEqual({
+    expect(getSavingsRateDisplay(savingsRate, 'USD', testCurrencies)).toEqual({
       value: '−∞%',
       caption: 'No income this month',
     })
@@ -41,7 +42,7 @@ describe('account metric display helpers', () => {
       fxStatus: { state: 'unavailable', missing_pairs: [] },
     }
 
-    expect(getCreditUsageDisplay(creditUsage, 'USD')).toEqual({
+    expect(getCreditUsageDisplay(creditUsage, 'USD', testCurrencies)).toEqual({
       value: 'N/A',
       caption: 'FX unavailable',
     })

--- a/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
+++ b/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 import { getFilteredRows } from '@/pages/accounts/utils/filters'
 import {
   formatTaxAdvantagedMeterMoney,
+  formatTaxAdvantagedRawMoney,
   getLifetimeAvailableBoundary,
   getTaxAdvantagedLimitSummaries,
   getTaxAdvantagedUsageColor,
@@ -28,10 +29,24 @@ describe('tax-advantaged limit helpers', () => {
   })
 
   it('keeps meter amounts whole and unprefixed below the compaction thresholds', () => {
-    // The meter shows this beside the limit it is measured against, so an amount small enough to
-    // render in full must not come back carrying cents, or a "≈" the limit next to it does not have
+    // The meter shows this beside the limit it is measured against, so a small amount must match
+    // how that limit is written: no cents, and no "≈" marking one of the pair as approximate
     expect(formatTaxAdvantagedMeterMoney(50_000, 'CAD', testCurrencies)).toBe('$500')
     expect(formatTaxAdvantagedMeterMoney(0, 'CAD', testCurrencies)).toBe('$0')
+  })
+
+  it('shows an amount too small for the meter as zero rather than as a negative', () => {
+    // The meter renders no decimals, and accounting style decides to wrap a negative before it
+    // rounds, so being 40 cents over a limit would otherwise read as ($0)
+    expect(formatTaxAdvantagedMeterMoney(-40, 'CAD', testCurrencies)).toBe('$0')
+    expect(formatTaxAdvantagedRawMoney(-40, 'CAD', testCurrencies)).toBe('$0')
+    // Far enough from zero to keep its sign
+    expect(formatTaxAdvantagedRawMoney(-60, 'CAD', testCurrencies)).toBe('($1)')
+  })
+
+  it('renders tooltip amounts whole, and keeps the suffix inside a negative', () => {
+    expect(formatTaxAdvantagedRawMoney(123_456, 'CAD', testCurrencies)).toBe('$1,235')
+    expect(formatTaxAdvantagedMeterMoney(-12_300_000, 'USD', testCurrencies)).toBe('(US$123K)')
   })
 
   it('rounds a compacted meter amount rather than rounding it up', () => {

--- a/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
+++ b/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
@@ -24,35 +24,35 @@ describe('tax-advantaged limit helpers', () => {
   })
 
   it('formats compact meter values without losing the currency sign', () => {
-    expect(formatTaxAdvantagedMeterMoney(123_456, 'USD', testCurrencies)).toBe('US$1K')
-    expect(formatTaxAdvantagedMeterMoney(12_300_000, 'USD', testCurrencies)).toBe('US$123K')
+    expect(formatTaxAdvantagedMeterMoney(123_456, 'USD', testCurrencies)).toBe('$1K')
+    expect(formatTaxAdvantagedMeterMoney(12_300_000, 'USD', testCurrencies)).toBe('$123K')
   })
 
   it('keeps meter amounts whole and unprefixed below the compaction thresholds', () => {
     // The meter shows this beside the limit it is measured against, so a small amount must match
     // how that limit is written: no cents, and no "≈" marking one of the pair as approximate
-    expect(formatTaxAdvantagedMeterMoney(50_000, 'CAD', testCurrencies)).toBe('$500')
-    expect(formatTaxAdvantagedMeterMoney(0, 'CAD', testCurrencies)).toBe('$0')
+    expect(formatTaxAdvantagedMeterMoney(50_000, 'CAD', testCurrencies)).toBe('CA$500')
+    expect(formatTaxAdvantagedMeterMoney(0, 'CAD', testCurrencies)).toBe('CA$0')
   })
 
   it('shows an amount too small for the meter as zero rather than as a negative', () => {
     // The meter renders no decimals, and accounting style decides to wrap a negative before it
     // rounds, so being 40 cents over a limit would otherwise read as ($0)
-    expect(formatTaxAdvantagedMeterMoney(-40, 'CAD', testCurrencies)).toBe('$0')
-    expect(formatTaxAdvantagedRawMoney(-40, 'CAD', testCurrencies)).toBe('$0')
+    expect(formatTaxAdvantagedMeterMoney(-40, 'CAD', testCurrencies)).toBe('CA$0')
+    expect(formatTaxAdvantagedRawMoney(-40, 'CAD', testCurrencies)).toBe('CA$0')
     // Far enough from zero to keep its sign
-    expect(formatTaxAdvantagedRawMoney(-60, 'CAD', testCurrencies)).toBe('($1)')
+    expect(formatTaxAdvantagedRawMoney(-60, 'CAD', testCurrencies)).toBe('(CA$1)')
   })
 
   it('renders tooltip amounts whole, and keeps the suffix inside a negative', () => {
-    expect(formatTaxAdvantagedRawMoney(123_456, 'CAD', testCurrencies)).toBe('$1,235')
-    expect(formatTaxAdvantagedMeterMoney(-12_300_000, 'USD', testCurrencies)).toBe('(US$123K)')
+    expect(formatTaxAdvantagedRawMoney(123_456, 'CAD', testCurrencies)).toBe('CA$1,235')
+    expect(formatTaxAdvantagedMeterMoney(-12_300_000, 'USD', testCurrencies)).toBe('($123K)')
   })
 
   it('rounds a compacted meter amount rather than rounding it up', () => {
     // 1100 major units is 1.1 thousand, which rounds down to one. Rounding up would report a
     // contribution of $2K against a limit the account is nowhere near
-    expect(formatTaxAdvantagedMeterMoney(110_000, 'CAD', testCurrencies)).toBe('$1K')
+    expect(formatTaxAdvantagedMeterMoney(110_000, 'CAD', testCurrencies)).toBe('CA$1K')
   })
 
   it('shows lifetime available boundary only when accrued room is between used and the lifetime cap', () => {

--- a/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
+++ b/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
@@ -23,8 +23,8 @@ describe('tax-advantaged limit helpers', () => {
   })
 
   it('formats compact meter values without losing the currency sign', () => {
-    expect(formatTaxAdvantagedMeterMoney(123_456, 'USD')).toBe('$1K')
-    expect(formatTaxAdvantagedMeterMoney(12_300_000, 'USD')).toBe('$123K')
+    expect(formatTaxAdvantagedMeterMoney(123_456, 'USD')).toBe('US$1K')
+    expect(formatTaxAdvantagedMeterMoney(12_300_000, 'USD')).toBe('US$123K')
   })
 
   it('shows lifetime available boundary only when accrued room is between used and the lifetime cap', () => {

--- a/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
+++ b/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
@@ -1,6 +1,10 @@
 /**
  * Tests the tax-advantaged limit helpers, so the usage percentages, meter labels and plan summaries
  * cannot drift from the contribution room recorded against each plan
+ *
+ * A currency's symbol is written the reader's way, so the amounts below assume the region the suite
+ * pins through LC_ALL in its package script: read from the United States, where US dollars are the
+ * plain ones and Canadian dollars are marked CA$
  */
 import { describe, expect, it } from 'vitest'
 import { getFilteredRows } from '@/pages/accounts/utils/filters'
@@ -37,7 +41,7 @@ describe('tax-advantaged limit helpers', () => {
 
   it('shows an amount too small for the meter as zero rather than as a negative', () => {
     // The meter renders no decimals, and accounting style decides to wrap a negative before it
-    // rounds, so being 40 cents over a limit would otherwise read as ($0)
+    // rounds, so being 40 cents over a limit would otherwise read as (CA$0)
     expect(formatTaxAdvantagedMeterMoney(-40, 'CAD', testCurrencies)).toBe('CA$0')
     expect(formatTaxAdvantagedRawMoney(-40, 'CAD', testCurrencies)).toBe('CA$0')
     // Far enough from zero to keep its sign
@@ -51,7 +55,7 @@ describe('tax-advantaged limit helpers', () => {
 
   it('rounds a compacted meter amount rather than rounding it up', () => {
     // 1100 major units is 1.1 thousand, which rounds down to one. Rounding up would report a
-    // contribution of $2K against a limit the account is nowhere near
+    // contribution of CA$2K against a limit the account is nowhere near
     expect(formatTaxAdvantagedMeterMoney(110_000, 'CAD', testCurrencies)).toBe('CA$1K')
   })
 

--- a/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
+++ b/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
@@ -12,7 +12,7 @@ import {
   getTaxAdvantagedUsagePercent,
   hasTaxAdvantagedLimitTracking,
 } from '@/pages/accounts/utils/taxAdvantagedLimits'
-import { createAccount, createInstitution, createTaxAdvantagedCategory } from './fixtures'
+import { createAccount, createInstitution, createTaxAdvantagedCategory, testCurrencies } from './fixtures'
 
 describe('tax-advantaged limit helpers', () => {
   it('bounds usage percentages and marks over-limit usage as negative', () => {
@@ -23,8 +23,21 @@ describe('tax-advantaged limit helpers', () => {
   })
 
   it('formats compact meter values without losing the currency sign', () => {
-    expect(formatTaxAdvantagedMeterMoney(123_456, 'USD')).toBe('US$1K')
-    expect(formatTaxAdvantagedMeterMoney(12_300_000, 'USD')).toBe('US$123K')
+    expect(formatTaxAdvantagedMeterMoney(123_456, 'USD', testCurrencies)).toBe('US$1K')
+    expect(formatTaxAdvantagedMeterMoney(12_300_000, 'USD', testCurrencies)).toBe('US$123K')
+  })
+
+  it('keeps meter amounts whole and unprefixed below the compaction thresholds', () => {
+    // The meter shows this beside the limit it is measured against, so an amount small enough to
+    // render in full must not come back carrying cents, or a "≈" the limit next to it does not have
+    expect(formatTaxAdvantagedMeterMoney(50_000, 'CAD', testCurrencies)).toBe('$500')
+    expect(formatTaxAdvantagedMeterMoney(0, 'CAD', testCurrencies)).toBe('$0')
+  })
+
+  it('rounds a compacted meter amount rather than rounding it up', () => {
+    // 1100 major units is 1.1 thousand, which rounds down to one. Rounding up would report a
+    // contribution of $2K against a limit the account is nowhere near
+    expect(formatTaxAdvantagedMeterMoney(110_000, 'CAD', testCurrencies)).toBe('$1K')
   })
 
   it('shows lifetime available boundary only when accrued room is between used and the lifetime cap', () => {

--- a/frontend/tests/pages/dashboard/utils/fixtures.ts
+++ b/frontend/tests/pages/dashboard/utils/fixtures.ts
@@ -9,12 +9,17 @@
 import type { AccountsOverview } from '@/api/accounts'
 import type { LatestBudgetUtilization } from '@/api/budgets'
 import type { Category } from '@/api/categories'
+import type { Currency } from '@/api/currency'
 import type { SpendingComparisonResponse } from '@/api/dashboard'
 import type { FxStatus } from '@/api/shared/fx'
 import type { Transaction } from '@/api/transactions'
 import type { RunwayResult } from '@/api/user'
 
 export const fxStatus: FxStatus = { state: 'none', missing_pairs: [] }
+
+export const currencies: Currency[] = [
+  { id: 'USD', name: 'US Dollar', symbol: 'US$', minor_unit_exponent: 2 },
+]
 
 export function createAccount(overrides: Partial<AccountsOverview>): AccountsOverview {
   return {

--- a/frontend/tests/pages/dashboard/utils/formatDashboardMoney.test.ts
+++ b/frontend/tests/pages/dashboard/utils/formatDashboardMoney.test.ts
@@ -4,12 +4,13 @@
  */
 import { describe, expect, it } from 'vitest'
 import { formatDashboardMoney } from '@/pages/dashboard/utils/formatDashboardMoney'
+import { currencies } from './fixtures'
 
 describe('dashboard money formatting', () => {
   it('formats dashboard money using widget-specific compaction rules', () => {
-    expect(formatDashboardMoney(12345678900, 'USD', 'netWorth')).toBe('≈US$123M')
-    expect(formatDashboardMoney(12345678, 'USD', 'credit')).toBe('≈US$123K')
-    expect(formatDashboardMoney(123456, 'USD', 'breakdown')).toBe('≈US$2K')
-    expect(formatDashboardMoney(123456, 'USD', 'raw')).toBe('US$1,234.56')
+    expect(formatDashboardMoney(12345678900, 'USD', 'netWorth', currencies)).toBe('≈US$123M')
+    expect(formatDashboardMoney(12345678, 'USD', 'credit', currencies)).toBe('≈US$123K')
+    expect(formatDashboardMoney(123456, 'USD', 'breakdown', currencies)).toBe('≈US$2K')
+    expect(formatDashboardMoney(123456, 'USD', 'raw', currencies)).toBe('US$1,234.56')
   })
 })

--- a/frontend/tests/pages/dashboard/utils/formatDashboardMoney.test.ts
+++ b/frontend/tests/pages/dashboard/utils/formatDashboardMoney.test.ts
@@ -8,9 +8,9 @@ import { currencies } from './fixtures'
 
 describe('dashboard money formatting', () => {
   it('formats dashboard money using widget-specific compaction rules', () => {
-    expect(formatDashboardMoney(12345678900, 'USD', 'netWorth', currencies)).toBe('≈US$123M')
-    expect(formatDashboardMoney(12345678, 'USD', 'credit', currencies)).toBe('≈US$123K')
-    expect(formatDashboardMoney(123456, 'USD', 'breakdown', currencies)).toBe('≈US$2K')
-    expect(formatDashboardMoney(123456, 'USD', 'raw', currencies)).toBe('US$1,234.56')
+    expect(formatDashboardMoney(12345678900, 'USD', 'netWorth', currencies)).toBe('≈$123M')
+    expect(formatDashboardMoney(12345678, 'USD', 'credit', currencies)).toBe('≈$123K')
+    expect(formatDashboardMoney(123456, 'USD', 'breakdown', currencies)).toBe('≈$2K')
+    expect(formatDashboardMoney(123456, 'USD', 'raw', currencies)).toBe('$1,234.56')
   })
 })

--- a/frontend/tests/pages/dashboard/utils/formatDashboardMoney.test.ts
+++ b/frontend/tests/pages/dashboard/utils/formatDashboardMoney.test.ts
@@ -7,9 +7,9 @@ import { formatDashboardMoney } from '@/pages/dashboard/utils/formatDashboardMon
 
 describe('dashboard money formatting', () => {
   it('formats dashboard money using widget-specific compaction rules', () => {
-    expect(formatDashboardMoney(12345678900, 'USD', 'netWorth')).toBe('≈$123M')
-    expect(formatDashboardMoney(12345678, 'USD', 'credit')).toBe('≈$123K')
-    expect(formatDashboardMoney(123456, 'USD', 'breakdown')).toBe('≈$2K')
-    expect(formatDashboardMoney(123456, 'USD', 'raw')).toBe('$1,234.56')
+    expect(formatDashboardMoney(12345678900, 'USD', 'netWorth')).toBe('≈US$123M')
+    expect(formatDashboardMoney(12345678, 'USD', 'credit')).toBe('≈US$123K')
+    expect(formatDashboardMoney(123456, 'USD', 'breakdown')).toBe('≈US$2K')
+    expect(formatDashboardMoney(123456, 'USD', 'raw')).toBe('US$1,234.56')
   })
 })

--- a/frontend/tests/pages/dashboard/utils/formatDashboardMoney.test.ts
+++ b/frontend/tests/pages/dashboard/utils/formatDashboardMoney.test.ts
@@ -1,6 +1,10 @@
 /**
  * Tests dashboard money formatting, so how far an amount is shortened cannot drift from the widget it
  * is being shown in
+ *
+ * A currency's symbol is written the reader's way, so the amounts below assume the region the suite
+ * pins through LC_ALL in its package script: read from the United States, where US dollars are the
+ * plain ones and Canadian dollars are marked CA$
  */
 import { describe, expect, it } from 'vitest'
 import { formatDashboardMoney } from '@/pages/dashboard/utils/formatDashboardMoney'

--- a/frontend/tests/pages/dashboard/utils/getRunwayCaption.test.ts
+++ b/frontend/tests/pages/dashboard/utils/getRunwayCaption.test.ts
@@ -4,11 +4,11 @@
  */
 import { describe, expect, it } from 'vitest'
 import { getRunwayCaption } from '@/pages/dashboard/utils/getRunwayCaption'
-import { runway } from './fixtures'
+import { currencies, runway } from './fixtures'
 
 describe('runway caption', () => {
   it('builds runway captions', () => {
-    expect(getRunwayCaption({ ...runway, reason: 'no_accounts' }, 'USD')).toBe('Choose accounts in Settings')
-    expect(getRunwayCaption(runway, 'USD')).toContain('/mth · 3 mths basis')
+    expect(getRunwayCaption({ ...runway, reason: 'no_accounts' }, 'USD', currencies)).toBe('Choose accounts in Settings')
+    expect(getRunwayCaption(runway, 'USD', currencies)).toContain('/mth · 3 mths basis')
   })
 })

--- a/frontend/tests/utils/formatCompactMoney.test.ts
+++ b/frontend/tests/utils/formatCompactMoney.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests compact money formatting, so an amount either side of a threshold is scaled by the same
+ * decimal places and the caller's choice of prefix and plain decimals is honoured
+ */
+import { describe, expect, it } from 'vitest'
+import type { Currency } from '@/api/currency'
+import { type CompactMoneyRule, formatCompactMoney } from '@/utils/formatCompactMoney'
+import { formatCurrency } from '@/utils/formatCurrency'
+
+const currencies: Currency[] = [
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+  { id: 'IQD', name: 'Iraqi Dinar', symbol: 'ع.د', minor_unit_exponent: 3 },
+]
+
+const RULES: CompactMoneyRule[] = [
+  { threshold: 1_000_000, divisor: 1_000_000, suffix: 'M', fractionDigits: 1 },
+  { threshold: 1_000, divisor: 1_000, suffix: 'K', fractionDigits: 0 },
+]
+
+describe('compact money formatting', () => {
+  it('compacts once an amount crosses a threshold', () => {
+    expect(formatCompactMoney(123_456_789_00, 'CAD', RULES, currencies)).toBe('≈$123.5M')
+    expect(formatCompactMoney(1_234_56, 'CAD', RULES, currencies)).toBe('≈$1K')
+  })
+
+  it('renders an amount below every threshold at the currency decimals the list records', () => {
+    // IQD has three decimal places, and the browser reports none, so an amount falling through to
+    // the full formatter has to scale the same way one that was compacted does
+    expect(formatCompactMoney(999_999, 'IQD', RULES, currencies))
+      .toBe(formatCurrency(999_999, 'IQD', currencies))
+    expect(formatCompactMoney(999_999, 'IQD', RULES, currencies)).toBe('IQD\u00A0999.999')
+  })
+
+  it('takes the caller\'s decimals for an amount below every threshold', () => {
+    // Without this the meters would show cents on a small amount and whole units on a large one
+    expect(formatCompactMoney(50_000, 'CAD', RULES, currencies, {
+      prefix: '',
+      plainFractionDigits: 0,
+    })).toBe('$500')
+  })
+})

--- a/frontend/tests/utils/formatCompactMoney.test.ts
+++ b/frontend/tests/utils/formatCompactMoney.test.ts
@@ -1,6 +1,10 @@
 /**
  * Tests compact money formatting, so an amount either side of a threshold is scaled by the same
  * decimal places and the caller's choice of prefix and plain decimals is honoured
+ *
+ * A currency's symbol is written the reader's way, so the amounts below assume the region the suite
+ * pins through LC_ALL in its package script: read from the United States, where US dollars are the
+ * plain ones and Canadian dollars are marked CA$
  */
 import { describe, expect, it } from 'vitest'
 import type { Currency } from '@/api/currency'

--- a/frontend/tests/utils/formatCompactMoney.test.ts
+++ b/frontend/tests/utils/formatCompactMoney.test.ts
@@ -19,8 +19,8 @@ const RULES: CompactMoneyRule[] = [
 
 describe('compact money formatting', () => {
   it('compacts once an amount crosses a threshold', () => {
-    expect(formatCompactMoney(123_456_789_00, 'CAD', RULES, currencies)).toBe('≈$123.5M')
-    expect(formatCompactMoney(1_234_56, 'CAD', RULES, currencies)).toBe('≈$1K')
+    expect(formatCompactMoney(123_456_789_00, 'CAD', RULES, currencies)).toBe('≈CA$123.5M')
+    expect(formatCompactMoney(1_234_56, 'CAD', RULES, currencies)).toBe('≈CA$1K')
   })
 
   it('renders an amount below every threshold at the currency decimals the list records', () => {
@@ -36,6 +36,6 @@ describe('compact money formatting', () => {
     expect(formatCompactMoney(50_000, 'CAD', RULES, currencies, {
       prefix: '',
       plainFractionDigits: 0,
-    })).toBe('$500')
+    })).toBe('CA$500')
   })
 })

--- a/frontend/tests/utils/formatCurrency.test.ts
+++ b/frontend/tests/utils/formatCurrency.test.ts
@@ -1,11 +1,19 @@
 /**
- * Tests the shared money formatter, covering the currency convention it renders, which must not drift
- * with the region of whatever machine runs the suite or opens the app, and the decimal places it
- * scales by, which come from the seeded currency list rather than from the browser
+ * Tests the shared money formatter, covering the currency convention it renders and the decimal
+ * places it scales by, which come from the seeded currency list rather than from the browser
+ *
+ * The symbol a currency is written with is the reader's own convention, so these assertions only hold
+ * for one region. The suite pins itself to en-US through LC_ALL in the test script, which is why a
+ * Canadian dollar reads CA$ below: that is what a reader in the United States correctly sees, and a
+ * reader in Canada sees the opposite. The first test fails legibly if that pinning ever stops working
+ *
+ * Where a code stands in place of a symbol, PKR and IQD below, what separates it from the digits is a
+ * non-breaking space rather than a plain one. It is invisible in this file, so an assertion that
+ * looks right and fails on the separator is what to suspect first
  */
 import { describe, expect, it } from 'vitest'
 import type { Currency } from '@/api/currency'
-import { MONEY_LOCALE, formatCurrency } from '@/utils/formatCurrency'
+import { formatCurrency } from '@/utils/formatCurrency'
 
 // The exponents here are the seeded ones. PKR and IQD are two of the 16 codes the browser's own
 // tables disagree about, reporting no decimal places for either
@@ -18,40 +26,38 @@ const currencies: Currency[] = [
 ]
 
 describe('money formatting', () => {
-  // A Node built against an ICU without en-CA resolves this to plain en, where CAD is CA$ again and
-  // every assertion below fails for a reason that has nothing to do with the formatter
-  it('resolves the pinned locale', () => {
-    expect(new Intl.NumberFormat(MONEY_LOCALE).resolvedOptions().locale).toBe('en-CA')
+  it('runs in the region every assertion below assumes', () => {
+    expect(new Intl.NumberFormat().resolvedOptions().locale).toBe('en-US')
   })
 
-  it('renders one currency convention whatever region the reader is in', () => {
-    expect(formatCurrency(123456, 'CAD', currencies)).toBe('$1,234.56')
-    expect(formatCurrency(123456, 'USD', currencies)).toBe('US$1,234.56')
+  it('writes the reader\'s own currency bare and marks the rest', () => {
+    // Read from the United States, so US dollars are the plain ones and Canadian dollars are marked
+    expect(formatCurrency(123456, 'USD', currencies)).toBe('$1,234.56')
+    expect(formatCurrency(123456, 'CAD', currencies)).toBe('CA$1,234.56')
   })
 
   it('scales by the decimal places the currency list records, not the browser', () => {
-    // The browser reports no decimal places for either code, which would render these as
-    // PKR 123,456 and IQD 123,456. A code used in place of a symbol is separated by a non-breaking
-    // space, written as an escape here so it cannot be retyped as a plain one
-    expect(formatCurrency(123456, 'PKR', currencies)).toBe('PKR\u00A01,234.56')
-    expect(formatCurrency(123456, 'IQD', currencies)).toBe('IQD\u00A0123.456')
-    expect(formatCurrency(500000, 'JPY', currencies)).toBe('JP¥500,000')
+    // The browser reports no decimal places for either code, so without the list these would render
+    // as PKR 123,456 and IQD 123,456
+    expect(formatCurrency(123456, 'PKR', currencies)).toBe('PKR 1,234.56')
+    expect(formatCurrency(123456, 'IQD', currencies)).toBe('IQD 123.456')
+    expect(formatCurrency(500000, 'JPY', currencies)).toBe('¥500,000')
   })
 
   it('falls back to the browser for a code the list does not carry', () => {
     // Reading the browser is right for 139 of the 155 seeded codes. A flat two places instead would
-    // render this yen balance as JP\u00A55,000.00, a hundredth of the real amount
-    expect(formatCurrency(500000, 'JPY', [])).toBe('JP\u00A5500,000')
-    expect(formatCurrency(123456, 'IQD', [])).toBe('IQD\u00A0123,456')
+    // render this yen balance as ¥5,000.00, a hundredth of the real amount
+    expect(formatCurrency(500000, 'JPY', [])).toBe('¥500,000')
+    expect(formatCurrency(123456, 'IQD', [])).toBe('IQD 123,456')
     // A loaded list missing one code takes the same path as no list at all
-    expect(formatCurrency(123456, 'JPY', [currencies[0]])).toBe('JP\u00A5123,456')
+    expect(formatCurrency(123456, 'JPY', [currencies[0]])).toBe('¥123,456')
   })
 
   it('wraps a negative amount in parentheses and leaves zero plain', () => {
-    expect(formatCurrency(-123456, 'CAD', currencies)).toBe('($1,234.56)')
-    expect(formatCurrency(0, 'CAD', currencies)).toBe('$0.00')
+    expect(formatCurrency(-123456, 'CAD', currencies)).toBe('(CA$1,234.56)')
+    expect(formatCurrency(0, 'CAD', currencies)).toBe('CA$0.00')
     // Dividing -0 by the exponent keeps the sign, and accounting style would wrap it, so a zero
     // amount reaching this as -0 has to come out identical to one reaching it as 0
-    expect(formatCurrency(-0, 'CAD', currencies)).toBe('$0.00')
+    expect(formatCurrency(-0, 'CAD', currencies)).toBe('CA$0.00')
   })
 })

--- a/frontend/tests/utils/formatCurrency.test.ts
+++ b/frontend/tests/utils/formatCurrency.test.ts
@@ -39,9 +39,8 @@ describe('money formatting', () => {
   })
 
   it('falls back to the browser for a code the list does not carry', () => {
-    // A list that failed to load leaves the app on what it rendered before the list was read at all,
-    // which is right for 139 of the 155 seeded codes. A flat two places instead would render this
-    // yen balance as JP\u00A55,000.00, a hundredth of the real amount
+    // Reading the browser is right for 139 of the 155 seeded codes. A flat two places instead would
+    // render this yen balance as JP\u00A55,000.00, a hundredth of the real amount
     expect(formatCurrency(500000, 'JPY', [])).toBe('JP\u00A5500,000')
     expect(formatCurrency(123456, 'IQD', [])).toBe('IQD\u00A0123,456')
     // A loaded list missing one code takes the same path as no list at all

--- a/frontend/tests/utils/formatCurrency.test.ts
+++ b/frontend/tests/utils/formatCurrency.test.ts
@@ -38,8 +38,14 @@ describe('money formatting', () => {
     expect(formatCurrency(500000, 'JPY', currencies)).toBe('JP¥500,000')
   })
 
-  it('falls back to two decimal places for a code the list does not carry', () => {
-    expect(formatCurrency(123456, 'IQD', [])).toBe('IQD\u00A01,234.56')
+  it('falls back to the browser for a code the list does not carry', () => {
+    // A list that failed to load leaves the app on what it rendered before the list was read at all,
+    // which is right for 139 of the 155 seeded codes. A flat two places instead would render this
+    // yen balance as JP\u00A55,000.00, a hundredth of the real amount
+    expect(formatCurrency(500000, 'JPY', [])).toBe('JP\u00A5500,000')
+    expect(formatCurrency(123456, 'IQD', [])).toBe('IQD\u00A0123,456')
+    // A loaded list missing one code takes the same path as no list at all
+    expect(formatCurrency(123456, 'JPY', [currencies[0]])).toBe('JP\u00A5123,456')
   })
 
   it('wraps a negative amount in parentheses and leaves zero plain', () => {

--- a/frontend/tests/utils/formatCurrency.test.ts
+++ b/frontend/tests/utils/formatCurrency.test.ts
@@ -1,9 +1,21 @@
 /**
- * Tests the shared money formatter, so the currency convention the product renders cannot drift with
- * the region of whatever machine runs the suite or opens the app
+ * Tests the shared money formatter, covering the currency convention it renders, which must not drift
+ * with the region of whatever machine runs the suite or opens the app, and the decimal places it
+ * scales by, which come from the seeded currency list rather than from the browser
  */
 import { describe, expect, it } from 'vitest'
+import type { Currency } from '@/api/currency'
 import { MONEY_LOCALE, formatCurrency } from '@/utils/formatCurrency'
+
+// The exponents here are the seeded ones. PKR and IQD are two of the 16 codes the browser's own
+// tables disagree about, reporting no decimal places for either
+const currencies: Currency[] = [
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+  { id: 'USD', name: 'US Dollar', symbol: 'US$', minor_unit_exponent: 2 },
+  { id: 'JPY', name: 'Japanese Yen', symbol: '¥', minor_unit_exponent: 0 },
+  { id: 'PKR', name: 'Pakistani Rupee', symbol: '₨', minor_unit_exponent: 2 },
+  { id: 'IQD', name: 'Iraqi Dinar', symbol: 'ع.د', minor_unit_exponent: 3 },
+]
 
 describe('money formatting', () => {
   // A Node built against an ICU without en-CA resolves this to plain en, where CAD is CA$ again and
@@ -13,15 +25,28 @@ describe('money formatting', () => {
   })
 
   it('renders one currency convention whatever region the reader is in', () => {
-    expect(formatCurrency(123456, 'CAD')).toBe('$1,234.56')
-    expect(formatCurrency(123456, 'USD')).toBe('US$1,234.56')
+    expect(formatCurrency(123456, 'CAD', currencies)).toBe('$1,234.56')
+    expect(formatCurrency(123456, 'USD', currencies)).toBe('US$1,234.56')
+  })
+
+  it('scales by the decimal places the currency list records, not the browser', () => {
+    // The browser reports no decimal places for either code, which would render these as
+    // PKR 123,456 and IQD 123,456. A code used in place of a symbol is separated by a non-breaking
+    // space, written as an escape here so it cannot be retyped as a plain one
+    expect(formatCurrency(123456, 'PKR', currencies)).toBe('PKR\u00A01,234.56')
+    expect(formatCurrency(123456, 'IQD', currencies)).toBe('IQD\u00A0123.456')
+    expect(formatCurrency(500000, 'JPY', currencies)).toBe('JP¥500,000')
+  })
+
+  it('falls back to two decimal places for a code the list does not carry', () => {
+    expect(formatCurrency(123456, 'IQD', [])).toBe('IQD\u00A01,234.56')
   })
 
   it('wraps a negative amount in parentheses and leaves zero plain', () => {
-    expect(formatCurrency(-123456, 'CAD')).toBe('($1,234.56)')
-    expect(formatCurrency(0, 'CAD')).toBe('$0.00')
+    expect(formatCurrency(-123456, 'CAD', currencies)).toBe('($1,234.56)')
+    expect(formatCurrency(0, 'CAD', currencies)).toBe('$0.00')
     // Dividing -0 by the exponent keeps the sign, and accounting style would wrap it, so a zero
     // amount reaching this as -0 has to come out identical to one reaching it as 0
-    expect(formatCurrency(-0, 'CAD')).toBe('$0.00')
+    expect(formatCurrency(-0, 'CAD', currencies)).toBe('$0.00')
   })
 })

--- a/frontend/tests/utils/formatCurrency.test.ts
+++ b/frontend/tests/utils/formatCurrency.test.ts
@@ -8,8 +8,7 @@
  * reader in Canada sees the opposite. The first test fails legibly if that pinning ever stops working
  *
  * Where a code stands in place of a symbol, PKR and IQD below, what separates it from the digits is a
- * non-breaking space rather than a plain one. It is invisible in this file, so an assertion that
- * looks right and fails on the separator is what to suspect first
+ * non-breaking space, written as an escape so it cannot be retyped as a plain one
  */
 import { describe, expect, it } from 'vitest'
 import type { Currency } from '@/api/currency'
@@ -39,8 +38,8 @@ describe('money formatting', () => {
   it('scales by the decimal places the currency list records, not the browser', () => {
     // The browser reports no decimal places for either code, so without the list these would render
     // as PKR 123,456 and IQD 123,456
-    expect(formatCurrency(123456, 'PKR', currencies)).toBe('PKR 1,234.56')
-    expect(formatCurrency(123456, 'IQD', currencies)).toBe('IQD 123.456')
+    expect(formatCurrency(123456, 'PKR', currencies)).toBe('PKR\u00A01,234.56')
+    expect(formatCurrency(123456, 'IQD', currencies)).toBe('IQD\u00A0123.456')
     expect(formatCurrency(500000, 'JPY', currencies)).toBe('¥500,000')
   })
 
@@ -48,7 +47,7 @@ describe('money formatting', () => {
     // Reading the browser is right for 139 of the 155 seeded codes. A flat two places instead would
     // render this yen balance as ¥5,000.00, a hundredth of the real amount
     expect(formatCurrency(500000, 'JPY', [])).toBe('¥500,000')
-    expect(formatCurrency(123456, 'IQD', [])).toBe('IQD 123,456')
+    expect(formatCurrency(123456, 'IQD', [])).toBe('IQD\u00A0123,456')
     // A loaded list missing one code takes the same path as no list at all
     expect(formatCurrency(123456, 'JPY', [currencies[0]])).toBe('¥123,456')
   })

--- a/frontend/tests/utils/formatCurrency.test.ts
+++ b/frontend/tests/utils/formatCurrency.test.ts
@@ -1,0 +1,27 @@
+/**
+ * Tests the shared money formatter, so the currency convention the product renders cannot drift with
+ * the region of whatever machine runs the suite or opens the app
+ */
+import { describe, expect, it } from 'vitest'
+import { MONEY_LOCALE, formatCurrency } from '@/utils/formatCurrency'
+
+describe('money formatting', () => {
+  // A Node built against an ICU without en-CA resolves this to plain en, where CAD is CA$ again and
+  // every assertion below fails for a reason that has nothing to do with the formatter
+  it('resolves the pinned locale', () => {
+    expect(new Intl.NumberFormat(MONEY_LOCALE).resolvedOptions().locale).toBe('en-CA')
+  })
+
+  it('renders one currency convention whatever region the reader is in', () => {
+    expect(formatCurrency(123456, 'CAD')).toBe('$1,234.56')
+    expect(formatCurrency(123456, 'USD')).toBe('US$1,234.56')
+  })
+
+  it('wraps a negative amount in parentheses and leaves zero plain', () => {
+    expect(formatCurrency(-123456, 'CAD')).toBe('($1,234.56)')
+    expect(formatCurrency(0, 'CAD')).toBe('$0.00')
+    // Dividing -0 by the exponent keeps the sign, and accounting style would wrap it, so a zero
+    // amount reaching this as -0 has to come out identical to one reaching it as 0
+    expect(formatCurrency(-0, 'CAD')).toBe('$0.00')
+  })
+})


### PR DESCRIPTION
Instead of reading each currency's decimal places from the seeded currency table, every amount in the app asked the browser, whose figures disagree with that table for 16 of the 155 seeded codes, so those currencies rendered at the wrong scale. The money formatters now take the fetched currency list and set both the divisor and the rendered decimal places from the exponent it records. Since no amount can be shown before that list arrives, the app holds its loading screen until the request settles and shows the recovery screen if it fails.
