### PR TITLE
fix: correct account spending totals and break ties by recency

### DIFF
--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -125,9 +125,14 @@ class AccountSpendingBreakdown(BaseModel):
     don't leak into either breakdown; merchants are further narrowed by an
     inner join (transactions without a merchant are dropped)
 
-    ``grand_total_spend`` sums every expense transaction in the range — the
-    frontend divides each row's total by it to draw the proportional fills and
-    displays it on the "Total" row. ``other_categories_count`` and
+    A category and a merchant each qualify on their own net, so each card carries
+    its own total rather than sharing one. ``categories_total_spend`` and
+    ``merchants_total_spend`` sum the entries that still net spending, hidden ones
+    included, so each card's rows always add up to its own total and the two
+    totals can differ. The frontend divides each row by its card's total to draw
+    the proportional fills and displays that total on the "Total" row. An entry
+    whose refunds outweigh its purchases is not spending, so it is absent from
+    both the rows and the total. ``other_categories_count`` and
     ``other_merchants_count`` are the number of distinct categories/merchants
     with spend *beyond* the top 5, so the frontend can render an "Other (N)"
     row without a second request. They are ``0`` when ≤ 5 distinct entries exist
@@ -136,6 +141,7 @@ class AccountSpendingBreakdown(BaseModel):
     range: RangeKind
     top_categories: list[AccountTopCategory]
     top_merchants: list[AccountTopMerchant]
-    grand_total_spend: int
+    categories_total_spend: int
+    merchants_total_spend: int
     other_categories_count: int
     other_merchants_count: int

--- a/backend/app/services/accounts/spending.py
+++ b/backend/app/services/accounts/spending.py
@@ -10,7 +10,8 @@ from app.models.transaction import Transaction
 from app.schemas.account import AccountSpendingBreakdown
 from app.schemas.dashboard import RangeKind
 from app.services.accounts.spending_query_helpers import (
-    get_account_grand_total_spend,
+    get_account_categories_total_spend,
+    get_account_merchants_total_spend,
     get_account_top_categories,
     get_account_top_merchants,
 )
@@ -35,14 +36,19 @@ async def get_account_spending_breakdown(
     """
     start, end = _get_current_period_date_bounds(range_, now.date())
     expense_predicate = _build_expense_transaction_predicate(account_id, start, end)
-    grand_total_spend = await get_account_grand_total_spend(db, expense_predicate)
+    categories_total_spend = await get_account_categories_total_spend(db, expense_predicate)
+    merchants_total_spend = await get_account_merchants_total_spend(db, expense_predicate)
 
-    if grand_total_spend == 0:
+    # A card holds rows only where something netted spending, which leaves that card's total
+    # above zero, so two zero totals mean both cards are empty. One alone does not: a category
+    # refunded past zero can still hold a merchant that was not
+    if categories_total_spend == 0 and merchants_total_spend == 0:
         empty_breakdown = AccountSpendingBreakdown(
             range=range_,
             top_categories=[],
             top_merchants=[],
-            grand_total_spend=0,
+            categories_total_spend=0,
+            merchants_total_spend=0,
             other_categories_count=0,
             other_merchants_count=0,
         )
@@ -54,7 +60,8 @@ async def get_account_spending_breakdown(
         range=range_,
         top_categories=top_categories,
         top_merchants=top_merchants,
-        grand_total_spend=grand_total_spend,
+        categories_total_spend=categories_total_spend,
+        merchants_total_spend=merchants_total_spend,
         other_categories_count=other_categories_count,
         other_merchants_count=other_merchants_count,
     )

--- a/backend/app/services/accounts/spending_query_helpers.py
+++ b/backend/app/services/accounts/spending_query_helpers.py
@@ -34,18 +34,20 @@ async def get_account_merchants_total_spend(db: AsyncSession, expense_predicate)
     Returns:
         Positive total spending in minor units
     """
+    # Reaching merchants through the same join the card's rows use, rather than through the
+    # transaction column, keeps one set behind the rows, the hidden count and this total. The join
+    # drops spending that carries no merchant, and it is what puts row-level security on merchants
+    # in front of this query, so a merchant the viewer cannot see cannot reach the figure above
+    # rows they were never shown
     return await _get_grouped_total_spend(
         db,
         expense_predicate,
         Transaction.merchant_id,
-
-        # The merchant card reaches its rows through an inner join, so spending on a transaction
-        # carrying no merchant belongs to no row and must stay out of the total above them
-        Transaction.merchant_id.is_not(None),
+        (Merchant, Transaction.merchant_id == Merchant.id),
     )
 
 
-async def _get_grouped_total_spend(db: AsyncSession, expense_predicate, group_by, *extra_filters) -> int:
+async def _get_grouped_total_spend(db: AsyncSession, expense_predicate, group_by, *extra_joins) -> int:
     """Return total spending across the groups that still net spending
 
     A card's total is the sum of the entries it lists, hidden ones included, so each card totals
@@ -56,16 +58,19 @@ async def _get_grouped_total_spend(db: AsyncSession, expense_predicate, group_by
         db: Active database session
         expense_predicate: SQLAlchemy predicate for expense transactions
         group_by: Column the card groups its rows by
-        extra_filters: Further predicates narrowing the rows the card can reach
+        extra_joins: Further (model, condition) pairs the card's own rows join through
 
     Returns:
         Positive total spending in minor units
     """
     group_total = func.sum(Transaction.amount)
+    grouped_spend = select(group_total.label("total")).join(Category, Transaction.category_id == Category.id)
+    for model, condition in extra_joins:
+        grouped_spend = grouped_spend.join(model, condition)
+
     spending_groups = (
-        select(group_total.label("total"))
-        .join(Category, Transaction.category_id == Category.id)
-        .where(expense_predicate, *extra_filters)
+        grouped_spend
+        .where(expense_predicate)
         .group_by(group_by)
         .having(group_total < 0)
         .subquery()
@@ -200,8 +205,9 @@ async def _count_hidden_merchants(db: AsyncSession, expense_predicate, merchant_
     spending_merchants = (
         select(Transaction.merchant_id)
         .join(Category, Transaction.category_id == Category.id)
-        .where(expense_predicate, Transaction.merchant_id.is_not(None))
+        .join(Merchant, Transaction.merchant_id == Merchant.id)
         .group_by(Transaction.merchant_id)
+        .where(expense_predicate)
         .having(func.sum(Transaction.amount) < 0)
         .subquery()
     )

--- a/backend/app/services/accounts/spending_query_helpers.py
+++ b/backend/app/services/accounts/spending_query_helpers.py
@@ -11,8 +11,8 @@ from app.schemas.account import AccountTopCategory, AccountTopMerchant
 _TOP_SPENDING_ROWS_LIMIT = 5
 
 
-async def get_account_grand_total_spend(db: AsyncSession, expense_predicate) -> int:
-    """Return total account spend for an expense predicate
+async def get_account_categories_total_spend(db: AsyncSession, expense_predicate) -> int:
+    """Return total spending across the categories the category card lists
 
     Args:
         db: Active database session
@@ -21,14 +21,60 @@ async def get_account_grand_total_spend(db: AsyncSession, expense_predicate) -> 
     Returns:
         Positive total spending in minor units
     """
-    total_spend_query = (
-        select(func.coalesce(func.sum(Transaction.amount), 0))
-        .join(Category, Transaction.category_id == Category.id)
-        .where(expense_predicate)
+    return await _get_grouped_total_spend(db, expense_predicate, Transaction.category_id)
+
+
+async def get_account_merchants_total_spend(db: AsyncSession, expense_predicate) -> int:
+    """Return total spending across the merchants the merchant card lists
+
+    Args:
+        db: Active database session
+        expense_predicate: SQLAlchemy predicate for expense transactions
+
+    Returns:
+        Positive total spending in minor units
+    """
+    return await _get_grouped_total_spend(
+        db,
+        expense_predicate,
+        Transaction.merchant_id,
+
+        # The merchant card reaches its rows through an inner join, so spending on a transaction
+        # carrying no merchant belongs to no row and must stay out of the total above them
+        Transaction.merchant_id.is_not(None),
     )
 
-    # Sum all expense transactions in the period before ranking categories or merchants
-    total_result = await db.execute(total_spend_query)
+
+async def _get_grouped_total_spend(db: AsyncSession, expense_predicate, group_by, *extra_filters) -> int:
+    """Return total spending across the groups that still net spending
+
+    A card's total is the sum of the entries it lists, hidden ones included, so each card totals
+    its own grouping rather than sharing one figure. Netting per group before summing is what
+    keeps a group refunded past zero from crediting the total it was dropped from
+
+    Args:
+        db: Active database session
+        expense_predicate: SQLAlchemy predicate for expense transactions
+        group_by: Column the card groups its rows by
+        extra_filters: Further predicates narrowing the rows the card can reach
+
+    Returns:
+        Positive total spending in minor units
+    """
+    group_total = func.sum(Transaction.amount)
+    spending_groups = (
+        select(group_total.label("total"))
+        .join(Category, Transaction.category_id == Category.id)
+        .where(expense_predicate, *extra_filters)
+        .group_by(group_by)
+        .having(group_total < 0)
+        .subquery()
+    )
+
+    # Add up the netted groups, coalescing because a card with no spending sums to NULL
+    total_result = await db.execute(
+        select(func.coalesce(func.sum(spending_groups.c.total), 0)),
+    )
     total_spend = -int(total_result.scalar_one())
     return total_spend
 

--- a/backend/app/services/accounts/spending_query_helpers.py
+++ b/backend/app/services/accounts/spending_query_helpers.py
@@ -41,11 +41,12 @@ async def get_account_top_categories(db: AsyncSession, expense_predicate) -> tup
         expense_predicate: SQLAlchemy predicate for expense transactions
 
     Returns:
-        Top category rows and count of hidden nonzero categories
+        Top category rows and count of hidden spending categories
     """
     category_total = func.sum(Transaction.amount)
 
-    # Fetch the largest spending categories plus one extra row to detect hidden results
+    # Fetch the largest spending categories plus one extra row to detect hidden results. A
+    # category whose refunds outweigh its purchases is not spending, so it never reaches the list
     category_result = await db.execute(
         select(
             Category.id,
@@ -55,7 +56,7 @@ async def get_account_top_categories(db: AsyncSession, expense_predicate) -> tup
         .join(Category, Transaction.category_id == Category.id)
         .where(expense_predicate)
         .group_by(Category.id, Category.name)
-        .having(category_total != 0)
+        .having(category_total < 0)
         .order_by(category_total.asc())
         .limit(_TOP_SPENDING_ROWS_LIMIT + 1),
     )
@@ -69,7 +70,7 @@ async def get_account_top_categories(db: AsyncSession, expense_predicate) -> tup
 
 
 async def _count_hidden_categories(db: AsyncSession, expense_predicate, category_rows) -> int:
-    """Return count of nonzero categories beyond the visible limit
+    """Return count of spending categories beyond the visible limit
 
     Args:
         db: Active database session
@@ -77,23 +78,23 @@ async def _count_hidden_categories(db: AsyncSession, expense_predicate, category
         category_rows: Limited category result rows
 
     Returns:
-        Count of nonzero categories hidden behind the visible limit
+        Count of spending categories hidden behind the visible limit
     """
     if len(category_rows) <= _TOP_SPENDING_ROWS_LIMIT:
         return 0
 
-    nonzero_categories = (
+    spending_categories = (
         select(Transaction.category_id)
         .join(Category, Transaction.category_id == Category.id)
         .where(expense_predicate)
         .group_by(Transaction.category_id)
-        .having(func.sum(Transaction.amount) != 0)
+        .having(func.sum(Transaction.amount) < 0)
         .subquery()
     )
 
-    # Count all nonzero categories so the response can report how many are hidden
+    # Count every spending category so the response can report how many are hidden
     total_categories = (await db.execute(
-        select(func.count()).select_from(nonzero_categories),
+        select(func.count()).select_from(spending_categories),
     )).scalar_one()
     hidden_count = int(total_categories) - _TOP_SPENDING_ROWS_LIMIT
     return hidden_count
@@ -107,11 +108,12 @@ async def get_account_top_merchants(db: AsyncSession, expense_predicate) -> tupl
         expense_predicate: SQLAlchemy predicate for expense transactions
 
     Returns:
-        Top merchant rows and count of hidden nonzero merchants
+        Top merchant rows and count of hidden spending merchants
     """
     merchant_total = func.sum(Transaction.amount)
 
-    # Fetch the largest spending merchants plus one extra row to detect hidden results
+    # Fetch the largest spending merchants plus one extra row to detect hidden results. A
+    # merchant whose refunds outweigh its purchases is not spending, so it never reaches the list
     merchant_result = await db.execute(
         select(
             Merchant.id,
@@ -122,7 +124,7 @@ async def get_account_top_merchants(db: AsyncSession, expense_predicate) -> tupl
         .join(Merchant, Transaction.merchant_id == Merchant.id)
         .where(expense_predicate)
         .group_by(Merchant.id, Merchant.name)
-        .having(merchant_total != 0)
+        .having(merchant_total < 0)
         .order_by(merchant_total.asc())
         .limit(_TOP_SPENDING_ROWS_LIMIT + 1),
     )
@@ -136,7 +138,7 @@ async def get_account_top_merchants(db: AsyncSession, expense_predicate) -> tupl
 
 
 async def _count_hidden_merchants(db: AsyncSession, expense_predicate, merchant_rows) -> int:
-    """Return count of nonzero merchants beyond the visible limit
+    """Return count of spending merchants beyond the visible limit
 
     Args:
         db: Active database session
@@ -144,23 +146,23 @@ async def _count_hidden_merchants(db: AsyncSession, expense_predicate, merchant_
         merchant_rows: Limited merchant result rows
 
     Returns:
-        Count of nonzero merchants hidden behind the visible limit
+        Count of spending merchants hidden behind the visible limit
     """
     if len(merchant_rows) <= _TOP_SPENDING_ROWS_LIMIT:
         return 0
 
-    nonzero_merchants = (
+    spending_merchants = (
         select(Transaction.merchant_id)
         .join(Category, Transaction.category_id == Category.id)
         .where(expense_predicate, Transaction.merchant_id.is_not(None))
         .group_by(Transaction.merchant_id)
-        .having(func.sum(Transaction.amount) != 0)
+        .having(func.sum(Transaction.amount) < 0)
         .subquery()
     )
 
-    # Count all nonzero merchants so the response can report how many are hidden
+    # Count every spending merchant so the response can report how many are hidden
     total_merchants = (await db.execute(
-        select(func.count()).select_from(nonzero_merchants),
+        select(func.count()).select_from(spending_merchants),
     )).scalar_one()
     hidden_count = int(total_merchants) - _TOP_SPENDING_ROWS_LIMIT
     return hidden_count

--- a/backend/app/services/transactions/overview/outliers.py
+++ b/backend/app/services/transactions/overview/outliers.py
@@ -44,8 +44,14 @@ async def convert_overview_outliers(
 
         converted_outlier_candidates.append((row, converted_amount))
 
-    # Rank by each transaction's own converted outflow, so a purchase refunded later still counts
-    converted_outlier_candidates.sort(key=lambda candidate: candidate[1])
+    # Rank by each transaction's own converted outflow, so a purchase refunded later still counts.
+    # Equal outflows go to the most recent, then to the identifier, because the database promises
+    # no order of its own and the panel would otherwise change under a reload that changed no data.
+    # The tie has to break here rather than in the query, which orders on amounts as stored: two
+    # rows in different currencies can differ there and still land on one converted outflow
+    converted_outlier_candidates.sort(
+        key=lambda candidate: (candidate[1], -candidate[0].date.toordinal(), str(candidate[0].id)),
+    )
     outliers = [
         OutlierTransaction(
             id=row.id,

--- a/backend/tests/routes/accounts/test_spending_breakdown.py
+++ b/backend/tests/routes/accounts/test_spending_breakdown.py
@@ -273,7 +273,7 @@ async def test_ytd_includes_transactions_since_january_first_and_excludes_earlie
 
 
 async def test_transfer_and_income_transactions_do_not_contribute(client):
-    """Transfer- and income-kind transactions are excluded from both breakdowns and the grand total."""
+    """Transfer- and income-kind transactions are excluded from both breakdowns and both totals."""
     headers, account_id = await _setup_account(client)
 
     expense_cat = (await _create_category(client, headers, name="Test Groceries", kind="expense")).json()
@@ -679,7 +679,7 @@ async def test_both_cards_are_empty_when_everything_is_refunded_past_zero(client
     assert resp.status_code == 200
     data = resp.json()
 
-    # Transactions exist, so this reaches the guard rather than the no-activity path
+    # Both totals come out zero while transactions exist, which is the case the guard turns on
     assert data["top_categories"] == []
     assert data["top_merchants"] == []
     assert data["categories_total_spend"] == 0
@@ -795,8 +795,8 @@ async def test_hidden_merchant_count_excludes_over_refunded_merchants(client):
     # Eight merchants still net spending, so three sit behind the visible five
     assert data["other_merchants_count"] == 3
 
-    # The merchant total covers the hidden three, while the category total also keeps the 8.00 the
-    # two refunded merchants left behind in a category that still nets spending
+    # The merchant total covers the hidden three. The category total lands 8.00 below it, because
+    # the two refunded merchants leave their refunds inside a category that still nets spending
     assert data["merchants_total_spend"] == 36_000
     assert data["categories_total_spend"] == 35_200
 

--- a/backend/tests/routes/accounts/test_spending_breakdown.py
+++ b/backend/tests/routes/accounts/test_spending_breakdown.py
@@ -543,6 +543,173 @@ async def test_zero_sum_category_and_merchant_are_excluded(client):
     assert data["other_merchants_count"] == 0
 
 
+async def test_over_refunded_category_and_merchant_are_excluded(client):
+    """A category refunded past zero is not spending, so neither it nor its merchant is listed."""
+    headers, account_id = await _setup_account(client)
+    groceries = (await _create_category(client, headers, name="Test Groceries Refunded")).json()
+    rent = (await _create_category(client, headers, name="Test Rent")).json()
+    grocer = (await _create_merchant(client, headers, name="Sobeys")).json()
+    landlord = (await _create_merchant(client, headers, name="Landlord")).json()
+
+    today = _today_utc().isoformat()
+    await _create_transaction(
+        client, headers, account_id, groceries["id"],
+        dt=today, amount=-10_000, merchant_id=grocer["id"],
+    )
+    await _create_transaction(
+        client, headers, account_id, groceries["id"],
+        dt=today, amount=15_000, merchant_id=grocer["id"],
+    )
+    await _create_transaction(
+        client, headers, account_id, rent["id"],
+        dt=today, amount=-200_000, merchant_id=landlord["id"],
+    )
+
+    resp = await client.get(
+        f"/accounts/{account_id}/spending-breakdown",
+        params={"range": "MTD"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [c["category_id"] for c in data["top_categories"]] == [rent["id"]]
+    assert [m["merchant_id"] for m in data["top_merchants"]] == [landlord["id"]]
+
+
+async def test_over_refunded_merchant_inside_a_spending_category_is_excluded(client):
+    """A merchant refunded past zero drops out even while its category still nets spending."""
+    headers, account_id = await _setup_account(client)
+    dining = (await _create_category(client, headers, name="Test Dining")).json()
+    refunded_merchant = (await _create_merchant(client, headers, name="Returned Bistro")).json()
+    kept_merchant = (await _create_merchant(client, headers, name="Kept Bistro")).json()
+
+    today = _today_utc().isoformat()
+    await _create_transaction(
+        client, headers, account_id, dining["id"],
+        dt=today, amount=-5_000, merchant_id=refunded_merchant["id"],
+    )
+    await _create_transaction(
+        client, headers, account_id, dining["id"],
+        dt=today, amount=8_000, merchant_id=refunded_merchant["id"],
+    )
+    await _create_transaction(
+        client, headers, account_id, dining["id"],
+        dt=today, amount=-20_000, merchant_id=kept_merchant["id"],
+    )
+
+    resp = await client.get(
+        f"/accounts/{account_id}/spending-breakdown",
+        params={"range": "MTD"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [c["category_id"] for c in data["top_categories"]] == [dining["id"]]
+    assert data["top_categories"][0]["total"] == 17_000
+    assert [m["merchant_id"] for m in data["top_merchants"]] == [kept_merchant["id"]]
+
+
+async def test_merchant_is_judged_on_its_own_net_across_categories(client):
+    """A merchant qualifies on its own net, even where one category behind it was refunded past zero."""
+    headers, account_id = await _setup_account(client)
+    groceries = (await _create_category(client, headers, name="Test Groceries Crossover")).json()
+    dining = (await _create_category(client, headers, name="Test Dining Crossover")).json()
+    merchant = (await _create_merchant(client, headers, name="Sobeys")).json()
+
+    today = _today_utc().isoformat()
+    await _create_transaction(
+        client, headers, account_id, groceries["id"],
+        dt=today, amount=-10_000, merchant_id=merchant["id"],
+    )
+    await _create_transaction(
+        client, headers, account_id, groceries["id"],
+        dt=today, amount=15_000, merchant_id=merchant["id"],
+    )
+    await _create_transaction(
+        client, headers, account_id, dining["id"],
+        dt=today, amount=-20_000, merchant_id=merchant["id"],
+    )
+
+    resp = await client.get(
+        f"/accounts/{account_id}/spending-breakdown",
+        params={"range": "MTD"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Groceries netted positive and drops out, while the merchant keeps the 50.00 refund against
+    # its own 300.00 of purchases and is listed at 150.00
+    assert [c["category_id"] for c in data["top_categories"]] == [dining["id"]]
+    assert data["top_categories"][0]["total"] == 20_000
+    assert [m["merchant_id"] for m in data["top_merchants"]] == [merchant["id"]]
+    assert data["top_merchants"][0]["total"] == 15_000
+
+
+async def test_hidden_category_count_excludes_over_refunded_categories(client):
+    """The "and N more" figure counts only categories that still net spending."""
+    headers, account_id = await _setup_account(client)
+    today = _today_utc().isoformat()
+
+    for index, amount in enumerate((-6_000, -5_000, -4_000, -3_000, -2_000, -1_000)):
+        category = (await _create_category(client, headers, name=f"Test Spend {index}")).json()
+        await _create_transaction(client, headers, account_id, category["id"], dt=today, amount=amount)
+
+    for index in range(2):
+        refunded = (await _create_category(client, headers, name=f"Test Refunded {index}")).json()
+        await _create_transaction(client, headers, account_id, refunded["id"], dt=today, amount=-100)
+        await _create_transaction(client, headers, account_id, refunded["id"], dt=today, amount=500)
+
+    resp = await client.get(
+        f"/accounts/{account_id}/spending-breakdown",
+        params={"range": "MTD"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [c["total"] for c in data["top_categories"]] == [6_000, 5_000, 4_000, 3_000, 2_000]
+
+    # Six categories still net spending, so one sits behind the visible five
+    assert data["other_categories_count"] == 1
+
+
+async def test_hidden_merchant_count_excludes_over_refunded_merchants(client):
+    """The merchant "and N more" figure counts only merchants that still net spending."""
+    headers, account_id = await _setup_account(client)
+    category = (await _create_category(client, headers, name="Test Everything")).json()
+    today = _today_utc().isoformat()
+
+    for index, amount in enumerate((-8_000, -7_000, -6_000, -5_000, -4_000, -3_000, -2_000, -1_000)):
+        merchant = (await _create_merchant(client, headers, name=f"Spender {index}")).json()
+        await _create_transaction(
+            client, headers, account_id, category["id"],
+            dt=today, amount=amount, merchant_id=merchant["id"],
+        )
+
+    for index in range(2):
+        refunded = (await _create_merchant(client, headers, name=f"Returner {index}")).json()
+        await _create_transaction(
+            client, headers, account_id, category["id"],
+            dt=today, amount=-100, merchant_id=refunded["id"],
+        )
+        await _create_transaction(
+            client, headers, account_id, category["id"],
+            dt=today, amount=500, merchant_id=refunded["id"],
+        )
+
+    resp = await client.get(
+        f"/accounts/{account_id}/spending-breakdown",
+        params={"range": "MTD"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [m["total"] for m in data["top_merchants"]] == [8_000, 7_000, 6_000, 5_000, 4_000]
+
+    # Eight merchants still net spending, so three sit behind the visible five
+    assert data["other_merchants_count"] == 3
+
+
 async def test_mixed_currency_transactions_are_summed_as_raw_minor_units(client):
     """Endpoint sums all expense rows regardless of currency — no fx conversion
 

--- a/backend/tests/routes/accounts/test_spending_breakdown.py
+++ b/backend/tests/routes/accounts/test_spending_breakdown.py
@@ -1134,6 +1134,53 @@ async def test_group_member_with_explicit_read_permission_succeeds(client):
     assert resp.status_code == 200
 
 
+async def test_merchant_total_leaves_out_a_merchant_the_viewer_cannot_see(client):
+    """A merchant hidden from the viewer reaches neither the merchant rows nor the total above them.
+
+    The category is a seeded system one so it stays visible to both users, which leaves the
+    merchant as the only thing the member cannot see
+    """
+    signup_resp = await _create_user(client)
+    admin_headers = _get_auth_header(signup_resp)
+
+    group_id = await _create_group(client, admin_headers)
+    account_id = (await _create_account(client, admin_headers, group_id=group_id)).json()["id"]
+    categories = (await client.get("/categories", headers=admin_headers)).json()
+    shared_category = next(c for c in categories if c["is_system"] and c["kind"] == "expense")
+
+    # A merchant the admin owns personally, which row-level security keeps from the member
+    private_merchant = (await _create_merchant(client, admin_headers, name="Private Diner")).json()
+    create_resp = await _create_transaction(
+        client, admin_headers, account_id, shared_category["id"],
+        dt=_today_utc().isoformat(), amount=-5_000, merchant_id=private_merchant["id"],
+    )
+    assert create_resp.status_code == 201
+
+    member_headers, member_user_id = await _create_second_user(client)
+    await client.post(
+        f"/groups/{group_id}/members",
+        json={"user_id": member_user_id},
+        headers=admin_headers,
+    )
+    await _grant_account_permission(client, admin_headers, account_id, member_user_id, "read")
+
+    resp = await client.get(
+        f"/accounts/{account_id}/spending-breakdown",
+        params={"range": "MTD"},
+        headers=member_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # The category is visible, so the spending reaches that card and its total
+    assert data["categories_total_spend"] == 5_000
+
+    # The merchant is not, so no merchant total may stand above an empty merchant card
+    assert data["top_merchants"] == []
+    assert data["other_merchants_count"] == 0
+    assert data["merchants_total_spend"] == 0
+
+
 async def test_closed_account_still_returns_breakdown(client):
     """Closed accounts remain readable — the handler does not require require_open."""
     headers, account_id = await _setup_account(client)

--- a/backend/tests/routes/accounts/test_spending_breakdown.py
+++ b/backend/tests/routes/accounts/test_spending_breakdown.py
@@ -146,7 +146,7 @@ async def test_wtd_includes_transactions_since_monday_and_excludes_earlier(clien
     assert resp.status_code == 200
     data = resp.json()
     assert data["range"] == "WTD"
-    assert data["grand_total_spend"] == 1000
+    assert data["categories_total_spend"] == 1000
     assert len(data["top_categories"]) == 1
     assert data["top_categories"][0]["total"] == 1000
 
@@ -176,7 +176,7 @@ async def test_mtd_includes_transactions_since_first_of_month_and_excludes_earli
     assert resp.status_code == 200
     data = resp.json()
     assert data["range"] == "MTD"
-    assert data["grand_total_spend"] == 2000
+    assert data["categories_total_spend"] == 2000
     assert len(data["top_categories"]) == 1
     assert data["top_categories"][0]["total"] == 2000
 
@@ -206,7 +206,7 @@ async def test_mtd_uses_viewer_timezone_at_utc_year_boundary(client, monkeypatch
     )
 
     assert resp.status_code == 200
-    assert resp.json()["grand_total_spend"] == 3100
+    assert resp.json()["categories_total_spend"] == 3100
 
 
 async def test_qtd_includes_transactions_since_first_of_quarter_and_excludes_earlier(client):
@@ -234,7 +234,7 @@ async def test_qtd_includes_transactions_since_first_of_quarter_and_excludes_ear
     assert resp.status_code == 200
     data = resp.json()
     assert data["range"] == "QTD"
-    assert data["grand_total_spend"] == 3000
+    assert data["categories_total_spend"] == 3000
     assert len(data["top_categories"]) == 1
     assert data["top_categories"][0]["total"] == 3000
 
@@ -264,7 +264,7 @@ async def test_ytd_includes_transactions_since_january_first_and_excludes_earlie
     assert resp.status_code == 200
     data = resp.json()
     assert data["range"] == "YTD"
-    assert data["grand_total_spend"] == 4000
+    assert data["categories_total_spend"] == 4000
     assert len(data["top_categories"]) == 1
     assert data["top_categories"][0]["total"] == 4000
 
@@ -310,7 +310,7 @@ async def test_transfer_and_income_transactions_do_not_contribute(client):
     data = resp.json()
 
     # Only the expense transaction contributes
-    assert data["grand_total_spend"] == 1500
+    assert data["categories_total_spend"] == 1500
     assert len(data["top_categories"]) == 1
     assert data["top_categories"][0]["category_id"] == expense_cat["id"]
     assert data["top_categories"][0]["name"] == "Test Groceries"
@@ -325,8 +325,8 @@ async def test_transfer_and_income_transactions_do_not_contribute(client):
 # --- Merchant inner-join: category-only expense contributes to categories/total but not merchants ---
 
 
-async def test_expense_without_merchant_contributes_to_categories_and_total_only(client):
-    """An expense with merchant_id=None shows up in top_categories and grand_total but NOT top_merchants."""
+async def test_expense_without_merchant_stays_out_of_the_merchants_total(client):
+    """An expense with merchant_id=None reaches the category card only, total included."""
     headers, account_id = await _setup_account(client)
     category = (await _create_category(client, headers)).json()
     merchant = (await _create_merchant(client, headers)).json()
@@ -360,8 +360,10 @@ async def test_expense_without_merchant_contributes_to_categories_and_total_only
     assert resp.status_code == 200
     data = resp.json()
 
-    # Grand total includes both expenses
-    assert data["grand_total_spend"] == 1400
+    # The category card counts both expenses, while the merchant card counts neither the
+    # merchant-less one nor its spending, so the two cards carry different totals
+    assert data["categories_total_spend"] == 1400
+    assert data["merchants_total_spend"] == 1000
     # Category total includes both — category id is the same for both rows
     assert len(data["top_categories"]) == 1
     assert data["top_categories"][0]["category_id"] == category["id"]
@@ -471,12 +473,11 @@ async def test_exactly_five_entries_yields_zero_other_counts(client):
 
 
 async def test_positive_amount_on_expense_category_subtracts_from_total(client):
-    """A refund (positive amount on an expense category) reduces grand_total_spend
+    """A refund on an expense category reduces what that category reports as spending
 
-    The service flips the raw SUM's sign, so a -1000 expense plus a +200 refund
-    sums to -800 in the DB and returns 800 — the net expense. This locks in the
-    refund semantics and documents that grand_total_spend can go negative if
-    refunds exceed charges
+    A -1000 expense plus a +200 refund nets to -800 and reports 800, the spending left
+    once the refund is taken off. A category refunded past zero drops out instead of
+    reporting a credit, so neither total can go negative
     """
     headers, account_id = await _setup_account(client)
     category = (await _create_category(client, headers)).json()
@@ -500,7 +501,7 @@ async def test_positive_amount_on_expense_category_subtracts_from_total(client):
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["grand_total_spend"] == 800
+    assert data["categories_total_spend"] == 800
     assert data["top_categories"][0]["total"] == 800
     assert data["top_merchants"][0]["total"] == 800
 
@@ -534,7 +535,7 @@ async def test_zero_sum_category_and_merchant_are_excluded(client):
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["grand_total_spend"] == 1200
+    assert data["categories_total_spend"] == 1200
     assert [c["category_id"] for c in data["top_categories"]] == [spend_category["id"]]
     assert [m["merchant_id"] for m in data["top_merchants"]] == [spend_merchant["id"]]
     assert data["top_categories"][0]["total"] == 1200
@@ -574,6 +575,10 @@ async def test_over_refunded_category_and_merchant_are_excluded(client):
     data = resp.json()
     assert [c["category_id"] for c in data["top_categories"]] == [rent["id"]]
     assert [m["merchant_id"] for m in data["top_merchants"]] == [landlord["id"]]
+
+    # The 50.00 the groceries refund left over credits neither total
+    assert data["categories_total_spend"] == 200_000
+    assert data["merchants_total_spend"] == 200_000
 
 
 async def test_over_refunded_merchant_inside_a_spending_category_is_excluded(client):
@@ -644,6 +649,51 @@ async def test_merchant_is_judged_on_its_own_net_across_categories(client):
     assert data["top_categories"][0]["total"] == 20_000
     assert [m["merchant_id"] for m in data["top_merchants"]] == [merchant["id"]]
     assert data["top_merchants"][0]["total"] == 15_000
+
+    # Each card totals its own rows, so the two legitimately disagree
+    assert data["categories_total_spend"] == 20_000
+    assert data["merchants_total_spend"] == 15_000
+
+
+async def test_merchant_card_survives_a_category_refunded_past_zero(client):
+    """A merchant still netting spending is listed even where its only category is not."""
+    headers, account_id = await _setup_account(client)
+    groceries = (await _create_category(client, headers, name="Test Groceries Reversed")).json()
+    merchant = (await _create_merchant(client, headers, name="Sobeys")).json()
+
+    today = _today_utc()
+    purchase = await _create_transaction(
+        client, headers, account_id, groceries["id"],
+        dt=today.isoformat(), amount=-10_000, merchant_id=merchant["id"],
+    )
+
+    # The refund carries no merchant, so it lands on the category without touching the merchant
+    async with TestSession() as session:
+        session.add(Transaction(
+            created_by_user_id=uuid.UUID(purchase.json()["created_by_user_id"]),
+            account_id=uuid.UUID(account_id),
+            dt=today,
+            category_id=uuid.UUID(groceries["id"]),
+            merchant_id=None,
+            amount=15_000,
+            currency="CAD",
+        ))
+        await session.commit()
+
+    resp = await client.get(
+        f"/accounts/{account_id}/spending-breakdown",
+        params={"range": "MTD"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # An empty category card must not blank the merchant card beside it
+    assert data["top_categories"] == []
+    assert data["categories_total_spend"] == 0
+    assert [m["merchant_id"] for m in data["top_merchants"]] == [merchant["id"]]
+    assert data["top_merchants"][0]["total"] == 10_000
+    assert data["merchants_total_spend"] == 10_000
 
 
 async def test_hidden_category_count_excludes_over_refunded_categories(client):
@@ -716,7 +766,7 @@ async def test_mixed_currency_transactions_are_summed_as_raw_minor_units(client)
     Locks in current behaviour for a future fx-aware change to catch. The account
     is CAD and a USD transaction (with fx_rate to satisfy POST /transactions'
     cross-currency guard) is posted alongside a CAD one; both contribute their
-    raw minor-unit amounts to grand_total_spend
+    raw minor-unit amounts to categories_total_spend
     """
     await _seed_usd_currency()
 
@@ -741,7 +791,7 @@ async def test_mixed_currency_transactions_are_summed_as_raw_minor_units(client)
     assert resp.status_code == 200
     data = resp.json()
     # Raw mix: 1000 + 500 = 1500 (no fx applied)
-    assert data["grand_total_spend"] == 1500
+    assert data["categories_total_spend"] == 1500
     assert data["top_categories"][0]["total"] == 1500
 
 
@@ -771,7 +821,7 @@ async def test_future_dated_transaction_is_excluded_from_range(client):
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["grand_total_spend"] == 1000
+    assert data["categories_total_spend"] == 1000
     assert data["top_categories"][0]["total"] == 1000
 
 
@@ -806,7 +856,7 @@ async def test_transactions_on_other_accounts_are_excluded(client):
     )
     assert resp.status_code == 200
     data = resp.json()
-    assert data["grand_total_spend"] == 1000
+    assert data["categories_total_spend"] == 1000
     assert len(data["top_categories"]) == 1
     assert data["top_categories"][0]["total"] == 1000
     assert len(data["top_merchants"]) == 1
@@ -908,7 +958,8 @@ async def test_empty_state_returns_200_with_zeros_and_empty_lists(client):
     assert data["range"] == "MTD"
     assert data["top_categories"] == []
     assert data["top_merchants"] == []
-    assert data["grand_total_spend"] == 0
+    assert data["categories_total_spend"] == 0
+    assert data["merchants_total_spend"] == 0
     assert data["other_categories_count"] == 0
     assert data["other_merchants_count"] == 0
 
@@ -940,7 +991,7 @@ async def test_missing_range_param_defaults_to_mtd(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data["range"] == "MTD"
-    assert data["grand_total_spend"] == 1000
+    assert data["categories_total_spend"] == 1000
 
 
 async def test_invalid_range_param_returns_422(client):
@@ -1065,4 +1116,4 @@ async def test_closed_account_still_returns_breakdown(client):
         headers=headers,
     )
     assert resp.status_code == 200
-    assert resp.json()["grand_total_spend"] == 1000
+    assert resp.json()["categories_total_spend"] == 1000

--- a/backend/tests/routes/accounts/test_spending_breakdown.py
+++ b/backend/tests/routes/accounts/test_spending_breakdown.py
@@ -655,6 +655,39 @@ async def test_merchant_is_judged_on_its_own_net_across_categories(client):
     assert data["merchants_total_spend"] == 15_000
 
 
+async def test_both_cards_are_empty_when_everything_is_refunded_past_zero(client):
+    """A range whose every entry was refunded past zero reports the empty payload."""
+    headers, account_id = await _setup_account(client)
+    groceries = (await _create_category(client, headers, name="Test Groceries Cancelled")).json()
+    grocer = (await _create_merchant(client, headers, name="Refunding Grocer")).json()
+
+    today = _today_utc().isoformat()
+    await _create_transaction(
+        client, headers, account_id, groceries["id"],
+        dt=today, amount=-10_000, merchant_id=grocer["id"],
+    )
+    await _create_transaction(
+        client, headers, account_id, groceries["id"],
+        dt=today, amount=15_000, merchant_id=grocer["id"],
+    )
+
+    resp = await client.get(
+        f"/accounts/{account_id}/spending-breakdown",
+        params={"range": "MTD"},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Transactions exist, so this reaches the guard rather than the no-activity path
+    assert data["top_categories"] == []
+    assert data["top_merchants"] == []
+    assert data["categories_total_spend"] == 0
+    assert data["merchants_total_spend"] == 0
+    assert data["other_categories_count"] == 0
+    assert data["other_merchants_count"] == 0
+
+
 async def test_merchant_card_survives_a_category_refunded_past_zero(client):
     """A merchant still netting spending is listed even where its only category is not."""
     headers, account_id = await _setup_account(client)
@@ -722,6 +755,9 @@ async def test_hidden_category_count_excludes_over_refunded_categories(client):
     # Six categories still net spending, so one sits behind the visible five
     assert data["other_categories_count"] == 1
 
+    # The total covers the hidden sixth as well, so it exceeds the five rows on screen
+    assert data["categories_total_spend"] == 21_000
+
 
 async def test_hidden_merchant_count_excludes_over_refunded_merchants(client):
     """The merchant "and N more" figure counts only merchants that still net spending."""
@@ -758,6 +794,11 @@ async def test_hidden_merchant_count_excludes_over_refunded_merchants(client):
 
     # Eight merchants still net spending, so three sit behind the visible five
     assert data["other_merchants_count"] == 3
+
+    # The merchant total covers the hidden three, while the category total also keeps the 8.00 the
+    # two refunded merchants left behind in a category that still nets spending
+    assert data["merchants_total_spend"] == 36_000
+    assert data["categories_total_spend"] == 35_200
 
 
 async def test_mixed_currency_transactions_are_summed_as_raw_minor_units(client):

--- a/backend/tests/routes/transactions/test_overview.py
+++ b/backend/tests/routes/transactions/test_overview.py
@@ -716,6 +716,86 @@ async def test_transactions_overview_outliers_rank_by_each_transactions_own_outf
     assert data["outliers_fx_status"] == {"state": "none", "missing_pairs": []}
 
 
+async def test_transactions_overview_outliers_break_amount_ties_by_recency(client):
+    """Equal outflows resolve to the most recent, so the panel holds still across reloads."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+
+    # Seeded oldest first, which is the order an unfixed query hands back
+    tied_dates = [date(2026, 3, 12), date(2026, 3, 13), date(2026, 3, 14), date(2026, 3, 15)]
+    for tied_date in tied_dates:
+        await _create_transaction(
+            client, headers, account_id, category_id,
+            dt=tied_date.isoformat(), amount=-10_000,
+        )
+
+    resp = await client.get("/transactions/overview", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert [row["dt"] for row in data["outliers"]] == ["2026-03-15", "2026-03-14", "2026-03-13"]
+
+
+async def test_transactions_overview_outliers_break_same_day_ties_by_id(client):
+    """Outflows tied on amount and date resolve by identifier, so repeated requests agree."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+
+    for _ in range(3):
+        await _create_transaction(
+            client, headers, account_id, category_id,
+            dt="2026-03-15", amount=-10_000,
+        )
+
+    first = await client.get("/transactions/overview", headers=headers)
+    second = await client.get("/transactions/overview", headers=headers)
+
+    assert first.status_code == 200
+    assert second.status_code == 200
+    shown_ids = [row["id"] for row in first.json()["outliers"]]
+
+    # Pins the rule rather than catching the old code, which identifiers being random leaves
+    # free to agree with this by chance
+    assert shown_ids == sorted(shown_ids)
+    assert [row["id"] for row in second.json()["outliers"]] == shown_ids
+
+
+async def test_transactions_overview_outliers_break_converted_ties_by_recency(client, monkeypatch):
+    """Two currencies landing on one converted outflow still resolve to the most recent."""
+    from app.services.fx import FrankfurterProvider
+
+    async def fake_get_rates(self, base, quote, start_date, end_date):
+        return {date(2026, 3, 14): Decimal("1.5"), date(2026, 3, 15): Decimal("1.5")}
+
+    monkeypatch.setattr(FrankfurterProvider, "get_rates", fake_get_rates)
+
+    await _seed_usd_currency()
+    headers, cad_account_id, category_id = await _setup_user_with_deps(client)
+    usd_account_id = (await _create_account(
+        client,
+        headers,
+        name="USD Chequing",
+        currency="USD",
+    )).json()["id"]
+
+    # -6,000 USD converts to -9,000 CAD, the same outflow as the CAD row, on a later date
+    cad_txn = await _create_transaction(
+        client, headers, cad_account_id, category_id,
+        dt="2026-03-14", amount=-9_000,
+    )
+    usd_txn = await _create_transaction(
+        client, headers, usd_account_id, category_id,
+        dt="2026-03-15", amount=-6_000, currency="USD",
+    )
+
+    resp = await client.get("/transactions/overview", headers=headers)
+
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Ordering on stored amounts would put the CAD row first, since -9,000 sorts below -6,000
+    assert [row["id"] for row in data["outliers"]] == [usd_txn.json()["id"], cad_txn.json()["id"]]
+    assert data["outliers_fx_status"] == {"state": "complete", "missing_pairs": []}
+
+
 async def test_transactions_overview_outliers_convert_and_rank_foreign_accounts(client, monkeypatch):
     """Most expensive transactions are ranked by converted base-currency amount."""
     from app.services.fx import FrankfurterProvider

--- a/frontend/src/api/accounts/types.ts
+++ b/frontend/src/api/accounts/types.ts
@@ -137,7 +137,12 @@ export interface AccountSpendingBreakdown {
   range: SpendingRange;
   top_categories: AccountTopCategory[];
   top_merchants: AccountTopMerchant[];
-  grand_total_spend: number;
+
+  /** Spending across every category the card lists, hidden ones included */
+  categories_total_spend: number;
+
+  /** Spending across every merchant the card lists, which excludes spending carrying no merchant */
+  merchants_total_spend: number;
   other_categories_count: number;
   other_merchants_count: number;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -18,6 +18,14 @@ import { hasUncacheableFxStatus } from '@/api/shared/fxCache'
 
 const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000;
 
+// Throws away every persisted entry whenever a stored response changes shape, so the app cannot
+// restore a payload whose fields the code then looks for and fails to find. Persisted data
+// outlives a deploy by up to six months and a fresh one is not refetched while it is still
+// within its stale window, so without this the first render after such a change draws a card from
+// fields that are no longer there. Bump it on any shape change. Version 1 is the account spending
+// breakdown carrying a total per card in place of one shared figure
+const PERSISTED_CACHE_SHAPE = '1';
+
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
@@ -50,6 +58,7 @@ createRoot(document.getElementById('root')!).render(
         client={queryClient}
         persistOptions={{
           persister,
+          buster: PERSISTED_CACHE_SHAPE,
           maxAge: SIX_MONTHS_MS,
           dehydrateOptions: { shouldDehydrateQuery },
         }}

--- a/frontend/src/pages/accounts/detail/components/spending-breakdown/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/spending-breakdown/Card.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, type ReactNode } from 'react'
 import type { SpendingRange } from '@/api/accounts'
 import { LoadingContent, LoadingOverlay } from '@/components/loading/Transition'
 import { TimeRangeSelector } from '@/components/time-range/Selector'
@@ -25,6 +25,9 @@ type SpendingBreakdownCardProps = {
   emptyLabel: string
   loading: boolean
   transitionKey: string
+
+  /** Explanation shown after the total amount, for a card whose figure needs one */
+  totalTooltip?: ReactNode
 }
 
 /**
@@ -41,6 +44,7 @@ export function SpendingBreakdownCard({
   emptyLabel,
   loading,
   transitionKey,
+  totalTooltip,
 }: SpendingBreakdownCardProps) {
   const { formatCurrency } = useMoneyFormatters()
   const incomingSnapshot = useMemo<BreakdownSnapshot>(() => ({
@@ -138,15 +142,17 @@ export function SpendingBreakdownCard({
                 className="flex items-center gap-3 pt-3"
                 style={{ borderTop: '1px solid var(--app-border)' }}
               >
-                <div className="w-2 shrink-0" />
                 <span
                   className="flex-1 text-xs font-semibold uppercase tracking-wide"
                   style={{ color: 'var(--app-text-muted)' }}
                 >
                   Total
                 </span>
-                <span className="font-financial font-semibold tabular-nums text-sm">
-                  {formatCurrency(displaySnapshot.cardTotal, displaySnapshot.currency)}
+                <span className="inline-flex items-center gap-1.5">
+                  <span className="font-financial font-semibold tabular-nums text-sm">
+                    {formatCurrency(displaySnapshot.cardTotal, displaySnapshot.currency)}
+                  </span>
+                  {totalTooltip}
                 </span>
               </div>
             </>

--- a/frontend/src/pages/accounts/detail/components/spending-breakdown/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/spending-breakdown/Card.tsx
@@ -20,7 +20,7 @@ type SpendingBreakdownCardProps = {
   range: SpendingRange
   onRangeChange: (range: SpendingRange) => void
   rows: BreakdownRow[]
-  grandTotal: number
+  cardTotal: number
   currency: string
   emptyLabel: string
   loading: boolean
@@ -36,7 +36,7 @@ export function SpendingBreakdownCard({
   range,
   onRangeChange,
   rows,
-  grandTotal,
+  cardTotal,
   currency,
   emptyLabel,
   loading,
@@ -45,10 +45,10 @@ export function SpendingBreakdownCard({
   const { formatCurrency } = useMoneyFormatters()
   const incomingSnapshot = useMemo<BreakdownSnapshot>(() => ({
     rows,
-    grandTotal,
+    cardTotal,
     currency,
     emptyLabel,
-  }), [currency, emptyLabel, grandTotal, rows])
+  }), [currency, emptyLabel, cardTotal, rows])
   const {
     displaySnapshot,
     contentConcealed,
@@ -102,7 +102,7 @@ export function SpendingBreakdownCard({
             <>
               <div className="flex flex-col gap-1.5" style={{ minHeight: BREAKDOWN_CARD_LIST_MIN_HEIGHT }}>
                 {displaySnapshot.rows.map((item) => {
-                  const barPct = getBreakdownRowFillPercent(item.total, displaySnapshot.grandTotal)
+                  const barPct = getBreakdownRowFillPercent(item.total, displaySnapshot.cardTotal)
                   const color = item.isOther ? BREAKDOWN_OTHER_COLOR : item.color ?? getDeterministicChartColor(item.key || item.name)
 
                   return (
@@ -146,7 +146,7 @@ export function SpendingBreakdownCard({
                   Total
                 </span>
                 <span className="font-financial font-semibold tabular-nums text-sm">
-                  {formatCurrency(displaySnapshot.grandTotal, displaySnapshot.currency)}
+                  {formatCurrency(displaySnapshot.cardTotal, displaySnapshot.currency)}
                 </span>
               </div>
             </>

--- a/frontend/src/pages/accounts/detail/components/spending-breakdown/TopCategoriesCard.tsx
+++ b/frontend/src/pages/accounts/detail/components/spending-breakdown/TopCategoriesCard.tsx
@@ -52,7 +52,7 @@ export function TopCategoriesBySpendingCard({ account }: { account: Account }) {
       range={range}
       onRangeChange={handleRangeChange}
       rows={rows}
-      grandTotal={data?.categories_total_spend ?? 0}
+      cardTotal={data?.categories_total_spend ?? 0}
       currency={account.currency}
       emptyLabel="No spending in this range"
       loading={isFetching}

--- a/frontend/src/pages/accounts/detail/components/spending-breakdown/TopCategoriesCard.tsx
+++ b/frontend/src/pages/accounts/detail/components/spending-breakdown/TopCategoriesCard.tsx
@@ -42,6 +42,7 @@ export function TopCategoriesBySpendingCard({ account }: { account: Account }) {
       }),
     })),
     (breakdown) => breakdown.other_categories_count,
+    (breakdown) => breakdown.categories_total_spend,
   )
 
   return (
@@ -51,7 +52,7 @@ export function TopCategoriesBySpendingCard({ account }: { account: Account }) {
       range={range}
       onRangeChange={handleRangeChange}
       rows={rows}
-      grandTotal={data?.grand_total_spend ?? 0}
+      grandTotal={data?.categories_total_spend ?? 0}
       currency={account.currency}
       emptyLabel="No spending in this range"
       loading={isFetching}

--- a/frontend/src/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard.tsx
+++ b/frontend/src/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from 'react'
+import { CircleHelp } from 'lucide-react'
 import {
   useAccountSpendingBreakdown,
   type Account,
@@ -8,8 +9,33 @@ import {
   getDeterministicChartColor,
   getDeterministicChartColorMap,
 } from '@/utils/chartColor'
-import { getBreakdownRows } from '@/pages/accounts/detail/utils/spendingBreakdownViewModel'
+import {
+  getBreakdownRows,
+  shouldExplainMerchantsTotal,
+} from '@/pages/accounts/detail/utils/spendingBreakdownViewModel'
+import IconTooltip from '@/components/tooltips/IconTooltip'
 import { SpendingBreakdownCard } from './Card'
+
+/**
+ * Explains why this card's total differs from the one on the categories card beside it
+ *
+ * The two figures are built from different groupings and are both correct, so the difference needs
+ * saying rather than looking like an error
+ */
+function MerchantSpendingTotalTooltip() {
+  return (
+    <IconTooltip
+      label="Why this total differs from the categories total"
+      icon={CircleHelp}
+      placement="top"
+      widthClassName="w-64"
+      size={13}
+    >
+      A merchant refunded more than it charged is left out of this total. Its category can still
+      count as spending, so the Categories by Spending card can show a different figure.
+    </IconTooltip>
+  )
+}
 
 /**
  * Renders top spending merchants for one account and owns merchant colour mapping
@@ -56,6 +82,7 @@ export function TopMerchantsBySpendingCard({ account }: { account: Account }) {
       onRangeChange={handleRangeChange}
       rows={rows}
       cardTotal={data?.merchants_total_spend ?? 0}
+      totalTooltip={shouldExplainMerchantsTotal(data) ? <MerchantSpendingTotalTooltip /> : undefined}
       currency={account.currency}
       emptyLabel="No merchant activity in this range"
       loading={isFetching}

--- a/frontend/src/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard.tsx
+++ b/frontend/src/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard.tsx
@@ -45,6 +45,7 @@ export function TopMerchantsBySpendingCard({ account }: { account: Account }) {
       }
     }),
     (breakdown) => breakdown.other_merchants_count,
+    (breakdown) => breakdown.merchants_total_spend,
   )
 
   return (
@@ -54,7 +55,7 @@ export function TopMerchantsBySpendingCard({ account }: { account: Account }) {
       range={range}
       onRangeChange={handleRangeChange}
       rows={rows}
-      grandTotal={data?.grand_total_spend ?? 0}
+      grandTotal={data?.merchants_total_spend ?? 0}
       currency={account.currency}
       emptyLabel="No merchant activity in this range"
       loading={isFetching}

--- a/frontend/src/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard.tsx
+++ b/frontend/src/pages/accounts/detail/components/spending-breakdown/TopMerchantsCard.tsx
@@ -55,7 +55,7 @@ export function TopMerchantsBySpendingCard({ account }: { account: Account }) {
       range={range}
       onRangeChange={handleRangeChange}
       rows={rows}
-      grandTotal={data?.merchants_total_spend ?? 0}
+      cardTotal={data?.merchants_total_spend ?? 0}
       currency={account.currency}
       emptyLabel="No merchant activity in this range"
       loading={isFetching}

--- a/frontend/src/pages/accounts/detail/utils/spendingBreakdownViewModel.ts
+++ b/frontend/src/pages/accounts/detail/utils/spendingBreakdownViewModel.ts
@@ -63,3 +63,14 @@ export function getBreakdownRows(
   if (!data) return []
   return appendOtherBreakdownRow(toRows(data), otherCount(data), cardTotal(data))
 }
+
+/**
+ * Decides whether the merchants card explains its total
+ *
+ * The two cards cover the same account over the same range, so the explanation is only worth
+ * showing where their totals are not the same number
+ */
+export function shouldExplainMerchantsTotal(data: AccountSpendingBreakdown | undefined): boolean {
+  if (!data) return false
+  return data.categories_total_spend !== data.merchants_total_spend
+}

--- a/frontend/src/pages/accounts/detail/utils/spendingBreakdownViewModel.ts
+++ b/frontend/src/pages/accounts/detail/utils/spendingBreakdownViewModel.ts
@@ -21,7 +21,7 @@ export type BreakdownRow = {
 
 export type BreakdownSnapshot = {
   rows: BreakdownRow[]
-  grandTotal: number
+  cardTotal: number
   currency: string
   emptyLabel: string
 }
@@ -32,19 +32,19 @@ export type BreakdownSnapshot = {
 export function appendOtherBreakdownRow(
   rows: BreakdownRow[],
   otherCount: number,
-  grandTotal: number,
+  cardTotal: number,
 ): BreakdownRow[] {
   if (otherCount <= 0) return rows
   const topSum = rows.reduce((sum, row) => sum + row.total, 0)
-  const otherTotal = Math.max(grandTotal - topSum, 0)
+  const otherTotal = Math.max(cardTotal - topSum, 0)
   return [...rows, { key: 'other', name: `Other (${otherCount})`, total: otherTotal, isOther: true }]
 }
 
 /**
  * Converts a row total into the proportional fill width shown behind the breakdown row
  */
-export function getBreakdownRowFillPercent(rowTotal: number, grandTotal: number): number {
-  const totalAbs = Math.abs(grandTotal)
+export function getBreakdownRowFillPercent(rowTotal: number, cardTotal: number): number {
+  const totalAbs = Math.abs(cardTotal)
   return totalAbs > 0 ? Math.max((Math.abs(rowTotal) / totalAbs) * 100, 4) : 0
 }
 

--- a/frontend/src/pages/accounts/detail/utils/spendingBreakdownViewModel.ts
+++ b/frontend/src/pages/accounts/detail/utils/spendingBreakdownViewModel.ts
@@ -50,12 +50,16 @@ export function getBreakdownRowFillPercent(rowTotal: number, grandTotal: number)
 
 /**
  * Projects a backend breakdown payload into rows and optional Other row
+ *
+ * Each card carries its own total, so the caller says which one its rows belong to. Handing the
+ * other card's total here would size the Other row against spending these rows never held
  */
 export function getBreakdownRows(
   data: AccountSpendingBreakdown | undefined,
   toRows: (breakdown: AccountSpendingBreakdown) => BreakdownRow[],
   otherCount: (breakdown: AccountSpendingBreakdown) => number,
+  cardTotal: (breakdown: AccountSpendingBreakdown) => number,
 ): BreakdownRow[] {
   if (!data) return []
-  return appendOtherBreakdownRow(toRows(data), otherCount(data), data.grand_total_spend)
+  return appendOtherBreakdownRow(toRows(data), otherCount(data), cardTotal(data))
 }

--- a/frontend/tests/pages/accounts/detail/utils/spendingBreakdownViewModel.test.ts
+++ b/frontend/tests/pages/accounts/detail/utils/spendingBreakdownViewModel.test.ts
@@ -56,4 +56,36 @@ describe('spending breakdown view model helpers', () => {
       { key: 'other', name: 'Other (2)', total: 3_000, isOther: true },
     ])
   })
+
+  it('sizes the Other row from the total of the card it belongs to', () => {
+    const payload: AccountSpendingBreakdown = {
+      range: 'MTD',
+      top_categories: [
+        { category_id: 'food', name: 'Food', total: 7_000 },
+      ],
+      top_merchants: [
+        { merchant_id: 'grocer', name: 'Grocer', total: 4_000 },
+      ],
+      categories_total_spend: 10_000,
+      merchants_total_spend: 6_000,
+      other_categories_count: 1,
+      other_merchants_count: 1,
+    }
+
+    // Reading the categories total here instead would size this Other row at 6_000
+    expect(getBreakdownRows(
+      payload,
+      (breakdown) => breakdown.top_merchants.map((merchant) => ({
+        key: merchant.merchant_id,
+        name: merchant.name,
+        total: merchant.total,
+        isOther: false,
+      })),
+      (breakdown) => breakdown.other_merchants_count,
+      (breakdown) => breakdown.merchants_total_spend,
+    )).toEqual([
+      { key: 'grocer', name: 'Grocer', total: 4_000, isOther: false },
+      { key: 'other', name: 'Other (1)', total: 2_000, isOther: true },
+    ])
+  })
 })

--- a/frontend/tests/pages/accounts/detail/utils/spendingBreakdownViewModel.test.ts
+++ b/frontend/tests/pages/accounts/detail/utils/spendingBreakdownViewModel.test.ts
@@ -35,7 +35,8 @@ describe('spending breakdown view model helpers', () => {
         { category_id: 'food', name: 'Food', total: 7_000 },
       ],
       top_merchants: [],
-      grand_total_spend: 10_000,
+      categories_total_spend: 10_000,
+      merchants_total_spend: 0,
       other_categories_count: 2,
       other_merchants_count: 0,
     }
@@ -49,6 +50,7 @@ describe('spending breakdown view model helpers', () => {
         isOther: false,
       })),
       (breakdown) => breakdown.other_categories_count,
+      (breakdown) => breakdown.categories_total_spend,
     )).toEqual([
       { key: 'food', name: 'Food', total: 7_000, isOther: false },
       { key: 'other', name: 'Other (2)', total: 3_000, isOther: true },

--- a/frontend/tests/pages/accounts/detail/utils/spendingBreakdownViewModel.test.ts
+++ b/frontend/tests/pages/accounts/detail/utils/spendingBreakdownViewModel.test.ts
@@ -1,6 +1,7 @@
 /**
- * Tests the account spending breakdown view model so the Other row, the bar fills and the rows built
- * from a backend payload cannot drift from the totals they are derived from
+ * Tests the account spending breakdown view model so the Other row, the bar fills, the rows built
+ * from a backend payload and the merchant total explanation cannot drift from the totals they are
+ * derived from
  */
 import { describe, expect, it } from 'vitest'
 import type { AccountSpendingBreakdown } from '@/api/accounts'
@@ -8,6 +9,7 @@ import {
   appendOtherBreakdownRow,
   getBreakdownRowFillPercent,
   getBreakdownRows,
+  shouldExplainMerchantsTotal,
 } from '@/pages/accounts/detail/utils/spendingBreakdownViewModel'
 
 describe('spending breakdown view model helpers', () => {
@@ -87,5 +89,21 @@ describe('spending breakdown view model helpers', () => {
       { key: 'grocer', name: 'Grocer', total: 4_000, isOther: false },
       { key: 'other', name: 'Other (1)', total: 2_000, isOther: true },
     ])
+  })
+
+  it('explains the merchant total only where it differs from the categories total', () => {
+    const payload: AccountSpendingBreakdown = {
+      range: 'MTD',
+      top_categories: [],
+      top_merchants: [],
+      categories_total_spend: 10_000,
+      merchants_total_spend: 6_000,
+      other_categories_count: 0,
+      other_merchants_count: 0,
+    }
+
+    expect(shouldExplainMerchantsTotal(payload)).toBe(true)
+    expect(shouldExplainMerchantsTotal({ ...payload, merchants_total_spend: 10_000 })).toBe(false)
+    expect(shouldExplainMerchantsTotal(undefined)).toBe(false)
   })
 })

--- a/frontend/tests/pages/accounts/detail/utils/spendingBreakdownViewModel.test.ts
+++ b/frontend/tests/pages/accounts/detail/utils/spendingBreakdownViewModel.test.ts
@@ -11,7 +11,7 @@ import {
 } from '@/pages/accounts/detail/utils/spendingBreakdownViewModel'
 
 describe('spending breakdown view model helpers', () => {
-  it('adds an Other row using the remaining grand total', () => {
+  it('adds an Other row from what the card total leaves over', () => {
     expect(appendOtherBreakdownRow([
       { key: 'groceries', name: 'Groceries', total: 6_000, isOther: false },
       { key: 'travel', name: 'Travel', total: 3_000, isOther: false },


### PR DESCRIPTION
The Categories by Spending and Merchants by Spending cards on an account now exclude anything refunded past zero, and each carries its own total. Instead of one figure summing every expense transaction in the range, each total sums only the entries that still net spending, so a card's rows and bars agree with the total beneath them. Additionally, the most expensive transactions panel breaks a tie on amount by recency, then by transaction identifier.
