### PR TITLE
refactor: unify the overlay stacking levels

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -44,16 +44,32 @@ const crossFolderRelativeImport = {
 const restrictedImportPatterns = [crossFolderRelativeImport]
 
 const STACKING_LEVEL_MESSAGE =
-  'Take the stacking level from STACKING_LEVELS in @/constants/stackingLevels, or name a module-level constant where the value only orders siblings inside one container'
+  'Name the stacking level: a class from the scale such as z-popover, or STACKING_LEVELS from @/constants/stackingLevels where a style object or a DOM write needs the number. Where the value only orders siblings inside one container, name a module-level constant beside it instead'
+
+// Interpolating a level into an arbitrary class is worse than the bare number it replaces. Tailwind
+// only generates a class it finds as complete literal text, so the element ends up with no stacking
+// level at all rather than the wrong one, and nothing reports it
+const INTERPOLATED_CLASS_MESSAGE =
+  'Tailwind never generates a class assembled by interpolation, so this element would carry no stacking level at all. Use a class from the scale, such as z-popover'
+
+const SET_PROPERTY_MESSAGE =
+  'Set a stacking level through element.style.zIndex rather than through setProperty, so it reads as a level and the scale covers it'
 
 // A stacking level written as a bare number is how the app ended up with five overlays at 110 and no
-// statement anywhere of which belongs above which. Only the arbitrary bracket form is rejected, so
-// z-10 through z-50 stay available for a level that orders siblings inside a single container.
+// statement anywhere of which belongs above which. Only the arbitrary bracket form of the class is
+// rejected, so a bare z-10 or z-30 stays available for a level ordering siblings inside one container.
 //
-// Each form needs two selectors. A class in a plain string is a Literal, while one built in a
-// template literal lives in TemplateElement.value.raw, which App.tsx does. A numeric zIndex is
-// matched on raw rather than value, because esquery applies a regex attribute test only to strings,
-// and an assignment to element.style.zIndex is an AssignmentExpression rather than a Property
+// One form needs several selectors, because the same value reaches the tree differently depending on
+// how it was written. A class in a plain string is a Literal, while one built in a template literal
+// lives in TemplateElement.value.raw, which App.tsx does. A numeric zIndex is matched on raw rather
+// than value, since esquery applies a regex attribute test only to strings, and it needs a variant
+// for a quoted key, for a negative value, which the parser gives as a unary minus over the digits and
+// never as a literal carrying the sign, and for an assignment to element.style.zIndex.
+//
+// Two forms still get through: a class assembled by string concatenation, and a value chosen by a
+// conditional inside the property. Neither appears anywhere in the tree, and catching either costs a
+// false positive on legitimate code. A z-index written straight into a .css file is out of reach too,
+// since the block applying this matches TypeScript alone
 const restrictedStackingLevels = [
   {
     selector: 'Literal[value=/z-\\[\\d+\\]/]',
@@ -64,12 +80,31 @@ const restrictedStackingLevels = [
     message: STACKING_LEVEL_MESSAGE,
   },
   {
-    selector: "Property[key.name='zIndex'] > Literal[raw=/^-?\\d/]",
+    selector: 'TemplateElement[value.raw=/z-\\[$/]',
+    message: INTERPOLATED_CLASS_MESSAGE,
+  },
+  {
+    selector: ":matches(Property[key.name='zIndex'], Property[key.value='zIndex']) > Literal[raw=/^\\d/]",
     message: STACKING_LEVEL_MESSAGE,
   },
   {
-    selector: "AssignmentExpression[left.property.name='zIndex'] > Literal[raw=/^-?\\d/]",
+    selector:
+      ":matches(Property[key.name='zIndex'], Property[key.value='zIndex']) > UnaryExpression > Literal[raw=/^\\d/]",
     message: STACKING_LEVEL_MESSAGE,
+  },
+  {
+    selector:
+      ":matches(AssignmentExpression[left.property.name='zIndex'], AssignmentExpression[left.property.value='zIndex']) > Literal[raw=/^\\d/]",
+    message: STACKING_LEVEL_MESSAGE,
+  },
+  {
+    selector:
+      ":matches(AssignmentExpression[left.property.name='zIndex'], AssignmentExpression[left.property.value='zIndex']) > UnaryExpression > Literal[raw=/^\\d/]",
+    message: STACKING_LEVEL_MESSAGE,
+  },
+  {
+    selector: "CallExpression[callee.property.name='setProperty'][arguments.0.value='z-index']",
+    message: SET_PROPERTY_MESSAGE,
   },
 ]
 

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -43,6 +43,36 @@ const crossFolderRelativeImport = {
 // no-restricted-imports has to restate every pattern that should still apply to its files
 const restrictedImportPatterns = [crossFolderRelativeImport]
 
+const STACKING_LEVEL_MESSAGE =
+  'Take the stacking level from STACKING_LEVELS in @/constants/stackingLevels, or name a module-level constant where the value only orders siblings inside one container'
+
+// A stacking level written as a bare number is how the app ended up with five overlays at 110 and no
+// statement anywhere of which belongs above which. Only the arbitrary bracket form is rejected, so
+// z-10 through z-50 stay available for a level that orders siblings inside a single container.
+//
+// Each form needs two selectors. A class in a plain string is a Literal, while one built in a
+// template literal lives in TemplateElement.value.raw, which App.tsx does. A numeric zIndex is
+// matched on raw rather than value, because esquery applies a regex attribute test only to strings,
+// and an assignment to element.style.zIndex is an AssignmentExpression rather than a Property
+const restrictedStackingLevels = [
+  {
+    selector: 'Literal[value=/z-\\[\\d+\\]/]',
+    message: STACKING_LEVEL_MESSAGE,
+  },
+  {
+    selector: 'TemplateElement[value.raw=/z-\\[\\d+\\]/]',
+    message: STACKING_LEVEL_MESSAGE,
+  },
+  {
+    selector: "Property[key.name='zIndex'] > Literal[raw=/^-?\\d/]",
+    message: STACKING_LEVEL_MESSAGE,
+  },
+  {
+    selector: "AssignmentExpression[left.property.name='zIndex'] > Literal[raw=/^-?\\d/]",
+    message: STACKING_LEVEL_MESSAGE,
+  },
+]
+
 export default defineConfig([
   globalIgnores(['dist']),
   {
@@ -59,6 +89,7 @@ export default defineConfig([
     },
     rules: {
       'no-restricted-imports': ['error', { patterns: restrictedImportPatterns }],
+      'no-restricted-syntax': ['error', ...restrictedStackingLevels],
     },
   },
   {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -199,9 +199,16 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
           <AnimatePresence>
             {routeLoading && routeLoaderDelayElapsed && !isInitialLoad && <LoadingScreen key="route-loader" variant="main" />}
           </AnimatePresence>
+          {/* isolate makes this a stacking context for good, so every level set inside a page orders
+              only against the rest of the page and never against the navigation, a dialog or a
+              toast. Without it the transform on the wrapper below is the only thing containing them,
+              and that exists just while a route transition animates, so an in-page overlay could
+              reach the top of the page at rest and paint over chrome it belongs under. It scopes
+              painting alone: a fixed child still measures against the viewport, which is what keeps
+              an open drop-down pinned where it was placed */}
           <main
             id="app-page-content"
-            className={`min-w-0 flex-1 ${isFocusedPage ? 'fixed inset-0 z-focused-page p-0' : `relative px-4 pb-8 pt-6 ${navOffsetClass} min-[1050px]:px-6 ${desktopBottomPadding} min-[1050px]:pt-10 transition-[margin] duration-[450ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`}`}
+            className={`min-w-0 flex-1 isolate ${isFocusedPage ? 'fixed inset-0 z-focused-page p-0' : `relative px-4 pb-8 pt-6 ${navOffsetClass} min-[1050px]:px-6 ${desktopBottomPadding} min-[1050px]:pt-10 transition-[margin] duration-[450ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`}`}
             aria-busy={pageTransitioning}
           >
             <motion.div

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -199,13 +199,14 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
           <AnimatePresence>
             {routeLoading && routeLoaderDelayElapsed && !isInitialLoad && <LoadingScreen key="route-loader" variant="main" />}
           </AnimatePresence>
-          {/* isolate makes this a stacking context for good, so every level set inside a page orders
-              only against the rest of the page and never against the navigation, a dialog or a
-              toast. Without it the transform on the wrapper below is the only thing containing them,
-              and that exists just while a route transition animates, so an in-page overlay could
-              reach the top of the page at rest and paint over chrome it belongs under. It scopes
-              painting alone: a fixed child still measures against the viewport, which is what keeps
-              an open drop-down pinned where it was placed */}
+          {/* isolate makes this a stacking context for good, so a level set on an element that stays
+              in the page orders only against the rest of the page and never against the navigation, a
+              dialog or a toast. An overlay portalled out to the body is a sibling of those instead, so
+              it still competes with them and takes its level from the scale. Without this the
+              transform on the wrapper below is the only thing containing the in-page ones, and that
+              exists just while a route transition animates, so one could reach the top of the page at
+              rest and paint over chrome it belongs under. It scopes painting alone: a fixed child
+              still measures against the viewport, which keeps an open drop-down where it was placed */}
           <main
             id="app-page-content"
             className={`min-w-0 flex-1 isolate ${isFocusedPage ? 'fixed inset-0 z-focused-page p-0' : `relative px-4 pb-8 pt-6 ${navOffsetClass} min-[1050px]:px-6 ${desktopBottomPadding} min-[1050px]:pt-10 transition-[margin] duration-[450ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`}`}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -201,7 +201,7 @@ function ProtectedRoute({ displayLocation, onContentReady, pageTransitionPhase, 
           </AnimatePresence>
           <main
             id="app-page-content"
-            className={`min-w-0 flex-1 ${isFocusedPage ? 'fixed inset-0 z-[60] p-0' : `relative px-4 pb-8 pt-6 ${navOffsetClass} min-[1050px]:px-6 ${desktopBottomPadding} min-[1050px]:pt-10 transition-[margin] duration-[450ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`}`}
+            className={`min-w-0 flex-1 ${isFocusedPage ? 'fixed inset-0 z-focused-page p-0' : `relative px-4 pb-8 pt-6 ${navOffsetClass} min-[1050px]:px-6 ${desktopBottomPadding} min-[1050px]:pt-10 transition-[margin] duration-[450ms] ease-[cubic-bezier(0.22,1,0.36,1)] motion-reduce:transition-none`}`}
             aria-busy={pageTransitioning}
           >
             <motion.div

--- a/frontend/src/components/category-icon-selector/Selector.tsx
+++ b/frontend/src/components/category-icon-selector/Selector.tsx
@@ -309,7 +309,7 @@ function EmojiMartIconPicker({
 
   return createPortal(
     <div
-      className="fixed z-[110] inline-block pb-2 pl-1 pr-1 pt-1"
+      className="fixed z-popover inline-block pb-2 pl-1 pr-1 pt-1"
       data-category-emoji-picker="true"
       role="dialog"
       aria-label={`Select ${categoryName} icon`}

--- a/frontend/src/components/charts/CursorTooltipPortal.tsx
+++ b/frontend/src/components/charts/CursorTooltipPortal.tsx
@@ -5,7 +5,7 @@ import {
   type TransitionEvent as ReactTransitionEvent,
 } from 'react'
 import { createPortal } from 'react-dom'
-import { CURSOR_TOOLTIP_Z_INDEX } from '@/utils/tooltipPosition'
+import { STACKING_LEVELS } from '@/constants/stackingLevels'
 
 type CursorTooltipPortalProps = {
   children: ReactNode
@@ -15,7 +15,7 @@ type CursorTooltipPortalProps = {
 }
 
 const defaultTooltipStyle: CSSProperties = {
-  zIndex: CURSOR_TOOLTIP_Z_INDEX,
+  zIndex: STACKING_LEVELS.tooltip,
   transition: 'opacity 150ms ease-out, transform 160ms cubic-bezier(0.22, 1, 0.36, 1)',
   willChange: 'opacity, transform',
 }

--- a/frontend/src/components/date-field/CalendarPopover.tsx
+++ b/frontend/src/components/date-field/CalendarPopover.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { parseIsoDate } from '@/components/date-field/dateSegments'
+import { STACKING_LEVELS } from '@/constants/stackingLevels'
 import { useAuth } from '@/hooks/useAuth'
 import { formatYmd, getTodayYmd, getWeekdayIndex } from '@/utils/date'
 import { FLOATING_LAYER_PROPS } from '@/utils/floatingLayer'
@@ -18,9 +19,6 @@ interface CalendarPopoverProps {
 
 const POPOVER_WIDTH = 264
 
-// The popover portals to the body, so it has to clear the full-screen sheets and modals at 100 to
-// draw above whatever opened it. Nothing in the app renders above this
-const POPOVER_Z_INDEX = 110
 const POPOVER_ESTIMATED_HEIGHT = 320
 const VIEWPORT_MARGIN = 8
 const WEEKDAY_LABELS = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su']
@@ -229,7 +227,7 @@ export default function CalendarPopover({ open, anchorRef, value, onSelect, onCl
             top: position.top,
             left: position.left,
             width: POPOVER_WIDTH,
-            zIndex: POPOVER_Z_INDEX,
+            zIndex: STACKING_LEVELS.popover,
             background: 'var(--app-input-bg)',
             border: '1px solid var(--app-border-strong)',
             boxShadow: 'var(--app-shadow-soft)',

--- a/frontend/src/components/dropdown/Box.tsx
+++ b/frontend/src/components/dropdown/Box.tsx
@@ -1,5 +1,6 @@
 import { useLayoutEffect, type ReactNode, type RefObject } from 'react'
 import { animate, motion, useMotionValue, useReducedMotion } from 'motion/react'
+import { STACKING_LEVELS } from '@/constants/stackingLevels'
 import { joinClassNames } from '@/utils/classNames'
 import {
   DROPDOWN_INSTANT_TRANSITION,
@@ -27,10 +28,6 @@ interface DropdownBoxProps {
 
   position: DropdownBoxPosition
 }
-
-// Above both modal levels and the mobile filter sheet, matching the level the date picker already
-// takes so a menu and a calendar opened from the same form agree on which sits in front
-const DROPDOWN_OPEN_Z_INDEX = 110
 
 // What the box is while it sits in its slot, which is the whole of it. Written as the width rather
 // than left with none, so the value the animation drives is the only thing that ever sets it
@@ -120,7 +117,12 @@ export function DropdownBox({
           // room the box leaves clear of the edge of the screen
           maxWidth: position.openWidth,
           maxHeight: position.boxMaxHeight,
-          zIndex: DROPDOWN_OPEN_Z_INDEX,
+          // The box is fixed in place rather than portalled, so this orders it against whatever
+          // stacking context it lands in. On a page that is the whole app, since page content is
+          // isolated as one context and the box is the popover level within it. Opened inside a
+          // modal or the filter sheet, both of which are fixed with a level of their own, it orders
+          // only against that container's contents
+          zIndex: STACKING_LEVELS.popover,
         }
         : { position: 'absolute', top: 0, left: 0, right: 0, width: boxWidth }}
       // Sinks under a press and springs back when it is let go. Suppressed for as long as the box is

--- a/frontend/src/components/dropdown/Box.tsx
+++ b/frontend/src/components/dropdown/Box.tsx
@@ -118,10 +118,11 @@ export function DropdownBox({
           maxWidth: position.openWidth,
           maxHeight: position.boxMaxHeight,
           // The box is fixed in place rather than portalled, so this orders it against whatever
-          // stacking context it lands in. On a page that is the whole app, since page content is
-          // isolated as one context and the box is the popover level within it. Opened inside a
-          // modal or the filter sheet, both of which are fixed with a level of their own, it orders
-          // only against that container's contents
+          // stacking context it lands in and never against the whole app. Opened from a page that is
+          // the page, which is isolated as one context, so the navigation and a toast still draw over
+          // the open list. Opened inside a modal or the filter sheet, both fixed with a level of
+          // their own, it is that container. What the level buys either way is the box over the
+          // content it grows across, and agreement with the calendar, which takes the same one
           zIndex: STACKING_LEVELS.popover,
         }
         : { position: 'absolute', top: 0, left: 0, right: 0, width: boxWidth }}

--- a/frontend/src/components/feedback/Toast.tsx
+++ b/frontend/src/components/feedback/Toast.tsx
@@ -35,7 +35,7 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
           <motion.div
             role={toast.status === 'error' ? 'alert' : 'status'}
             aria-live={toast.status === 'error' ? 'assertive' : 'polite'}
-            className="fixed bottom-5 right-5 z-[110] flex max-w-[min(24rem,calc(100vw-2.5rem))] items-start gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium shadow-lg"
+            className="fixed bottom-5 right-5 z-toast flex max-w-[min(24rem,calc(100vw-2.5rem))] items-start gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium shadow-lg"
             style={{
               background: 'var(--app-bg)',
               border: '1px solid var(--app-border-strong)',

--- a/frontend/src/components/list-controls/DesktopToolbarControls.tsx
+++ b/frontend/src/components/list-controls/DesktopToolbarControls.tsx
@@ -47,6 +47,10 @@ export function DesktopToolbarControls({
         {filterPanel}
       </div>
 
+      {/* Deliberately a step under the 44px the search field and the collapsed filter pill take. The
+          row is tuned to look even rather than to measure even, so this is a compromise and not an
+          oversight: do not square it up with the rest. The invisible twin below is measured by the
+          toolbar to decide when the row wraps, so any height change has to happen on both */}
       <button
         type="button"
         className={`app-glass-button-primary h-10 shrink-0 ${desktopCreateStacked ? 'basis-full justify-center' : 'w-auto'}`}

--- a/frontend/src/components/list-controls/FilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/FilterGlassPanel.tsx
@@ -19,11 +19,13 @@ import { isFloatingLayerOpen, isInsideFloatingLayer } from '@/utils/floatingLaye
 // Collapsed footprint used before the head is measured, so the toolbar slot does not jump on mount
 const COLLAPSED_FALLBACK = { width: 140, height: 34 }
 
-// Lifts the open panel over the toolbar rows beside it. Page content is isolated as one stacking
-// context, so this orders the panel within the page and never against the navigation or a dialog
+// Lifts the open panel over the controls beside it in the toolbar. It reaches no further than that
+// row, which is sticky with a level of its own and so a stacking context, meaning this never competed
+// with the navigation or a dialog even before the page content was isolated
 const PANEL_Z_INDEX = 50
 
-// Above the panel's own glass, so the clear control stays pressable over it
+// The clear control would sit above the glass it is a child of with no level at all. Kept because it
+// says the control belongs over the panel rather than among the rows inside it
 const CLEAR_BUTTON_Z_INDEX = 2
 
 // Chrome around the measured content span in the collapsed pill: horizontal padding, the gap to the

--- a/frontend/src/components/list-controls/FilterGlassPanel.tsx
+++ b/frontend/src/components/list-controls/FilterGlassPanel.tsx
@@ -19,6 +19,13 @@ import { isFloatingLayerOpen, isInsideFloatingLayer } from '@/utils/floatingLaye
 // Collapsed footprint used before the head is measured, so the toolbar slot does not jump on mount
 const COLLAPSED_FALLBACK = { width: 140, height: 34 }
 
+// Lifts the open panel over the toolbar rows beside it. Page content is isolated as one stacking
+// context, so this orders the panel within the page and never against the navigation or a dialog
+const PANEL_Z_INDEX = 50
+
+// Above the panel's own glass, so the clear control stays pressable over it
+const CLEAR_BUTTON_Z_INDEX = 2
+
 // Chrome around the measured content span in the collapsed pill: horizontal padding, the gap to the
 // chevron, the chevron itself, and the borders, plus a couple of pixels so sub-pixel rounding never
 // clips the label. Added to the content width to size the pill
@@ -201,7 +208,7 @@ export function FilterGlassPanel({
           bottom: openUpward ? 0 : undefined,
           right: 0,
           maxWidth: '90vw',
-          zIndex: 50,
+          zIndex: PANEL_Z_INDEX,
           marginLeft: 0,
         }}
         initial={false}
@@ -247,7 +254,7 @@ export function FilterGlassPanel({
             type="button"
             aria-label="Clear all filters"
             className="app-range-glass-clear absolute inline-flex items-center justify-center"
-            style={{ top: 5, right: 8, height: 28, width: 28, zIndex: 2 }}
+            style={{ top: 5, right: 8, height: 28, width: 28, zIndex: CLEAR_BUTTON_Z_INDEX }}
             onClick={(event) => {
               event.stopPropagation()
               clearAll()

--- a/frontend/src/components/list-controls/MobileFilterSheet.tsx
+++ b/frontend/src/components/list-controls/MobileFilterSheet.tsx
@@ -59,7 +59,7 @@ export function MobileFilterSheet({
           role="dialog"
           aria-modal="true"
           aria-label={ariaLabel}
-          className="fixed inset-x-0 top-0 z-[100] flex flex-col min-[750px]:hidden"
+          className="fixed inset-x-0 top-0 z-sheet flex flex-col min-[750px]:hidden"
           style={{
             // 100dvh tracks the dynamic viewport so the sheet covers the screen even as the mobile
             // browser chrome shows or hides, leaving no strip of the list peeking below it

--- a/frontend/src/components/loading/Screen.tsx
+++ b/frontend/src/components/loading/Screen.tsx
@@ -9,8 +9,8 @@ type LoadingScreenProps = {
 // time it is mounted, otherwise its exit fade keeps swallowing taps on the menu and
 // in-page buttons for the length of the fade after the content is already interactive
 const loadingScreenClassNames = {
-  screen: 'pointer-events-none fixed inset-0 z-50 flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6',
-  main: 'pointer-events-none fixed inset-0 z-30 flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6 min-[1050px]:left-[260px]',
+  screen: 'pointer-events-none fixed inset-0 z-loading-screen flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6',
+  main: 'pointer-events-none fixed inset-0 z-page-overlay flex flex-col items-center justify-center gap-5 px-6 text-center min-[730px]:gap-6 min-[1050px]:left-[260px]',
 };
 
 const LoadingScreen = ({ variant = 'screen', message = 'Your financial future awaits' }: LoadingScreenProps) => (

--- a/frontend/src/components/modal/Shell.tsx
+++ b/frontend/src/components/modal/Shell.tsx
@@ -44,7 +44,7 @@ interface ModalShellProps {
   titleId: string
   /** Size and layout classes for the panel. Its background, border and shadow come from app-modal-panel */
   panelClassName: string
-  /** Whether the modal was opened from the page or from another modal, which sets its stacking level, backdrop blur and timing */
+  /** Whether the modal was opened from the page or from another modal, which sets its stacking level and its entrance timing */
   level?: ModalLevel
   /** Blocks Escape and backdrop dismissal while an action is in flight */
   closeDisabled?: boolean

--- a/frontend/src/components/modal/Shell.tsx
+++ b/frontend/src/components/modal/Shell.tsx
@@ -11,8 +11,10 @@ const EASE = [0.25, 0.1, 0.25, 1] as const
 // reads as the content settling rather than as the panel animating again
 const LAYOUT_TRANSITION = { duration: 0.22, ease: EASE } as const
 
-// A modal opened from the page and a modal opened from another modal. The stacked level sits above every
-// page-level modal and settles a little faster so the second one never feels slower to arrive than the first
+// A modal opened from the page and a modal opened from another modal. Both take their stacking level from
+// the named scale in constants/stackingLevels.ts, where the stacked one sits above every page-level modal
+// and above the full-screen filter sheet. It also settles a little faster, so the second modal never feels
+// slower to arrive than the first
 //
 // Neither level filters its own backdrop. The frosting comes from blurring whatever the dialog covers, the
 // page in app-behind-modal and the panel underneath in app-modal-panel-covered, both of which are inert and
@@ -20,13 +22,13 @@ const LAYOUT_TRANSITION = { duration: 0.22, ease: EASE } as const
 // anything above it moves, which took the GPU to saturation whenever a chart in a modal tracked the pointer
 const LEVELS = {
   page: {
-    className: 'z-[60]',
+    className: 'z-modal',
     backdropDuration: 0.2,
     panelOffset: { opacity: 0, scale: 0.96, y: 12 },
     panelTransition: { duration: 0.25, ease: EASE },
   },
   stacked: {
-    className: 'z-[100]',
+    className: 'z-stacked-modal',
     backdropDuration: 0.15,
     panelOffset: { opacity: 0, scale: 0.94, y: 16 },
     panelTransition: { duration: 0.22, ease: EASE },
@@ -42,7 +44,7 @@ interface ModalShellProps {
   titleId: string
   /** Size and layout classes for the panel. Its background, border and shadow come from app-modal-panel */
   panelClassName: string
-  /** Whether the modal was opened from the page or from another modal, which sets its z-index, backdrop blur and timing */
+  /** Whether the modal was opened from the page or from another modal, which sets its stacking level, backdrop blur and timing */
   level?: ModalLevel
   /** Blocks Escape and backdrop dismissal while an action is in flight */
   closeDisabled?: boolean

--- a/frontend/src/components/navigation/Desktop.tsx
+++ b/frontend/src/components/navigation/Desktop.tsx
@@ -51,7 +51,7 @@ export function DesktopNavigation({
     <motion.nav
       aria-label="Primary"
       className={joinClassNames(
-        'app-desktop-nav fixed left-5 z-40 hidden flex-col rounded-2xl px-4 pb-4 pt-7 min-[1050px]:flex',
+        'app-desktop-nav fixed left-5 z-navigation hidden flex-col rounded-2xl px-4 pb-4 pt-7 min-[1050px]:flex',
         !navExpanded && 'app-desktop-nav-glass',
         !expanded && 'app-desktop-nav-collapsed',
       )}

--- a/frontend/src/components/navigation/Mobile.tsx
+++ b/frontend/src/components/navigation/Mobile.tsx
@@ -48,7 +48,7 @@ export function MobileNavigation({
         aria-controls="mobile-primary-navigation"
         aria-expanded={isOpen}
         onClick={() => setIsOpen((open) => !open)}
-        className="app-glass-icon-button fixed right-4 top-2 z-50 h-11 w-11 min-[1050px]:hidden"
+        className="app-glass-icon-button fixed right-4 top-2 z-navigation-toggle h-11 w-11 min-[1050px]:hidden"
       >
         <AnimatedMobileMenuIcon isOpen={isOpen} shouldReduceMotion={shouldReduceMotion} />
       </button>
@@ -58,7 +58,7 @@ export function MobileNavigation({
           <motion.nav
             id="mobile-primary-navigation"
             aria-label="Primary"
-            className="fixed inset-x-0 -bottom-40 top-0 z-40 flex overscroll-contain flex-col overflow-y-auto px-5 pt-6 min-[1050px]:hidden"
+            className="fixed inset-x-0 -bottom-40 top-0 z-navigation flex overscroll-contain flex-col overflow-y-auto px-5 pt-6 min-[1050px]:hidden"
             style={{
               background: 'var(--app-nav-bg)',
               color: 'var(--app-text)',

--- a/frontend/src/components/passkeys/OverflowMenu.tsx
+++ b/frontend/src/components/passkeys/OverflowMenu.tsx
@@ -102,7 +102,7 @@ export function OverflowMenu({ label, items, disabled = false }: OverflowMenuPro
             <motion.div
               ref={menuRef}
               role="menu"
-              className="app-modal-panel fixed z-[80] overflow-hidden rounded-lg"
+              className="app-modal-panel fixed z-menu overflow-hidden rounded-lg"
               style={{
                 top: position.top,
                 left: position.left,

--- a/frontend/src/components/time-range/Selector.tsx
+++ b/frontend/src/components/time-range/Selector.tsx
@@ -30,6 +30,10 @@ const glassSpring = { type: 'spring', stiffness: 420, damping: 34, mass: 0.9 } a
 // the blooming panel free to overlay the content below without nudging it
 const GLASS_BORDER_ALLOWANCE = 2
 
+// Lifts the glass over the content the open panel blooms across. Open, the wrapper takes z-30 and
+// becomes a stacking context of its own, so this orders the glass only within this control
+const GLASS_Z_INDEX = 50
+
 /**
  * Resolves whether the compact shortcut label adds information beyond the main label
  */
@@ -196,7 +200,7 @@ function MobileTimeRangeSelector<T extends string>({
     >
       <motion.div
         className={joinClassNames('app-range-glass app-range-glass-full', open && 'app-range-glass-open')}
-        style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 50 }}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: GLASS_Z_INDEX }}
         whileTap={open || shouldReduceMotion ? undefined : { scale: 0.94 }}
       >
         <button

--- a/frontend/src/components/time-range/Selector.tsx
+++ b/frontend/src/components/time-range/Selector.tsx
@@ -30,8 +30,10 @@ const glassSpring = { type: 'spring', stiffness: 420, damping: 34, mass: 0.9 } a
 // the blooming panel free to overlay the content below without nudging it
 const GLASS_BORDER_ALLOWANCE = 2
 
-// Lifts the glass over the content the open panel blooms across. Open, the wrapper takes z-30 and
-// becomes a stacking context of its own, so this orders the glass only within this control
+// Lifts the glass over the content the open panel blooms across. Open, the wrapper takes z-30 and is
+// a stacking context, so this resolves inside this control. Closed, the wrapper is only relative and
+// what holds the 50 inside the page is the isolation on app-page-content, without which it would
+// reach the top of the page and tie with the mobile navigation button, which is also 50
 const GLASS_Z_INDEX = 50
 
 /**

--- a/frontend/src/constants/stackingLevels.ts
+++ b/frontend/src/constants/stackingLevels.ts
@@ -1,0 +1,90 @@
+/**
+ * Every stacking level in the app that can reach the top of the page, in one ordered list, so an
+ * overlay is placed by naming what it is rather than by copying a number out of a nearby file.
+ *
+ * A level belongs here when the element is portalled into the body, or is fixed with nothing above
+ * it that establishes a stacking context. Anything ordering siblings inside a card, a table, a
+ * sticky header or a segmented control keeps a plain Tailwind class instead, because its number
+ * only ever competes with the other children of that container.
+ *
+ * Two containers scope whatever is opened inside them, so a level here does not reach past either:
+ * a modal, whose backdrop is fixed and carries its own level, and the mobile filter sheet, which is
+ * fixed at the sheet level. Page content is a stacking context too, through the isolation on
+ * app-page-content, which is what keeps the numbers below meaningful against everything in a page.
+ *
+ * Markup reads these as Tailwind classes, z-modal and the rest, generated from this object by
+ * toTailwindZIndexTheme in tailwind.config.js. Anything computing a style object or writing to an
+ * element reads the number directly.
+ */
+export const STACKING_LEVELS = {
+  /** An overlay covering the page content area while leaving the navigation visible */
+  pageOverlay: 30,
+
+  /** The desktop sidebar and the mobile navigation panel */
+  navigation: 40,
+
+  /** The button that opens the mobile navigation, which has to stay reachable over the panel */
+  navigationToggle: 50,
+
+  /** The full-screen loading screen, over the navigation and its button alike */
+  loadingScreen: 55,
+
+  /** A route that covers the whole viewport instead of sitting beside the navigation */
+  focusedPage: 60,
+
+  /** A dialog opened from a page */
+  modal: 65,
+
+  /** The transient save confirmation on the tax-advantaged category dialog */
+  notice: 70,
+
+  /** A small action menu portalled out of the row that owns it, so it is never clipped */
+  menu: 80,
+
+  /** The full-screen filter sheet on a phone */
+  sheet: 90,
+
+  /**
+   * A dialog opened from another dialog. Above every full-screen cover, since a dialog reached from
+   * inside one is the thing being answered
+   */
+  stackedModal: 100,
+
+  /**
+   * A layer opened from a control and positioned against it: the calendar, an open drop-down, the
+   * category icon picker. Above every dialog, because one opened inside a dialog is portalled beside
+   * it rather than into its panel, and at an equal level document order would decide
+   */
+  popover: 110,
+
+  /**
+   * A toast, above any popover, so a message that arrives while a drop-down happens to be open is
+   * not hidden behind the list
+   */
+  toast: 115,
+
+  /**
+   * A tooltip following the pointer, above everything. A chart's tooltip inside a dialog is
+   * portalled beside the dialog, so anything less left it painting underneath the panel it describes
+   */
+  tooltip: 120,
+} as const
+
+export type StackingLevel = keyof typeof STACKING_LEVELS
+
+/**
+ * The scale as Tailwind zIndex theme entries, so `popover` generates `z-popover`.
+ *
+ * The keys are kebab-cased here rather than left to Tailwind. Its compatibility layer for a
+ * JavaScript config kebab-cases only the first segment of a key path, so `navigationToggle` would
+ * otherwise reach the stylesheet as `z-navigationToggle` while the markup asks for
+ * `z-navigation-toggle`, and a Tailwind class that matches nothing fails silently.
+ */
+export function toTailwindZIndexTheme(): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(STACKING_LEVELS).map(([level, value]) => [
+      level.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`),
+      String(value),
+    ]),
+  )
+}

--- a/frontend/src/constants/stackingLevels.ts
+++ b/frontend/src/constants/stackingLevels.ts
@@ -12,9 +12,9 @@
  * fixed at the sheet level. Page content is a stacking context too, through the isolation on
  * app-page-content, which is what keeps the numbers below meaningful against everything in a page.
  *
- * Markup reads these as Tailwind classes, z-modal and the rest, generated from this object by
- * toTailwindZIndexTheme in tailwind.config.js. Anything computing a style object or writing to an
- * element reads the number directly.
+ * Markup reads these as Tailwind classes, z-modal and the rest. toTailwindZIndexTheme below turns
+ * this object into the theme entries that generate them, and tailwind.config.js calls it. Anything
+ * computing a style object or writing to an element reads the number directly.
  */
 export const STACKING_LEVELS = {
   /** An overlay covering the page content area while leaving the navigation visible */
@@ -75,10 +75,11 @@ export type StackingLevel = keyof typeof STACKING_LEVELS
 /**
  * The scale as Tailwind zIndex theme entries, so `popover` generates `z-popover`.
  *
- * The keys are kebab-cased here rather than left to Tailwind. Its compatibility layer for a
- * JavaScript config kebab-cases only the first segment of a key path, so `navigationToggle` would
- * otherwise reach the stylesheet as `z-navigationToggle` while the markup asks for
- * `z-navigation-toggle`, and a Tailwind class that matches nothing fails silently.
+ * The keys are kebab-cased here rather than left to Tailwind, which puts a theme key into the class
+ * name exactly as written. Building with the keys left camelCase emits `.z-navigationToggle` and
+ * emits nothing at all for the five class names the markup actually asks for, since Tailwind only
+ * generates a class it finds as literal text somewhere in the source. Neither the build nor the type
+ * check nor the suite reports that, so the overlays would simply carry no level.
  */
 export function toTailwindZIndexTheme(): Record<string, string> {
   return Object.fromEntries(

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
@@ -18,7 +18,9 @@ import {
 // transaction facets, so the tabs are laid out three across
 const FACET_GRID_COLUMNS = 'repeat(3, minmax(0, 1fr))'
 
-// Keeps the count badge over its own tab's background, ordering it inside the tab and nowhere else
+// Says the badge belongs over the sliding highlight behind it rather than among the tab's own
+// content. It would land there from document order alone, being the last child and absolutely
+// positioned, so this states the intent rather than achieving it
 const FACET_COUNT_BADGE_Z_INDEX = 1
 
 /**

--- a/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/accounts/components/toolbar/FilterPanelBody.tsx
@@ -18,6 +18,9 @@ import {
 // transaction facets, so the tabs are laid out three across
 const FACET_GRID_COLUMNS = 'repeat(3, minmax(0, 1fr))'
 
+// Keeps the count badge over its own tab's background, ordering it inside the tab and nowhere else
+const FACET_COUNT_BADGE_Z_INDEX = 1
+
 /**
  * Renders the shared filter panel body: the facet tabs, the active facet checklist, the removable
  * active-filter chips, and the apply and clear actions, driven by the shared draft
@@ -91,7 +94,7 @@ export function FilterPanelBody({
                 {facetCount > 0 && (
                   <span
                     className="absolute flex h-[14px] min-w-[14px] items-center justify-center rounded-full px-1 text-[9px] font-medium"
-                    style={{ top: 2, right: 2, zIndex: 1, background: 'var(--app-accent)', color: 'var(--app-button-primary-text)' }}
+                    style={{ top: 2, right: 2, zIndex: FACET_COUNT_BADGE_Z_INDEX, background: 'var(--app-accent)', color: 'var(--app-button-primary-text)' }}
                   >
                     {facetCount}
                   </span>

--- a/frontend/src/pages/imports/components/ProgressOverlay.tsx
+++ b/frontend/src/pages/imports/components/ProgressOverlay.tsx
@@ -10,11 +10,10 @@ const OVERLAY_ACCENT = 'var(--app-accent)'
 const OVERLAY_SUCCESS = 'var(--app-positive)'
 const OVERLAY_ERROR = 'var(--app-negative)'
 /**
- * Covers the imports page and nothing else, so this orders it only against the rest of that page
- * rather than against the app. What scopes it is the `fixed inset-0 z-focused-page` on
- * app-page-content, which the imports route takes: naming that rather than the isolation beside it
- * matters, because only that branch also decides where this overlay's own `fixed inset-0` measures
- * from. It is not a level on the named scale, since it competes with nothing outside the page
+ * Covers the imports page and nothing else, so this orders it only against the rest of that page and
+ * competes with nothing outside it, which is why it is not a level on the app's stacking scale.
+ * app-page-content is a stacking context twice over on this route, through the isolation it always
+ * carries and through the `fixed inset-0 z-focused-page` the imports page takes
  */
 const OVERLAY_Z_INDEX = 90
 

--- a/frontend/src/pages/imports/components/ProgressOverlay.tsx
+++ b/frontend/src/pages/imports/components/ProgressOverlay.tsx
@@ -9,6 +9,15 @@ const OVERLAY_MUTED_TEXT = 'var(--app-text-muted)'
 const OVERLAY_ACCENT = 'var(--app-accent)'
 const OVERLAY_SUCCESS = 'var(--app-positive)'
 const OVERLAY_ERROR = 'var(--app-negative)'
+/**
+ * Covers the imports page and nothing else, so this orders it only against the rest of that page
+ * rather than against the app. What scopes it is the `fixed inset-0 z-focused-page` on
+ * app-page-content, which the imports route takes: naming that rather than the isolation beside it
+ * matters, because only that branch also decides where this overlay's own `fixed inset-0` measures
+ * from. It is not a level on the named scale, since it competes with nothing outside the page
+ */
+const OVERLAY_Z_INDEX = 90
+
 const OVERLAY_EASE: [number, number, number, number] = [0.25, 0.1, 0.25, 1]
 const OVERLAY_SPRING_EASE: [number, number, number, number] = [0.16, 1, 0.3, 1]
 const overlayButtonClass = 'h-10 w-full box-border whitespace-nowrap leading-none sm:w-auto'
@@ -192,8 +201,8 @@ export function ImportProgressOverlay({
         // to how a value dropped from the target is treated
         <motion.div
           key="import-progress-overlay"
-          className="fixed inset-0 z-[90] flex items-center justify-center px-5 py-8"
-          style={{ background: OVERLAY_BACKGROUND, color: OVERLAY_TEXT }}
+          className="fixed inset-0 flex items-center justify-center px-5 py-8"
+          style={{ background: OVERLAY_BACKGROUND, color: OVERLAY_TEXT, zIndex: OVERLAY_Z_INDEX }}
           initial={{ opacity: 0 }}
           animate={{ opacity: 1, pointerEvents: 'auto' }}
           exit={{ opacity: 0, pointerEvents: 'none' }}

--- a/frontend/src/pages/imports/components/tables/SkippedTable.tsx
+++ b/frontend/src/pages/imports/components/tables/SkippedTable.tsx
@@ -22,6 +22,12 @@ const SKIPPED_TABLE_MAX_HEIGHT = '21rem'
 // visibly slide beneath them
 const FROZEN_COLUMN_BACKGROUND = IMPORT_INSET_STYLE.background
 
+// The three layers inside this table's own scroller, in order. They order the table's cells against
+// each other and reach nothing outside it, so they are not levels on the app's stacking scale
+const FROZEN_COLUMN_Z_INDEX = 1
+const HEADER_ROW_Z_INDEX = 2
+const FROZEN_HEADER_Z_INDEX = 3
+
 /**
  * Builds the frozen lead cell style, whose width doubles as the sticky
  * offset of the frozen Reason column beside it
@@ -34,7 +40,7 @@ function buildFrozenLeadCellStyle(leadColumnWidth: string): CSSProperties {
     minWidth: leadColumnWidth,
     maxWidth: leadColumnWidth,
     background: FROZEN_COLUMN_BACKGROUND,
-    zIndex: 1,
+    zIndex: FROZEN_COLUMN_Z_INDEX,
   }
 }
 
@@ -48,7 +54,7 @@ function buildFrozenReasonCellStyle(leadColumnWidth: string): CSSProperties {
     left: leadColumnWidth,
     background: FROZEN_COLUMN_BACKGROUND,
     borderRight: '1px solid var(--app-border)',
-    zIndex: 1,
+    zIndex: FROZEN_COLUMN_Z_INDEX,
   }
 }
 
@@ -59,10 +65,8 @@ const HEADER_CELL_STYLE: CSSProperties = {
   top: 0,
   background: FROZEN_COLUMN_BACKGROUND,
   borderBottom: '1px solid var(--app-border)',
-  zIndex: 2,
+  zIndex: HEADER_ROW_Z_INDEX,
 }
-
-const FROZEN_HEADER_Z_INDEX = 3
 
 /**
  * Sizes the reason content, asking for the longest reason on one line and

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -372,6 +372,9 @@ export function InsightsFloatingRangeControl(props: InsightsFloatingRangeControl
         document.body,
       )}
 
+      {/* The desktop control stays in the page rather than portalled, so this 40 lifts it over the
+          cards beside it and is not the navigation level it happens to share a number with. Page
+          content is isolated as one stacking context, so it cannot reach past the page either way */}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 top-0 z-40 hidden pt-[3.8rem] min-[1050px]:block">
         <div className="sticky top-6 flex justify-end">
           <div className="pointer-events-auto w-[24rem]">

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -358,7 +358,7 @@ export function InsightsFloatingRangeControl(props: InsightsFloatingRangeControl
           bottom-floating mobile control is portaled to the body to stay pinned to the viewport */}
       {createPortal(
         <div
-          className="pointer-events-none fixed inset-x-4 bottom-1.5 z-30 min-[1050px]:hidden"
+          className="pointer-events-none fixed inset-x-4 bottom-1.5 z-page-overlay min-[1050px]:hidden"
           style={keyboardLift > 0 ? { transform: `translateY(-${keyboardLift}px)` } : undefined}
           onFocusCapture={(event) => setIsEditingField(event.target instanceof HTMLInputElement)}
           onBlurCapture={(event) => {

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryModal.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryModal.tsx
@@ -178,7 +178,7 @@ export default function TaxAdvantagedCategoryModal({
             <motion.div
               role={autosaveNotice.status === 'error' ? 'alert' : 'status'}
               aria-live={autosaveNotice.status === 'error' ? 'assertive' : 'polite'}
-              className="fixed bottom-5 right-5 z-[70] flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium shadow-lg"
+              className="fixed bottom-5 right-5 z-notice flex items-center gap-3 rounded-xl px-4 py-3 text-sm font-medium shadow-lg"
               style={{
                 background: 'var(--app-bg)',
                 border: '1px solid var(--app-border-strong)',

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -31,7 +31,9 @@ const NO_DISABLED_FACETS = new Set<string>()
 // The account facet is disabled on an account's own transaction list, where the scope is fixed
 const ACCOUNT_DISABLED_FACETS = new Set(['accounts'])
 
-// Keeps the count badge over its own tab's background, ordering it inside the tab and nowhere else
+// Says the badge belongs over the sliding highlight behind it rather than among the tab's own
+// content. It would land there from document order alone, being the last child and absolutely
+// positioned, so this states the intent rather than achieving it
 const FACET_COUNT_BADGE_Z_INDEX = 1
 
 /**

--- a/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/FilterPanelBody.tsx
@@ -31,6 +31,9 @@ const NO_DISABLED_FACETS = new Set<string>()
 // The account facet is disabled on an account's own transaction list, where the scope is fixed
 const ACCOUNT_DISABLED_FACETS = new Set(['accounts'])
 
+// Keeps the count badge over its own tab's background, ordering it inside the tab and nowhere else
+const FACET_COUNT_BADGE_Z_INDEX = 1
+
 /**
  * Names why the amount range cannot be shown or changed, for the line the currency note usually holds
  *
@@ -143,7 +146,7 @@ export function FilterPanelBody({
                 {!isDisabled && facetCount > 0 && (
                   <span
                     className="absolute flex h-[14px] min-w-[14px] items-center justify-center rounded-full px-1 text-[9px] font-medium"
-                    style={{ top: 2, right: 2, zIndex: 1, background: 'var(--app-accent)', color: 'var(--app-button-primary-text)' }}
+                    style={{ top: 2, right: 2, zIndex: FACET_COUNT_BADGE_Z_INDEX, background: 'var(--app-accent)', color: 'var(--app-button-primary-text)' }}
                   >
                     {facetCount}
                   </span>

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -40,15 +40,17 @@ export default function TransactionListToolbar({
   const shell = useToolbarShellState()
   useToolbarStickyOffset(shell.toolbarRef, onStickyOffsetChange)
 
-  // One node for both widths, sized to match the buttons it stands beside, which are taller on a
-  // phone than on a desktop. The accessible name says which import this is, since the word on the
-  // button cannot: on a list fixed to one account it files every row into that account, and on the
-  // list of every account it is the way to the import page. The reason it is blocked rides on the
-  // title alone, the way the create button's does, so the name still says what the control is
+  // One node for both widths, at the 44px control height the row is built on, which the search field
+  // and the collapsed filter pill it stands against both take. Square on a phone and widening for its
+  // word on a desktop, but the same height throughout. The accessible name says which import this is,
+  // since the word on the button cannot: on a list fixed to one account it files every row into that
+  // account, and on the list of every account it is the way to the import page. The reason it is
+  // blocked rides on the title alone, the way the create button's does, so the name still says what
+  // the control is
   const importAction = onImport ? (
     <button
       type="button"
-      className="app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:h-10 min-[750px]:w-auto min-[750px]:px-4"
+      className="app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:w-auto min-[750px]:px-4"
       onClick={onImport}
       disabled={importDisabled}
       title={importDisabledReason}

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -298,8 +298,15 @@
     transition: opacity 0.2s ease, max-width 0.28s ease;
   }
 
-  .app-nav-link-label,
-  .app-nav-user-meta {
+  .app-nav-link-label {
+    max-width: 12rem;
+  }
+
+  /* Only the sidebar folds, and this cap is the property that animates to zero as it does, so it is
+     scoped to the sidebar. The mobile panel is as wide as the screen, where a capped name block stops
+     growing with room to spare and the row's leftover width collects after the last child, leaving
+     the logout button stranded mid-row rather than against the right edge */
+  .app-desktop-nav .app-nav-user-meta {
     max-width: 12rem;
   }
 

--- a/frontend/src/utils/tooltipPosition.ts
+++ b/frontend/src/utils/tooltipPosition.ts
@@ -1,3 +1,5 @@
+import { STACKING_LEVELS } from '@/constants/stackingLevels'
+
 type CursorTooltipPositionStrategy = 'absolute' | 'fixed'
 
 type CursorTooltipPositionOptions = {
@@ -15,12 +17,6 @@ type ApplyCursorTooltipPositionOptions = CursorTooltipPositionOptions & {
   xProperty: string
   yProperty: string
 }
-
-// Above every modal level the modal shell uses, which reaches 100 for a modal opened from another
-// modal. A tooltip belonging to a chart inside a modal is portalled into the body beside the modal
-// rather than into the panel, so at an equal level whichever of the two React appended last would
-// paint on top, and the tooltip could end up underneath the panel it belongs to
-export const CURSOR_TOOLTIP_Z_INDEX = 110
 
 const DEFAULT_CURSOR_TOOLTIP_OFFSET = 10
 const DEFAULT_CURSOR_TOOLTIP_MARGIN = 8
@@ -100,7 +96,7 @@ export function applyCursorTooltipPosition({
 }: ApplyCursorTooltipPositionOptions) {
   const position = getCursorTooltipPosition({ tooltip, ...options })
   tooltip.style.position = options.strategy ?? DEFAULT_CURSOR_TOOLTIP_STRATEGY
-  tooltip.style.zIndex = String(CURSOR_TOOLTIP_Z_INDEX)
+  tooltip.style.zIndex = String(STACKING_LEVELS.tooltip)
   tooltip.style.setProperty('--app-cursor-tooltip-max-width', `${position.maxWidth}px`)
   tooltip.style.setProperty(xProperty, `${position.x}px`)
   tooltip.style.setProperty(yProperty, `${position.y}px`)

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -17,9 +17,12 @@ export default {
         mono: ['"DM Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
         display: ['"Cormorant Garamond Variable"', 'Georgia', 'serif'],
       },
-      // The one ordered list of stacking levels that can reach the top of the page, kept in
-      // src/constants/stackingLevels.ts so the sites that compute a style object read the same
-      // numbers these classes carry
+      // The named levels an overlay that can reach the top of the page picks from, kept in
+      // src/constants/stackingLevels.ts so the sites computing a style object read the same numbers
+      // these classes carry. Extending rather than replacing, so Tailwind's own z-0 through z-50
+      // survive for a level ordering siblings inside one container. That does leave three numbers
+      // reachable two ways, z-30 and z-page-overlay among them, which is why the page content is
+      // isolated: an in-page number cannot compete with a named level whatever it is set to
       zIndex: toTailwindZIndexTheme(),
       colors: {
         gold: '#C9A96A',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,3 +1,5 @@
+import { toTailwindZIndexTheme } from './src/constants/stackingLevels.ts'
+
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: 'class',
@@ -15,6 +17,10 @@ export default {
         mono: ['"DM Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
         display: ['"Cormorant Garamond Variable"', 'Georgia', 'serif'],
       },
+      // The one ordered list of stacking levels that can reach the top of the page, kept in
+      // src/constants/stackingLevels.ts so the sites that compute a style object read the same
+      // numbers these classes carry
+      zIndex: toTailwindZIndexTheme(),
       colors: {
         gold: '#C9A96A',
         'gold-bright': '#E4C17A',

--- a/frontend/tests/constants/stackingLevels.test.ts
+++ b/frontend/tests/constants/stackingLevels.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { STACKING_LEVELS, toTailwindZIndexTheme } from '@/constants/stackingLevels'
+
+describe('STACKING_LEVELS', () => {
+  it('rises strictly from the first level to the last', () => {
+    const values = Object.values(STACKING_LEVELS)
+
+    for (let index = 1; index < values.length; index += 1) {
+      expect(values[index]).toBeGreaterThan(values[index - 1])
+    }
+  })
+
+  // Two levels at one number is the bug the scale exists to remove: the browser then falls back to
+  // document order, so which overlay paints on top depends on which one React happened to append
+  it('gives no two levels the same number', () => {
+    const values = Object.values(STACKING_LEVELS)
+
+    expect(new Set(values).size).toBe(values.length)
+  })
+
+  it('puts a toast and a pointer tooltip above every popover, and every popover above every dialog', () => {
+    expect(STACKING_LEVELS.popover).toBeGreaterThan(STACKING_LEVELS.stackedModal)
+    expect(STACKING_LEVELS.toast).toBeGreaterThan(STACKING_LEVELS.popover)
+    expect(STACKING_LEVELS.tooltip).toBeGreaterThan(STACKING_LEVELS.toast)
+  })
+
+  it('puts a dialog opened from another dialog above every full-screen cover', () => {
+    expect(STACKING_LEVELS.stackedModal).toBeGreaterThan(STACKING_LEVELS.sheet)
+    expect(STACKING_LEVELS.sheet).toBeGreaterThan(STACKING_LEVELS.modal)
+  })
+})
+
+describe('toTailwindZIndexTheme', () => {
+  // Tailwind's compatibility layer for a JavaScript config kebab-cases only the first segment of a
+  // key path, so a key left camelCase reaches the stylesheet as z-navigationToggle while the markup
+  // asks for z-navigation-toggle, and a class matching nothing fails without an error anywhere
+  it('kebab-cases a multi-word level so the class name matches the markup', () => {
+    const theme = toTailwindZIndexTheme()
+
+    expect(theme['navigation-toggle']).toBe('50')
+    expect(theme['stacked-modal']).toBe('100')
+    expect(theme['loading-screen']).toBe('55')
+    expect(theme['page-overlay']).toBe('30')
+    expect(theme['focused-page']).toBe('60')
+  })
+
+  it('leaves a single-word level alone', () => {
+    const theme = toTailwindZIndexTheme()
+
+    expect(theme.modal).toBe('65')
+    expect(theme.popover).toBe('110')
+    expect(theme.tooltip).toBe('120')
+  })
+
+  it('carries every level across', () => {
+    expect(Object.keys(toTailwindZIndexTheme())).toHaveLength(Object.keys(STACKING_LEVELS).length)
+  })
+})

--- a/frontend/tests/constants/stackingLevels.test.ts
+++ b/frontend/tests/constants/stackingLevels.test.ts
@@ -1,3 +1,6 @@
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { STACKING_LEVELS, toTailwindZIndexTheme } from '@/constants/stackingLevels'
 
@@ -31,28 +34,65 @@ describe('STACKING_LEVELS', () => {
 })
 
 describe('toTailwindZIndexTheme', () => {
-  // Tailwind's compatibility layer for a JavaScript config kebab-cases only the first segment of a
-  // key path, so a key left camelCase reaches the stylesheet as z-navigationToggle while the markup
-  // asks for z-navigation-toggle, and a class matching nothing fails without an error anywhere
-  it('kebab-cases a multi-word level so the class name matches the markup', () => {
-    const theme = toTailwindZIndexTheme()
-
-    expect(theme['navigation-toggle']).toBe('50')
-    expect(theme['stacked-modal']).toBe('100')
-    expect(theme['loading-screen']).toBe('55')
-    expect(theme['page-overlay']).toBe('30')
-    expect(theme['focused-page']).toBe('60')
+  // Written out rather than derived from STACKING_LEVELS, so this fails on a renamed level, a changed
+  // value and a broken transform alike. Deriving the expectation from the same object would pass
+  // whatever the transform did to the keys.
+  //
+  // Tailwind puts a theme key into the class name exactly as written, so a key left camelCase emits
+  // z-navigationToggle and emits nothing for the class the markup asks for. Neither the build nor the
+  // type check nor the suite reports that on its own, which is what the next test covers
+  it('generates exactly the kebab-case keys the markup asks for', () => {
+    expect(toTailwindZIndexTheme()).toEqual({
+      'page-overlay': '30',
+      navigation: '40',
+      'navigation-toggle': '50',
+      'loading-screen': '55',
+      'focused-page': '60',
+      modal: '65',
+      notice: '70',
+      menu: '80',
+      sheet: '90',
+      'stacked-modal': '100',
+      popover: '110',
+      toast: '115',
+      tooltip: '120',
+    })
   })
+})
 
-  it('leaves a single-word level alone', () => {
-    const theme = toTailwindZIndexTheme()
+// Tailwind drops a class it cannot resolve without reporting it, so a level renamed in the scale and
+// left alone in the markup takes that overlay's stacking level away with nothing failing. This walks
+// the source for what the markup actually asks for and holds it against what the theme generates
+describe('the classes the markup asks for', () => {
+  const SOURCE_ROOT = fileURLToPath(new URL('../../src', import.meta.url))
 
-    expect(theme.modal).toBe('65')
-    expect(theme.popover).toBe('110')
-    expect(theme.tooltip).toBe('120')
-  })
+  // Tailwind's own numeric scale survives alongside the named one for a level ordering siblings
+  // inside one container, and z-auto is Tailwind's too. "index" is the CSS property named in a comment
+  const CLASSES_NOT_FROM_THE_SCALE = new Set(['auto', 'index'])
 
-  it('carries every level across', () => {
-    expect(Object.keys(toTailwindZIndexTheme())).toHaveLength(Object.keys(STACKING_LEVELS).length)
+  /** Every .ts and .tsx file under src, so the walk covers markup and the helpers building it */
+  function collectSourceFiles(directory: string): string[] {
+    return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+      const path = join(directory, entry.name)
+      if (entry.isDirectory()) return collectSourceFiles(path)
+
+      return /\.tsx?$/.test(entry.name) ? [path] : []
+    })
+  }
+
+  it('generates every one of them', () => {
+    const generated = toTailwindZIndexTheme()
+    const missing = new Map<string, string[]>()
+
+    for (const file of collectSourceFiles(SOURCE_ROOT)) {
+      // A letter-led suffix, so Tailwind's numeric z-30 and the rejected arbitrary z-[30] are left out
+      for (const [, suffix] of readFileSync(file, 'utf8').matchAll(/\bz-([a-z][a-z-]*)\b/g)) {
+        if (CLASSES_NOT_FROM_THE_SCALE.has(suffix) || suffix in generated) continue
+
+        missing.set(suffix, [...(missing.get(suffix) ?? []), file.slice(SOURCE_ROOT.length + 1)])
+      }
+    }
+
+    expect(Object.fromEntries(missing)).toEqual({})
   })
 })


### PR DESCRIPTION
Every overlay in the app picked its own stacking number in the markup, so which of two layers drew on top depended on whoever remembered the ordering, and any two that shared a number were left to document order. The levels come from one named scale: a class in markup and a constant where the value is set from JavaScript. Page content is a stacking context of its own, so an overlay that stays in the page can't compete with the chrome around it.