### PR TITLE
fix: repair importer defects and cover its untested paths

### DIFF
--- a/backend/tests/routes/transactions/test_imports.py
+++ b/backend/tests/routes/transactions/test_imports.py
@@ -1382,3 +1382,45 @@ async def test_holding_a_run_does_not_bound_the_locks_taken_after_it(client):
     # Left in place, this bound would cancel any later lock the same transaction waited on, which
     # for a commit is every account snapshot and cache row the import touches
     assert lock_timeout == "0"
+
+
+async def test_an_import_across_two_accounts_recomputes_each_from_its_own_earliest_row(client):
+    """Each account rebuilds from the earliest row it received, not from the first row of the file."""
+    headers, chequing_id, category_id = await _setup_user_with_deps(client)
+    savings_resp = await _create_account(client, headers, name="Main Savings", account_type="savings")
+    savings_id = savings_resp.json()["id"]
+
+    # The rows for each account are given latest first, so an import that kept the first date it saw
+    # would rebuild from the later one and never write a snapshot for the earlier row at all
+    rows = [
+        {"account_source": "Chequing", "category_source": "Groceries", "dt": "2026-04-20", "amount": "-10.00"},
+        {"account_source": "Chequing", "category_source": "Groceries", "dt": "2026-04-10", "amount": "-5.00"},
+        {"account_source": "Savings", "category_source": "Groceries", "dt": "2026-04-22", "amount": "-20.00"},
+        {"account_source": "Savings", "category_source": "Groceries", "dt": "2026-04-12", "amount": "-30.00"},
+    ]
+
+    # Whichever account sorts later is named first, so the order the accounts are reached in is the
+    # reverse of the sorted order and dropping the sort fails this rather than passing on the ids
+    # that happened to come up
+    if chequing_id < savings_id:
+        rows = rows[2:] + rows[:2]
+
+    resp = await _import_transactions(client, headers, {
+        "accounts": [
+            {"source": "Chequing", "account_id": chequing_id},
+            {"source": "Savings", "account_id": savings_id},
+        ],
+        "categories": [{"source": "Groceries", "category_id": category_id}],
+        "rows": rows,
+    })
+
+    assert resp.status_code == 201
+    assert resp.json()["affected_account_ids"] == sorted([chequing_id, savings_id])
+
+    chequing_snapshots = (await client.get(f"/accounts/{chequing_id}/snapshots", headers=headers)).json()
+    savings_snapshots = (await client.get(f"/accounts/{savings_id}/snapshots", headers=headers)).json()
+
+    assert {"account_id": chequing_id, "dt": "2026-04-10", "balance": -500} in chequing_snapshots
+    assert {"account_id": chequing_id, "dt": "2026-04-20", "balance": -1500} in chequing_snapshots
+    assert {"account_id": savings_id, "dt": "2026-04-12", "balance": -3000} in savings_snapshots
+    assert {"account_id": savings_id, "dt": "2026-04-22", "balance": -5000} in savings_snapshots

--- a/backend/tests/services/transactions/imports/test_account_sources.py
+++ b/backend/tests/services/transactions/imports/test_account_sources.py
@@ -1,0 +1,63 @@
+"""Errors the shared account-source resolver raises before any account query
+
+Both branches are refused by validating the payload's shape alone, so calling the function directly
+is what reaches them: staging re-runs the same checks, and the schema refuses an over-long source
+name before a request carrying either shape reaches the route.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.currency import Currency
+from app.models.user import User
+from app.schemas.transaction import TransactionImportAccountMapping
+from app.services.importers.shared.accounts import resolve_import_account_sources
+from app.services.importers.shared.stats import ImportStats
+from tests.conftest import TestSession
+
+
+async def _seed_user(session) -> User:
+    """Insert the user the account sources resolve for
+
+    Args:
+        session: Database session the test runs in
+
+    Returns:
+        The seeded user
+    """
+    session.add(Currency(id="CAD", name="Canadian Dollar", symbol="$", minor_unit_exponent=2))
+    user = User(
+        email="account-sources-import@example.com",
+        first_name="Import",
+        tz="America/Toronto",
+        base_currency="CAD",
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def test_naming_one_source_twice_as_outside_money_is_refused_as_a_duplicate():
+    """Two mappings answering the same source as outside the tracked accounts raise on the second."""
+    async with TestSession() as session:
+        user = await _seed_user(session)
+        mapping = TransactionImportAccountMapping(source="Cash", outside=True)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_import_account_sources(session, user, [mapping, mapping], ImportStats(), set())
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "Duplicate account source: Cash"
+
+
+async def test_a_mapping_naming_no_account_and_no_create_is_refused():
+    """A source mapped to neither an existing account nor a new one raises before any account query."""
+    async with TestSession() as session:
+        user = await _seed_user(session)
+        mapping = TransactionImportAccountMapping(source="Chequing")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resolve_import_account_sources(session, user, [mapping], ImportStats(), set())
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "Account source must map to exactly one account action: Chequing"

--- a/backend/tests/services/transactions/imports/test_cache_invalidation.py
+++ b/backend/tests/services/transactions/imports/test_cache_invalidation.py
@@ -1,0 +1,91 @@
+"""Which cached figures an import marks stale when it touches more than one account
+
+An import writes rows into every account its file names, and each of those accounts refreshes the
+scope that owns it: a personal account refreshes the user's cached figures, a group account the
+group's. Every import test before this one used a single personal account, so the loop over the
+affected accounts only ever went round once and the group branch never ran.
+
+The marking is called directly rather than through a committed import, because nothing the route
+returns says which scopes were marked, and the table holding them is not exposed by any endpoint.
+"""
+
+import uuid
+from datetime import date
+
+from sqlalchemy import select
+
+from app.models.account import Account
+from app.models.base import AccountKind, AccountType
+from app.models.cache_state import GroupCacheState, UserCacheState
+from app.models.currency import Currency
+from app.models.group import Group
+from app.models.user import User
+from app.services.importers.generic.service import _mark_caches_changed_for_imported_accounts
+from tests.conftest import TestSession
+
+
+async def _seed_user(session) -> uuid.UUID:
+    """Insert the user the accounts belong to
+
+    Args:
+        session: Database session the test runs in
+
+    Returns:
+        Identifier of the user
+    """
+    session.add(Currency(id="CAD", name="Canadian Dollar", symbol="$", minor_unit_exponent=2))
+    user = User(
+        email="import-cache@example.com",
+        first_name="Cache",
+        tz="America/Toronto",
+        base_currency="CAD",
+    )
+    session.add(user)
+    await session.flush()
+    return user.id
+
+
+async def test_an_import_across_a_personal_and_a_group_account_marks_both_scopes():
+    """Each affected account refreshes the scope that owns it, so both are marked from one import."""
+    async with TestSession() as session:
+        user_id = await _seed_user(session)
+        group = Group(owner_id=user_id, name="Household")
+        session.add(group)
+        await session.flush()
+
+        personal = Account(
+            owner_id=user_id,
+            group_id=None,
+            account_kind=AccountKind.ASSET,
+            account_type=AccountType.CHECKING,
+            name="Chequing",
+            currency="CAD",
+        )
+        shared = Account(
+            owner_id=None,
+            group_id=group.id,
+            account_kind=AccountKind.ASSET,
+            account_type=AccountType.SAVINGS,
+            name="Joint Savings",
+            currency="CAD",
+        )
+        session.add_all([personal, shared])
+        await session.flush()
+
+        await _mark_caches_changed_for_imported_accounts(
+            session,
+            user_id,
+            {"Chequing": personal, "Joint Savings": shared},
+            {personal.id: date(2026, 4, 10), shared.id: date(2026, 4, 12)},
+        )
+        await session.flush()
+
+        user_marks = await session.execute(
+            select(UserCacheState).where(UserCacheState.user_id == user_id),
+        )
+        group_marks = await session.execute(
+            select(GroupCacheState).where(GroupCacheState.group_id == group.id),
+        )
+
+        assert user_marks.scalar_one_or_none() is not None
+        assert group_marks.scalar_one_or_none() is not None

--- a/backend/tests/services/transactions/imports/test_cache_invalidation.py
+++ b/backend/tests/services/transactions/imports/test_cache_invalidation.py
@@ -1,9 +1,11 @@
 """Which cached figures an import marks stale when it touches more than one account
 
-An import writes rows into every account its file names, and each of those accounts refreshes the
-scope that owns it: a personal account refreshes the user's cached figures, a group account the
-group's. Every import test before this one used a single personal account, so the loop over the
-affected accounts only ever went round once and the group branch never ran.
+An import writes rows into every account its file names, and walks those accounts marking the scope
+that owns each one. Every import test before this one used a single personal account, so the walk
+only ever went round once and never reached a group.
+
+The group mark is what this can check. The user's own figures are marked once before the walk starts,
+whatever the walk then does, so finding that mark says nothing about the accounts at all.
 
 The marking is called directly rather than through a committed import, because nothing the route
 returns says which scopes were marked, and the table holding them is not exposed by any endpoint.
@@ -16,7 +18,7 @@ from sqlalchemy import select
 
 from app.models.account import Account
 from app.models.base import AccountKind, AccountType
-from app.models.cache_state import GroupCacheState, UserCacheState
+from app.models.cache_state import GroupCacheState
 from app.models.currency import Currency
 from app.models.group import Group
 from app.models.user import User
@@ -45,8 +47,8 @@ async def _seed_user(session) -> uuid.UUID:
     return user.id
 
 
-async def test_an_import_across_a_personal_and_a_group_account_marks_both_scopes():
-    """Each affected account refreshes the scope that owns it, so both are marked from one import."""
+async def test_an_import_reaching_a_group_account_after_a_personal_one_marks_the_group():
+    """The walk carries on past the first account, so a group account behind one still refreshes."""
     async with TestSession() as session:
         user_id = await _seed_user(session)
         group = Group(owner_id=user_id, name="Household")
@@ -80,12 +82,8 @@ async def test_an_import_across_a_personal_and_a_group_account_marks_both_scopes
         )
         await session.flush()
 
-        user_marks = await session.execute(
-            select(UserCacheState).where(UserCacheState.user_id == user_id),
-        )
         group_marks = await session.execute(
             select(GroupCacheState).where(GroupCacheState.group_id == group.id),
         )
 
-        assert user_marks.scalar_one_or_none() is not None
         assert group_marks.scalar_one_or_none() is not None

--- a/backend/tests/services/transactions/imports/test_category_mappings.py
+++ b/backend/tests/services/transactions/imports/test_category_mappings.py
@@ -1,0 +1,85 @@
+"""Errors the shared category-source resolver raises directly
+
+Each of these skips a request and calls the shared function on its own, since staging re-runs the
+same checks and the schema refuses an unsupported kind before a request carrying either shape
+reaches the route.
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.base import CategoryKind
+from app.models.category import Category
+from app.models.currency import Currency
+from app.models.user import User
+from app.schemas.transaction import TransactionImportCategoryMapping
+from app.services.importers.shared.categories import (
+    get_or_create_import_categories_by_source,
+    get_visible_import_category,
+    parse_import_category_kind,
+)
+from app.services.importers.shared.stats import ImportStats
+from tests.conftest import TestSession
+
+
+async def _seed_user(session) -> User:
+    """Insert the user the category sources resolve for
+
+    Args:
+        session: Database session the test runs in
+
+    Returns:
+        The seeded user
+    """
+    session.add(Currency(id="CAD", name="Canadian Dollar", symbol="$", minor_unit_exponent=2))
+    user = User(
+        email="category-mappings-import@example.com",
+        first_name="Import",
+        tz="America/Toronto",
+        base_currency="CAD",
+    )
+    session.add(user)
+    await session.flush()
+    return user
+
+
+async def test_naming_one_source_twice_is_refused_once_the_first_mapping_has_resolved():
+    """A second mapping for a source already resolved raises before its own action is even read."""
+    async with TestSession() as session:
+        user = await _seed_user(session)
+        category = Category(owner_id=user.id, group_id=None, name="Groceries", kind=CategoryKind.EXPENSE)
+        session.add(category)
+        await session.flush()
+        mappings = [
+            TransactionImportCategoryMapping(source="Groceries", category_id=category.id),
+            TransactionImportCategoryMapping(source="Groceries", category_id=category.id),
+        ]
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_or_create_import_categories_by_source(session, user, mappings, ImportStats())
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "Duplicate category source: Groceries"
+
+
+async def test_a_category_id_matching_nothing_visible_is_reported_not_found():
+    """Looking up a random category ID raises the same not-found error as a mismatched one."""
+    async with TestSession() as session:
+        user = await _seed_user(session)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await get_visible_import_category(session, uuid.uuid4(), user.id)
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "Category not found"
+
+
+def test_an_unsupported_category_kind_is_refused():
+    """Parsing a kind this app does not define raises without touching the database."""
+    with pytest.raises(HTTPException) as exc_info:
+        parse_import_category_kind("savings")
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "Invalid category kind"

--- a/backend/tests/services/transactions/imports/test_currencies.py
+++ b/backend/tests/services/transactions/imports/test_currencies.py
@@ -1,0 +1,33 @@
+"""Errors the shared currency checks raise for a code this app has not seeded
+
+Both read the currency table directly, so no account, mapping or user is needed to reach either
+raise: an unseeded code is enough on its own, and staging re-runs the same lookups before a request
+carrying one would reach the route.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.importers.shared.account_creation_helpers import validate_import_account_currency
+from app.services.importers.shared.currencies import get_import_currencies_by_code
+from tests.conftest import TestSession
+
+
+async def test_a_currency_code_no_account_uses_yet_is_reported_missing():
+    """Looking up an unseeded currency code raises rather than silently dropping it."""
+    async with TestSession() as session:
+        with pytest.raises(HTTPException) as exc_info:
+            await get_import_currencies_by_code(session, {"ZZZ"})
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "Invalid currency code: ZZZ"
+
+
+async def test_creating_an_account_in_an_unseeded_currency_is_refused():
+    """Validating a currency code for a create-account mapping raises the same way."""
+    async with TestSession() as session:
+        with pytest.raises(HTTPException) as exc_info:
+            await validate_import_account_currency(session, "ZZZ")
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == "Invalid currency code: ZZZ"

--- a/backend/tests/services/transactions/imports/test_name_limits.py
+++ b/backend/tests/services/transactions/imports/test_name_limits.py
@@ -1,0 +1,40 @@
+"""Errors the shared merchant and tag name checks raise before any name is written
+
+Both refuse a name too long for its column, which the request schema also refuses before a route
+ever sees it, so calling the function directly is what reaches either raise.
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.importers.shared.merchants import ImportMerchants, create_missing_import_merchants
+from app.services.importers.shared.stats import ImportStats
+from app.services.importers.shared.tags import create_missing_import_tags
+from tests.conftest import TestSession
+
+
+async def test_a_merchant_name_over_the_column_limit_is_refused():
+    """A 300-character merchant name raises before anything is inserted."""
+    async with TestSession() as session:
+        name = "A" * 300
+        merchants = ImportMerchants(existing_by_name_key={})
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_missing_import_merchants(session, uuid.uuid4(), [name], [], merchants, ImportStats())
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == f"Merchant name is too long: {name[:28]}"
+
+
+async def test_a_tag_name_over_the_column_limit_is_refused():
+    """A 65-character tag name raises before anything is inserted."""
+    async with TestSession() as session:
+        name = "B" * 65
+
+        with pytest.raises(HTTPException) as exc_info:
+            await create_missing_import_tags(session, uuid.uuid4(), [name], {}, ImportStats())
+
+        assert exc_info.value.status_code == 422
+        assert exc_info.value.detail == f"Tag name is too long: {name[:28]}"

--- a/backend/tests/services/transactions/imports/test_row_mappings.py
+++ b/backend/tests/services/transactions/imports/test_row_mappings.py
@@ -1,0 +1,39 @@
+"""Errors the shared row-mapping lookups raise without a database
+
+Both read only the arguments handed to them, so building a category and an account in memory and
+calling the function directly reaches branches a route test cannot: the schema and staging refuse
+these shapes before a request carrying either would reach the route.
+"""
+
+import uuid
+
+import pytest
+from fastapi import HTTPException
+
+from app.models.account import Account
+from app.models.category import Category
+from app.services.importers.shared.row_mappings import (
+    get_import_row_category,
+    validate_import_category_can_be_used_for_account,
+)
+
+
+def test_a_row_naming_a_category_source_the_payload_never_declared_is_refused():
+    """A category source absent from the declared mappings raises rather than matching nothing quietly."""
+    with pytest.raises(HTTPException) as exc_info:
+        get_import_row_category({}, "Groceries")
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "Category source is not mapped: Groceries"
+
+
+def test_a_group_categorys_group_not_matching_the_accounts_is_refused():
+    """A category belonging to one group cannot be used for an account belonging to a different one."""
+    category = Category(group_id=uuid.uuid4(), owner_id=None, is_system=False)
+    account = Account(group_id=uuid.uuid4())
+
+    with pytest.raises(HTTPException) as exc_info:
+        validate_import_category_can_be_used_for_account(category, account, uuid.uuid4())
+
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail == "Category not found"

--- a/frontend/src/api/transaction-imports/run.ts
+++ b/frontend/src/api/transaction-imports/run.ts
@@ -10,6 +10,7 @@ import type {
   TransactionImportPayload,
   TransactionImportResponse,
 } from '@/api/transaction-imports/types';
+import { getImportFailureMessage } from '@/utils/importFailure';
 
 /** Which half of the upload an import stopped in, which decides what can be done about it */
 export type TransactionImportPhase = 'staging' | 'commit';
@@ -63,7 +64,7 @@ export async function runTransactionImport(
       await stageTransactionImportRows(run.id, batch, signal);
     } catch (error) {
       await discardStagedRun(run.id);
-      throw new TransactionImportRunError(getImportErrorMessage(error), 'staging', null, { cause: error });
+      throw new TransactionImportRunError(getImportFailureMessage(error), 'staging', null, { cause: error });
     }
   }
 
@@ -86,7 +87,7 @@ export async function commitStagedImportRun(
   try {
     return await commitTransactionImportRun(runId, signal);
   } catch (error) {
-    throw new TransactionImportRunError(getImportErrorMessage(error), 'commit', runId, { cause: error });
+    throw new TransactionImportRunError(getImportFailureMessage(error), 'commit', runId, { cause: error });
   }
 }
 
@@ -120,8 +121,4 @@ export function isImportCommitWorthRepeating(error: unknown): boolean {
   const cause = error instanceof TransactionImportRunError ? error.cause : error;
   if (!(cause instanceof ApiError)) return true;
   return !PERMANENT_COMMIT_FAILURE_STATUSES.has(cause.status);
-}
-
-function getImportErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : 'Import failed.';
 }

--- a/frontend/src/pages/imports/components/ProgressOverlay.tsx
+++ b/frontend/src/pages/imports/components/ProgressOverlay.tsx
@@ -2,6 +2,7 @@ import { AlertCircle, CheckCircle2, CircleStop, LoaderCircle } from 'lucide-reac
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import type { Variants } from 'motion/react'
 import type { ImportOverlayPhase, ImportProgressStep, ImportProgressStepStatus } from '@/pages/imports/types'
+import { GENERIC_IMPORT_FAILURE } from '@/utils/importFailure'
 
 const OVERLAY_BACKGROUND = 'var(--app-bg)'
 const OVERLAY_TEXT = 'var(--app-text)'
@@ -174,7 +175,7 @@ export function ImportProgressOverlay({
           ? 'Importing'
           : 'Importing transactions'
   const message = ended
-    ? error ?? (stopped ? 'Import stopped.' : 'Import failed.')
+    ? error ?? (stopped ? 'Import stopped.' : GENERIC_IMPORT_FAILURE)
     : complete
       ? summary || 'Your import is complete.'
       : 'Your import is being added to your ledger, and nothing is saved until it finishes.'

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -333,11 +333,6 @@ export function getRowSignDisagreesWithCategoryReason(kind: 'expense' | 'income'
     : 'Money going out, filed under an income category. That is what returning money you were paid looks like, so the row imports as it stands.'
 }
 
-// Shown when an import fails with nothing usable to show for it, which is a rejection carrying no
-// message and anything thrown that is not an error at all. It says nothing about which record failed,
-// so a caller matching a detail against its own records must leave this one out
-export const GENERIC_IMPORT_FAILURE = 'Import failed.'
-
 // Shown once for the whole file where every amount reads as money coming in, which is either a file
 // of nothing but income or one being read backwards. It cannot tell those apart, so it says what the
 // rows come to and lists what to check, rather than asserting which of the two this is

--- a/frontend/src/pages/imports/constants.ts
+++ b/frontend/src/pages/imports/constants.ts
@@ -333,6 +333,11 @@ export function getRowSignDisagreesWithCategoryReason(kind: 'expense' | 'income'
     : 'Money going out, filed under an income category. That is what returning money you were paid looks like, so the row imports as it stands.'
 }
 
+// Shown when an import fails with nothing usable to show for it, which is a rejection carrying no
+// message and anything thrown that is not an error at all. It says nothing about which record failed,
+// so a caller matching a detail against its own records must leave this one out
+export const GENERIC_IMPORT_FAILURE = 'Import failed.'
+
 // Shown once for the whole file where every amount reads as money coming in, which is either a file
 // of nothing but income or one being read backwards. It cannot tell those apart, so it says what the
 // rows come to and lists what to check, rather than asserting which of the two this is

--- a/frontend/src/pages/imports/firefly/hooks/useFireflyImportWorkflow.ts
+++ b/frontend/src/pages/imports/firefly/hooks/useFireflyImportWorkflow.ts
@@ -6,7 +6,7 @@ import {
 } from '@/api/firefly-imports'
 import { waitForMilliseconds } from '@/utils/timing'
 import { BALANCE_ADJUSTMENT_CATEGORY_NAME } from '@/utils/transfers'
-import { CREATE_ACCOUNT_VALUE, CREATE_CATEGORY_VALUE } from '@/pages/imports/constants'
+import { CREATE_ACCOUNT_VALUE, CREATE_CATEGORY_VALUE, GENERIC_IMPORT_FAILURE } from '@/pages/imports/constants'
 import { useImportAccountCreateState, useImportReferenceData } from '@/pages/imports/hooks'
 import type {
   ImportCategoryKind,
@@ -546,7 +546,11 @@ export function useFireflyImportWorkflow() {
       // The batch is atomic, so nothing was imported and every row stays
       // retryable, with the backend detail landing on the budget it names
       const detail = getErrorMessage(error)
-      const failedDraft = drafts.find((draft) => detail.startsWith(draft.name))
+      // The generic failure names no budget, so a budget whose name it happens to start with must
+      // not be blamed for it and the rest told they were skipped for that budget's sake
+      const failedDraft = detail === GENERIC_IMPORT_FAILURE
+        ? undefined
+        : drafts.find((draft) => detail.startsWith(draft.name))
 
       setBudgetStageError(detail)
       setBudgetImportStatuses((current) => {

--- a/frontend/src/pages/imports/firefly/hooks/useFireflyImportWorkflow.ts
+++ b/frontend/src/pages/imports/firefly/hooks/useFireflyImportWorkflow.ts
@@ -6,7 +6,8 @@ import {
 } from '@/api/firefly-imports'
 import { waitForMilliseconds } from '@/utils/timing'
 import { BALANCE_ADJUSTMENT_CATEGORY_NAME } from '@/utils/transfers'
-import { CREATE_ACCOUNT_VALUE, CREATE_CATEGORY_VALUE, GENERIC_IMPORT_FAILURE } from '@/pages/imports/constants'
+import { CREATE_ACCOUNT_VALUE, CREATE_CATEGORY_VALUE } from '@/pages/imports/constants'
+import { GENERIC_IMPORT_FAILURE, getImportFailureMessage } from '@/utils/importFailure'
 import { useImportAccountCreateState, useImportReferenceData } from '@/pages/imports/hooks'
 import type {
   ImportCategoryKind,
@@ -17,7 +18,6 @@ import type {
 import {
   dropVanishedAccountMappings,
   dropVanishedCategoryMappings,
-  getErrorMessage,
   getImportUploadBlockReason,
   getSupportedCurrencyCodes,
   groupPreviewRowsByDate,
@@ -545,7 +545,7 @@ export function useFireflyImportWorkflow() {
     } catch (error) {
       // The batch is atomic, so nothing was imported and every row stays
       // retryable, with the backend detail landing on the budget it names
-      const detail = getErrorMessage(error)
+      const detail = getImportFailureMessage(error)
       // The generic failure names no budget, so a budget whose name it happens to start with must
       // not be blamed for it and the rest told they were skipped for that budget's sake
       const failedDraft = detail === GENERIC_IMPORT_FAILURE
@@ -598,7 +598,7 @@ export function useFireflyImportWorkflow() {
       setImportResult(result)
     } catch (error) {
       await minimumOverlay
-      setImportError(getErrorMessage(error))
+      setImportError(getImportFailureMessage(error))
       setImportOverlayPhase('error')
       return
     }

--- a/frontend/src/pages/imports/utils/columnMapping.ts
+++ b/frontend/src/pages/imports/utils/columnMapping.ts
@@ -460,6 +460,9 @@ export function answerImportDirectionValue(
  * column is not mapped to anything
  */
 export function getTargetForHeader(columnMap: ColumnMap, header: string) {
+  // An unmapped field holds an empty string, so an empty header would match the first of them
+  if (!header) return ''
+
   return COLUMN_TARGETS.find((target) => columnMap[target.id] === header)?.id ?? ''
 }
 

--- a/frontend/src/pages/imports/utils/commitFailure.ts
+++ b/frontend/src/pages/imports/utils/commitFailure.ts
@@ -1,5 +1,5 @@
 import { TransactionImportRunError, isImportCommitWorthRepeating } from '@/api/transaction-imports'
-import { getErrorMessage } from '@/pages/imports/utils/payload'
+import { getImportFailureMessage } from '@/utils/importFailure'
 
 // What the user is told after stopping an import themselves, which reads differently either side of
 // the commit: before it nothing has been written, and during it the write may already have finished
@@ -35,7 +35,7 @@ export function getImportCommitFailure(error: unknown, cancelled: boolean): Impo
   return {
     message: cancelled
       ? (stoppedDuringCommit ? IMPORT_STOPPED_WHILE_COMMITTING_MESSAGE : IMPORT_STOPPED_WHILE_STAGING_MESSAGE)
-      : getErrorMessage(error),
+      : getImportFailureMessage(error),
     retryableRunId: worthRepeating ? runId : null,
     discardableRunId: worthRepeating ? null : runId,
   }

--- a/frontend/src/pages/imports/utils/csv.ts
+++ b/frontend/src/pages/imports/utils/csv.ts
@@ -144,7 +144,9 @@ export async function readCsvFile(
 
   try {
     const text = await file.text()
-    const replacementLimit = Math.floor(text.length * MAX_REPLACEMENT_CHARACTER_SHARE)
+    // One unreadable character is always allowed, since the share alone rounds down to none at all
+    // below twenty characters and would refuse a short file outright for a single accented name
+    const replacementLimit = Math.max(1, Math.floor(text.length * MAX_REPLACEMENT_CHARACTER_SHARE))
     const replacementCount = countReplacementCharacters(text, replacementLimit)
 
     // Text in a two-byte encoding decodes to characters the reader can read, every other one of them

--- a/frontend/src/pages/imports/utils/payload.ts
+++ b/frontend/src/pages/imports/utils/payload.ts
@@ -6,7 +6,6 @@ import {
   CREATE_ACCOUNT_VALUE,
   CREATE_CATEGORY_VALUE,
   DEFAULT_CATEGORY_ICON,
-  GENERIC_IMPORT_FAILURE,
   getCategoryDirectionClashError,
   getDirectionValuesAgreeError,
   getTooManyMappingsError,
@@ -485,15 +484,4 @@ export function formatImportSummary(result: TransactionImportResponse) {
   ]
 
   return parts.join(' · ')
-}
-
-/**
- * Extracts a user-facing message from a failed import request, falling back to a generic message
- * where the rejection carries nothing to show
- *
- * A rejection that is not an error, and one carrying an empty message, both fall back, since an
- * empty message reaches the user as a failure notice with nothing in it
- */
-export function getErrorMessage(error: unknown) {
-  return error instanceof Error && error.message ? error.message : GENERIC_IMPORT_FAILURE
 }

--- a/frontend/src/pages/imports/utils/payload.ts
+++ b/frontend/src/pages/imports/utils/payload.ts
@@ -6,6 +6,7 @@ import {
   CREATE_ACCOUNT_VALUE,
   CREATE_CATEGORY_VALUE,
   DEFAULT_CATEGORY_ICON,
+  GENERIC_IMPORT_FAILURE,
   getCategoryDirectionClashError,
   getDirectionValuesAgreeError,
   getTooManyMappingsError,
@@ -488,8 +489,11 @@ export function formatImportSummary(result: TransactionImportResponse) {
 
 /**
  * Extracts a user-facing message from a failed import request, falling back to a generic message
- * for a non-Error rejection
+ * where the rejection carries nothing to show
+ *
+ * A rejection that is not an error, and one carrying an empty message, both fall back, since an
+ * empty message reaches the user as a failure notice with nothing in it
  */
 export function getErrorMessage(error: unknown) {
-  return error instanceof Error ? error.message : 'Import failed.'
+  return error instanceof Error && error.message ? error.message : GENERIC_IMPORT_FAILURE
 }

--- a/frontend/src/utils/importFailure.ts
+++ b/frontend/src/utils/importFailure.ts
@@ -1,0 +1,21 @@
+/**
+ * What an import shows the user when it fails
+ *
+ * Both the request layer and the import pages need this, and the request layer cannot reach into a
+ * page, so the message and the reading of it live here rather than beside either caller
+ */
+
+// Shown when an import fails with nothing usable to show for it, which is a rejection carrying no
+// message and anything thrown that is not an error at all. It says nothing about which record failed,
+// so a caller matching a detail against its own records must leave this one out
+export const GENERIC_IMPORT_FAILURE = 'Import failed.'
+
+/**
+ * Reads a user-facing message off a failed import
+ *
+ * A rejection that is not an error, and one carrying an empty message, both fall back, since an
+ * empty message reaches the user as a failure notice with nothing in it
+ */
+export function getImportFailureMessage(error: unknown) {
+  return error instanceof Error && error.message ? error.message : GENERIC_IMPORT_FAILURE
+}

--- a/frontend/tests/api/transaction-imports.test.ts
+++ b/frontend/tests/api/transaction-imports.test.ts
@@ -207,6 +207,26 @@ describe('staging a transaction import', () => {
     expect(authenticatedFetchMock.mock.calls[2][1].method).toBe('DELETE');
   });
 
+  // A commit rejected with nothing to say gave the run error an empty message, which the overlay
+  // then showed as a failure notice with no words in it
+  it('says an import failed when the commit is rejected with no message', async () => {
+    const payload = buildImportPayload([buildImportRow()]);
+    mockRunCalls(new Error(''));
+
+    const error = await runTransactionImport(payload).catch((thrown: unknown) => thrown);
+
+    expect((error as TransactionImportRunError).message).toBe('Import failed.');
+  });
+
+  it('keeps the message a rejected commit carries', async () => {
+    const payload = buildImportPayload([buildImportRow()]);
+    mockRunCalls(new ApiError('Invalid amount: $2.00', 422));
+
+    const error = await runTransactionImport(payload).catch((thrown: unknown) => thrown);
+
+    expect((error as TransactionImportRunError).message).toBe('Invalid amount: $2.00');
+  });
+
   it('keeps the run when the commit fails, so it can be committed again', async () => {
     const payload = buildImportPayload([buildImportRow()]);
     mockRunCalls(new ApiError('Request failed (503)', 503));

--- a/frontend/tests/pages/imports/utils/accountMapping.nameMatching.test.ts
+++ b/frontend/tests/pages/imports/utils/accountMapping.nameMatching.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests which existing account the import guesses for a source by name, now that the rule scoring
+ * one name contained inside the other is what settles most of them, and what the guesser leaves
+ * alone rather than choosing between
+ */
+import { describe, expect, it } from 'vitest'
+import type { AccountsOverview } from '@/api/accounts'
+import type { ImportAccountSource } from '@/pages/imports/types'
+import { OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
+import { inferAccountMappings } from '@/pages/imports/utils'
+
+/**
+ * Creates a mapping source, defaulting to one rows are written to
+ */
+function createSource(id: string, overrides: Partial<ImportAccountSource> = {}): ImportAccountSource {
+  return { id, label: id, matchText: id, isCounterpartyOnly: false, ...overrides }
+}
+
+/**
+ * Creates an account overview, carrying only the fields the name match reads
+ */
+function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverview {
+  return {
+    id: 'acct-1',
+    owner_id: null,
+    group_id: null,
+    account_kind: 'asset',
+    account_type: 'checking',
+    tax_advantaged_category_id: null,
+    name: 'Everyday',
+    institution: null,
+    currency: 'CAD',
+    current_balance: 0,
+    base_currency_current_balance: 0,
+    current_balance_fx_status: { state: 'complete', missing_pairs: [] },
+    credit_limit: null,
+    is_archived: false,
+    closed_at: null,
+    ...overrides,
+  }
+}
+
+describe('guessing which account a source belongs to by name', () => {
+  it('refuses to choose between two accounts sharing a name', () => {
+    const source = createSource('Savings')
+    const accounts = [
+      createAccount({ id: 'acct-1', name: 'Savings' }),
+      createAccount({ id: 'acct-2', name: 'Savings' }),
+    ]
+
+    expect(inferAccountMappings([source], {}, { rowAccounts: accounts, counterpartyAccounts: accounts })).toEqual({})
+  })
+
+  // Without the chequing-to-checking rewrite the two share only one word out of two, which fails
+  // both the shared-word rule and the substring rule, so this genuinely fails if the rewrite goes
+  it('matches an account spelling chequing the British way against one spelling it checking', () => {
+    const source = createSource('Everyday Chequing')
+    const accounts = [createAccount({ id: 'acct-1', name: 'Everyday Checking' })]
+
+    expect(inferAccountMappings([source], {}, { rowAccounts: accounts, counterpartyAccounts: accounts }))
+      .toEqual({ 'Everyday Chequing': 'acct-1' })
+  })
+
+  it('leaves a source and an account unmatched where both clean away to nothing', () => {
+    const source = createSource('Transactions')
+    const accounts = [createAccount({ id: 'acct-1', name: 'Statement' })]
+
+    expect(inferAccountMappings([source], {}, { rowAccounts: accounts, counterpartyAccounts: accounts })).toEqual({})
+  })
+
+  it('fills in a stored blank answer but leaves a stored outside answer alone', () => {
+    const sources = [createSource('Empty'), createSource('Outside', { isCounterpartyOnly: true })]
+    const accounts = [createAccount({ id: 'acct-1', name: 'Empty' })]
+
+    const result = inferAccountMappings(
+      sources,
+      { Empty: '', Outside: OUTSIDE_ACCOUNT_VALUE },
+      { rowAccounts: accounts, counterpartyAccounts: accounts },
+    )
+
+    expect(result.Empty).toBe('acct-1')
+    expect(result.Outside).toBe(OUTSIDE_ACCOUNT_VALUE)
+  })
+})

--- a/frontend/tests/pages/imports/utils/autoColumnMapping.test.ts
+++ b/frontend/tests/pages/imports/utils/autoColumnMapping.test.ts
@@ -660,3 +660,152 @@ describe('guessing the column that specifies money in or money out', () => {
     expect(map.amount_direction).toBe('')
   })
 })
+
+describe('reaching the branches only an unusual arrangement of columns exercises', () => {
+  it('skips a column whose values fail its own rule rather than mapping it with an error', () => {
+    const files = [createFile(
+      ['Date'],
+      [
+        { Date: '2026-01-01' },
+        { Date: '' },
+        { Date: '2026-01-03' },
+      ],
+    )]
+
+    const { map, errors } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(map.dt).toBe('')
+    expect(errors.Date).toBeUndefined()
+  })
+
+  // Inference cannot produce an error of its own, since each candidate is checked against the
+  // same rule before it is claimed, so only a mapping that arrived with the argument can come
+  // back flagged. Every other case in this file reads the map alone, so this is the first to
+  // observe that the errors half of the return is forwarded at all
+  it('carries an error the caller supplied through the return, not just what inference finds', () => {
+    const files = [createFile(
+      ['Date', 'Amount'],
+      [
+        { Date: '2026-04-11', Amount: '-12.34' },
+        { Date: '2026-04-12', Amount: '-8.00' },
+        { Date: '2026-04-13', Amount: '45.00' },
+      ],
+    )]
+    const columnMap = { ...EMPTY_COLUMN_MAP, category_id: 'Amount' }
+
+    const { errors } = inferColumnMap(columnMap, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(errors.Amount).toBeDefined()
+  })
+
+  it('returns the empty map by reference and no errors when there are no files', () => {
+    const { map, errors } = inferColumnMap(EMPTY_COLUMN_MAP, [], SUPPORTED_CURRENCY_CODES)
+
+    expect(map).toBe(EMPTY_COLUMN_MAP)
+    expect(errors).toEqual({})
+  })
+
+  it('maps fields from the union of headers across two files', () => {
+    const files = [
+      createFile(
+        ['Date', 'Amount'],
+        [
+          { Date: '2026-04-11', Amount: '-12.00' },
+          { Date: '2026-04-12', Amount: '-8.00' },
+        ],
+      ),
+      createFile(
+        ['Date', 'Category'],
+        [
+          { Date: '2026-04-11', Category: 'Groceries' },
+          { Date: '2026-04-12', Category: 'Transit' },
+        ],
+      ),
+    ]
+
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(map.dt).toBe('Date')
+    expect(map.amount).toBe('Amount')
+    expect(map.category_id).toBe('Category')
+  })
+
+  it('maps the currency field on its values alone when the heading gives it no score', () => {
+    const files = [createFile(
+      ['Date', 'Amount', 'Ccy'],
+      [
+        { Date: '2026-04-11', Amount: '-12.00', Ccy: 'CAD' },
+        { Date: '2026-04-12', Amount: '-8.00', Ccy: 'USD' },
+      ],
+    )]
+
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(map.currency).toBe('Ccy')
+  })
+
+  // Three rows of the plan's own example ('a;b' twice, 'c;d' once) still score merchant higher
+  // than tags, since a uniqueRatio of 0.667 clears the merchant field's 0.35 floor and merchant is
+  // asked first. Only once the repeat brings that ratio down to 0.35 or below does merchant stop
+  // scoring and leave the column for tags, which takes six rows split between the two values
+  it('claims a repetitive semicolon-separated column for tags rather than merchant', () => {
+    const files = [createFile(
+      ['Date', 'Amount', 'Misc'],
+      [
+        { Date: '2026-04-11', Amount: '-12.00', Misc: 'a;b' },
+        { Date: '2026-04-12', Amount: '-8.00', Misc: 'a;b' },
+        { Date: '2026-04-13', Amount: '-20.00', Misc: 'a;b' },
+        { Date: '2026-04-14', Amount: '-5.00', Misc: 'c;d' },
+        { Date: '2026-04-15', Amount: '-6.00', Misc: 'c;d' },
+        { Date: '2026-04-16', Amount: '-7.00', Misc: 'c;d' },
+      ],
+    )]
+
+    const { map } = inferColumnMap(EMPTY_COLUMN_MAP, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(map.tag_ids).toBe('Misc')
+    expect(map.merchant_id).not.toBe('Misc')
+  })
+
+  describe('scoring a repetitive column of words no alias or contains table recognises', () => {
+    /**
+     * Builds a file whose Misc column repeats each of the given words three times, so the ratio of
+     * distinct to repeated values only depends on how many words are given
+     */
+    function createRepeatedWordFile(words: string[]) {
+      const misc = words.flatMap((word) => [word, word, word])
+      return [createFile(
+        ['Date', 'Amount', 'Misc'],
+        misc.map((word, index) => ({
+          Date: `2026-04-${String(index + 1).padStart(2, '0')}`,
+          Amount: `-${index + 1}.00`,
+          Misc: word,
+        })),
+      )]
+    }
+
+    it('leaves the column unmapped for category or merchant below the distinct-value floor', () => {
+      const { map } = inferColumnMap(
+        EMPTY_COLUMN_MAP,
+        createRepeatedWordFile(['Zeta', 'Eta', 'Theta']),
+        SUPPORTED_CURRENCY_CODES,
+      )
+
+      expect(map.category_id).toBe('')
+      expect(map.merchant_id).not.toBe('Misc')
+    })
+
+    // Asserting the category field alone would pass whether or not the merchant field had
+    // quietly taken the column instead, so both are checked
+    it('claims the column for category once it holds enough distinct words, still leaving merchant without it', () => {
+      const { map } = inferColumnMap(
+        EMPTY_COLUMN_MAP,
+        createRepeatedWordFile(['Zeta', 'Eta', 'Theta', 'Iota']),
+        SUPPORTED_CURRENCY_CODES,
+      )
+
+      expect(map.category_id).toBe('Misc')
+      expect(map.merchant_id).not.toBe('Misc')
+    })
+  })
+})

--- a/frontend/tests/pages/imports/utils/categoryMatching.matchState.test.ts
+++ b/frontend/tests/pages/imports/utils/categoryMatching.matchState.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests the small pieces the category matching step is built from: which sources keep their
+ * current answers when the imported list changes, what kind a matched category counts as, and
+ * whether a selection points at a category that already exists
+ */
+import { describe, expect, it } from 'vitest'
+import type { Category } from '@/api/categories'
+import { CREATE_CATEGORY_VALUE } from '@/pages/imports/constants'
+import { getCategoryMatchKind, isExistingCategoryMatch, keepCurrentMatchMap } from '@/pages/imports/utils'
+
+/**
+ * Creates a category fixture, defaulting to one the user owns
+ */
+function createCategory(overrides: Partial<Category> = {}): Category {
+  return {
+    id: overrides.id ?? 'cat-1',
+    group_id: null,
+    owner_id: 'user-1',
+    name: overrides.name ?? 'Groceries',
+    kind: overrides.kind ?? 'expense',
+    icon: null,
+    is_system: false,
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('keeping a match map in step with the imported sources', () => {
+  // Losing this identity re-runs the category step on every render
+  it('returns the same object when nothing changed', () => {
+    const current = { a: 'x' }
+
+    expect(keepCurrentMatchMap(current, ['a'])).toBe(current)
+  })
+
+  it('drops a source the file no longer carries', () => {
+    expect(keepCurrentMatchMap({ a: 'x', b: 'y' }, ['a'])).toEqual({ a: 'x' })
+  })
+
+  it('adds a blank answer for a new source', () => {
+    expect(keepCurrentMatchMap({ a: 'x' }, ['a', 'b'])).toEqual({ a: 'x', b: '' })
+  })
+
+  // The length check alone cannot catch this: one source is dropped and one is added, so the count
+  // stays the same while the sources themselves have changed
+  it('rebuilds the map when the source list changes without changing size', () => {
+    expect(keepCurrentMatchMap({ a: 'x', b: 'y' }, ['a', 'c'])).toEqual({ a: 'x', c: '' })
+  })
+})
+
+describe('working out what kind a matched category counts as', () => {
+  const NO_CATEGORIES = new Map<string, Category>()
+
+  // A chosen category outranks both other arguments even when the map does not hold it, so a
+  // fall-through would show a kind the commit will not use
+  it('reads nothing for a selection the map does not hold', () => {
+    expect(getCategoryMatchKind('cat-1', 'income', 'Income', NO_CATEGORIES)).toBe('')
+  })
+
+  it('takes the kind off the selected category', () => {
+    const categoryById = new Map([['cat-1', createCategory({ kind: 'expense' })]])
+
+    expect(getCategoryMatchKind('cat-1', undefined, 'Income', categoryById)).toBe('expense')
+  })
+
+  it('falls back to the chosen create kind for a queued category', () => {
+    expect(getCategoryMatchKind(CREATE_CATEGORY_VALUE, 'transfer', 'Expense', NO_CATEGORIES)).toBe('transfer')
+  })
+
+  it('falls back to the type inferred from the amounts when no kind is chosen', () => {
+    expect(getCategoryMatchKind('', undefined, 'Transfer', NO_CATEGORIES)).toBe('transfer')
+    expect(getCategoryMatchKind('', undefined, 'Income', NO_CATEGORIES)).toBe('income')
+  })
+
+  // The second case fails on its own if the decode stops being case sensitive
+  it('reads nothing from a type label it does not recognise', () => {
+    expect(getCategoryMatchKind('', undefined, 'Mixed', NO_CATEGORIES)).toBe('')
+    expect(getCategoryMatchKind('', undefined, 'expense', NO_CATEGORIES)).toBe('')
+  })
+})
+
+describe('whether a selection points at a category that already exists', () => {
+  it('accepts a real category id', () => {
+    expect(isExistingCategoryMatch('cat-1')).toBe(true)
+  })
+
+  it('refuses the create-new placeholder', () => {
+    expect(isExistingCategoryMatch(CREATE_CATEGORY_VALUE)).toBe(false)
+  })
+
+  it('refuses nothing selected at all', () => {
+    expect(isExistingCategoryMatch('')).toBe(false)
+  })
+})

--- a/frontend/tests/pages/imports/utils/categoryMatching.nameOnlyMatching.test.ts
+++ b/frontend/tests/pages/imports/utils/categoryMatching.nameOnlyMatching.test.ts
@@ -86,3 +86,43 @@ describe('the category a create answer would land on', () => {
     expect(findReusedImportCategory('Bonus', [SYSTEM_INCOME, PERSONAL_EXPENSE])?.id).toBe('personal-expense')
   })
 })
+
+describe('scoring a source against a category by more than an exact match', () => {
+  // The contains rule needs four characters and the shared-word rule needs half of them, so a
+  // three-letter source matches nothing and the value comes up present but unanswered
+  it('leaves a three-letter source unmatched against a category it barely touches', () => {
+    const fuel: Category = { ...PERSONAL_EXPENSE, id: 'fuel', name: 'Gas & Fuel' }
+
+    expect(inferCategoryMappings(['Gas'], {}, [fuel])).toEqual({ Gas: '' })
+  })
+
+  it('matches a source punctuated with an ampersand against a category spelling it out', () => {
+    const category: Category = { ...PERSONAL_EXPENSE, id: 'household', name: 'Groceries and Household' }
+
+    expect(inferCategoryMappings(['Groceries & Household'], {}, [category]))
+      .toEqual({ 'Groceries & Household': 'household' })
+  })
+
+  it('matches a source carrying an accent against a category written without one', () => {
+    const category: Category = { ...PERSONAL_EXPENSE, id: 'cafe', name: 'Cafe' }
+
+    expect(inferCategoryMappings(['Café'], {}, [category])).toEqual({ 'Café': 'cafe' })
+  })
+
+  it('matches a source and a category naming the same words in a different order', () => {
+    const category: Category = { ...PERSONAL_EXPENSE, id: 'dining', name: 'Out Dining' }
+
+    expect(inferCategoryMappings(['Dining Out'], {}, [category])).toEqual({ 'Dining Out': 'dining' })
+  })
+
+  it('drops a stored answer for a source the file no longer carries', () => {
+    const result = inferCategoryMappings(['Bonus'], { Vanished: 'some-id' }, [PERSONAL_INCOME])
+
+    expect(result).not.toHaveProperty('Vanished')
+    expect(result).toEqual({ Bonus: 'personal-income' })
+  })
+
+  it('keeps a blank source present and unmatched', () => {
+    expect(inferCategoryMappings(['   '], {}, [PERSONAL_INCOME])).toEqual({ '   ': '' })
+  })
+})

--- a/frontend/tests/pages/imports/utils/columnMapping.headerHelpers.test.ts
+++ b/frontend/tests/pages/imports/utils/columnMapping.headerHelpers.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests the two small readers the mapping step and its samples rely on: which target a header is
+ * currently mapped to, and what a column's own values look like before anyone maps it to anything
+ */
+import { describe, expect, it } from 'vitest'
+import { EMPTY_COLUMN_MAP } from '@/pages/imports/constants'
+import type { ColumnMap, CsvRow, ImportFileDraft } from '@/pages/imports/types'
+import { getColumnSamples, getTargetForHeader } from '@/pages/imports/utils'
+
+/**
+ * Creates a one-file draft from the given headers and rows
+ */
+function createFile(headers: string[], rows: CsvRow[]): ImportFileDraft {
+  return {
+    id: 'file-1',
+    name: 'Chequing.csv',
+    size: 1024,
+    headers,
+    hasHeaderRow: true,
+    rows,
+    error: null,
+  }
+}
+
+/**
+ * Builds a one-column file from the values it holds
+ */
+function createColumn(header: string, values: string[]) {
+  return [createFile([header], values.map((value) => ({ [header]: value })))]
+}
+
+describe('finding which target a header is mapped to', () => {
+  // Every unmapped field holds '', which used to make an empty header match account_id, the first
+  // target the loop reached
+  it('returns nothing for an empty header', () => {
+    expect(getTargetForHeader(EMPTY_COLUMN_MAP, '')).toBe('')
+  })
+
+  it('picks the earlier target when two point at the same header', () => {
+    const map: ColumnMap = { ...EMPTY_COLUMN_MAP, merchant_id: 'Payee', notes: 'Payee' }
+
+    expect(getTargetForHeader(map, 'Payee')).toBe('merchant_id')
+  })
+
+  it('is case sensitive', () => {
+    const map: ColumnMap = { ...EMPTY_COLUMN_MAP, dt: 'Date' }
+
+    expect(getTargetForHeader(map, 'date')).toBe('')
+  })
+})
+
+describe('sampling a column\'s own values', () => {
+  // A regression that caps before it dedupes would return only ['Acme', 'Bee']
+  it('dedupes before capping at three', () => {
+    const files = createColumn('Merchant', ['Acme', 'Acme', 'Bee', 'Cee', 'Dee'])
+
+    expect(getColumnSamples(files, 'Merchant')).toEqual(['Acme', 'Bee', 'Cee'])
+  })
+
+  it('trims whitespace and drops a blank cell', () => {
+    const files = createColumn('Merchant', [' Acme ', 'Acme', '  '])
+
+    expect(getColumnSamples(files, 'Merchant')).toEqual(['Acme'])
+  })
+
+  it('returns nothing for a header no file carries', () => {
+    const files = createColumn('Merchant', ['Acme'])
+
+    expect(getColumnSamples(files, 'Payee')).toEqual([])
+  })
+})

--- a/frontend/tests/pages/imports/utils/columnMapping.mapValidation.test.ts
+++ b/frontend/tests/pages/imports/utils/columnMapping.mapValidation.test.ts
@@ -84,13 +84,15 @@ describe('one header mapped to two targets', () => {
   // stops overwriting the earlier target's entry with the later one's
   it('keeps only the later target\'s message', () => {
     const map: ColumnMap = { ...EMPTY_COLUMN_MAP, amount: 'SameCol', currency: 'SameCol' }
-    const files = [createFile(['SameCol'], [{ SameCol: '-12.34' }])]
+    // Refused by both targets, so Amount writes an entry the Currency pass then has to replace. A
+    // value only Currency refuses would leave nothing to overwrite and the case would prove nothing
+    const files = [createFile(['SameCol'], [{ SameCol: 'abc' }])]
 
     const result = validateColumnMap(map, files, SUPPORTED_CURRENCY_CODES)
 
     expect(Object.keys(result.errors)).toEqual(['SameCol'])
     expect(result.errors.SameCol).toBe(
-      'Expected ISO currency codes this app supports, such as CAD or USD. Row 1 has "-12.34", which does not match.',
+      'Expected ISO currency codes this app supports, such as CAD or USD. Row 1 has "abc", which does not match.',
     )
   })
 })

--- a/frontend/tests/pages/imports/utils/columnMapping.mapValidation.test.ts
+++ b/frontend/tests/pages/imports/utils/columnMapping.mapValidation.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests what validateColumnMap keeps and drops when the uploaded files change: which mappings
+ * survive against the headers actually present, and which validation error lands against which
+ * header when two targets are mapped to the same column
+ */
+import { describe, expect, it } from 'vitest'
+import { EMPTY_COLUMN_MAP } from '@/pages/imports/constants'
+import type { ColumnMap, CsvRow, ImportFileDraft } from '@/pages/imports/types'
+import { validateColumnMap } from '@/pages/imports/utils'
+
+const SUPPORTED_CURRENCY_CODES = new Set(['CAD', 'USD'])
+
+/**
+ * Creates a one-file draft from the given headers and rows
+ */
+function createFile(headers: string[], rows: CsvRow[]): ImportFileDraft {
+  return {
+    id: 'file-1',
+    name: 'Chequing.csv',
+    size: 1024,
+    headers,
+    hasHeaderRow: true,
+    rows,
+    error: null,
+  }
+}
+
+describe('pairing a failing column with its error', () => {
+  it('keeps a failing mapping in the map, flagged beside it', () => {
+    const map: ColumnMap = { ...EMPTY_COLUMN_MAP, category_id: 'Amount' }
+    const files = [createFile(['Amount'], [
+      { Amount: '-12.34' },
+      { Amount: '-8.00' },
+      { Amount: '45.00' },
+    ])]
+
+    const result = validateColumnMap(map, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(result.map.category_id).toBe('Amount')
+    expect(result.errors.Amount).toBeTruthy()
+  })
+})
+
+describe('dropping a mapping whose header the files no longer carry', () => {
+  it('clears the mapping quietly, without an error', () => {
+    const map: ColumnMap = { ...EMPTY_COLUMN_MAP, dt: 'Missing' }
+    const files = [createFile(['Date', 'Amount'], [])]
+
+    const result = validateColumnMap(map, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(result.map.dt).toBe('')
+    expect(result.errors).toEqual({})
+  })
+})
+
+describe('no files staged', () => {
+  // A caller mutating the result would corrupt the shared constant every other empty state reads
+  it('returns the shared empty map by reference', () => {
+    const map: ColumnMap = { ...EMPTY_COLUMN_MAP, dt: 'Date' }
+
+    const result = validateColumnMap(map, [], SUPPORTED_CURRENCY_CODES)
+
+    expect(result.map).toBe(EMPTY_COLUMN_MAP)
+  })
+})
+
+describe('mappings spread across several files', () => {
+  it('keeps both, reading the header union rather than either file alone', () => {
+    const map: ColumnMap = { ...EMPTY_COLUMN_MAP, dt: 'Date', amount: 'Amount' }
+    const files = [
+      createFile(['Date'], [{ Date: '2026-01-01' }]),
+      createFile(['Amount'], [{ Amount: '12.34' }]),
+    ]
+
+    const result = validateColumnMap(map, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(result.map.dt).toBe('Date')
+    expect(result.map.amount).toBe('Amount')
+  })
+})
+
+describe('one header mapped to two targets', () => {
+  // Amount runs before Currency in COLUMN_TARGETS, so this is the case that fails if the loop
+  // stops overwriting the earlier target's entry with the later one's
+  it('keeps only the later target\'s message', () => {
+    const map: ColumnMap = { ...EMPTY_COLUMN_MAP, amount: 'SameCol', currency: 'SameCol' }
+    const files = [createFile(['SameCol'], [{ SameCol: '-12.34' }])]
+
+    const result = validateColumnMap(map, files, SUPPORTED_CURRENCY_CODES)
+
+    expect(Object.keys(result.errors)).toEqual(['SameCol'])
+    expect(result.errors.SameCol).toBe(
+      'Expected ISO currency codes this app supports, such as CAD or USD. Row 1 has "-12.34", which does not match.',
+    )
+  })
+})

--- a/frontend/tests/pages/imports/utils/columnMapping.test.ts
+++ b/frontend/tests/pages/imports/utils/columnMapping.test.ts
@@ -319,3 +319,19 @@ describe('answering what one word in the Direction column means', () => {
     expect(answerImportDirectionValue({}, PAIR, 'debit', 'out')).toEqual({ debit: 'out' })
   })
 })
+
+describe('checking a column mapped to the single amount field', () => {
+  it('refuses a column with a blank row, giving the count', () => {
+    const files = createColumn('Amount', ['12.34', '', '5.00'])
+    const result = validateColumnValues(files, 'Amount', 'amount', SUPPORTED_CURRENCY_CODES)
+
+    expect(result.valid).toBe(false)
+    expect(result.message).toContain('1 row is blank.')
+  })
+
+  it('refuses a column holding a value that is not a number', () => {
+    const files = createColumn('Amount', ['abc'])
+
+    expect(validateColumnValues(files, 'Amount', 'amount', SUPPORTED_CURRENCY_CODES).valid).toBe(false)
+  })
+})

--- a/frontend/tests/pages/imports/utils/common.test.ts
+++ b/frontend/tests/pages/imports/utils/common.test.ts
@@ -4,7 +4,7 @@
  */
 import { describe, expect, it } from 'vitest'
 import type { ImportFileDraft } from '@/pages/imports/types'
-import { hasAcceptedFile } from '@/pages/imports/utils'
+import { formatBytes, hasAcceptedFile, removeRecordKey, removeSetValue } from '@/pages/imports/utils'
 
 /**
  * Builds a staged draft, taking the error and notice the reader would have recorded on it
@@ -46,5 +46,50 @@ describe('whether a usable file is staged', () => {
     const noticed = createFile({ notice: 'Some characters could not be read.' })
 
     expect(hasAcceptedFile([noticed])).toBe(true)
+  })
+})
+
+describe('removing a value from a set that may not hold it', () => {
+  it('returns the same set when the value was never in it', () => {
+    const set = new Set(['a'])
+
+    expect(removeSetValue(set, 'b')).toBe(set)
+  })
+
+  it('returns a new set without the value, leaving the original untouched', () => {
+    const set = new Set(['a', 'b'])
+
+    expect(removeSetValue(set, 'a')).toEqual(new Set(['b']))
+    expect(set.has('a')).toBe(true)
+  })
+})
+
+describe('removing a key from a record that may not hold it', () => {
+  it('returns the same record when the key was never present', () => {
+    const record = { a: 'x' }
+
+    expect(removeRecordKey(record, 'b')).toBe(record)
+  })
+
+  it('returns a new record without the key, leaving the original untouched', () => {
+    const record = { a: 'x', b: 'y' }
+
+    expect(removeRecordKey(record, 'b')).toEqual({ a: 'x' })
+    expect(record.b).toBe('y')
+  })
+})
+
+describe('rendering a file size', () => {
+  it('stays in kilobytes one byte short of a megabyte', () => {
+    expect(formatBytes(1048575)).toBe('1024.0 KB')
+  })
+
+  it('switches from bytes to kilobytes exactly at 1024', () => {
+    expect(formatBytes(1023)).toBe('1023 B')
+    expect(formatBytes(1024)).toBe('1.0 KB')
+  })
+
+  it('renders the size the refusal message quotes', () => {
+    expect(formatBytes(26214400)).toBe('25.0 MB')
   })
 })

--- a/frontend/tests/pages/imports/utils/csv.fileIntake.test.ts
+++ b/frontend/tests/pages/imports/utils/csv.fileIntake.test.ts
@@ -199,3 +199,82 @@ describe('keeping what the reader already handled', () => {
     expect(draft.headers).toEqual(['Date', 'Merchant', 'Amount'])
   })
 })
+
+describe('surfacing a failure the reader itself could not recover from', () => {
+  /**
+   * Stands in for a file whose read rejects, since a real File offers no way to make that happen
+   */
+  function stageUnreadableFile(rejection: unknown) {
+    const file = new File(['Date,Amount\n2026-01-01,-5.00\n'], 'statement.csv')
+    file.text = () => Promise.reject(rejection)
+
+    return readCsvFile(file, SUPPORTED_CURRENCY_CODES, { requireDataRows: true })
+  }
+
+  it('reports the underlying message when reading the file rejects', async () => {
+    const draft = await stageUnreadableFile(new Error('boom'))
+
+    expect(draft.error).toBe('Unable to parse CSV: boom')
+    expect(draft.rows).toEqual([])
+    expect(draft.headers).toEqual([])
+  })
+
+  it('falls back to a generic message when the rejection carries no Error', async () => {
+    const draft = await stageUnreadableFile('boom')
+
+    expect(draft.error).toBe('Unable to read file')
+  })
+})
+
+describe('allowing one unreadable character in a file too short for the share rule alone to catch it', () => {
+  // Math.floor(19 * 0.05) is 0, which used to refuse a 19-character file outright for a single
+  // unreadable character before the share rule could ever apply
+  it('stages a 19-character file carrying one replacement character', async () => {
+    const draft = await stage('Date,Amount\n2026,\uFFFD\n')
+
+    expect(draft.error).toBeNull()
+    expect(draft.notice).toBe('1 character could not be read')
+  })
+
+  it('counts more than one replacement character once the file is long enough for the share rule to govern', async () => {
+    const draft = await stage(
+      'Date,Merchant,Amount\n2026-01-01,Caf\uFFFD Bleu,-5.00\n2026-01-02,Bo\uFFFDte,-6.00\n',
+    )
+
+    expect(draft.error).toBeNull()
+    expect(draft.notice).toBe('2 characters could not be read')
+  })
+})
+
+describe('staging a file at exactly the row count it reads', () => {
+  it('accepts a file whose data rows equal the row limit', async () => {
+    const rows = Array.from({ length: MAX_IMPORT_ROWS }, (_, index) => `2026-01-01,${index}`)
+    const draft = await stage(`Date,Amount\n${rows.join('\n')}\n`)
+
+    expect(draft.error).toBeNull()
+  })
+})
+
+describe('carrying header detection onto a file actually read', () => {
+  it('marks a headerless file with generated column names', async () => {
+    // The detection rule itself is covered on the same input elsewhere; what is new here is that
+    // reading a real file carries both hasHeaderRow and the generated headers onto the draft
+    const draft = await stage('2026-01-01,-5.00\n2026-01-02,-6.00\n')
+
+    expect(draft.hasHeaderRow).toBe(false)
+    expect(draft.headers).toEqual(['Column 1', 'Column 2'])
+  })
+})
+
+describe('creating a fresh id for each read', () => {
+  it('gives two reads of the same file different ids, while keeping its name and size', async () => {
+    const file = new File(['Date,Amount\n2026-01-01,-5.00\n'], 'statement.csv')
+
+    const first = await readCsvFile(file, SUPPORTED_CURRENCY_CODES, { requireDataRows: true })
+    const second = await readCsvFile(file, SUPPORTED_CURRENCY_CODES, { requireDataRows: true })
+
+    expect(first.id).not.toBe(second.id)
+    expect(first.name).toBe('statement.csv')
+    expect(first.size).toBe(file.size)
+  })
+})

--- a/frontend/tests/pages/imports/utils/payload.mappingGaps.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.mappingGaps.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Tests the mapping-answer error paths the commit payload builder reaches only through an unusual
+ * combination of answers, plus the two payload shapes no test asserts directly: an account queued
+ * for creation and a merchant answer that resolves, both success paths as unexercised as the
+ * failures beside them
+ */
+import { describe, expect, it } from 'vitest'
+import type { AccountsOverview } from '@/api/accounts'
+import type { Category } from '@/api/categories'
+import type { Currency } from '@/api/currency'
+import {
+  CREATE_ACCOUNT_VALUE,
+  CREATE_CATEGORY_VALUE,
+  CREATE_MERCHANT_VALUE,
+  EMPTY_COLUMN_MAP,
+  getTooManyMappingsError,
+  MAX_IMPORT_MAPPINGS,
+} from '@/pages/imports/constants'
+import type { ColumnMap, CsvRow, ImportAccountSource, ImportFileDraft } from '@/pages/imports/types'
+import { buildTransactionImportPayload } from '@/pages/imports/utils'
+
+const CURRENCIES: Currency[] = [
+  { id: 'CAD', name: 'Canadian Dollar', symbol: '$', minor_unit_exponent: 2 },
+]
+
+const CATEGORY: Category = {
+  id: 'category-1',
+  group_id: null,
+  owner_id: null,
+  name: 'Groceries',
+  kind: 'expense',
+  icon: null,
+  is_system: false,
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const ACCOUNT: AccountsOverview = {
+  id: 'account-1',
+  owner_id: null,
+  group_id: null,
+  account_kind: 'asset',
+  account_type: 'checking',
+  tax_advantaged_category_id: null,
+  name: 'Chequing',
+  institution: null,
+  currency: 'CAD',
+  current_balance: 0,
+  base_currency_current_balance: 0,
+  current_balance_fx_status: { state: 'complete', missing_pairs: [] },
+  credit_limit: null,
+  is_archived: false,
+  closed_at: null,
+}
+
+const COLUMN_MAP: ColumnMap = { ...EMPTY_COLUMN_MAP, dt: 'Date', category_id: 'Category', amount: 'Amount' }
+const HEADERS = ['Date', 'Category', 'Amount']
+const VALID_ROW: CsvRow = { Date: '2026-04-10', Category: 'Groceries', Amount: '-12.34' }
+
+/**
+ * Creates a one-file draft carrying the given rows under the file's usual headers
+ */
+function createFile(rows: CsvRow[], overrides: Partial<ImportFileDraft> = {}): ImportFileDraft {
+  return { id: 'file-1', name: 'Chequing.csv', size: 512, headers: HEADERS, hasHeaderRow: true, rows, error: null, ...overrides }
+}
+
+/**
+ * Creates a mapping source rows are written to, unless overridden
+ */
+function createSource(id: string, overrides: Partial<ImportAccountSource> = {}): ImportAccountSource {
+  return { id, label: id, matchText: id, isCounterpartyOnly: false, ...overrides }
+}
+
+/**
+ * Builds a commit payload for one row, defaulting to an import every answer already settles, so
+ * each test overrides only the piece it means to put wrong
+ */
+function build(overrides: Partial<Parameters<typeof buildTransactionImportPayload>[0]> = {}) {
+  return buildTransactionImportPayload({
+    accountById: new Map([[ACCOUNT.id, ACCOUNT]]),
+    accountCreateCurrencies: {},
+    accountCreateInstitutions: {},
+    accountCreateTypes: {},
+    accountMappings: { 'file-1': ACCOUNT.id },
+    accountSources: [createSource('file-1', { label: 'Chequing', matchText: 'Chequing' })],
+    categoryById: new Map([[CATEGORY.id, CATEGORY]]),
+    categoryCreateKinds: {},
+    categoryMappings: { Groceries: CATEGORY.id },
+    categoryTypesBySource: {},
+    columnMap: COLUMN_MAP,
+    columnValidationErrors: {},
+    currencies: CURRENCIES,
+    dateFormat: 'yearFirst',
+    directionAnswers: {},
+    files: [createFile([VALID_ROW])],
+    importedCategories: ['Groceries'],
+    ...overrides,
+  })
+}
+
+describe('refusing an import with nothing to build a payload from', () => {
+  it('refuses an import with no files', () => {
+    const result = build({ files: [] })
+
+    expect(result.errors).toEqual(['Upload a CSV file.'])
+    expect(result.payload).toBeNull()
+  })
+
+  it('prefixes the error with the file it belongs to', () => {
+    const result = build({ files: [createFile([], { error: 'A quoted value is never closed.' })] })
+
+    expect(result.errors).toEqual(['Chequing.csv: A quoted value is never closed.'])
+    expect(result.payload).toBeNull()
+  })
+
+  it('refuses a file with a heading row and no problems on any of its rows, since it has none', () => {
+    const result = build({ files: [createFile([])] })
+
+    expect(result.errors).toEqual(['This file has no transaction rows to import.'])
+    expect(result.payload).toBeNull()
+  })
+})
+
+describe('refusing an import for what the mapping step never asked', () => {
+  it('lists the required columns still unmapped, asserted whole', () => {
+    const result = build({ columnMap: { ...EMPTY_COLUMN_MAP, dt: 'Date', category_id: 'Category' } })
+
+    // The label states all three ways a file can carry its amount, so asserting only that the
+    // message mentions Amount would pass on any wording at all
+    expect(result.errors).toEqual(['Map the required columns: Amount (or Money out / Money in)'])
+  })
+
+  it('refuses an import declaring more account sources than it may carry, the counterpart of the category limit', () => {
+    const sources = Array.from({ length: MAX_IMPORT_MAPPINGS + 1 }, (_, index) => createSource(`Source ${index}`))
+    const result = build({ accountSources: sources, accountMappings: {} })
+
+    expect(result.errors).toContain(getTooManyMappingsError('account', MAX_IMPORT_MAPPINGS + 1))
+    expect(result.payload).toBeNull()
+  })
+})
+
+describe('refusing a category or merchant answer the builder cannot use', () => {
+  it('asks for a create-category source\'s kind before anything else about it', () => {
+    const result = build({
+      categoryMappings: { Groceries: CREATE_CATEGORY_VALUE },
+      categoryCreateKinds: {},
+      categoryTypesBySource: {},
+    })
+
+    expect(result.errors).toEqual(['Choose category type: Groceries'])
+  })
+
+  it('forwards a merchant answer the builder refuses, no test having passed this function one before', () => {
+    const result = build({
+      merchantAnswers: {
+        importedMerchants: ['Acme'],
+        matchedMerchantByKey: new Map(),
+        merchantMappings: { Acme: CREATE_MERCHANT_VALUE },
+        merchantCreateNames: { Acme: '   ' },
+      },
+    })
+
+    expect(result.errors).toContain('Choose a name for the new merchant: Acme')
+  })
+})
+
+describe('refusing an account mapping answer', () => {
+  it('asks to map an account source with no answer at all', () => {
+    const result = build({ accountMappings: {} })
+
+    expect(result.errors).toEqual(['Map account: Chequing'])
+  })
+
+  // The type-support check can only be reached once both fields are answered, so a second source
+  // carrying a currency and an unsupported type is what proves the function ever reaches it
+  it('asks for both create-account fields before it can reach the type-support check on a second source', () => {
+    const result = build({
+      accountSources: [
+        createSource('blank-source', { label: 'Blank Source', matchText: 'Blank Source' }),
+        createSource('bad-type-source', { label: 'Bad Type Source', matchText: 'Bad Type Source' }),
+      ],
+      accountMappings: { 'blank-source': CREATE_ACCOUNT_VALUE, 'bad-type-source': CREATE_ACCOUNT_VALUE },
+      accountCreateCurrencies: { 'bad-type-source': 'CAD' },
+      accountCreateTypes: { 'bad-type-source': 'not-a-real-type' },
+    })
+
+    expect(result.errors).toContain('Choose account type: Blank Source')
+    expect(result.errors).toContain('Choose account currency: Blank Source')
+    expect(result.errors).toContain('Choose an account type this app supports: Bad Type Source')
+  })
+})
+
+describe('carrying a resolved mapping through to the payload', () => {
+  it('carries a fully answered create-account source through as a create entry', () => {
+    const result = build({
+      accountCreateTypes: { 'file-1': 'checking' },
+      accountCreateCurrencies: { 'file-1': 'CAD' },
+      accountCreateInstitutions: { 'file-1': 'inst-1' },
+      accountMappings: { 'file-1': CREATE_ACCOUNT_VALUE },
+    })
+
+    expect(result.errors).toEqual([])
+    expect(result.payload?.accounts).toContainEqual({
+      source: 'file-1',
+      create: { name: 'Chequing', account_type: 'checking', currency: 'CAD', institution_id: 'inst-1' },
+    })
+  })
+
+  it('carries an existing-category source through as a category_id entry', () => {
+    const result = build()
+
+    expect(result.errors).toEqual([])
+    expect(result.payload?.categories).toEqual([{ source: 'Groceries', category_id: CATEGORY.id }])
+  })
+
+  it('carries a merchant answer that resolves into the payload', () => {
+    const result = build({
+      merchantAnswers: {
+        importedMerchants: ['Acme'],
+        matchedMerchantByKey: new Map(),
+        merchantMappings: { Acme: CREATE_MERCHANT_VALUE },
+        merchantCreateNames: { Acme: 'Acme Store' },
+      },
+    })
+
+    expect(result.errors).toEqual([])
+    expect(result.payload?.merchants).toEqual([{ source: 'Acme', create: { name: 'Acme Store' } }])
+  })
+})

--- a/frontend/tests/pages/imports/utils/payload.summary.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.summary.test.ts
@@ -1,10 +1,9 @@
 /**
- * Tests the one-line summary shown once an import finishes, and the fallback message shown when it
- * fails with nothing usable to report
+ * Tests the one-line summary shown once an import finishes
  */
 import { describe, expect, it } from 'vitest'
 import type { TransactionImportResponse } from '@/api/transaction-imports'
-import { formatImportSummary, getErrorMessage } from '@/pages/imports/utils'
+import { formatImportSummary } from '@/pages/imports/utils'
 
 /**
  * Creates a completed import's response, defaulting every count to zero
@@ -51,17 +50,5 @@ describe('summarizing a completed import', () => {
     const summary = createSummary({ transactions_created: 1234, accounts_created: 2, categories_created: 7 })
 
     expect(formatImportSummary(summary)).toBe('1234 transactions imported · 2 accounts created · 7 categories created')
-  })
-})
-
-describe('falling back to a generic failure message', () => {
-  // An empty message used to reach the user as a blank failure notice, since nothing here caught it
-  it('falls back for an Error with no message', () => {
-    expect(getErrorMessage(new Error(''))).toBe('Import failed.')
-  })
-
-  it('falls back for a rejection that is not an Error', () => {
-    expect(getErrorMessage('boom')).toBe('Import failed.')
-    expect(getErrorMessage({ message: 'boom' })).toBe('Import failed.')
   })
 })

--- a/frontend/tests/pages/imports/utils/payload.summary.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.summary.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests the one-line summary shown once an import finishes, and the fallback message shown when it
+ * fails with nothing usable to report
+ */
+import { describe, expect, it } from 'vitest'
+import type { TransactionImportResponse } from '@/api/transaction-imports'
+import { formatImportSummary, getErrorMessage } from '@/pages/imports/utils'
+
+/**
+ * Creates a completed import's response, defaulting every count to zero
+ */
+function createSummary(overrides: Partial<TransactionImportResponse> = {}): TransactionImportResponse {
+  return {
+    transactions_created: 0,
+    accounts_created: 0,
+    accounts_reused: 0,
+    categories_created: 0,
+    categories_reused: 0,
+    merchants_created: 0,
+    merchants_reused: 0,
+    tags_created: 0,
+    tags_reused: 0,
+    affected_account_ids: [],
+    account_source_ids: {},
+    category_source_ids: {},
+    created_account_ids: [],
+    created_category_ids: [],
+    created_merchant_ids: [],
+    created_tag_ids: [],
+    ...overrides,
+  }
+}
+
+describe('summarizing a completed import', () => {
+  it('states one of each, singular, joined by the separator', () => {
+    const summary = createSummary({ transactions_created: 1, accounts_created: 1, categories_created: 1 })
+
+    expect(formatImportSummary(summary)).toBe('1 transaction imported · 1 account created · 1 category created')
+  })
+
+  // Zero takes the plural in all three, the same as any count above one
+  it('states zero of each, plural', () => {
+    expect(formatImportSummary(createSummary())).toBe(
+      '0 transactions imported · 0 accounts created · 0 categories created',
+    )
+  })
+
+  // The count has to pass a thousand for this case to mean anything, since a switch to a grouped
+  // number would render 1,234 and any smaller count reads the same either way
+  it('writes a count past a thousand ungrouped', () => {
+    const summary = createSummary({ transactions_created: 1234, accounts_created: 2, categories_created: 7 })
+
+    expect(formatImportSummary(summary)).toBe('1234 transactions imported · 2 accounts created · 7 categories created')
+  })
+})
+
+describe('falling back to a generic failure message', () => {
+  // An empty message used to reach the user as a blank failure notice, since nothing here caught it
+  it('falls back for an Error with no message', () => {
+    expect(getErrorMessage(new Error(''))).toBe('Import failed.')
+  })
+
+  it('falls back for a rejection that is not an Error', () => {
+    expect(getErrorMessage('boom')).toBe('Import failed.')
+    expect(getErrorMessage({ message: 'boom' })).toBe('Import failed.')
+  })
+})

--- a/frontend/tests/pages/imports/utils/preview.grouping.test.ts
+++ b/frontend/tests/pages/imports/utils/preview.grouping.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests how the preview list groups its rows under one date heading, since the step renders one
+ * heading per run of neighbouring rows rather than one per distinct date
+ */
+import { describe, expect, it } from 'vitest'
+import type { PreviewTransactionRow } from '@/pages/imports/types'
+import { groupPreviewRowsByDate } from '@/pages/imports/utils'
+
+/**
+ * Creates a minimal preview row under the given date label, with everything else fixed
+ */
+function createRow(id: string, dateLabel: string): PreviewTransactionRow {
+  return {
+    id,
+    accountInstitution: null,
+    accountName: 'Checking',
+    category: undefined,
+    currency: 'CAD',
+    dateLabel,
+    transaction: {
+      id: `txn-${id}`,
+      created_by_user_id: 'user-1',
+      account_id: 'account-1',
+      dt: '2026-01-01',
+      merchant_id: null,
+      merchant_name: null,
+      category_id: '',
+      amount: -1000,
+      account_amount: -1000,
+      base_currency_amount: -1000,
+      currency: 'CAD',
+      fx_rate: null,
+      notes: null,
+      counterparty_account_id: null,
+      counterparty_account_scope: null,
+      created_at: '2026-01-01T00:00:00Z',
+      updated_at: '2026-01-01T00:00:00Z',
+      tag_ids: [],
+      tags: [],
+    },
+  }
+}
+
+describe('grouping preview rows by date', () => {
+  // The function groups runs of neighbouring rows, and a regression turning it into one group per
+  // distinct date would collapse this into two groups and reorder the user's preview
+  it('starts a new group when a date repeats after another date breaks the run', () => {
+    const rows = [createRow('r1', 'A'), createRow('r2', 'B'), createRow('r3', 'A')]
+
+    const groups = groupPreviewRowsByDate(rows)
+
+    expect(groups).toHaveLength(3)
+    expect(groups.map((group) => group.dateLabel)).toEqual(['A', 'B', 'A'])
+  })
+
+  it('keeps a run of neighbouring rows sharing a date in one group', () => {
+    const rows = [createRow('r1', 'A'), createRow('r2', 'A'), createRow('r3', 'B')]
+
+    const groups = groupPreviewRowsByDate(rows)
+
+    expect(groups).toHaveLength(2)
+    expect(groups[0].rows).toHaveLength(2)
+    expect(groups[1].rows).toHaveLength(1)
+  })
+
+  it('returns nothing for no rows', () => {
+    expect(groupPreviewRowsByDate([])).toEqual([])
+  })
+})

--- a/frontend/tests/pages/imports/utils/preview.test.ts
+++ b/frontend/tests/pages/imports/utils/preview.test.ts
@@ -154,12 +154,17 @@ describe('import preview rows', () => {
       category: {
         name: 'Groceries',
         kind: 'expense',
+        icon: '🏷️',
       },
       transaction: {
         account_id: CREATE_ACCOUNT_VALUE,
         amount: -1234,
+        account_amount: -1234,
+        fx_rate: null,
+        merchant_id: 'import-preview-merchant-file-1-0',
         merchant_name: 'Market',
         notes: 'Weekly shop',
+        tag_ids: ['file-1-0-tag-0-food', 'file-1-0-tag-1-essentials'],
         tags: [
           { name: 'food' },
           { name: 'essentials' },
@@ -249,6 +254,8 @@ describe('import preview rows', () => {
 
     expect(rows).toHaveLength(5)
     expect(rows.at(-1)?.transaction.dt).toBe('2026-06-05')
+    // The category lookup runs on every row, so the last row inside the cap has to carry one too
+    expect(rows.at(-1)?.category).toMatchObject({ id: 'groceries', name: 'Groceries', kind: 'expense' })
   })
 
   // The preview used to fall back to the row's own sign, so a refund inside a source going both ways

--- a/frontend/tests/pages/imports/utils/valueParsers.amountValues.test.ts
+++ b/frontend/tests/pages/imports/utils/valueParsers.amountValues.test.ts
@@ -40,9 +40,12 @@ describe('shortening a value for display', () => {
     expect(truncateValue(value)).toBe('1234567890123456789012345...')
   })
 
-  it('returns a 25-character value whole, since the cut only touches a value longer than that', () => {
-    const value = '1234567890123456789012345'
+  // The cut is on longer than 28, not on longer than the 25 it keeps, so a value of 26, 27 or 28
+  // characters is left alone rather than shortened to something barely different
+  it('returns a 28-character value whole and shortens a 29-character one', () => {
+    const value = '12345678901234567890123456789'
 
-    expect(truncateValue(value)).toBe(value)
+    expect(truncateValue(value.slice(0, 28))).toBe('1234567890123456789012345678')
+    expect(truncateValue(value)).toBe('1234567890123456789012345...')
   })
 })

--- a/frontend/tests/pages/imports/utils/valueParsers.amountValues.test.ts
+++ b/frontend/tests/pages/imports/utils/valueParsers.amountValues.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Tests which raw cell values the amount column accepts, told apart from a formatted number, and
+ * the truncation every row message quoting a value back to the user runs through
+ */
+import { describe, expect, it } from 'vitest'
+import { isValidAmountValue, truncateValue } from '@/pages/imports/utils/valueParsers'
+
+describe('reading a cell as a raw signed amount', () => {
+  // These separate an amount column from a formatted one, and loosening the rule imports a
+  // different number than the file states
+  it('refuses a formatted number', () => {
+    for (const value of ['$5.00', '(5.00)', '1 234', '1.234,56', '1,23']) {
+      expect(isValidAmountValue(value)).toBe(false)
+    }
+  })
+
+  it('accepts a raw signed number, grouped or not', () => {
+    for (const value of ['1,234.56', '-12.34', '+5', '0', ' -12.34 ']) {
+      expect(isValidAmountValue(value)).toBe(true)
+    }
+  })
+
+  // The only input that reaches the finite-number guard, since the pattern itself accepts a run of
+  // digits this long
+  it('refuses a number too long to read as finite', () => {
+    expect(isValidAmountValue('9'.repeat(400))).toBe(false)
+  })
+
+  it('refuses a blank cell and a value with no digits on both sides of the point', () => {
+    for (const value of ['', '-', '12.', '.5', '1e3']) {
+      expect(isValidAmountValue(value)).toBe(false)
+    }
+  })
+})
+
+describe('shortening a value for display', () => {
+  it('cuts a long value to 25 characters and adds an ellipsis', () => {
+    const value = '1234567890123456789012345678901234567890'
+
+    expect(truncateValue(value)).toBe('1234567890123456789012345...')
+  })
+
+  it('returns a 25-character value whole, since the cut only touches a value longer than that', () => {
+    const value = '1234567890123456789012345'
+
+    expect(truncateValue(value)).toBe(value)
+  })
+})

--- a/frontend/tests/pages/imports/utils/workflowOptions.test.ts
+++ b/frontend/tests/pages/imports/utils/workflowOptions.test.ts
@@ -136,7 +136,7 @@ describe('import workflow option helpers', () => {
       { value: CREATE_CATEGORY_VALUE, label: 'Create new category', group: 'Import action' },
       { value: 'food', label: 'Food', group: 'Expense' },
       { value: 'rent', label: 'Rent', group: 'Expense' },
-      { value: 'salary', label: 'Salary', group: 'Income' },
+      { value: 'salary', label: 'Salary', group: 'Income', icon: '💵' },
       { value: 'transfer', label: 'Between accounts', group: 'Transfer' },
     ])
   })

--- a/frontend/tests/utils/importFailure.test.ts
+++ b/frontend/tests/utils/importFailure.test.ts
@@ -1,0 +1,24 @@
+/**
+ * Tests what an import shows the user when it fails with nothing usable to report
+ *
+ * The request layer and the import pages both read a failure this way, so a rejection carrying no
+ * message has to produce the same words wherever it is caught
+ */
+import { describe, expect, it } from 'vitest'
+import { getImportFailureMessage } from '@/utils/importFailure'
+
+describe('reading a message off a failed import', () => {
+  // An empty message used to reach the user as a blank failure notice, since nothing caught it
+  it('falls back for an Error carrying no message', () => {
+    expect(getImportFailureMessage(new Error(''))).toBe('Import failed.')
+  })
+
+  it('falls back for a rejection that is not an Error', () => {
+    expect(getImportFailureMessage('boom')).toBe('Import failed.')
+    expect(getImportFailureMessage({ message: 'boom' })).toBe('Import failed.')
+  })
+
+  it('keeps the message an Error carries', () => {
+    expect(getImportFailureMessage(new Error('Row 3 is broken'))).toBe('Row 3 is broken')
+  })
+})

--- a/frontend/tests/utils/importFailure.test.ts
+++ b/frontend/tests/utils/importFailure.test.ts
@@ -1,5 +1,6 @@
 /**
- * Tests what an import shows the user when it fails with nothing usable to report
+ * Tests what an import shows the user when it fails, both where the failure says something and
+ * where it says nothing at all
  *
  * The request layer and the import pages both read a failure this way, so a rejection carrying no
  * message has to produce the same words wherever it is caught


### PR DESCRIPTION
Fixed four importer defects, including an import failure that showed an empty notice and a short file refused for one unreadable character. Added tests for the untested helpers, the branches the narrow tests missed and the refusals no request can reach.