### PR TITLE
refactor: improve the wording used in the import page

### DIFF
--- a/frontend/src/pages/imports/components/Primitives.tsx
+++ b/frontend/src/pages/imports/components/Primitives.tsx
@@ -173,11 +173,15 @@ export function ImportLoadFailure({
  * The title says which of those it is about, since a step can carry more than one and they would
  * otherwise be told apart only by reading them
  *
+ * @param children - What the notice has to say before its list, omitted by a notice whose title and
+ *   list say the whole thing between them
  * @param items - The things the text is about, one bulleted line each under it. Passing them here
  *   rather than joining them into the text keeps a list out of the paragraph, which is markup the
  *   browser rearranges on its own, and gives every notice that lists something the same shape. The
  *   marker is set back on, since Tailwind's reset takes it off. A notice with nothing to list omits
- *   the list and renders as it always did
+ *   the list and renders as it always did. They carry the full-strength text colour rather than the
+ *   muted one the paragraph takes, because a list holds the particulars, whether those are account
+ *   names or the reasons an import cannot go ahead, and those are what the reader came for
  * @param tone - How much the notice is asking of the reader. The danger tone is for the one a user
  *   has to act on before importing, rather than the ordinary ones saying what the import will do,
  *   and it takes the same colours the load failure already uses. The question tone is for a notice
@@ -191,7 +195,7 @@ export function ImportNotice({
   tone = 'warning',
 }: {
   title: string
-  children: ReactNode
+  children?: ReactNode
   items?: ReactNode[]
   tone?: 'warning' | 'danger' | 'question'
 }) {
@@ -225,11 +229,13 @@ export function ImportNotice({
         >
           {title}
         </p>
-        <p className="mt-1 text-sm leading-5">
-          {children}
-        </p>
+        {children && (
+          <p className="mt-1 text-sm leading-5">
+            {children}
+          </p>
+        )}
         {items && items.length > 0 && (
-          <ul className="mt-1 list-disc space-y-0.5 pl-4 text-sm leading-5">
+          <ul className="mt-1 list-disc space-y-0.5 pl-4 text-sm leading-5" style={{ color: 'var(--app-text)' }}>
             {items.map((item, index) => (
               <li key={index}>{item}</li>
             ))}

--- a/frontend/src/pages/imports/components/Primitives.tsx
+++ b/frontend/src/pages/imports/components/Primitives.tsx
@@ -178,9 +178,6 @@ export function ImportLoadFailure({
  *   browser rearranges on its own, and gives every notice that lists something the same shape. The
  *   marker is set back on, since Tailwind's reset takes it off. A notice with nothing to list omits
  *   the list and renders as it always did
- * @param footer - A closing line under the list, for a notice whose list is a set of choices and
- *   which has a rule to state about all of them. Without it that rule would have to lead, ahead of
- *   the choices it is about, or sit in the list as though it were one of them
  * @param tone - How much the notice is asking of the reader. The danger tone is for the one a user
  *   has to act on before importing, rather than the ordinary ones saying what the import will do,
  *   and it takes the same colours the load failure already uses. The question tone is for a notice
@@ -191,13 +188,11 @@ export function ImportNotice({
   title,
   children,
   items,
-  footer,
   tone = 'warning',
 }: {
   title: string
   children: ReactNode
   items?: ReactNode[]
-  footer?: ReactNode
   tone?: 'warning' | 'danger' | 'question'
 }) {
   const isDanger = tone === 'danger'
@@ -240,7 +235,6 @@ export function ImportNotice({
             ))}
           </ul>
         )}
-        {footer && <p className="mt-1 text-sm leading-5">{footer}</p>}
       </div>
     </div>
   )

--- a/frontend/src/pages/imports/components/Primitives.tsx
+++ b/frontend/src/pages/imports/components/Primitives.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react'
-import { Check, ChevronDown, Info, TriangleAlert } from 'lucide-react'
+import { Check, ChevronDown, CircleHelp, Info, TriangleAlert } from 'lucide-react'
 import { IMPORT_INSET_STYLE } from '@/pages/imports/constants'
 
 /**
@@ -178,22 +178,31 @@ export function ImportLoadFailure({
  *   browser rearranges on its own, and gives every notice that lists something the same shape. The
  *   marker is set back on, since Tailwind's reset takes it off. A notice with nothing to list omits
  *   the list and renders as it always did
+ * @param footer - A closing line under the list, for a notice whose list is a set of choices and
+ *   which has a rule to state about all of them. Without it that rule would have to lead, ahead of
+ *   the choices it is about, or sit in the list as though it were one of them
  * @param tone - How much the notice is asking of the reader. The danger tone is for the one a user
  *   has to act on before importing, rather than the ordinary ones saying what the import will do,
- *   and it takes the same colours the load failure already uses
+ *   and it takes the same colours the load failure already uses. The question tone is for a notice
+ *   that asks something rather than reporting anything, where a warning triangle would state a
+ *   fault that does not exist
  */
 export function ImportNotice({
   title,
   children,
   items,
+  footer,
   tone = 'warning',
 }: {
   title: string
   children: ReactNode
   items?: ReactNode[]
-  tone?: 'warning' | 'danger'
+  footer?: ReactNode
+  tone?: 'warning' | 'danger' | 'question'
 }) {
   const isDanger = tone === 'danger'
+  const isQuestion = tone === 'question'
+  const NoticeIcon = isQuestion ? CircleHelp : TriangleAlert
 
   return (
     <div
@@ -209,10 +218,10 @@ export function ImportNotice({
     >
       <span
         className="mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center"
-        style={{ color: isDanger ? 'var(--app-negative)' : 'var(--app-warning-text)' }}
+        style={{ color: isDanger ? 'var(--app-negative)' : isQuestion ? 'var(--app-accent)' : 'var(--app-warning-text)' }}
         aria-hidden
       >
-        <TriangleAlert size={16} strokeWidth={2.25} />
+        <NoticeIcon size={16} strokeWidth={2.25} />
       </span>
       <div className="min-w-0">
         <p
@@ -231,6 +240,7 @@ export function ImportNotice({
             ))}
           </ul>
         )}
+        {footer && <p className="mt-1 text-sm leading-5">{footer}</p>}
       </div>
     </div>
   )

--- a/frontend/src/pages/imports/components/tables/RowProblemsTable.tsx
+++ b/frontend/src/pages/imports/components/tables/RowProblemsTable.tsx
@@ -7,14 +7,19 @@ import { ImportSkippedTable, type ImportSkippedTableRow } from './SkippedTable'
 const ROW_NUMBER_COLUMN_WIDTH = '3.5rem'
 
 /**
- * Collapsible panel listing the rows the import cannot convert, freezing which row each one is and
- * why it was refused on the left while every column of the uploaded file scrolls beside them
+ * Collapsible panel listing the rows the import has something to say about, freezing which row each
+ * one is and what was found on the left while every column of the uploaded file scrolls beside them
+ *
+ * Used for both kinds of row, so the three presentation props default to the refusal this was
+ * written for and the list of rows that import as they are passes all three
  */
 export function ImportRowProblemsTable({
   title,
   rowProblems,
   headers,
   toggleLabel = 'rows to fix',
+  tone = 'danger',
+  reasonHeader = 'Reason',
 }: {
   title: string
   rowProblems: ImportRowProblem[]
@@ -25,6 +30,12 @@ export function ImportRowProblemsTable({
    * Defaults to the refused rows this table was written for
    */
   toggleLabel?: string
+
+  /** Whether these rows are refused or merely worth a look, which is the icon's colour */
+  tone?: 'warning' | 'danger'
+
+  /** What the frozen second column is headed, for a list of notes rather than refusals */
+  reasonHeader?: string
 }) {
   // Only the rows the table will show are shaped for it, and the count it summarizes the rest
   // against comes from the full list. A file whose every row is refused would otherwise rebuild a
@@ -46,6 +57,8 @@ export function ImportRowProblemsTable({
       headers={headers}
       rows={tableRows}
       totalCount={rowProblems.length}
+      tone={tone}
+      reasonHeader={reasonHeader}
     />
   )
 }

--- a/frontend/src/pages/imports/components/tables/SkippedTable.tsx
+++ b/frontend/src/pages/imports/components/tables/SkippedTable.tsx
@@ -30,7 +30,7 @@ const FROZEN_HEADER_Z_INDEX = 3
 
 /**
  * Builds the frozen lead cell style, whose width doubles as the sticky
- * offset of the frozen Reason column beside it
+ * offset of the frozen reason column beside it
  */
 function buildFrozenLeadCellStyle(leadColumnWidth: string): CSSProperties {
   return {
@@ -114,9 +114,9 @@ function RawCellValue({ value }: { value: string }) {
 }
 
 /**
- * Collapsible panel listing items the import will not or did not bring in,
- * keeping only the count headline visible until expanded, then freezing the
- * lead cell and skip reason on the left while every other column scrolls
+ * Collapsible panel listing rows the import has something to say about, keeping
+ * only the count headline visible until expanded, then freezing the lead cell
+ * and the note beside it on the left while every other column scrolls
  * horizontally beside them, capped to a visible sample with the hidden
  * remainder summarized underneath
  */
@@ -129,19 +129,34 @@ export function ImportSkippedTable({
   headers,
   rows,
   totalCount,
+  tone = 'danger',
+  reasonHeader = 'Reason',
 }: {
   title: string
 
-  /** Names what expands and collapses for the toggle's accessible label */
+  /** What the expand and collapse control calls the rows in its accessible label */
   toggleLabel: string
   leadHeader: string
 
-  /** Fixed width of the frozen lead column, which sets the Reason offset */
+  /** Fixed width of the frozen lead column, which sets the note column's offset */
   leadColumnWidth: string
   leadCellClassName: string
   headers: string[]
   rows: ImportSkippedTableRow[]
   totalCount: number
+
+  /**
+   * Whether the rows are refused or merely worth a look, which is the icon's colour. Defaults to
+   * the refusal this table was written for, so a caller listing rows the import will not take says
+   * nothing. Takes the same two words `ImportNotice` uses
+   */
+  tone?: 'warning' | 'danger'
+
+  /**
+   * What the frozen second column is headed. Reason is the right word for a refusal and the wrong
+   * one for a note against a row that imports as it stands
+   */
+  reasonHeader?: string
 }) {
   // Expanded by default so skipped items are in view before the commit
   const [expanded, setExpanded] = useState(true)
@@ -172,7 +187,7 @@ export function ImportSkippedTable({
             size={16}
             strokeWidth={2.25}
             className="shrink-0"
-            style={{ color: 'var(--app-negative)' }}
+            style={{ color: tone === 'danger' ? 'var(--app-negative)' : 'var(--app-warning-text)' }}
             aria-hidden
           />
           <p className="text-sm font-semibold">{title}</p>
@@ -203,7 +218,7 @@ export function ImportSkippedTable({
                     className="py-1.5 pr-4 align-top font-medium"
                     style={{ ...frozenReasonCellStyle, ...HEADER_CELL_STYLE, zIndex: FROZEN_HEADER_Z_INDEX }}
                   >
-                    Reason
+                    {reasonHeader}
                   </th>
                   {headers.map((header, headerIndex) => (
                     <th

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -330,14 +330,27 @@ export const NO_OUTFLOWS_WARNING = 'Every row in this file reads as money coming
 /**
  * Shown above the column mapping table, saying how the importer reads an amount
  *
- * All three arrangements are stated because a file can be mapped any of the three ways, and each one
- * is answered by mapping columns rather than by a separate question
+ * Three parts rather than one paragraph: the question, the arrangements that answer it, and the rule
+ * holding across them. Every arrangement is offered because a file can be mapped any of these ways,
+ * and each is answered by mapping columns rather than by a question of its own, so they are a list of
+ * choices rather than steps to work through
  *
  * It stops at what the columns have to hold. How a category's kind reads against an amount's
  * direction is said against the rows it is about, in ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON, since
  * a rule stated here would be read five steps before those rows appear
  */
-export const AMOUNT_CONVENTION_NOTE = 'Every imported row carries a direction. Map one Amount column, negative for money out and positive for money in, or a Money out and a Money in column where the file keeps them apart, or just one of those where the file only holds money going one way. Where the amounts are unsigned and a column of words specifies the direction, map that column as the Direction and answer below the table what its words mean. Money out, Money in and Direction each specify the direction themselves, so an amount beside one may only carry a sign that agrees, and a row breaking that is listed rather than read the other way.'
+export const AMOUNT_CONVENTION_NOTE = 'Every imported row carries a direction. Map whichever of these your file uses:'
+export const AMOUNT_ARRANGEMENT_OPTIONS = [
+  'One Amount column, written negative for money out and positive for money in',
+  'A Money out and a Money in column, where the file keeps the two apart',
+  'Just one of those two, where the file holds money going only one way',
+  'An Amount column of unsigned amounts beside a Direction column of words, whose meanings you answer below the table',
+]
+
+// Closes the notice above, because it holds across every arrangement in it rather than belonging to
+// one of them. Stated after the choices rather than before, since it speaks of the columns by the
+// labels the list has just given them
+export const AMOUNT_SIGN_RULE_NOTE = 'Money out, Money in and Direction each specify the direction themselves, so an amount beside one may only carry a sign that agrees. A row breaking that is listed rather than read the other way.'
 
 // Shown where a source rows are written to matches an account the user has archived, which is the
 // one account that source is not offered. The matched account names follow it
@@ -396,6 +409,13 @@ export const IMPORT_NOT_PERMITTED_EXPLANATION = 'Transactions can only be import
 // question this page never reaches
 export const IMPORT_SCOPE_FAILURE_TITLE = 'Your accounts could not be loaded'
 export const IMPORT_SCOPE_FAILURE_EXPLANATION = 'Without them this import cannot tell whether it may write to the account it was started from.'
+
+// Shown above the column mapping table, under the note about amounts, because what currency an
+// amount lands in is the other half of how a number is read and the Currency column is mapped here.
+// It speaks of the account each source is mapped to, which is the step after this one, since that is
+// where the answer comes from even though the question arises while the columns are being chosen
+export const CURRENCY_HANDLING_TITLE = 'How currencies are read'
+export const CURRENCY_HANDLING_NOTE = 'Imported amounts are treated as raw values. Each one is assigned the currency of the account its row is mapped to, or the currency shown against a new account, which is taken from the file where it states one and can be changed on any row.'
 
 /**
  * Says what a scoped import does with the currency of the account it writes to

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -240,6 +240,10 @@ export const CURRENCIES_FAILED_UPLOAD_BLOCK = 'Currencies could not be loaded, a
 // built on it: refused rows in both import flows, and the Firefly budgets it cannot bring in
 export const SKIPPED_TABLE_VISIBLE_LIMIT = 20
 
+// How many compiled transactions the preview shows. Read by the builder that stops at it and by the
+// step description that states it, so the two cannot disagree about what is on screen
+export const IMPORT_SAMPLE_PREVIEW_LIMIT = 5
+
 // Why one row cannot be converted, listed against that row in the preview step. They read as one
 // family: what is wrong with this row, then what to do about it where there is a choice about that.
 // Each speaks of the row itself, since the entry carries the row number and the row's own cells, and
@@ -341,16 +345,16 @@ export const ARCHIVED_ACCOUNT_MATCH_EXPLANATION = 'An archived account takes no 
 
 // Shown once any source on either table is answered create, since nothing else in the flow says
 // what an account made this way is and is not given
-export const CREATED_ACCOUNT_TITLE = 'New Accounts'
-export const CREATED_ACCOUNT_EXPLANATION = 'Accounts imported as new accounts (by selecting "Create New Account" in the "Existing Account" column) won\'t create starting balance nor credit limits automatically:'
+export const CREATED_ACCOUNT_TITLE = 'New accounts'
+export const CREATED_ACCOUNT_EXPLANATION = 'These will be created as new accounts, each starting with no opening balance and no credit limit:'
 // A balance adjustment rather than a field, because an account that already exists has no starting
 // balance to set. Left to the user to want one rather than told to enter one, since a Firefly
 // export carries its own opening balances and the import writes those as balance adjustments
 // already
-export const CREATED_ACCOUNT_BALANCE_NOTE = 'If you\'d like to enter a starting balance of an imported account, please create a balance adjustment transaction in that account'
+export const CREATED_ACCOUNT_BALANCE_NOTE = 'To give one an opening balance, add a balance adjustment transaction in that account'
 // The edit button this describes is the pencil on the account's own card, which is the only place a
 // credit limit can be set once the account exists
-export const CREATED_ACCOUNT_CREDIT_LIMIT_NOTE = 'If you\'d like to set a credit limit for that account, you can do so by opening it from Accounts and using the edit button on its card'
+export const CREATED_ACCOUNT_CREDIT_LIMIT_NOTE = 'To set a credit limit, open the account from Accounts and use the edit button on its card'
 
 // Shown in place of a mapping step whose list could not be fetched at all, since answering one
 // against nothing maps every value to a new record and duplicates what the user already has
@@ -424,7 +428,7 @@ export function getFixedAccountWarning(accountName: string) {
 
 // Shown over the accounts that appear only as a counterparty, which the import writes nothing to
 export const COUNTERPARTY_ONLY_TABLE_TITLE = 'Counterparty accounts'
-export const COUNTERPARTY_ONLY_EXPLANATION = 'These accounts only ever appeared as the counterparty of a transfer. Matching one to an account of your own records where the money came from or went to and writes no transaction into that account, which is why an account you have archived can be chosen here and stays archived. Leaving one unmatched records the transfer as going outside this app. To bring a name in as an account of your own instead, select Create New Account in its Existing Account column.'
+export const COUNTERPARTY_ONLY_EXPLANATION = 'These only ever appeared as the other side of a transfer. Matching one records where the money came from or went to without writing a transaction into that account, which is why an archived account can be chosen here and stays archived. Leave one unmatched and the transfer is recorded as going outside this app. To bring a name in as an account of your own, choose Create New Account in its Existing Account column.'
 
 // Each format is named by an example of its shape rather than by a standard, because the year-first
 // option deliberately takes a slash and an unpadded part, which ISO 8601 does not. Keyed by format

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -266,7 +266,7 @@ export const ROW_AMOUNT_BOTH_SIDES_REASON = 'This row states both a money out an
 export const ROW_AMOUNT_NO_SIDE_REASON = 'This row leaves every amount column mapped for this file blank. If the file holds the other direction in a column of its own, map that column too.'
 // Told apart from the reason above because the row is not empty and the table shows the user the
 // zero it holds, so being told it states nothing would contradict what is in front of them
-export const ROW_AMOUNT_SIDE_STATES_ZERO_REASON = 'The one amount column mapped states zero on this row, so its money went the other way. If the file holds that direction in a column of its own, map that column too.'
+export const ROW_AMOUNT_SIDE_STATES_ZERO_REASON = 'The one amount column mapped states zero on this row, so this row is the direction that column does not hold. If the file states that direction in a separate column, map that column too.'
 
 // The last two are a sign the column cannot mean. Both fixes are offered because either one can be
 // what happened: the sign was written where the column already states the direction, or the value
@@ -308,19 +308,30 @@ export const ROW_COUNTERPARTY_IS_OWN_ACCOUNT_REASON = 'This row states its own a
 export function getRowCurrencyMismatchReason(rowCurrency: string, accountCurrency: string) {
   return `This row is in ${rowCurrency} but the account it would be written to is kept in ${accountCurrency}. Amounts are stored in the account's currency and are not converted, so write these rows to a ${rowCurrency} account, or set the Currency column to Do not import to bring them in as ${accountCurrency}.`
 }
-// Said against a row whose amount moves the opposite way to the kind of the category it is filed
-// under. It states what was noticed, then the ordinary reason for it, then that the row is taken, in
-// that order, because a refund inside an expense category is exactly what this fires on and reading
-// it as a fault the user introduced would be wrong. That the row is taken is stated here rather than
-// in the heading above the table, which offers a look and cannot also carry it
-//
-// Worth saying at all because the app then counts the row two ways: cash flow reads the sign while
-// the category total reads the kind
-//
-// This is the one place the direction rule between an amount and a category kind is stated, since it
-// sits with the rows it is about. The note above the column mapping table covers the arrangements
-// and the sign rule and leaves this to it
-export const ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON = 'The amount moves the opposite way to the kind of category this row is filed under, which is what a refund or a loss looks like. It imports as it stands.'
+/**
+ * Says a row is money going the way its category does not usually record
+ *
+ * Written per kind rather than as one sentence, so it can state what the row is and what it is filed
+ * under. One sentence covering both had to describe the relation between them instead, and a
+ * category kind is a classification rather than a direction, so an amount cannot move against it
+ *
+ * It states what the row is, then the ordinary thing that looks like this, then that it is taken, in
+ * that order, because a refund inside an expense category is exactly what this fires on and reading
+ * it as a fault the user introduced would be wrong. That the row is taken is stated here rather than
+ * in the heading above the table, which offers a look and cannot also carry it
+ *
+ * Worth saying at all because the app then counts the row two ways: cash flow reads the sign while
+ * the category total reads the kind
+ *
+ * This is the one place the direction rule between an amount and a category kind is stated, since it
+ * sits with the rows it is about. The note above the column mapping table covers the arrangements
+ * and the sign rule and leaves this to it
+ */
+export function getRowSignDisagreesWithCategoryReason(kind: 'expense' | 'income') {
+  return kind === 'expense'
+    ? 'Money coming in, filed under an expense category. That is what a refund looks like, so the row imports as it stands.'
+    : 'Money going out, filed under an income category. That is what returning money you were paid looks like, so the row imports as it stands.'
+}
 
 // Shown once for the whole file where every amount reads as money coming in, which is either a file
 // of nothing but income or one being read backwards. It cannot tell those apart, so it says what the
@@ -336,8 +347,8 @@ export const NO_OUTFLOWS_WARNING = 'Every row in this file reads as money coming
  * choices rather than steps to work through
  *
  * It stops at what the columns have to hold. How a category's kind reads against an amount's
- * direction is said against the rows it is about, in ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON, since
- * a rule stated here would be read five steps before those rows appear
+ * direction is said against the rows it is about, in getRowSignDisagreesWithCategoryReason, since a
+ * rule stated here would be read five steps before those rows appear
  */
 export const AMOUNT_CONVENTION_NOTE = 'Every imported row carries a direction. Map whichever of these your file uses:'
 export const AMOUNT_ARRANGEMENT_OPTIONS = [

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -299,10 +299,19 @@ export const ROW_COUNTERPARTY_IS_OWN_ACCOUNT_REASON = 'A transfer cannot record 
 export function getRowCurrencyMismatchReason(rowCurrency: string, accountCurrency: string) {
   return `This row is in ${rowCurrency} but the account it would be written to is kept in ${accountCurrency}. Amounts are stored in the account's currency and are not converted, so write these rows to a ${rowCurrency} account, or set the Currency column to Do not import to bring them in as ${accountCurrency}.`
 }
-// Said against a row whose amount runs the opposite way to the kind of the category it is filed
-// under. It imports, because a refund inside an expense category is real, but the app counts such a
-// row two ways: cash flow reads the sign while the category total reads the kind
-export const ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON = 'The amount runs the opposite way to the kind of category this row is filed under.'
+// Said against a row whose amount moves the opposite way to the kind of the category it is filed
+// under. It states what was noticed, then the ordinary reason for it, then that the row is taken, in
+// that order, because a refund inside an expense category is exactly what this fires on and reading
+// it as a fault the user introduced would be wrong. That the row is taken is stated here rather than
+// in the heading above the table, which offers a look and cannot also carry it
+//
+// Worth saying at all because the app then counts the row two ways: cash flow reads the sign while
+// the category total reads the kind
+//
+// This is the one place the direction rule between an amount and a category kind is stated, since it
+// sits with the rows it is about. The note above the column mapping table covers the arrangements
+// and the sign rule and leaves this to it
+export const ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON = 'The amount moves the opposite way to the kind of category this row is filed under, which is what a refund or a loss looks like. It imports as it stands.'
 
 // Shown once for the whole file where every amount reads as money coming in, which is either a file
 // of nothing but income or one being read backwards. It cannot tell those apart, so it says what the

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -33,7 +33,7 @@ export const COLUMN_TARGETS: Array<{
   {
     id: 'counterparty_account_id',
     label: 'Counterparty account',
-    hint: 'Says which account a transfer\'s money went to, or came from, without writing a transaction into that account. Only transfer rows can use it, and a blank cell records the transfer as going outside this app.',
+    hint: 'Specifies which account a transfer\'s money went to, or came from, without writing a transaction into that account. Only transfer rows can use it, and a blank cell records the transfer as going outside this app.',
     group: 'optional',
   },
   { id: 'dt', label: 'Date', hint: 'Transaction date.', group: 'required' },
@@ -337,31 +337,6 @@ export function getRowSignDisagreesWithCategoryReason(kind: 'expense' | 'income'
 // of nothing but income or one being read backwards. It cannot tell those apart, so it says what the
 // rows come to and lists what to check, rather than asserting which of the two this is
 export const NO_OUTFLOWS_WARNING = 'Every row in this file reads as money coming in. If that is right, there is nothing to do. If it is not, check three things: that the money going out is mapped to the column actually holding it, that a file using one Amount column writes its money out with a minus sign, and that a file using a Direction column has its words set the way round the file means them.'
-
-/**
- * Shown above the column mapping table, saying how the importer reads an amount
- *
- * Three parts rather than one paragraph: the question, the arrangements that answer it, and the rule
- * holding across them. Every arrangement is offered because a file can be mapped any of these ways,
- * and each is answered by mapping columns rather than by a question of its own, so they are a list of
- * choices rather than steps to work through
- *
- * It stops at what the columns have to hold. How a category's kind reads against an amount's
- * direction is said against the rows it is about, in getRowSignDisagreesWithCategoryReason, since a
- * rule stated here would be read five steps before those rows appear
- */
-export const AMOUNT_CONVENTION_NOTE = 'Every imported row carries a direction. Map whichever of these your file uses:'
-export const AMOUNT_ARRANGEMENT_OPTIONS = [
-  'One Amount column, written negative for money out and positive for money in',
-  'A Money out and a Money in column, where the file keeps the two apart',
-  'Just one of those two, where the file holds money going only one way',
-  'An Amount column of unsigned amounts beside a Direction column of words, whose meanings you answer below the table',
-]
-
-// Closes the notice above, because it holds across every arrangement in it rather than belonging to
-// one of them. Stated after the choices rather than before, since it speaks of the columns by the
-// labels the list has just given them
-export const AMOUNT_SIGN_RULE_NOTE = 'Money out, Money in and Direction each specify the direction themselves, so an amount beside one may only carry a sign that agrees. A row breaking that is listed rather than read the other way.'
 
 // Shown where a source rows are written to matches an account the user has archived, which is the
 // one account that source is not offered. The matched account names follow it

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -240,14 +240,16 @@ export const CURRENCIES_FAILED_UPLOAD_BLOCK = 'Currencies could not be loaded, a
 // built on it: refused rows in both import flows, and the Firefly budgets it cannot bring in
 export const SKIPPED_TABLE_VISIBLE_LIMIT = 20
 
-// Why one row cannot be converted, listed against that row in the preview step. Each says what is
-// wrong with the row itself, since the entry carries the row number and the row's own cells. A
-// blank cell is told apart from an unreadable one, because filling it in and correcting the whole
-// column's format are different jobs
-export const ROW_ACCOUNT_BLANK_REASON = 'The account source is blank.'
-export const ROW_CATEGORY_BLANK_REASON = 'The category source is blank.'
+// Why one row cannot be converted, listed against that row in the preview step. They read as one
+// family: what is wrong with this row, then what to do about it where there is a choice about that.
+// Each speaks of the row itself, since the entry carries the row number and the row's own cells, and
+// each speaks of a cell rather than a source, which is the word the mapping step uses for the values
+// a column holds. A blank cell is told apart from an unreadable one, because filling it in and
+// correcting the whole column's format are different jobs
+export const ROW_ACCOUNT_BLANK_REASON = 'The account cell is blank.'
+export const ROW_CATEGORY_BLANK_REASON = 'The category cell is blank.'
 export const ROW_DATE_BLANK_REASON = 'The date cell is blank.'
-export const ROW_DATE_UNREADABLE_REASON = 'The date does not match the chosen format.'
+export const ROW_DATE_UNREADABLE_REASON = 'The date does not match the date format chosen above.'
 export const ROW_AMOUNT_BLANK_REASON = 'The amount cell is blank.'
 export const ROW_AMOUNT_UNREADABLE_REASON = 'The amount is not a number.'
 export const ROW_AMOUNT_TOO_LARGE_REASON = 'The amount is larger than this app can store.'
@@ -262,13 +264,13 @@ export const ROW_AMOUNT_NO_SIDE_REASON = 'This row leaves every amount column ma
 // zero it holds, so being told it states nothing would contradict what is in front of them
 export const ROW_AMOUNT_SIDE_STATES_ZERO_REASON = 'The one amount column mapped states zero on this row, so its money went the other way. If the file holds that direction in a column of its own, map that column too.'
 
-// The last two are a sign the column cannot mean. Each says which column it found the sign in and
-// which one that value belongs in, because the fix is moving the value rather than editing its sign:
-// the file has a column for the other direction and this row did not use it. They are separate
+// The last two are a sign the column cannot mean. Both fixes are offered because either one can be
+// what happened: the sign was written where the column already states the direction, or the value
+// belongs in the column for the other direction and this row did not use it. They are separate
 // constants rather than one, since the reason is looked up by problem alone and a single sentence
 // could not say which of the two columns it meant
-export const ROW_AMOUNT_OUT_SIDE_PLUS_REASON = 'The money out column carries a plus sign on this row. A value there is money leaving the account, so write it unsigned or with a minus sign. Money coming in belongs in the money in column.'
-export const ROW_AMOUNT_IN_SIDE_MINUS_REASON = 'The money in column carries a minus sign on this row. A value there is money coming into the account, so write it unsigned or with a plus sign. Money going out belongs in the money out column.'
+export const ROW_AMOUNT_OUT_SIDE_PLUS_REASON = 'The money out column carries a plus sign on this row. Write it unsigned or with a minus sign, or move it to the money in column where it is money arriving.'
+export const ROW_AMOUNT_IN_SIDE_MINUS_REASON = 'The money in column carries a minus sign on this row. Write it unsigned or with a plus sign, or move it to the money out column where it is money leaving.'
 
 // The two ways a row cannot be read from a file carrying its direction in a column of words. Neither
 // can be answered in the app, since one is a cell nobody filled in and the other is two cells of the
@@ -287,8 +289,11 @@ export const ROW_DIRECTION_SIGN_DISAGREES_REASON = 'The sign on this row\'s amou
 export function getRowAmountTooPreciseReason(currency: string) {
   return `The amount has more decimal places than ${currency} has. A period is read as a decimal point, never as a separator between thousands.`
 }
-export const ROW_COUNTERPARTY_NOT_A_TRANSFER_REASON = 'A non-transfer transaction should not have a counterparty account recorded.'
-export const ROW_COUNTERPARTY_IS_OWN_ACCOUNT_REASON = 'A transfer cannot record its own account as its counterparty.'
+// The two ways the counterparty column contradicts the rest of the row. Both open with what this row
+// states rather than with the rule it breaks, since a rule leaves the user working out which of
+// their cells it was about
+export const ROW_COUNTERPARTY_NOT_A_TRANSFER_REASON = 'This row states a counterparty account but is not filed under a transfer category. Only a transfer records where the money went, so clear that cell or change the category.'
+export const ROW_COUNTERPARTY_IS_OWN_ACCOUNT_REASON = 'This row states its own account as the counterparty, so the transfer would go nowhere. That cell holds the account on the other side of the transfer.'
 
 /**
  * Says a row states a currency its account is not kept in

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -256,7 +256,7 @@ export const ROW_AMOUNT_TOO_LARGE_REASON = 'The amount is larger than this app c
 // needs both mapped to happen at all, since one side alone leaves the other empty. The next two each
 // send the user to map the column holding the other direction, which is the fix whichever way the
 // file leaves the unstated side
-export const ROW_AMOUNT_BOTH_SIDES_REASON = 'This row states a money out and a money in amount, so which way it runs is not clear.'
+export const ROW_AMOUNT_BOTH_SIDES_REASON = 'This row states both a money out and a money in amount, so its direction is unclear.'
 export const ROW_AMOUNT_NO_SIDE_REASON = 'This row leaves every amount column mapped for this file blank. If the file holds the other direction in a column of its own, map that column too.'
 // Told apart from the reason above because the row is not empty and the table shows the user the
 // zero it holds, so being told it states nothing would contradict what is in front of them

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -323,8 +323,12 @@ export const NO_OUTFLOWS_WARNING = 'Every row in this file reads as money coming
  *
  * All three arrangements are stated because a file can be mapped any of the three ways, and each one
  * is answered by mapping columns rather than by a separate question
+ *
+ * It stops at what the columns have to hold. How a category's kind reads against an amount's
+ * direction is said against the rows it is about, in ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON, since
+ * a rule stated here would be read five steps before those rows appear
  */
-export const AMOUNT_CONVENTION_NOTE = 'Every imported row carries a direction. Map one Amount column, negative for money out and positive for money in, or map Money out and Money in where the file keeps the two apart, or just one of those two where the file holds money going only one way. Where the amounts are unsigned and a column of words specifies the direction, map that column as the Direction and specify below the table what its words mean. A Money out, Money in or Direction column states the direction on its own, so an amount may only carry a sign that agrees with it, and a row breaking that is listed rather than read the other way. An expense category normally holds money going out and an income category money coming in. The other way round is accepted for a refund or a loss, and those rows are listed for you to check before the import runs.'
+export const AMOUNT_CONVENTION_NOTE = 'Every imported row carries a direction. Map one Amount column, negative for money out and positive for money in, or a Money out and a Money in column where the file keeps them apart, or just one of those where the file only holds money going one way. Where the amounts are unsigned and a column of words specifies the direction, map that column as the Direction and answer below the table what its words mean. Money out, Money in and Direction each specify the direction themselves, so an amount beside one may only carry a sign that agrees, and a row breaking that is listed rather than read the other way.'
 
 // Shown where a source rows are written to matches an account the user has archived, which is the
 // one account that source is not offered. The matched account names follow it

--- a/frontend/src/pages/imports/firefly/sections/FireflyAccountMappingStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyAccountMappingStep.tsx
@@ -148,7 +148,7 @@ export function FireflyAccountMappingStep({
       description="Asset and liability accounts from the export must map to an existing account or a new one."
     >
       {!accountsFailed && (
-        <ImportNotice title="Currency Handling">
+        <ImportNotice title="How currencies are read">
           Amounts are written in each mapped account&apos;s currency. Rows without an amount in that currency are skipped and reported after the import.
         </ImportNotice>
       )}

--- a/frontend/src/pages/imports/firefly/sections/FireflyBudgetImportStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyBudgetImportStep.tsx
@@ -58,11 +58,11 @@ export function FireflyBudgetImportStep({
       title="Budget Import"
       description="Budgets derived from the budgets export and the staged transactions, imported together with them."
     >
-      <ImportInfoCard title="Periods As Exported">
+      <ImportInfoCard title="Periods as exported">
         Each budget keeps its limit periods exactly as exported, with their original dates and amounts, and continues on the cadence of its most recent period.
       </ImportInfoCard>
 
-      <ImportInfoCard title="Merged Categories">
+      <ImportInfoCard title="Merged categories">
         If you merged categories in the category matching step, a budget tracking them counts spending across the whole merged category, so its remaining amount will read differently than it does in Firefly III. This is expected behaviour.
       </ImportInfoCard>
 

--- a/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyFilesStep.tsx
@@ -80,7 +80,7 @@ export function FireflyFilesStep({
           onFileChange={handleFireflyFileChange}
           onRemove={removeFireflyFile}
           note={slot.kind === 'budgets' ? (
-            <ImportInfoCard title="No Budgets Export?">
+            <ImportInfoCard title="No budgets export?">
               Budgets can be backdated and their historical spending is rebuilt automatically from the imported transactions. If you skip this export, it is easy to create budgets by hand after the import with a past start date.
             </ImportInfoCard>
           ) : undefined}

--- a/frontend/src/pages/imports/firefly/utils/payload.ts
+++ b/frontend/src/pages/imports/firefly/utils/payload.ts
@@ -67,7 +67,7 @@ export function buildFireflyImportPayload({
       // Every Firefly source takes rows, and an archived account takes none, so an account archived
       // after it was chosen is refused here rather than by the server part way through the import
       if (accountById.get(choice)?.is_archived) {
-        addError(`Rows cannot be written to an archived account: ${name}`)
+        addError(`Map to an account that is not archived: ${name}`)
         continue
       }
 
@@ -81,7 +81,7 @@ export function buildFireflyImportPayload({
     if (!details?.accountType || !details.currency) continue
 
     if (!isImportAccountType(details.accountType)) {
-      addError(`Invalid account type: ${name}`)
+      addError(`Choose an account type this app supports: ${name}`)
       continue
     }
 
@@ -97,7 +97,7 @@ export function buildFireflyImportPayload({
   }
 
   if (trackedAccountNames.length === 0 && rows.length > 0) {
-    addError('No asset or liability accounts were found in the transactions file.')
+    addError('This export has no asset or liability accounts to import into.')
   }
 
   const categories: FireflyTransactionImportPayload['categories'] = []
@@ -130,7 +130,7 @@ export function buildFireflyImportPayload({
   }
 
   const payloadRows = buildFireflyImportRows(rows)
-  if (payloadRows.length === 0) addError('No transaction rows are available to import.')
+  if (payloadRows.length === 0) addError('This export has no transaction rows to import.')
 
   if (errors.length > 0) return { errors, payload: null }
   return { errors: [], payload: { accounts, categories, rows: payloadRows } }

--- a/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
+++ b/frontend/src/pages/imports/hooks/useTransactionImportWorkflow.ts
@@ -17,6 +17,7 @@ import {
   buildImportAccountMappingSources,
   buildImportAccountOptions,
   buildTransactionImportPayload,
+  answerImportDirectionValue,
   buildImportPreviewRows,
   countRowsWithNoPayee,
   formatImportSummary,
@@ -413,7 +414,12 @@ export function useTransactionImportWorkflow(fixedAccount: AccountsOverview | nu
   const setDirectionAnswer = (value: string, direction: ImportAmountDirection) => {
     setScopedDirectionAnswers((current) => writeScopedImportAnswers(
       current,
-      { ...readScopedImportAnswers(current, getDirectionValueScope), [value]: direction },
+      answerImportDirectionValue(
+        readScopedImportAnswers(current, getDirectionValueScope),
+        directionValues,
+        value,
+        direction,
+      ),
       getDirectionValueScope,
     ))
   }

--- a/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
@@ -197,7 +197,7 @@ export function ImportAccountMappingStep({
   return (
     <ImportStep index="03" title="Account Mapping">
       {!accountsFailed && (
-        <ImportNotice title="Currency Handling">
+        <ImportNotice title="How currencies are read">
           {fixedAccount
             ? getFixedAccountCurrencyNote(fixedAccount.name, fixedAccount.currency)
             : 'Imported amounts are treated as raw values. During import, each amount will be assigned the base currency of the mapped account, or the currency shown against a new account, which is taken from the file where it states one and can be changed on any row.'}
@@ -229,8 +229,8 @@ export function ImportAccountMappingStep({
         // asks it for a file a second time
         fixedAccount ? null : (
           <EmptyState
-            title="No account sources detected"
-            description="Upload a file or check the mapped account column."
+            title="No accounts yet"
+            description="Upload a file, or check which column is mapped as the account."
           />
         )
       ) : (
@@ -242,7 +242,7 @@ export function ImportAccountMappingStep({
           )}
           {archivedAccountMatches.length > 0 && (
             <ImportNotice
-              title="Archived Accounts"
+              title="Archived accounts"
               items={archivedAccountMatches.map((match) => (
                 // The visible text is the account name, so the label is what says where following
                 // it goes, which is all a screen reader's list of links would otherwise show

--- a/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportAccountMappingStep.tsx
@@ -18,7 +18,6 @@ import {
   FIXED_ACCOUNT_WARNING_LINK_LABEL,
   FIXED_ACCOUNT_WARNING_TITLE,
   UNSET_BATCH_INSTITUTION,
-  getFixedAccountCurrencyNote,
   getFixedAccountWarning,
 } from '@/pages/imports/constants'
 import type { ImportAccountSource } from '@/pages/imports/types'
@@ -196,13 +195,6 @@ export function ImportAccountMappingStep({
 
   return (
     <ImportStep index="03" title="Account Mapping">
-      {!accountsFailed && (
-        <ImportNotice title="How currencies are read">
-          {fixedAccount
-            ? getFixedAccountCurrencyNote(fixedAccount.name, fixedAccount.currency)
-            : 'Imported amounts are treated as raw values. During import, each amount will be assigned the base currency of the mapped account, or the currency shown against a new account, which is taken from the file where it states one and can be changed on any row.'}
-        </ImportNotice>
-      )}
       {/* Says what this page will do with a file whether or not one is staged, since a file covering
           more than one account has to be sent elsewhere before it is uploaded rather than after */}
       {fixedAccount && (

--- a/frontend/src/pages/imports/sections/ImportCategoryMatchingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportCategoryMatchingStep.tsx
@@ -49,7 +49,7 @@ export function ImportCategoryMatchingStep({
     <ImportStep
       index="04"
       title="Category Matching"
-      description="Manually match imported category values to existing categories, or queue new ones."
+      description="Match each category in the file to one of yours, or queue a new one."
     >
       {categoriesFailed ? (
         <ImportLoadFailure
@@ -59,8 +59,8 @@ export function ImportCategoryMatchingStep({
         />
       ) : importedCategories.length === 0 ? (
         <EmptyState
-          title="No imported categories detected"
-          description="Map a category column first."
+          title="No categories yet"
+          description="Map the column holding the category first."
         />
       ) : (
         <>

--- a/frontend/src/pages/imports/sections/ImportColumnMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportColumnMappingStep.tsx
@@ -1,8 +1,5 @@
 import { EmptyState, ImportDirectionValueTable, ImportHeaderMappingTable, ImportNotice, ImportStep } from '@/pages/imports/components'
 import {
-  AMOUNT_ARRANGEMENT_OPTIONS,
-  AMOUNT_CONVENTION_NOTE,
-  AMOUNT_SIGN_RULE_NOTE,
   CURRENCY_HANDLING_NOTE,
   CURRENCY_HANDLING_TITLE,
   DIRECTION_VALUES_EXPLANATION,
@@ -39,10 +36,12 @@ type ImportColumnMappingStepProps = Pick<
  * Column mapping step of the generic CSV import flow, matching each header found in the uploaded
  * file to an app field
  *
- * The amount convention is stated above the table rather than offered as a choice, because which
- * arrangement a file uses is answered by mapping its columns rather than by a question of its own.
- * The currency note sits under it, since what an amount is worth and what currency it lands in are
- * one question to a reader looking at a column of numbers, and the Currency column is mapped here
+ * How an amount is read is left to the mapping dropdown, whose every option carries a sentence
+ * saying what that field holds and what a sign in it means. Those sentences are read at the moment
+ * of choosing, so a notice above the table restating them was one level less specific and said
+ * nothing the dropdown did not
+ *
+ * The currency note stays, because nothing in the dropdown says which currency an amount lands in
  *
  * A file mapping a Direction column has one more question, which words in that column mean money
  * leaving the account. It is asked here rather than in a separate step, so the column and what its
@@ -81,13 +80,6 @@ export function ImportColumnMappingStep({
       title="Column Mapping"
       description="Specify what each column in your file holds."
     >
-      <ImportNotice
-        title="How amounts are read"
-        items={AMOUNT_ARRANGEMENT_OPTIONS}
-        footer={AMOUNT_SIGN_RULE_NOTE}
-      >
-        {AMOUNT_CONVENTION_NOTE}
-      </ImportNotice>
       {!accountsFailed && (
         <ImportNotice title={CURRENCY_HANDLING_TITLE}>
           {fixedAccount

--- a/frontend/src/pages/imports/sections/ImportColumnMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportColumnMappingStep.tsx
@@ -70,15 +70,15 @@ export function ImportColumnMappingStep({
     <ImportStep
       index="02"
       title="Column Mapping"
-      description="Map each file column to an app field."
+      description="Specify what each column in your file holds."
     >
-      <ImportNotice title="Amount Handling">
+      <ImportNotice title="How amounts are read">
         {AMOUNT_CONVENTION_NOTE}
       </ImportNotice>
       {headers.length === 0 ? (
         <EmptyState
-          title="No columns available"
-          description="Upload a CSV file to map columns."
+          title="No columns yet"
+          description="Upload a CSV file and its columns appear here."
         />
       ) : (
         <ImportHeaderMappingTable

--- a/frontend/src/pages/imports/sections/ImportColumnMappingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportColumnMappingStep.tsx
@@ -1,8 +1,13 @@
 import { EmptyState, ImportDirectionValueTable, ImportHeaderMappingTable, ImportNotice, ImportStep } from '@/pages/imports/components'
 import {
+  AMOUNT_ARRANGEMENT_OPTIONS,
   AMOUNT_CONVENTION_NOTE,
+  AMOUNT_SIGN_RULE_NOTE,
+  CURRENCY_HANDLING_NOTE,
+  CURRENCY_HANDLING_TITLE,
   DIRECTION_VALUES_EXPLANATION,
   DIRECTION_VALUES_TITLE,
+  getFixedAccountCurrencyNote,
   getRowsWithNoPayeeExplanation,
   ROWS_WITH_NO_PAYEE_TITLE,
 } from '@/pages/imports/constants'
@@ -23,6 +28,8 @@ type ImportColumnMappingStepProps = Pick<
   | 'directionAnswers'
   | 'autoFilledDirectionValues'
   | 'rowsWithNoPayeeCount'
+  | 'fixedAccount'
+  | 'accountsFailed'
   | 'setDateFormat'
   | 'setDirectionAnswer'
   | 'updateColumnTarget'
@@ -34,8 +41,8 @@ type ImportColumnMappingStepProps = Pick<
  *
  * The amount convention is stated above the table rather than offered as a choice, because which
  * arrangement a file uses is answered by mapping its columns rather than by a question of its own.
- * It sits where the account step states its own currency handling, since both say what the import
- * will do with a number rather than asking anything
+ * The currency note sits under it, since what an amount is worth and what currency it lands in are
+ * one question to a reader looking at a column of numbers, and the Currency column is mapped here
  *
  * A file mapping a Direction column has one more question, which words in that column mean money
  * leaving the account. It is asked here rather than in a separate step, so the column and what its
@@ -54,6 +61,8 @@ export function ImportColumnMappingStep({
   directionAnswers,
   autoFilledDirectionValues,
   rowsWithNoPayeeCount,
+  fixedAccount,
+  accountsFailed,
   setDateFormat,
   setDirectionAnswer,
   updateColumnTarget,
@@ -72,9 +81,20 @@ export function ImportColumnMappingStep({
       title="Column Mapping"
       description="Specify what each column in your file holds."
     >
-      <ImportNotice title="How amounts are read">
+      <ImportNotice
+        title="How amounts are read"
+        items={AMOUNT_ARRANGEMENT_OPTIONS}
+        footer={AMOUNT_SIGN_RULE_NOTE}
+      >
         {AMOUNT_CONVENTION_NOTE}
       </ImportNotice>
+      {!accountsFailed && (
+        <ImportNotice title={CURRENCY_HANDLING_TITLE}>
+          {fixedAccount
+            ? getFixedAccountCurrencyNote(fixedAccount.name, fixedAccount.currency)
+            : CURRENCY_HANDLING_NOTE}
+        </ImportNotice>
+      )}
       {headers.length === 0 ? (
         <EmptyState
           title="No columns yet"
@@ -96,7 +116,7 @@ export function ImportColumnMappingStep({
       )}
       {showsDirectionValues && (
         <div className="mt-4 space-y-3">
-          <ImportNotice title={DIRECTION_VALUES_TITLE}>
+          <ImportNotice title={DIRECTION_VALUES_TITLE} tone="question">
             {DIRECTION_VALUES_EXPLANATION}
           </ImportNotice>
           <ImportDirectionValueTable

--- a/frontend/src/pages/imports/sections/ImportCommitPanel.tsx
+++ b/frontend/src/pages/imports/sections/ImportCommitPanel.tsx
@@ -2,62 +2,24 @@ import type { TransactionImportWorkflow } from '@/pages/imports/hooks'
 
 type ImportCommitPanelProps = Pick<
   TransactionImportWorkflow,
-  'importBuild' | 'importError' | 'handleCommitImport' | 'canCommitImport' | 'importResult'
+  'importError' | 'handleCommitImport' | 'canCommitImport' | 'importResult'
 >
 
-// Named rather than counted, because a row problem is listed in the preview step with the row it
-// belongs to and this panel would otherwise repeat all of it
-const ROWS_TO_FIX_MESSAGE = 'Some rows cannot be imported. The preview step lists them with the reason for each.'
-const ROWS_TO_CHECK_MESSAGE = 'Some rows will import but may not be what you meant. The preview step lists them.'
-
-// How many problems the panel spells out before counting the rest. A file of unmatched categories
-// produces one per category, each of them a blank dropdown already visible in the step it belongs
-// to, so a full list would push the button off the page to repeat what those steps show. The build
-// puts column problems first, which is what the cap keeps
-const VISIBLE_ERROR_LIMIT = 5
-
 /**
- * Commit panel for the generic CSV import flow, listing what still stands between the mappings and
- * a commit, above the button that starts one
+ * Commit panel for the generic CSV import flow, holding the button and the reason a commit that was
+ * actually attempted came back refused
+ *
+ * Everything the import knows before the button is pressed is shown in the preview step above,
+ * against the rows and columns it is about, so nothing here repeats it
  */
 export function ImportCommitPanel({
-  importBuild,
   importError,
   handleCommitImport,
   canCommitImport,
   importResult,
 }: ImportCommitPanelProps) {
-  const visibleErrors = importBuild.errors.slice(0, VISIBLE_ERROR_LIMIT)
-  const hiddenErrorCount = importBuild.errors.length - visibleErrors.length
-
   return (
     <div className="flex flex-col items-end gap-3 pb-1">
-      {visibleErrors.map((error) => (
-        <p key={error} className="max-w-xl text-right text-sm font-medium" style={{ color: 'var(--app-negative)' }}>
-          {error}
-        </p>
-      ))}
-      {hiddenErrorCount > 0 && (
-        <p className="max-w-xl text-right text-sm font-medium" style={{ color: 'var(--app-negative)' }}>
-          {`and ${hiddenErrorCount} more`}
-        </p>
-      )}
-      {importBuild.rowProblems.length > 0 && (
-        <p className="max-w-xl text-right text-sm font-medium" style={{ color: 'var(--app-negative)' }}>
-          {ROWS_TO_FIX_MESSAGE}
-        </p>
-      )}
-      {/* Amber rather than red, and below the errors, because none of these stops the commit */}
-      {importBuild.rowWarnings.length > 0 && (
-        <p className="max-w-xl text-right text-sm font-medium" style={{ color: 'var(--app-warning-text)' }}>
-          {ROWS_TO_CHECK_MESSAGE}
-        </p>
-      )}
-      {importBuild.warnings.map((warning) => (
-        <p key={warning} className="max-w-xl text-right text-sm font-medium" style={{ color: 'var(--app-warning-text)' }}>
-          {warning}
-        </p>
-      ))}
       {importError && (
         <p role="alert" className="max-w-xl text-right text-sm font-medium" style={{ color: 'var(--app-negative)' }}>
           {importError}

--- a/frontend/src/pages/imports/sections/ImportFilesStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportFilesStep.tsx
@@ -68,7 +68,7 @@ export function ImportFilesStep({
               replacement share, and the file refused above it or on any null character. It says the
               other encodings are unsupported rather than unreadable, since supporting them is open
               rather than ruled out */}
-          <ImportInfoCard title="Files Are Read As UTF-8">
+          <ImportInfoCard title="Files are read as UTF-8">
             Other encodings are not supported yet, so a file saved as ISO-8859-1 or UTF-16 may not import correctly. Look for a UTF-8 option when saving your file as CSV.
           </ImportInfoCard>
 

--- a/frontend/src/pages/imports/sections/ImportFilesStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportFilesStep.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef } from 'react'
 import { EmptyState, ImportInfoCard, ImportStagedFileList, ImportStat, ImportStep, ImportUploadCard } from '@/pages/imports/components'
 import type { TransactionImportWorkflow } from '@/pages/imports/hooks'
+import { hasAcceptedFile } from '@/pages/imports/utils'
 
 type ImportFilesStepProps = Pick<
   TransactionImportWorkflow,
@@ -16,6 +18,10 @@ type ImportFilesStepProps = Pick<
 /**
  * Files step of the generic CSV import flow, taking a single upload and showing the staged file's
  * row and mapped-field counts
+ *
+ * The upload control and the guidance above it are taken away once a usable file is staged, since
+ * this flow carries one file and uploading another would only replace it. A file the reader refused
+ * keeps them, because that is the file the user has to replace
  */
 export function ImportFilesStep({
   inputRef,
@@ -30,6 +36,21 @@ export function ImportFilesStep({
   // A file is read against the currency list, so uploading one before it is in hand would read the
   // file wrongly rather than merely leave a later step waiting
   const isUploadBlocked = isProcessingFiles || uploadBlockReason !== null
+  const isFileAccepted = hasAcceptedFile(files)
+  const stagedListRef = useRef<HTMLDivElement>(null)
+  const wasFileAcceptedRef = useRef(isFileAccepted)
+
+  // The upload card is what the keyboard user pressed to get here, so taking it away leaves them on
+  // the page body with the next tab starting from the top. The staged row's Remove button is the
+  // control that replaced it, and it is the only button the list holds. Focus is only taken back
+  // where the browser dropped it, so a user who moved on while the file was being read keeps where
+  // they are
+  useEffect(() => {
+    const hasJustBeenAccepted = isFileAccepted && !wasFileAcceptedRef.current
+    wasFileAcceptedRef.current = isFileAccepted
+    if (!hasJustBeenAccepted || document.activeElement !== document.body) return
+    stagedListRef.current?.querySelector('button')?.focus()
+  }, [isFileAccepted])
 
   return (
     <ImportStep
@@ -39,31 +60,36 @@ export function ImportFilesStep({
       className="xl:h-full"
       contentClassName="flex min-h-0 flex-col gap-3"
     >
-      {/* Stated before a file is chosen, since re-exporting is the only thing that answers it. The
-          wording stays loose about what goes wrong on purpose, because readCsvFile has two outcomes
-          for a file it cannot read as UTF-8: accented characters lost below the replacement share,
-          and the file refused above it or on any null character. It says the other encodings are
-          unsupported rather than unreadable, since supporting them is open rather than ruled out */}
-      <ImportInfoCard title="Files Are Read As UTF-8">
-        Other encodings are not supported yet, so a file saved as ISO-8859-1 or UTF-16 may not import correctly. Look for a UTF-8 option when saving your file as CSV.
-      </ImportInfoCard>
+      {!isFileAccepted && (
+        <>
+          {/* Stated before a file is chosen, since re-exporting is the only thing that answers it.
+              The wording stays loose about what goes wrong on purpose, because readCsvFile has two
+              outcomes for a file it cannot read as UTF-8: accented characters lost below the
+              replacement share, and the file refused above it or on any null character. It says the
+              other encodings are unsupported rather than unreadable, since supporting them is open
+              rather than ruled out */}
+          <ImportInfoCard title="Files Are Read As UTF-8">
+            Other encodings are not supported yet, so a file saved as ISO-8859-1 or UTF-16 may not import correctly. Look for a UTF-8 option when saving your file as CSV.
+          </ImportInfoCard>
 
-      <input
-        ref={inputRef}
-        type="file"
-        className="hidden"
-        accept=".csv,text/csv"
-        onChange={handleFileChange}
-        disabled={isUploadBlocked}
-      />
-      <ImportUploadCard
-        title="Upload CSV file"
-        hint="One file accepted."
-        processing={isProcessingFiles}
-        disabled={isUploadBlocked}
-        blockReason={uploadBlockReason}
-        onClick={() => inputRef.current?.click()}
-      />
+          <input
+            ref={inputRef}
+            type="file"
+            className="hidden"
+            accept=".csv,text/csv"
+            onChange={handleFileChange}
+            disabled={isUploadBlocked}
+          />
+          <ImportUploadCard
+            title="Upload CSV file"
+            hint="One file accepted."
+            processing={isProcessingFiles}
+            disabled={isUploadBlocked}
+            blockReason={uploadBlockReason}
+            onClick={() => inputRef.current?.click()}
+          />
+        </>
+      )}
 
       {files.length === 0 ? (
         <EmptyState
@@ -71,7 +97,9 @@ export function ImportFilesStep({
           description="The uploaded file will appear here."
         />
       ) : (
-        <ImportStagedFileList files={files} onRemove={(file) => removeFile(file.id)} />
+        <div ref={stagedListRef}>
+          <ImportStagedFileList files={files} onRemove={(file) => removeFile(file.id)} />
+        </div>
       )}
 
       <div className="mt-auto grid grid-cols-3 gap-3 pt-3">

--- a/frontend/src/pages/imports/sections/ImportMerchantMatchingStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportMerchantMatchingStep.tsx
@@ -56,7 +56,7 @@ export function ImportMerchantMatchingStep({
     <ImportStep
       index="05"
       title="Merchant Matching"
-      description="Every payee value in the file, against the merchant its rows will be filed under."
+      description="Match each payee in the file to the merchant its rows will be filed under."
     >
       {matchesFailed ? (
         <ImportLoadFailure
@@ -66,8 +66,8 @@ export function ImportMerchantMatchingStep({
         />
       ) : importedMerchants.length === 0 ? (
         <EmptyState
-          title="No imported merchants detected"
-          description="Map a merchant column first."
+          title="No payees yet"
+          description="Map the column holding the payee first."
         />
       ) : (
         <ImportValueMatchTable

--- a/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
@@ -21,7 +21,7 @@ type ImportPreviewStepProps = Pick<
 // produces one per category, each of them a blank dropdown already visible in the step it belongs
 // to, so a full list would bury the preview to repeat what those steps show. The build puts column
 // problems first, which is what the cap keeps
-const VISIBLE_ERROR_LIMIT = 5
+const VISIBLE_ERROR_LIMIT = 10
 
 /**
  * Builds the heading over the rows that cannot be converted, which says what has to happen rather

--- a/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
@@ -93,7 +93,9 @@ export function ImportPreviewStep({
           />
         </div>
       )}
-      {/* Amber, and above the block below, because none of these stops the commit */}
+      {/* Last of the three notices about the data, which run refusals first and then the things that
+          hold nothing up. What follows is the preview itself rather than a fourth notice, so a red
+          error list below this amber one is the body starting rather than the order breaking */}
       {importBuild.warnings.map((warning) => (
         <p key={warning} className="mb-4 text-sm font-medium" style={{ color: 'var(--app-warning-text)' }}>
           {warning}

--- a/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
@@ -1,12 +1,19 @@
-import { TriangleAlert } from 'lucide-react'
-import { EmptyState, ImportPreviewList, ImportRowProblemsTable, ImportStep } from '@/pages/imports/components'
-import { IMPORT_INSET_STYLE, IMPORT_SAMPLE_PREVIEW_LIMIT } from '@/pages/imports/constants'
+import { EmptyState, ImportNotice, ImportPreviewList, ImportRowProblemsTable, ImportStep } from '@/pages/imports/components'
+import { IMPORT_SAMPLE_PREVIEW_LIMIT } from '@/pages/imports/constants'
 import type { TransactionImportWorkflow } from '@/pages/imports/hooks'
 
-// Heads the reasons the import cannot go ahead, so a list of red lines reads as one panel about the
-// import rather than as loose text under the preview. Worded as the step before importing rather
-// than as a count, since the list is capped and its own last line carries what was left off
-const BLOCKING_ERRORS_TITLE = 'Answer these before importing'
+// Said under the count, because the count alone leaves what happens next unstated
+const BLOCKING_ERRORS_EXPLANATION = 'The import cannot go ahead until each one is answered.'
+
+/**
+ * Heads the reasons the import cannot go ahead
+ *
+ * Counted off the whole list rather than the part shown, since the list is capped and its last line
+ * carries the remainder
+ */
+function getBlockingErrorsTitle(count: number) {
+  return `We found ${count} error${count === 1 ? '' : 's'}`
+}
 
 type ImportPreviewStepProps = Pick<
   TransactionImportWorkflow,
@@ -108,24 +115,13 @@ export function ImportPreviewStep({
         </p>
       ))}
       {hasBlockingErrors ? (
-        <div className="rounded-lg px-4 py-3" style={IMPORT_INSET_STYLE}>
-          <span className="flex items-center gap-2">
-            <TriangleAlert
-              size={16}
-              strokeWidth={2.25}
-              className="shrink-0"
-              style={{ color: 'var(--app-negative)' }}
-              aria-hidden
-            />
-            <p className="text-sm font-semibold">{BLOCKING_ERRORS_TITLE}</p>
-          </span>
-          <ul className="mt-2 list-disc space-y-1 pl-4 text-sm leading-5" style={{ color: 'var(--app-text-muted)' }}>
-            {visibleErrors.map((error) => (
-              <li key={error}>{error}</li>
-            ))}
-            {hiddenErrorCount > 0 && <li>{getHiddenErrorSummary(hiddenErrorCount)}</li>}
-          </ul>
-        </div>
+        <ImportNotice
+          tone="danger"
+          title={getBlockingErrorsTitle(importBuild.errors.length)}
+          items={hiddenErrorCount > 0 ? [...visibleErrors, getHiddenErrorSummary(hiddenErrorCount)] : visibleErrors}
+        >
+          {BLOCKING_ERRORS_EXPLANATION}
+        </ImportNotice>
       ) : previewRows.length === 0 ? (
         <EmptyState
           title="No preview rows"

--- a/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
@@ -21,11 +21,14 @@ function getRowProblemsTitle(count: number) {
 }
 
 /**
- * Builds the heading over the rows that will import but are worth a look, which says they are not
- * blocking so the two tables are not read as the same thing
+ * Builds the heading over the rows that import as they are but are worth a second look
+ *
+ * It offers a look rather than stating a fault, since nothing is wrong with these rows. That they
+ * are taken is left to the note against each one, which the heading cannot also carry without
+ * reading like the refusal heading above it
  */
 function getRowWarningsTitle(count: number) {
-  return `${count} row${count === 1 ? '' : 's'} will import but may not be what you meant`
+  return `${count} row${count === 1 ? '' : 's'} worth a look`
 }
 
 /**
@@ -83,7 +86,9 @@ export function ImportPreviewStep({
             title={getRowWarningsTitle(importBuild.rowWarnings.length)}
             rowProblems={importBuild.rowWarnings}
             headers={headers}
-            toggleLabel="rows to check"
+            toggleLabel="rows worth a look"
+            tone="warning"
+            reasonHeader="Note"
           />
         </div>
       )}

--- a/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
@@ -3,8 +3,14 @@ import type { TransactionImportWorkflow } from '@/pages/imports/hooks'
 
 type ImportPreviewStepProps = Pick<
   TransactionImportWorkflow,
-  'missingRequiredColumnLabels' | 'previewRows' | 'previewGroups' | 'importBuild' | 'headers'
+  'files' | 'previewRows' | 'previewGroups' | 'importBuild' | 'headers'
 >
+
+// How many reasons the step spells out before counting the rest. A file of unmatched categories
+// produces one per category, each of them a blank dropdown already visible in the step it belongs
+// to, so a full list would bury the preview to repeat what those steps show. The build puts column
+// problems first, which is what the cap keeps
+const VISIBLE_ERROR_LIMIT = 5
 
 /**
  * Builds the heading over the rows that cannot be converted, which says what has to happen rather
@@ -23,20 +29,39 @@ function getRowWarningsTitle(count: number) {
 }
 
 /**
+ * Says how many reasons were left off the list
+ *
+ * Worded against the reasons rather than as a bare count, because the refused rows table in this
+ * same step ends with its own overflow line counting rows, and two lines reading alike would leave
+ * the numbers meaning whichever one the reader took first
+ */
+function getHiddenErrorSummary(count: number) {
+  return `and ${count} more to answer`
+}
+
+/**
  * Preview step of the generic CSV import flow, showing a sample of the compiled transactions or,
- * when required columns are still unmapped, which ones are missing instead
+ * while anything still stands between the mappings and a commit, the reasons instead
  *
  * Rows that cannot be converted are listed above the sample with the reason each was refused, and
  * the import stays refused until every one of them is gone. Rows that will import but are probably
  * not what the user meant are listed under them, and hold nothing up
+ *
+ * The reasons take the place of the sample rather than sitting over it, since a half-built preview
+ * shown beside a list of reasons it is wrong invites reading it as the real result. They wait for a
+ * file, so the step does not open by listing what the user has not done yet
  */
 export function ImportPreviewStep({
-  missingRequiredColumnLabels,
+  files,
   previewRows,
   previewGroups,
   importBuild,
   headers,
 }: ImportPreviewStepProps) {
+  const visibleErrors = importBuild.errors.slice(0, VISIBLE_ERROR_LIMIT)
+  const hiddenErrorCount = importBuild.errors.length - visibleErrors.length
+  const hasBlockingErrors = files.length > 0 && importBuild.errors.length > 0
+
   return (
     <ImportStep
       index="07"
@@ -62,11 +87,25 @@ export function ImportPreviewStep({
           />
         </div>
       )}
-      {missingRequiredColumnLabels.length > 0 ? (
-        <EmptyState
-          title="Missing required columns"
-          description={missingRequiredColumnLabels.join(', ')}
-        />
+      {/* Amber, and above the block below, because none of these stops the commit */}
+      {importBuild.warnings.map((warning) => (
+        <p key={warning} className="mb-4 text-sm font-medium" style={{ color: 'var(--app-warning-text)' }}>
+          {warning}
+        </p>
+      ))}
+      {hasBlockingErrors ? (
+        <div className="flex flex-col gap-2">
+          {visibleErrors.map((error) => (
+            <p key={error} className="text-sm font-medium" style={{ color: 'var(--app-negative)' }}>
+              {error}
+            </p>
+          ))}
+          {hiddenErrorCount > 0 && (
+            <p className="text-sm font-medium" style={{ color: 'var(--app-negative)' }}>
+              {getHiddenErrorSummary(hiddenErrorCount)}
+            </p>
+          )}
+        </div>
       ) : previewRows.length === 0 ? (
         <EmptyState
           title="No preview rows"

--- a/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
@@ -1,4 +1,5 @@
 import { EmptyState, ImportPreviewList, ImportRowProblemsTable, ImportStep } from '@/pages/imports/components'
+import { IMPORT_SAMPLE_PREVIEW_LIMIT } from '@/pages/imports/constants'
 import type { TransactionImportWorkflow } from '@/pages/imports/hooks'
 
 type ImportPreviewStepProps = Pick<
@@ -69,7 +70,7 @@ export function ImportPreviewStep({
     <ImportStep
       index="07"
       title="Imported Data Preview"
-      description="Showing the first 5 compiled transactions."
+      description={`The first ${IMPORT_SAMPLE_PREVIEW_LIMIT} transactions as they will appear in your ledger.`}
     >
       {importBuild.rowProblems.length > 0 && (
         <div className="mb-4">

--- a/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
@@ -1,6 +1,12 @@
+import { TriangleAlert } from 'lucide-react'
 import { EmptyState, ImportPreviewList, ImportRowProblemsTable, ImportStep } from '@/pages/imports/components'
-import { IMPORT_SAMPLE_PREVIEW_LIMIT } from '@/pages/imports/constants'
+import { IMPORT_INSET_STYLE, IMPORT_SAMPLE_PREVIEW_LIMIT } from '@/pages/imports/constants'
 import type { TransactionImportWorkflow } from '@/pages/imports/hooks'
+
+// Heads the reasons the import cannot go ahead, so a list of red lines reads as one panel about the
+// import rather than as loose text under the preview. Worded as the step before importing rather
+// than as a count, since the list is capped and its own last line carries what was left off
+const BLOCKING_ERRORS_TITLE = 'Answer these before importing'
 
 type ImportPreviewStepProps = Pick<
   TransactionImportWorkflow,
@@ -102,17 +108,23 @@ export function ImportPreviewStep({
         </p>
       ))}
       {hasBlockingErrors ? (
-        <div className="flex flex-col gap-2">
-          {visibleErrors.map((error) => (
-            <p key={error} className="text-sm font-medium" style={{ color: 'var(--app-negative)' }}>
-              {error}
-            </p>
-          ))}
-          {hiddenErrorCount > 0 && (
-            <p className="text-sm font-medium" style={{ color: 'var(--app-negative)' }}>
-              {getHiddenErrorSummary(hiddenErrorCount)}
-            </p>
-          )}
+        <div className="rounded-lg px-4 py-3" style={IMPORT_INSET_STYLE}>
+          <span className="flex items-center gap-2">
+            <TriangleAlert
+              size={16}
+              strokeWidth={2.25}
+              className="shrink-0"
+              style={{ color: 'var(--app-negative)' }}
+              aria-hidden
+            />
+            <p className="text-sm font-semibold">{BLOCKING_ERRORS_TITLE}</p>
+          </span>
+          <ul className="mt-2 list-disc space-y-1 pl-4 text-sm leading-5" style={{ color: 'var(--app-text-muted)' }}>
+            {visibleErrors.map((error) => (
+              <li key={error}>{error}</li>
+            ))}
+            {hiddenErrorCount > 0 && <li>{getHiddenErrorSummary(hiddenErrorCount)}</li>}
+          </ul>
         </div>
       ) : previewRows.length === 0 ? (
         <EmptyState

--- a/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
+++ b/frontend/src/pages/imports/sections/ImportPreviewStep.tsx
@@ -2,9 +2,6 @@ import { EmptyState, ImportNotice, ImportPreviewList, ImportRowProblemsTable, Im
 import { IMPORT_SAMPLE_PREVIEW_LIMIT } from '@/pages/imports/constants'
 import type { TransactionImportWorkflow } from '@/pages/imports/hooks'
 
-// Said under the count, because the count alone leaves what happens next unstated
-const BLOCKING_ERRORS_EXPLANATION = 'The import cannot go ahead until each one is answered.'
-
 /**
  * Heads the reasons the import cannot go ahead
  *
@@ -119,9 +116,7 @@ export function ImportPreviewStep({
           tone="danger"
           title={getBlockingErrorsTitle(importBuild.errors.length)}
           items={hiddenErrorCount > 0 ? [...visibleErrors, getHiddenErrorSummary(hiddenErrorCount)] : visibleErrors}
-        >
-          {BLOCKING_ERRORS_EXPLANATION}
-        </ImportNotice>
+        />
       ) : previewRows.length === 0 ? (
         <EmptyState
           title="No preview rows"

--- a/frontend/src/pages/imports/utils/columnMapping.ts
+++ b/frontend/src/pages/imports/utils/columnMapping.ts
@@ -421,6 +421,41 @@ export function getImportDirectionValues(files: ImportFileDraft[], header: strin
 }
 
 /**
+ * Answers one word in the Direction column, and the other word with the other direction
+ *
+ * A column separating money in from money out holds two words that cannot mean the same thing, so
+ * answering one settles both. That makes the second click the user used to make either redundant or
+ * wrong, and it repairs a stored pair that already agreed rather than leaving it to be corrected
+ * word by word
+ *
+ * Only a column of exactly two words is paired. One word is a file holding money going one way, and
+ * it has nothing to be the opposite of
+ *
+ * @param answers - The answers as they stand, which the result replaces rather than edits
+ * @param values - Every distinct word in the column, which is what settles whether there is a pair
+ * @param key - The folded word being answered
+ * @param direction - What the user chose it means
+ */
+export function answerImportDirectionValue(
+  answers: Record<string, ImportAmountDirection>,
+  values: Array<{ key: string }>,
+  key: string,
+  direction: ImportAmountDirection,
+): Record<string, ImportAmountDirection> {
+  const next = { ...answers, [key]: direction }
+  if (values.length !== MAX_DIRECTION_COLUMN_VALUES) return next
+
+  // The answered word has to be one of the pair, or the other one is whichever came first and
+  // answering a word the column no longer holds would rewrite a word it does
+  if (!values.some((value) => value.key === key)) return next
+
+  const other = values.find((value) => value.key !== key)
+  if (other) next[other.key] = direction === 'out' ? 'in' : 'out'
+
+  return next
+}
+
+/**
  * Finds which transaction field a column has been mapped to, returning an empty string when the
  * column is not mapped to anything
  */

--- a/frontend/src/pages/imports/utils/common.ts
+++ b/frontend/src/pages/imports/utils/common.ts
@@ -1,3 +1,5 @@
+import type { ImportFileDraft } from '@/pages/imports/types'
+
 /**
  * Returns a copy of a record without the given key, or the original record when the key was never
  * present, so state that did not actually change keeps the same identity and skips a re-render
@@ -36,6 +38,17 @@ export function unique(values: string[]) {
  */
 export function getImportRowId(fileId: string, rowIndex: number) {
   return `${fileId}-${rowIndex}`
+}
+
+/**
+ * Reports whether a file the import can go ahead with is staged
+ *
+ * A file the reader refused is still staged, carrying its reason and no rows, because that is what
+ * puts the reason in front of the user. Only a draft with no error counts, so the upload control
+ * stays on offer for exactly the file that has to be replaced
+ */
+export function hasAcceptedFile(files: ImportFileDraft[]) {
+  return files.some((file) => !file.error)
 }
 
 /**

--- a/frontend/src/pages/imports/utils/merchantMatching.ts
+++ b/frontend/src/pages/imports/utils/merchantMatching.ts
@@ -96,7 +96,7 @@ export function buildImportMerchantMappings({
     if (answer === CREATE_MERCHANT_VALUE) {
       const name = (merchantCreateNames[value] ?? value).trim()
       if (!name) {
-        errors.push(`Name the merchant being created for: ${value}`)
+        errors.push(`Choose a name for the new merchant: ${value}`)
         continue
       }
 

--- a/frontend/src/pages/imports/utils/payload.ts
+++ b/frontend/src/pages/imports/utils/payload.ts
@@ -9,10 +9,10 @@ import {
   getCategoryDirectionClashError,
   getDirectionValuesAgreeError,
   getTooManyMappingsError,
+  getRowSignDisagreesWithCategoryReason,
   getUnansweredDirectionValuesError,
   MAX_IMPORT_MAPPINGS,
   NO_OUTFLOWS_WARNING,
-  ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON,
 } from '@/pages/imports/constants'
 import { BALANCE_ADJUSTMENT_CATEGORY_NAME, doesTransferRecordCounterpartyAccount, OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
 import type {
@@ -287,12 +287,15 @@ export function buildTransactionImportPayload({
 
       // A row can be worth a second look for more than one reason, and each is listed on its own so
       // the table says every thing that is odd about it rather than only the first
-      if (doesSignDisagreeWithCategoryKind(resolved.amount, kindByCategorySource[resolved.categorySource])) {
+      const categoryKind = kindByCategorySource[resolved.categorySource]
+      if (doesSignDisagreeWithCategoryKind(resolved.amount, categoryKind)) {
         rowWarnings.push({
           id: getImportRowId(file.id, rowIndex),
           rowNumber: rowIndex + 1,
           cells: row,
-          reason: ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON,
+          // Only an expense or an income category reaches here, since the check above judges no
+          // other kind, so the note can say which of the two this row is filed under
+          reason: getRowSignDisagreesWithCategoryReason(categoryKind as 'expense' | 'income'),
         })
       }
 
@@ -335,7 +338,7 @@ function toPayloadRow(resolved: ReturnType<typeof resolveImportRow>): Transactio
 }
 
 /**
- * Reports whether a row's amount moves the opposite way to the kind of category it is filed under
+ * Reports whether a row is money going the way its category does not usually record
  *
  * A refund inside an expense category is real data, so this is only ever a warning. It is worth
  * saying because the app then counts the row two ways: cash flow reads the sign, while the category

--- a/frontend/src/pages/imports/utils/payload.ts
+++ b/frontend/src/pages/imports/utils/payload.ts
@@ -176,7 +176,7 @@ export function buildTransactionImportPayload({
   // source once and read back for every row using it
   const recordsCounterpartyBySource: Record<string, boolean> = {}
 
-  // The kind each category source settles on, read back per row to spot an amount running the other
+  // The kind each category source settles on, read back per row to spot an amount moving the other
   // way. A source mapped to an existing category takes that category's kind
   const kindByCategorySource: Record<string, ImportCategoryKind> = {}
   for (const source of importedCategories) {

--- a/frontend/src/pages/imports/utils/payload.ts
+++ b/frontend/src/pages/imports/utils/payload.ts
@@ -335,7 +335,7 @@ function toPayloadRow(resolved: ReturnType<typeof resolveImportRow>): Transactio
 }
 
 /**
- * Reports whether a row's amount runs the opposite way to the kind of category it is filed under
+ * Reports whether a row's amount moves the opposite way to the kind of category it is filed under
  *
  * A refund inside an expense category is real data, so this is only ever a warning. It is worth
  * saying because the app then counts the row two ways: cash flow reads the sign, while the category

--- a/frontend/src/pages/imports/utils/payload.ts
+++ b/frontend/src/pages/imports/utils/payload.ts
@@ -112,13 +112,13 @@ export function buildTransactionImportPayload({
     if (!errors.includes(message)) errors.push(message)
   }
 
-  if (files.length === 0) addError('Upload at least one CSV file.')
+  if (files.length === 0) addError('Upload a CSV file.')
   for (const file of files) {
     if (file.error) addError(`${file.name}: ${file.error}`)
   }
 
   const missingRequired = getMissingRequiredColumnLabels(columnMap)
-  if (missingRequired.length > 0) addError(`Missing required columns: ${missingRequired.join(', ')}`)
+  if (missingRequired.length > 0) addError(`Map the required columns: ${missingRequired.join(', ')}`)
 
   const arrangementClash = getAmountArrangementClashError(columnMap)
   if (arrangementClash) addError(arrangementClash.message)
@@ -302,7 +302,7 @@ export function buildTransactionImportPayload({
 
   // A file whose every row has a problem is described by the list of problems, so the empty-file
   // message is kept for the case it was written for
-  if (rows.length === 0 && rowProblems.length === 0) addError('No transaction rows are available to import.')
+  if (rows.length === 0 && rowProblems.length === 0) addError('This file has no transaction rows to import.')
 
   const warnings = getImportWarnings(rows, columnMap)
   const allErrors = [...columnErrors, ...errors]
@@ -429,7 +429,7 @@ function appendAccountMapping(
     // The dropdown only offers this answer where no row is written to the source, so it survives
     // here when a file added later carries rows for a name that was answered this way
     if (!accountSource.isCounterpartyOnly) {
-      addError(`Rows cannot be written to an account source that is outside the tracked accounts: ${createName}`)
+      addError(`Map to one of your accounts: ${createName} has rows of its own, so it cannot be answered as outside.`)
       return
     }
 
@@ -442,7 +442,7 @@ function appendAccountMapping(
     // that same column afterwards turns it into a source rows are written to while its answer
     // stands, which the dropdown no longer offers and the API refuses
     if (!accountSource.isCounterpartyOnly && accountById.get(choice)?.is_archived) {
-      addError(`Rows cannot be written to an archived account: ${createName}`)
+      addError(`Map to an account that is not archived: ${createName}`)
       return
     }
 
@@ -455,7 +455,7 @@ function appendAccountMapping(
   if (!createType || !createCurrency) return
 
   if (!isImportAccountType(createType)) {
-    addError(`Invalid account type: ${createName}`)
+    addError(`Choose an account type this app supports: ${createName}`)
     return
   }
 

--- a/frontend/src/pages/imports/utils/preview.ts
+++ b/frontend/src/pages/imports/utils/preview.ts
@@ -134,8 +134,9 @@ export function buildImportPreviewRows({
       const dt = resolved.dt
 
       // The currency the commit will store the row in, and the display fallback only where the
-      // account step has not been answered yet, which is a state the preview runs in and the
-      // commit does not
+      // account step has not been answered yet. Rows are still built in that state and the preview
+      // step shows the unanswered mappings instead of them, so the fallback is what keeps building
+      // a row from failing rather than something the user reads
       const currency = getPreviewCurrency(
         resolved.currency,
         account?.currency,

--- a/frontend/src/pages/imports/utils/preview.ts
+++ b/frontend/src/pages/imports/utils/preview.ts
@@ -310,7 +310,7 @@ export function getPreviewCurrency(
  * category queued to be created and looking up an existing one otherwise
  *
  * The kind comes from the same reading the commit uses, so the two cannot disagree. Where that
- * reading has no answer yet, which is a source whose amounts run both ways or one with no readable
+ * reading has no answer yet, which is a source whose amounts move both ways or one with no readable
  * amounts, the row previews without a category rather than being shown a kind guessed from its own
  * sign that the commit would then refuse
  */

--- a/frontend/src/pages/imports/utils/preview.ts
+++ b/frontend/src/pages/imports/utils/preview.ts
@@ -6,6 +6,7 @@ import {
   CREATE_ACCOUNT_VALUE,
   CREATE_CATEGORY_VALUE,
   DEFAULT_CATEGORY_ICON,
+  IMPORT_SAMPLE_PREVIEW_LIMIT,
   SELF_MERCHANT_NAME,
   UNKNOWN_MERCHANT_NAME,
 } from '@/pages/imports/constants'
@@ -223,7 +224,7 @@ export function buildImportPreviewRows({
         },
       })
 
-      if (rows.length >= 5) return rows
+      if (rows.length >= IMPORT_SAMPLE_PREVIEW_LIMIT) return rows
     }
   }
 

--- a/frontend/src/pages/imports/utils/valueParsers.ts
+++ b/frontend/src/pages/imports/utils/valueParsers.ts
@@ -254,7 +254,7 @@ export function parseImportNumber(value: string) {
  * left exactly as the file wrote it, thousands separators included, since the commit sends the
  * string for the API to parse with exact decimals
  *
- * A zero is written without a sign, because it runs neither way
+ * A zero is written without a sign, because it moves neither way
  *
  * @param value - The raw cell value, which the caller has already read as an amount
  * @param direction - Whether this row's money is leaving the account or arriving in it

--- a/frontend/tests/pages/imports/firefly/utils/payload.test.ts
+++ b/frontend/tests/pages/imports/firefly/utils/payload.test.ts
@@ -59,13 +59,13 @@ describe('a Firefly account archived after it was mapped', () => {
     const result = buildWithMapping(ARCHIVED.id, [CHEQUING, ARCHIVED])
 
     expect(result.payload).toBeNull()
-    expect(result.errors).toContain('Rows cannot be written to an archived account: Chequing')
+    expect(result.errors).toContain('Map to an account that is not archived: Chequing')
   })
 
   it('accepts the same mapping while the account is not archived', () => {
     const result = buildWithMapping(CHEQUING.id, [CHEQUING, ARCHIVED])
 
-    expect(result.errors).not.toContain('Rows cannot be written to an archived account: Chequing')
+    expect(result.errors).not.toContain('Map to an account that is not archived: Chequing')
     expect(result.payload?.accounts).toEqual([{ source: 'Chequing', account_id: CHEQUING.id }])
   })
 })

--- a/frontend/tests/pages/imports/utils/columnMapping.test.ts
+++ b/frontend/tests/pages/imports/utils/columnMapping.test.ts
@@ -3,8 +3,8 @@
  * refusal tells the user about where the problem is
  */
 import { describe, expect, it } from 'vitest'
-import type { CsvRow, ImportFileDraft } from '@/pages/imports/types'
-import { validateColumnValues } from '@/pages/imports/utils'
+import type { CsvRow, ImportAmountDirection, ImportFileDraft } from '@/pages/imports/types'
+import { answerImportDirectionValue, validateColumnValues } from '@/pages/imports/utils'
 
 const SUPPORTED_CURRENCY_CODES = new Set(['CAD', 'USD'])
 
@@ -281,5 +281,41 @@ describe('what a column mapped as the direction may hold', () => {
 
     expect(validation.valid).toBe(false)
     expect(validation.message).toContain('3 different values')
+  })
+})
+
+describe('answering what one word in the Direction column means', () => {
+  const PAIR = [{ key: 'sortie' }, { key: 'entrée' }]
+
+  // The column separates money in from money out, so its two words cannot mean the same thing and
+  // the second click was always either redundant or a mistake
+  it('answers the other word with the other direction', () => {
+    expect(answerImportDirectionValue({}, PAIR, 'sortie', 'out')).toEqual({ sortie: 'out', 'entrée': 'in' })
+    expect(answerImportDirectionValue({}, PAIR, 'entrée', 'out')).toEqual({ 'entrée': 'out', sortie: 'in' })
+  })
+
+  it('flips the other word when an answered pair changes', () => {
+    const answered: Record<string, ImportAmountDirection> = { sortie: 'out', 'entrée': 'in' }
+
+    expect(answerImportDirectionValue(answered, PAIR, 'sortie', 'in')).toEqual({ sortie: 'in', 'entrée': 'out' })
+  })
+
+  // Reachable from an answer stored before the pairing existed. Touching either word repairs it
+  // rather than leaving the user to correct both
+  it('repairs a stored pair that already agreed', () => {
+    const agreed: Record<string, ImportAmountDirection> = { sortie: 'out', 'entrée': 'out' }
+
+    expect(answerImportDirectionValue(agreed, PAIR, 'sortie', 'out')).toEqual({ sortie: 'out', 'entrée': 'in' })
+  })
+
+  // A file holding money going only one way has nothing for its single word to be the opposite of
+  it('answers a lone word without inventing a second', () => {
+    expect(answerImportDirectionValue({}, [{ key: 'debit' }], 'debit', 'out')).toEqual({ debit: 'out' })
+  })
+
+  // Pairing against a word this column does not hold would answer whichever of the two came first,
+  // rewriting a word the user had already settled
+  it('leaves the pair alone when the answered word is not one of them', () => {
+    expect(answerImportDirectionValue({}, PAIR, 'debit', 'out')).toEqual({ debit: 'out' })
   })
 })

--- a/frontend/tests/pages/imports/utils/common.test.ts
+++ b/frontend/tests/pages/imports/utils/common.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Covers which staged files count as one the import can go ahead with, since that is what decides
+ * whether the file step keeps offering an upload
+ */
+import { describe, expect, it } from 'vitest'
+import type { ImportFileDraft } from '@/pages/imports/types'
+import { hasAcceptedFile } from '@/pages/imports/utils'
+
+/**
+ * Builds a staged draft, taking the error and notice the reader would have recorded on it
+ */
+function createFile({ error = null, notice }: { error?: string | null; notice?: string }): ImportFileDraft {
+  return {
+    id: 'file_1',
+    name: 'Statement.csv',
+    size: 2048,
+    headers: ['Date', 'Amount'],
+    hasHeaderRow: true,
+    rows: error ? [] : [{ Date: '2026-06-01', Amount: '-12.40' }],
+    error,
+    notice,
+  }
+}
+
+describe('whether a usable file is staged', () => {
+  it('says no with nothing staged', () => {
+    expect(hasAcceptedFile([])).toBe(false)
+  })
+
+  it('says yes for a file that read cleanly', () => {
+    expect(hasAcceptedFile([createFile({})])).toBe(true)
+  })
+
+  // The reader records its refusal on the draft rather than throwing, so a refused file is staged
+  // like any other. Reading it as accepted would take away the upload control for exactly the file
+  // that has to be replaced
+  it('says no for a file the reader refused', () => {
+    const refused = createFile({ error: 'This file has a heading row and no transactions under it.' })
+
+    expect(hasAcceptedFile([refused])).toBe(false)
+  })
+
+  // A notice is the opposite case: the file is usable and the import goes ahead, so the upload
+  // control has nothing left to offer
+  it('says yes for a file staged with a notice and no error', () => {
+    const noticed = createFile({ notice: 'Some characters could not be read.' })
+
+    expect(hasAcceptedFile([noticed])).toBe(true)
+  })
+})

--- a/frontend/tests/pages/imports/utils/merchantMatching.test.ts
+++ b/frontend/tests/pages/imports/utils/merchantMatching.test.ts
@@ -76,7 +76,7 @@ describe('what the merchant step sends', () => {
     const { mappings, errors } = buildFor('SQ *COFFEE 4471', CREATE_MERCHANT_VALUE, '   ')
 
     expect(mappings).toEqual([])
-    expect(errors).toEqual(['Name the merchant being created for: SQ *COFFEE 4471'])
+    expect(errors).toEqual(['Choose a name for the new merchant: SQ *COFFEE 4471'])
   })
 
   it('sends nothing at all for a file of values nobody touched', () => {

--- a/frontend/tests/pages/imports/utils/payload.amountWarnings.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.amountWarnings.test.ts
@@ -7,8 +7,8 @@ import type { Category } from '@/api/categories'
 import type { Currency } from '@/api/currency'
 import {
   EMPTY_COLUMN_MAP,
+  getRowSignDisagreesWithCategoryReason,
   NO_OUTFLOWS_WARNING,
-  ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON,
 } from '@/pages/imports/constants'
 import type { CsvRow, ImportFileDraft } from '@/pages/imports/types'
 import { buildTransactionImportPayload } from '@/pages/imports/utils'
@@ -200,15 +200,27 @@ describe('warning about a row filed against its category\'s direction', () => {
     expect(result.payload?.rows).toHaveLength(2)
     expect(result.rowWarnings).toHaveLength(1)
     expect(result.rowWarnings[0].rowNumber).toBe(2)
-    expect(result.rowWarnings[0].reason).toBe(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON)
+    expect(result.rowWarnings[0].reason).toBe(getRowSignDisagreesWithCategoryReason('expense'))
   })
 
   // The heading over this table offers a look and no longer says the rows are taken, so the note
   // against each row is the only place that fact is left. It sits in one table cell repeated per
   // row, inside a column capped at a share of the panel width, so it also has a length to keep to
   it('says on the row itself that the import takes it, in a note short enough for the column', () => {
-    expect(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON).toContain('imports')
-    expect(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON.length).toBeLessThan(160)
+    for (const kind of ['expense', 'income'] as const) {
+      expect(getRowSignDisagreesWithCategoryReason(kind)).toContain('imports')
+      expect(getRowSignDisagreesWithCategoryReason(kind).length).toBeLessThan(160)
+    }
+  })
+
+  // Each kind gets its own note, so the row is told what it is and what it is filed under rather
+  // than how the two relate. Getting the pair the wrong way round would tell a refund it is money
+  // going out
+  it('says which direction the row is and which kind it sits under', () => {
+    expect(getRowSignDisagreesWithCategoryReason('expense')).toContain('Money coming in')
+    expect(getRowSignDisagreesWithCategoryReason('expense')).toContain('expense category')
+    expect(getRowSignDisagreesWithCategoryReason('income')).toContain('Money going out')
+    expect(getRowSignDisagreesWithCategoryReason('income')).toContain('income category')
   })
 
   it('lists a negative row inside an income category', () => {
@@ -216,6 +228,7 @@ describe('warning about a row filed against its category\'s direction', () => {
 
     expect(result.rowWarnings).toHaveLength(1)
     expect(result.rowWarnings[0].rowNumber).toBe(2)
+    expect(result.rowWarnings[0].reason).toBe(getRowSignDisagreesWithCategoryReason('income'))
   })
 
   it('says nothing where every row runs the way its category does', () => {

--- a/frontend/tests/pages/imports/utils/payload.amountWarnings.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.amountWarnings.test.ts
@@ -203,6 +203,14 @@ describe('warning about a row filed against its category\'s direction', () => {
     expect(result.rowWarnings[0].reason).toBe(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON)
   })
 
+  // The heading over this table offers a look and no longer says the rows are taken, so the note
+  // against each row is the only place that fact is left. It sits in one table cell repeated per
+  // row, inside a column capped at a share of the panel width, so it also has a length to keep to
+  it('says on the row itself that the import takes it, in a note short enough for the column', () => {
+    expect(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON).toContain('imports')
+    expect(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON.length).toBeLessThan(160)
+  })
+
   it('lists a negative row inside an income category', () => {
     const result = build(['2400.00', '-50.00'], 'income')
 

--- a/frontend/tests/pages/imports/utils/payload.counterpartyAccount.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.counterpartyAccount.test.ts
@@ -217,7 +217,7 @@ describe('CSV import counterparty account', () => {
     })
 
     expect(rowAccount.payload).toBeNull()
-    expect(rowAccount.errors).toContain('Rows cannot be written to an archived account: Chequing')
+    expect(rowAccount.errors).toContain('Map to an account that is not archived: Chequing')
   })
 
   it('refuses the outside answer for a source rows are written to', () => {
@@ -226,7 +226,7 @@ describe('CSV import counterparty account', () => {
     })
 
     expect(payload).toBeNull()
-    expect(errors).toContain('Rows cannot be written to an account source that is outside the tracked accounts: Chequing')
+    expect(errors).toContain('Map to one of your accounts: Chequing has rows of its own, so it cannot be answered as outside.')
   })
 
   it('refuses a counterparty account on a row that is not a transfer', () => {

--- a/frontend/tests/pages/imports/utils/workflowOptions.test.ts
+++ b/frontend/tests/pages/imports/utils/workflowOptions.test.ts
@@ -18,8 +18,8 @@ import {
   CURRENCIES_LOADING_UPLOAD_BLOCK,
   DIRECTION_ARRANGEMENT_CLASH_ERROR,
   EMPTY_COLUMN_MAP,
+  getRowSignDisagreesWithCategoryReason,
   MISSING_AMOUNT_COLUMN_LABEL,
-  ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON,
   UNSET_BATCH_INSTITUTION,
 } from '@/pages/imports/constants'
 import type { ImportFileDraft } from '@/pages/imports/types'
@@ -359,7 +359,7 @@ describe('the three ways a file can carry its amount', () => {
     const wholeNotice = [AMOUNT_CONVENTION_NOTE, ...AMOUNT_ARRANGEMENT_OPTIONS, AMOUNT_SIGN_RULE_NOTE].join(' ')
 
     expect(wholeNotice).not.toContain('expense category')
-    expect(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON).toContain('category')
+    expect(getRowSignDisagreesWithCategoryReason('expense')).toContain('expense category')
   })
 
   it('heads the three under one group of their own', () => {

--- a/frontend/tests/pages/imports/utils/workflowOptions.test.ts
+++ b/frontend/tests/pages/imports/utils/workflowOptions.test.ts
@@ -8,9 +8,6 @@ import type { Currency } from '@/api/currency'
 import type { Institution } from '@/api/institutions'
 import {
   AMOUNT_ARRANGEMENT_CLASH_ERROR,
-  AMOUNT_ARRANGEMENT_OPTIONS,
-  AMOUNT_CONVENTION_NOTE,
-  AMOUNT_SIGN_RULE_NOTE,
   COLUMN_TARGETS,
   CREATE_ACCOUNT_VALUE,
   CREATE_CATEGORY_VALUE,
@@ -350,15 +347,28 @@ describe('the three ways a file can carry its amount', () => {
     expect(MISSING_AMOUNT_COLUMN_LABEL).not.toContain(',')
   })
 
-  // How a category's kind reads against an amount's direction belongs against the rows it is about,
-  // five steps further down, so the note over the mapping table stops at what the columns hold. Kept
-  // in one place rather than two, since a rule stated twice drifts
-  it('leaves the category direction rule out of the note over the mapping table', () => {
-    // Every part of that notice, since it renders as a lead, a list of arrangements and a closing
-    // rule, and checking only the lead would miss the sentence moving into one of the others
-    const wholeNotice = [AMOUNT_CONVENTION_NOTE, ...AMOUNT_ARRANGEMENT_OPTIONS, AMOUNT_SIGN_RULE_NOTE].join(' ')
+  // There is no notice over the mapping table saying how an amount is read, so each option's own
+  // sentence is the only place the arrangements and the sign rule are stated. Stripping one of these
+  // would leave a user choosing between Amount, Money out and Money in with nothing saying what a
+  // sign in each one means
+  it('states every amount arrangement and the sign rule in the dropdown options', () => {
+    const options = buildColumnTargetOptions()
+    const hintFor = (value: string) => options.find((option) => option.value === value)?.description ?? ''
 
-    expect(wholeNotice).not.toContain('expense category')
+    expect(hintFor('amount')).toContain('negative for money out')
+    expect(hintFor('amount_out')).toContain('A plus sign there is refused')
+    expect(hintFor('amount_in')).toContain('A minus sign there is refused')
+    expect(hintFor('amount_direction')).toContain('unsigned amounts')
+  })
+
+  // How a category's kind reads against an amount's direction belongs against the rows it is about,
+  // five steps further down. Kept in one place rather than two, since a rule stated twice drifts
+  it('leaves the category direction rule to the rows it is about', () => {
+    const options = buildColumnTargetOptions()
+    const amountHints = ['amount', 'amount_out', 'amount_in', 'amount_direction']
+      .map((value) => options.find((option) => option.value === value)?.description ?? '')
+
+    for (const hint of amountHints) expect(hint).not.toContain('category')
     expect(getRowSignDisagreesWithCategoryReason('expense')).toContain('expense category')
   })
 

--- a/frontend/tests/pages/imports/utils/workflowOptions.test.ts
+++ b/frontend/tests/pages/imports/utils/workflowOptions.test.ts
@@ -8,7 +8,9 @@ import type { Currency } from '@/api/currency'
 import type { Institution } from '@/api/institutions'
 import {
   AMOUNT_ARRANGEMENT_CLASH_ERROR,
+  AMOUNT_ARRANGEMENT_OPTIONS,
   AMOUNT_CONVENTION_NOTE,
+  AMOUNT_SIGN_RULE_NOTE,
   COLUMN_TARGETS,
   CREATE_ACCOUNT_VALUE,
   CREATE_CATEGORY_VALUE,
@@ -352,7 +354,11 @@ describe('the three ways a file can carry its amount', () => {
   // five steps further down, so the note over the mapping table stops at what the columns hold. Kept
   // in one place rather than two, since a rule stated twice drifts
   it('leaves the category direction rule out of the note over the mapping table', () => {
-    expect(AMOUNT_CONVENTION_NOTE).not.toContain('expense category')
+    // Every part of that notice, since it renders as a lead, a list of arrangements and a closing
+    // rule, and checking only the lead would miss the sentence moving into one of the others
+    const wholeNotice = [AMOUNT_CONVENTION_NOTE, ...AMOUNT_ARRANGEMENT_OPTIONS, AMOUNT_SIGN_RULE_NOTE].join(' ')
+
+    expect(wholeNotice).not.toContain('expense category')
     expect(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON).toContain('category')
   })
 

--- a/frontend/tests/pages/imports/utils/workflowOptions.test.ts
+++ b/frontend/tests/pages/imports/utils/workflowOptions.test.ts
@@ -8,6 +8,7 @@ import type { Currency } from '@/api/currency'
 import type { Institution } from '@/api/institutions'
 import {
   AMOUNT_ARRANGEMENT_CLASH_ERROR,
+  AMOUNT_CONVENTION_NOTE,
   COLUMN_TARGETS,
   CREATE_ACCOUNT_VALUE,
   CREATE_CATEGORY_VALUE,
@@ -16,6 +17,7 @@ import {
   DIRECTION_ARRANGEMENT_CLASH_ERROR,
   EMPTY_COLUMN_MAP,
   MISSING_AMOUNT_COLUMN_LABEL,
+  ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON,
   UNSET_BATCH_INSTITUTION,
 } from '@/pages/imports/constants'
 import type { ImportFileDraft } from '@/pages/imports/types'
@@ -344,6 +346,14 @@ describe('the three ways a file can carry its amount', () => {
   // Two callers join these with commas, so a label carrying one would read as two missing columns
   it('asks for it as one label carrying no comma', () => {
     expect(MISSING_AMOUNT_COLUMN_LABEL).not.toContain(',')
+  })
+
+  // How a category's kind reads against an amount's direction belongs against the rows it is about,
+  // five steps further down, so the note over the mapping table stops at what the columns hold. Kept
+  // in one place rather than two, since a rule stated twice drifts
+  it('leaves the category direction rule out of the note over the mapping table', () => {
+    expect(AMOUNT_CONVENTION_NOTE).not.toContain('expense category')
+    expect(ROW_SIGN_DISAGREES_WITH_CATEGORY_REASON).toContain('category')
   })
 
   it('heads the three under one group of their own', () => {


### PR DESCRIPTION
The import flow's text was written a piece at a time across a dozen changes, so it asked users to read paragraphs mid-decision and kept offering controls that had nothing left to do. Its wording is rewritten throughout. The reasons an import cannot go ahead now sit in the preview step, in a red notice listing each one, rather than as right-aligned text below the commit button, and the upload card and its encoding banner go once a usable file is staged. Rows that import as they are read as amber notes worth a look instead of sharing the red table with rows the import refuses, and answering one word of a Direction column answers the other with the opposite direction.
