### PR TITLE
feat: add rotate-app-encryption-key command

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,13 +254,13 @@ Rotate the key if it has been exposed, or on whatever schedule your own policy s
    docker compose stop app
    ```
 
-4. Rotate, passing the key on standard input:
+4. Rotate, giving the new key as the argument:
 
    ```sh
    docker compose run --rm app rotate-app-encryption-key "your-new-key"
    ```
 
-   The key is visible in the process list while this runs, so rotate from a shell you trust. The rotation reports how many rows it rewrote per column. It rewrites every stored secret in one transaction, so a failure leaves the data exactly as it was, and it removes the old key file from the data volume when it succeeds.
+   The key is visible in the process list while this runs, so rotate from a shell you trust. The rotation reports how many rows it rewrote per column, then frames the step left to do. It rewrites every stored secret in one transaction, so a failure leaves the data exactly as it was, and it removes the old key file from the data volume where the deployment had one.
 
 5. Set `APP_ENCRYPTION_KEY` in `.env` to the new key, then start the stack:
 
@@ -268,7 +268,7 @@ Rotate the key if it has been exposed, or on whatever schedule your own policy s
    docker compose up -d
    ```
 
-If the rotation is interrupted after it commits, run step 4 again with the same key. It detects that the secrets already read under that key and clears what the interrupted run left behind.
+If the rotation is interrupted after it commits, run step 4 again with the same key. It detects that the stored secrets are already encrypted under that key and clears what the interrupted run left behind. Check for a leftover container too, with `docker compose ps -a`, and remove it with `docker compose rm -f app`: the key is part of its recorded command, and an interrupted run is the case where `--rm` does not delete it.
 
 ### [JWKS (JSON Web Key Set)](https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-key-sets) and JWT Configs
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,43 @@ Lumina Finance can accept sign-ins from any standards-compliant OpenID Connect p
 
 | Variable | Required | Expected Values | Default Value | Purpose |
 |-|-|-|-|-|
-| `APP_ENCRYPTION_KEY` | No | Fernet key | Auto-generated | Encrypts secrets stored in the database, such as two-factor secrets and the OIDC client secret. If unset, a key is generated on first start and persisted to `/data/secrets/app_encryption_key` on the data volume. Changing the encryption key stops the container at startup because existing secrets cannot be decrypted. Losing this key makes the stored secrets undecryptable, so back up the data volume alongside your database |
+| `APP_ENCRYPTION_KEY` | No | Fernet key | Auto-generated | Encrypts secrets stored in the database, such as two-factor secrets and the OIDC client secret. If unset, a key is generated on first start and persisted to `/data/secrets/app_encryption_key` on the data volume. Setting this to a key the stored secrets were not encrypted under stops the container at startup rather than making them unreadable. To change the key, follow [Rotating the encryption key](#rotating-the-encryption-key), which rewrites every stored secret under the new one. Losing this key makes the stored secrets undecryptable, so back up the data volume alongside your database |
+
+#### Rotating the encryption key
+
+Rotate the key if it has been exposed, or on whatever schedule your own policy sets. The app must be stopped while this runs: a serving container holds the old key for its lifetime, so a two-factor enrolment during the rotation is written under that key onto a row already rewritten, and nothing can read it afterwards. The rotation refuses to start while the app is still connected.
+
+1. Generate a key:
+
+   ```sh
+   docker compose run --rm app generate-app-encryption-key
+   ```
+
+   The key is printed and stored nowhere. It protects nothing yet, so generate another if you lose it at this point.
+
+2. Save the key in your password manager. From the next step on it is the only thing that reads your stored secrets.
+
+3. Stop the app, leaving PostgreSQL running:
+
+   ```sh
+   docker compose stop app
+   ```
+
+4. Rotate, passing the key on standard input:
+
+   ```sh
+   docker compose run --rm -T app rotate-app-encryption-key <<< "your-new-key"
+   ```
+
+   The rotation reports how many rows it rewrote per column. It rewrites every stored secret in one transaction, so a failure leaves the data exactly as it was, and it removes the old key file from the data volume when it succeeds.
+
+5. Set `APP_ENCRYPTION_KEY` in `.env` to the new key, then start the stack:
+
+   ```sh
+   docker compose up -d
+   ```
+
+If the rotation is interrupted after it commits, run step 4 again with the same key. It detects that the secrets already read under that key and clears what the interrupted run left behind.
 
 ### [JWKS (JSON Web Key Set)](https://auth0.com/docs/secure/tokens/json-web-tokens/json-web-key-sets) and JWT Configs
 

--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Rotate the key if it has been exposed, or on whatever schedule your own policy s
 4. Rotate, passing the key on standard input:
 
    ```sh
-   docker compose run --rm -T app rotate-app-encryption-key <<< "your-new-key"
+   printf '%s' "your-new-key" | docker compose run --rm -T app rotate-app-encryption-key
    ```
 
    The rotation reports how many rows it rewrote per column. It rewrites every stored secret in one transaction, so a failure leaves the data exactly as it was, and it removes the old key file from the data volume when it succeeds.

--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ Rotate the key if it has been exposed, or on whatever schedule your own policy s
 4. Rotate, passing the key on standard input:
 
    ```sh
-   printf '%s' "your-new-key" | docker compose run --rm -T app rotate-app-encryption-key
+   docker compose run --rm app rotate-app-encryption-key "your-new-key"
    ```
 
-   The rotation reports how many rows it rewrote per column. It rewrites every stored secret in one transaction, so a failure leaves the data exactly as it was, and it removes the old key file from the data volume when it succeeds.
+   The key is visible in the process list while this runs, so rotate from a shell you trust. The rotation reports how many rows it rewrote per column. It rewrites every stored secret in one transaction, so a failure leaves the data exactly as it was, and it removes the old key file from the data volume when it succeeds.
 
 5. Set `APP_ENCRYPTION_KEY` in `.env` to the new key, then start the stack:
 

--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -9,27 +9,11 @@ from sqlalchemy.ext.asyncio import async_engine_from_config
 from alembic import context
 from app.config.database import migration_database_url
 
-# Import all models so Alembic can detect them for autogenerate
-from app.models import (  # noqa: F401
-    account,
-    auth,
-    auth_session,
-    auth_token,
-    budget,
-    cache_state,
-    category,
-    currency,
-    group,
-    import_run,
-    institution,
-    merchant,
-    oidc,
-    saved_insights_range,
-    tag,
-    transaction,
-    user,
-)
+from app.models import import_all_models
 from app.models.base import Base
+
+# Import all models so Alembic can detect them for autogenerate
+import_all_models()
 
 config = context.config
 

--- a/backend/alembic/versions/51c17506619a_add_encryption_key_fingerprint.py
+++ b/backend/alembic/versions/51c17506619a_add_encryption_key_fingerprint.py
@@ -22,7 +22,9 @@ def upgrade() -> None:
     """Create the single row binding the database to its encryption key"""
     op.create_table(
         "encryption_key_fingerprint",
-        sa.Column("id", sa.Integer(), nullable=False),
+        # Not a sequence: the row is the fixed singleton id, and leaving autoincrement to
+        # be inferred would build a SERIAL here and a plain integer from the model metadata
+        sa.Column("id", sa.Integer(), autoincrement=False, nullable=False),
         sa.Column("fingerprint", sa.Text(), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
         sa.CheckConstraint("id = 1", name="ck_encryption_key_fingerprint_singleton"),

--- a/backend/alembic/versions/51c17506619a_add_encryption_key_fingerprint.py
+++ b/backend/alembic/versions/51c17506619a_add_encryption_key_fingerprint.py
@@ -1,0 +1,41 @@
+"""add encryption key fingerprint
+
+Revision ID: 51c17506619a
+Revises: ea697fdf5846
+Create Date: 2026-08-20 19:25:12.938671
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from app.db.rls import grant_global_read_table
+
+revision: str = "51c17506619a"
+down_revision: str | Sequence[str] | None = "ea697fdf5846"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Create the single row binding the database to its encryption key"""
+    op.create_table(
+        "encryption_key_fingerprint",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("fingerprint", sa.Text(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.CheckConstraint("id = 1", name="ck_encryption_key_fingerprint_singleton"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # This table is added after the row-level security bootstrap, so grant the app role here
+    grant_global_read_table(op.get_bind(), "encryption_key_fingerprint")
+
+    # No row is written here. The fingerprint is recorded by verify-fingerprint on the next
+    # boot, which proves the resolved key decrypts existing data before recording it
+
+
+def downgrade() -> None:
+    """Remove the encryption key binding"""
+    op.drop_table("encryption_key_fingerprint")

--- a/backend/app/db/encryption_key.py
+++ b/backend/app/db/encryption_key.py
@@ -1,7 +1,6 @@
 """Provision the encryption key and bind it to the data it protects"""
 
 import asyncio
-import os
 import sys
 
 from cryptography.fernet import Fernet, InvalidToken
@@ -16,29 +15,17 @@ from app.models.base import Base
 from app.models.encryption_key import SINGLETON_ID
 from app.models.types import find_encrypted_columns
 
-_FINGERPRINT_TABLE = "encryption_key_fingerprint"
+FINGERPRINT_TABLE = "encryption_key_fingerprint"
 
 # Present once the schema has been built, so its absence is what distinguishes a first
 # install from a deployment whose key file was removed
 _MIGRATION_TABLE = "alembic_version"
 
 
-async def _table_exists(connection: AsyncConnection, table: str) -> bool:
+async def table_exists(connection: AsyncConnection, table: str) -> bool:
     """Whether a public table is present in the database"""
     qualified = await connection.scalar(text("SELECT to_regclass(:qualified)"), {"qualified": f"public.{table}"})
     return qualified is not None
-
-
-async def fingerprint_table_exists(connection: AsyncConnection) -> bool:
-    """Whether the key record table has been created by a migration yet
-
-    Args:
-        connection: Open connection to the application database
-
-    Returns:
-        Whether the table is present
-    """
-    return await _table_exists(connection, _FINGERPRINT_TABLE)
 
 
 async def read_fingerprint(connection: AsyncConnection) -> str | None:
@@ -50,12 +37,12 @@ async def read_fingerprint(connection: AsyncConnection) -> str | None:
     Returns:
         The recorded SHA-256 hex digest, or None when the table or the row is absent
     """
-    if not await _table_exists(connection, _FINGERPRINT_TABLE):
+    if not await table_exists(connection, FINGERPRINT_TABLE):
         return None
 
     # Read the single row stating which key this database's secrets are under
     return await connection.scalar(
-        text(f"SELECT fingerprint FROM public.{_FINGERPRINT_TABLE} WHERE id = :id"),
+        text(f"SELECT fingerprint FROM public.{FINGERPRINT_TABLE} WHERE id = :id"),
         {"id": SINGLETON_ID},
     )
 
@@ -70,7 +57,7 @@ async def record_fingerprint(connection: AsyncConnection, key: str) -> None:
     # Upsert the single row, so recording after a rotation replaces the previous key
     await connection.execute(
         text(
-            f"INSERT INTO public.{_FINGERPRINT_TABLE} (id, fingerprint) VALUES (:id, :fingerprint) "
+            f"INSERT INTO public.{FINGERPRINT_TABLE} (id, fingerprint) VALUES (:id, :fingerprint) "
             f"ON CONFLICT (id) DO UPDATE SET fingerprint = EXCLUDED.fingerprint, updated_at = now()"
         ),
         {"id": SINGLETON_ID, "fingerprint": encryption.key_fingerprint(key)},
@@ -88,7 +75,7 @@ async def read_stored_secret(connection: AsyncConnection) -> str | None:
     """
     import_all_models()
     for table, column in find_encrypted_columns(Base.metadata):
-        if not await _table_exists(connection, table):
+        if not await table_exists(connection, table):
             continue
 
         # Table and column come from the model metadata rather than any caller, so they are
@@ -152,16 +139,17 @@ async def ensure_key(connection: AsyncConnection) -> None:
         connection: Open connection used to check whether anything is already encrypted
 
     Raises:
-        RuntimeError: No key is available and this database already holds encrypted secrets
+        RuntimeError: No key is available and this database either already holds encrypted
+            secrets or could not be checked for them
     """
-    if bool(os.getenv(encryption.KEY_ENV_VAR)) or encryption.KEY_FILE.exists():
+    if encryption.read_configured_key() is not None or encryption.KEY_FILE.exists():
         encryption.resolve_encryption_key(generate=True)
         print("Application encryption key already configured", file=sys.stderr)
         return
 
     # A schema that exists means this is not a first install, so anything encrypted under
     # the missing key would be lost behind a freshly generated one
-    if await _table_exists(connection, _MIGRATION_TABLE):
+    if await table_exists(connection, _MIGRATION_TABLE):
         try:
             already_encrypted = (
                 await read_fingerprint(connection) is not None or await read_stored_secret(connection) is not None
@@ -200,8 +188,8 @@ async def verify_fingerprint(connection: AsyncConnection) -> None:
             matches the record nor reads the stored secrets
     """
     key = encryption.resolve_encryption_key(generate=False)
-    if not await _table_exists(connection, _FINGERPRINT_TABLE):
-        raise RuntimeError(f"No {_FINGERPRINT_TABLE} table. Run the migrations before verifying the key")
+    if not await table_exists(connection, FINGERPRINT_TABLE):
+        raise RuntimeError(f"No {FINGERPRINT_TABLE} table. Run the migrations before verifying the key")
 
     if await read_fingerprint(connection) is not None:
         await verify_key_matches_data(connection)

--- a/backend/app/db/encryption_key.py
+++ b/backend/app/db/encryption_key.py
@@ -42,7 +42,7 @@ async def read_fingerprint(connection: AsyncConnection) -> str | None:
 
     # Read the single row stating which key this database's secrets are under
     return await connection.scalar(
-        text(f"SELECT fingerprint FROM public.{FINGERPRINT_TABLE} WHERE id = :id"),
+        text(f"SELECT fingerprint FROM public.{FINGERPRINT_TABLE} WHERE id = :id"),  # noqa: S608
         {"id": SINGLETON_ID},
     )
 
@@ -57,7 +57,7 @@ async def record_fingerprint(connection: AsyncConnection, key: str) -> None:
     # Upsert the single row, so recording after a rotation replaces the previous key
     await connection.execute(
         text(
-            f"INSERT INTO public.{FINGERPRINT_TABLE} (id, fingerprint) VALUES (:id, :fingerprint) "
+            f"INSERT INTO public.{FINGERPRINT_TABLE} (id, fingerprint) VALUES (:id, :fingerprint) "  # noqa: S608
             f"ON CONFLICT (id) DO UPDATE SET fingerprint = EXCLUDED.fingerprint, updated_at = now()"
         ),
         {"id": SINGLETON_ID, "fingerprint": encryption.key_fingerprint(key)},
@@ -81,7 +81,7 @@ async def read_stored_secret(connection: AsyncConnection) -> str | None:
         # Table and column come from the model metadata rather than any caller, so they are
         # safe to interpolate, as the row-level security statements do with the same values
         value = await connection.scalar(
-            text(f"SELECT {column} FROM public.{table} WHERE {column} IS NOT NULL LIMIT 1")
+            text(f"SELECT {column} FROM public.{table} WHERE {column} IS NOT NULL LIMIT 1")  # noqa: S608
         )
         if value is not None:
             return value

--- a/backend/app/db/encryption_key.py
+++ b/backend/app/db/encryption_key.py
@@ -1,0 +1,231 @@
+"""Provision the encryption key and bind it to the data it protects"""
+
+import asyncio
+import os
+import sys
+
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
+
+from app import encryption
+from app.config.database import admin_database_url, migration_database_url
+from app.models import import_all_models
+from app.models.base import Base
+from app.models.encryption_key import SINGLETON_ID
+from app.models.types import find_encrypted_columns
+
+_FINGERPRINT_TABLE = "encryption_key_fingerprint"
+
+# Present once the schema has been built, so its absence is what distinguishes a first
+# install from a deployment whose key file was removed
+_MIGRATION_TABLE = "alembic_version"
+
+
+async def _table_exists(connection: AsyncConnection, table: str) -> bool:
+    """Whether a public table is present in the database"""
+    qualified = await connection.scalar(text("SELECT to_regclass(:qualified)"), {"qualified": f"public.{table}"})
+    return qualified is not None
+
+
+async def read_fingerprint(connection: AsyncConnection) -> str | None:
+    """Return the recorded key fingerprint, or None when nothing is recorded yet
+
+    Args:
+        connection: Open connection to the application database
+
+    Returns:
+        The recorded SHA-256 hex digest, or None when the table or the row is absent
+    """
+    if not await _table_exists(connection, _FINGERPRINT_TABLE):
+        return None
+
+    # Read the single row stating which key this database's secrets are under
+    return await connection.scalar(
+        text(f"SELECT fingerprint FROM public.{_FINGERPRINT_TABLE} WHERE id = :id"),
+        {"id": SINGLETON_ID},
+    )
+
+
+async def record_fingerprint(connection: AsyncConnection, key: str) -> None:
+    """Record the key the stored secrets are under, replacing any earlier record
+
+    Args:
+        connection: Open connection inside the transaction that wrote the secrets
+        key: The url-safe base64 Fernet key the data is now encrypted under
+    """
+    # Upsert the single row, so recording after a rotation replaces the previous key
+    await connection.execute(
+        text(
+            f"INSERT INTO public.{_FINGERPRINT_TABLE} (id, fingerprint) VALUES (:id, :fingerprint) "
+            f"ON CONFLICT (id) DO UPDATE SET fingerprint = EXCLUDED.fingerprint, updated_at = now()"
+        ),
+        {"id": SINGLETON_ID, "fingerprint": encryption.key_fingerprint(key)},
+    )
+
+
+async def read_stored_secret(connection: AsyncConnection) -> str | None:
+    """Return one stored Fernet token, or None when nothing is encrypted yet
+
+    Args:
+        connection: Open connection to the application database
+
+    Returns:
+        A single stored token from any encrypted column, or None when every one is empty
+    """
+    import_all_models()
+    for table, column in find_encrypted_columns(Base.metadata):
+        if not await _table_exists(connection, table):
+            continue
+
+        # Table and column come from the model metadata rather than any caller, so they are
+        # safe to interpolate, as the row-level security statements do with the same values
+        value = await connection.scalar(
+            text(f"SELECT {column} FROM public.{table} WHERE {column} IS NOT NULL LIMIT 1")
+        )
+        if value is not None:
+            return value
+    return None
+
+
+def decrypts(key: str, token: str) -> bool:
+    """Whether a key reads a stored token
+
+    Args:
+        key: The url-safe base64 Fernet key to try
+        token: A Fernet token read from storage
+
+    Returns:
+        Whether the key decrypts the token
+    """
+    try:
+        Fernet(key.encode()).decrypt(token.encode())
+    except (InvalidToken, ValueError):
+        return False
+    return True
+
+
+async def verify_key_matches_data(connection: AsyncConnection) -> None:
+    """Raise when the resolved key is not the one this database's secrets are under
+
+    A recorded fingerprint that disagrees with the resolved key means every stored secret
+    is unreadable, and serving anyway would write new secrets under the wrong key and mix
+    two keys inside one column. Nothing is recorded before the first verify-fingerprint
+    run, and that state is not an error
+
+    Args:
+        connection: Open connection to the application database
+
+    Raises:
+        RuntimeError: The recorded fingerprint and the resolved key disagree
+    """
+    recorded = await read_fingerprint(connection)
+    if recorded is None:
+        return
+
+    key = encryption.resolve_encryption_key(generate=False)
+    if recorded != encryption.key_fingerprint(key):
+        raise RuntimeError(
+            "Refusing to start: the stored secrets were encrypted under a different key than "
+            f"the one resolved from {encryption.KEY_ENV_VAR} or {encryption.KEY_FILE}. Restore "
+            f"that key, or rotate to this one with rotate-app-encryption-key"
+        )
+
+
+async def ensure_key(connection: AsyncConnection) -> None:
+    """Generate and persist the encryption key when a deployment has none yet
+
+    Args:
+        connection: Open connection used to check whether anything is already encrypted
+
+    Raises:
+        RuntimeError: No key is available and this database already holds encrypted secrets
+    """
+    if bool(os.getenv(encryption.KEY_ENV_VAR)) or encryption.KEY_FILE.exists():
+        encryption.resolve_encryption_key(generate=True)
+        print("Application encryption key already configured", file=sys.stderr)
+        return
+
+    # A schema that exists means this is not a first install, so anything encrypted under
+    # the missing key would be lost behind a freshly generated one
+    if await _table_exists(connection, _MIGRATION_TABLE) and (
+        await read_fingerprint(connection) is not None or await read_stored_secret(connection) is not None
+    ):
+        raise RuntimeError(
+            f"No application encryption key, but this database already holds secrets "
+            f"encrypted under one. Set {encryption.KEY_ENV_VAR} to that key. Generating "
+            f"one here would leave every stored secret unreadable with nothing reporting it"
+        )
+
+    encryption.resolve_encryption_key(generate=True)
+    print(f"Generated application encryption key at {encryption.KEY_FILE}", file=sys.stderr)
+
+
+async def verify_fingerprint(connection: AsyncConnection) -> None:
+    """Bind the database to its encryption key, or refuse when the two disagree
+
+    Args:
+        connection: Open connection inside a transaction that may record the fingerprint
+
+    Raises:
+        RuntimeError: The schema has no fingerprint table, or the resolved key neither
+            matches the record nor reads the stored secrets
+    """
+    key = encryption.resolve_encryption_key(generate=False)
+    if not await _table_exists(connection, _FINGERPRINT_TABLE):
+        raise RuntimeError(f"No {_FINGERPRINT_TABLE} table. Run the migrations before verifying the key")
+
+    if await read_fingerprint(connection) is not None:
+        await verify_key_matches_data(connection)
+        return
+
+    # First run after upgrading, so the key in hand becomes the record. It only earns that
+    # if it reads what is already stored, since a deployment booting with the wrong key
+    # would otherwise have that key recorded as the one its secrets are under
+    stored_secret = await read_stored_secret(connection)
+    if stored_secret is not None and not decrypts(key, stored_secret):
+        raise RuntimeError(
+            "Refusing to record the encryption key: it does not decrypt the secrets already "
+            f"stored. Set {encryption.KEY_ENV_VAR} to the key they were encrypted under"
+        )
+
+    await record_fingerprint(connection, key)
+    print("Recorded the encryption key this database's secrets are under", file=sys.stderr)
+
+
+async def _run_ensure_key() -> None:
+    """Run the key check and generation against the admin role"""
+    # This runs before the roles are provisioned, so the admin role is the only one there
+    engine = create_async_engine(admin_database_url())
+    try:
+        async with engine.connect() as connection:
+            await ensure_key(connection)
+    finally:
+        await engine.dispose()
+
+
+async def _run_verify_fingerprint() -> None:
+    """Run the fingerprint check against the migrator role, after migrations"""
+    engine = create_async_engine(migration_database_url())
+    try:
+        async with engine.begin() as connection:
+            await verify_fingerprint(connection)
+    finally:
+        await engine.dispose()
+
+
+_COMMANDS = {
+    "ensure-key": _run_ensure_key,
+    "verify-fingerprint": _run_verify_fingerprint,
+}
+
+
+def main() -> None:
+    """Run the encryption key command named as the single command-line argument"""
+    if len(sys.argv) != 2 or sys.argv[1] not in _COMMANDS:
+        sys.exit(f"Usage: python -m app.db.encryption_key {{{'|'.join(_COMMANDS)}}}")
+    asyncio.run(_COMMANDS[sys.argv[1]]())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/app/db/encryption_key.py
+++ b/backend/app/db/encryption_key.py
@@ -6,6 +6,7 @@ import sys
 
 from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import text
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncConnection, create_async_engine
 
 from app import encryption
@@ -26,6 +27,18 @@ async def _table_exists(connection: AsyncConnection, table: str) -> bool:
     """Whether a public table is present in the database"""
     qualified = await connection.scalar(text("SELECT to_regclass(:qualified)"), {"qualified": f"public.{table}"})
     return qualified is not None
+
+
+async def fingerprint_table_exists(connection: AsyncConnection) -> bool:
+    """Whether the key record table has been created by a migration yet
+
+    Args:
+        connection: Open connection to the application database
+
+    Returns:
+        Whether the table is present
+    """
+    return await _table_exists(connection, _FINGERPRINT_TABLE)
 
 
 async def read_fingerprint(connection: AsyncConnection) -> str | None:
@@ -148,14 +161,29 @@ async def ensure_key(connection: AsyncConnection) -> None:
 
     # A schema that exists means this is not a first install, so anything encrypted under
     # the missing key would be lost behind a freshly generated one
-    if await _table_exists(connection, _MIGRATION_TABLE) and (
-        await read_fingerprint(connection) is not None or await read_stored_secret(connection) is not None
-    ):
-        raise RuntimeError(
-            f"No application encryption key, but this database already holds secrets "
-            f"encrypted under one. Set {encryption.KEY_ENV_VAR} to that key. Generating "
-            f"one here would leave every stored secret unreadable with nothing reporting it"
-        )
+    if await _table_exists(connection, _MIGRATION_TABLE):
+        try:
+            already_encrypted = (
+                await read_fingerprint(connection) is not None or await read_stored_secret(connection) is not None
+            )
+        except SQLAlchemyError as error:
+
+            # This step runs as the admin role, which owns none of the tables it reads here,
+            # so a deployment whose admin role is not a superuser cannot see them. Refusing
+            # is the safe answer: minting a key is what destroys data, and proving the
+            # database empty is what would justify it
+            raise RuntimeError(
+                f"No application encryption key, and this database could not be checked for "
+                f"existing secrets ({error}). Set {encryption.KEY_ENV_VAR} rather than having "
+                f"one generated here"
+            ) from error
+
+        if already_encrypted:
+            raise RuntimeError(
+                f"No application encryption key, but this database already holds secrets "
+                f"encrypted under one. Set {encryption.KEY_ENV_VAR} to that key. Generating "
+                f"one here would leave every stored secret unreadable with nothing reporting it"
+            )
 
     encryption.resolve_encryption_key(generate=True)
     print(f"Generated application encryption key at {encryption.KEY_FILE}", file=sys.stderr)

--- a/backend/app/db/rls/__init__.py
+++ b/backend/app/db/rls/__init__.py
@@ -13,6 +13,7 @@ from app.db.rls.policies import (
     apply_policies,
     drop_policies,
     grant_auth_table,
+    grant_global_read_table,
     secure_registered_table,
 )
 
@@ -21,6 +22,7 @@ __all__ = [
     "GLOBAL_READ_TABLES",
     "apply_rls",
     "grant_auth_table",
+    "grant_global_read_table",
     "revoke_rls",
     "secure_registered_table",
 ]

--- a/backend/app/db/rls/policies.py
+++ b/backend/app/db/rls/policies.py
@@ -66,8 +66,9 @@ SECURED_TABLES = (
      "AND EXISTS (SELECT 1 FROM public.tags g WHERE g.id = tag_id)"),
 )
 
-# Reference tables every authenticated user reads, with no per-row scoping
-GLOBAL_READ_TABLES = ("currencies", "institutions")
+# Tables the app role reads with no per-row scoping, either because every authenticated
+# user reads the same reference rows or because the row describes the deployment itself
+GLOBAL_READ_TABLES = ("currencies", "encryption_key_fingerprint", "institutions")
 
 # Auth tables stay out of RLS because the login and token flows query them before a
 # request identity exists, always by exact id, so the queries already scope them
@@ -104,6 +105,12 @@ def apply_policies(connection: Connection) -> None:
     _secure_groups(connection)
 
     for table in GLOBAL_READ_TABLES:
+
+        # A table added after the bootstrap RLS migration is created by its own later
+        # migration, so a from-scratch upgrade reaches this loop before that table exists.
+        # The apply-rls run after migrations is what grants it
+        if not _table_exists(connection, table):
+            continue
         connection.execute(text(f'GRANT SELECT ON public.{table} TO "{APP_DB_USER}"'))
     # Institutions are submitted and corrected by the users who read them, so the app role
     # writes the table as well, while the rest of the global-read tables stay read-only to it
@@ -161,6 +168,17 @@ def grant_auth_table(connection: Connection, table: str) -> None:
     if table not in AUTH_TABLES:
         raise KeyError(f"{table!r} is not a registered auth table")
     connection.execute(text(f'GRANT {APP_TABLE_PRIVILEGES} ON public.{table} TO "{APP_DB_USER}"'))
+
+
+def grant_global_read_table(connection: Connection, table: str) -> None:
+    """Grant the app role on one global-read table added after the bootstrap migration
+
+    Global-read tables carry no row-level policy, so an incremental migration that adds one
+    calls this to give the app role the read access the bootstrap grants the original ones
+    """
+    if table not in GLOBAL_READ_TABLES:
+        raise KeyError(f"{table!r} is not a registered global-read table")
+    connection.execute(text(f'GRANT SELECT ON public.{table} TO "{APP_DB_USER}"'))
 
 
 def drop_policies(connection: Connection) -> None:

--- a/backend/app/encryption.py
+++ b/backend/app/encryption.py
@@ -1,22 +1,41 @@
-"""Symmetric encryption for secrets stored at rest"""
+"""Symmetric encryption for secrets stored at rest
+
+This module holds no database dependency, so provisioning a key and binding it to the data
+it protects live in app.db.encryption_key instead
+"""
 
 import functools
+import hashlib
 import os
-import sys
 from pathlib import Path
 
 from cryptography.fernet import Fernet
 
 # Persisted alongside the database role secrets so a deployment keeps its secrets together
 _SECRETS_DIR = Path("/data/secrets")
-_KEY_FILE = _SECRETS_DIR / "app_encryption_key"
+KEY_FILE = _SECRETS_DIR / "app_encryption_key"
 _KEY_FILE_MODE = 0o600
-_KEY_ENV_VAR = "APP_ENCRYPTION_KEY"
+KEY_ENV_VAR = "APP_ENCRYPTION_KEY"
 
 
 def generate_encryption_key() -> str:
     """Return a new url-safe base64 Fernet key"""
     return Fernet.generate_key().decode()
+
+
+def key_fingerprint(key: str) -> str:
+    """Return the hex digest identifying a key without disclosing it
+
+    The digest is what a database records to state which key its secrets are under, so it
+    is stored where the key itself must never be
+
+    Args:
+        key: The url-safe base64 Fernet key
+
+    Returns:
+        The SHA-256 hex digest of the key
+    """
+    return hashlib.sha256(key.encode()).hexdigest()
 
 
 def resolve_encryption_key(*, generate: bool) -> str:
@@ -35,16 +54,19 @@ def resolve_encryption_key(*, generate: bool) -> str:
         RuntimeError: The configured and persisted keys conflict, or no key is configured
             or persisted and generation is not allowed
     """
-    configured_key = os.getenv(_KEY_ENV_VAR)
-    persisted_key = _KEY_FILE.read_text().strip() if _KEY_FILE.exists() else None
+    configured_key = os.getenv(KEY_ENV_VAR)
+    persisted_key = KEY_FILE.read_text().strip() if KEY_FILE.exists() else None
 
     # A configured key that differs from the persisted one would silently win and every
     # secret encrypted under the persisted key would fail to decrypt at runtime, so refuse
-    # to start instead of picking a winner
+    # to start instead of picking a winner. The guidance deliberately does not offer
+    # removing either one, since which of the two is live depends on whether a rotation
+    # has run, and removing the live one leaves the stored secrets unreadable
     if configured_key and persisted_key and configured_key != persisted_key:
         raise RuntimeError(
-            f"{_KEY_ENV_VAR} does not match the key persisted at {_KEY_FILE}. "
-            f"Remove the environment variable, remove the stale key file, or make them match"
+            f"{KEY_ENV_VAR} does not match the key persisted at {KEY_FILE}. "
+            f"Only one of them decrypts the stored secrets, so set both to that key. "
+            f"After a rotation it is the new key, and the stale file is the one to replace"
         )
 
     if configured_key:
@@ -54,12 +76,12 @@ def resolve_encryption_key(*, generate: bool) -> str:
         return persisted_key
 
     if not generate:
-        raise RuntimeError(f"No application encryption key. Set {_KEY_ENV_VAR} or provision it first")
+        raise RuntimeError(f"No application encryption key. Set {KEY_ENV_VAR} or provision it first")
 
     generated_key = generate_encryption_key()
     _SECRETS_DIR.mkdir(parents=True, exist_ok=True)
-    _KEY_FILE.write_text(generated_key)
-    _KEY_FILE.chmod(_KEY_FILE_MODE)
+    KEY_FILE.write_text(generated_key)
+    KEY_FILE.chmod(_KEY_FILE_MODE)
     return generated_key
 
 
@@ -67,8 +89,10 @@ def resolve_encryption_key(*, generate: bool) -> str:
 def _fernet() -> Fernet:
     """Return the Fernet built from the resolved key
 
-    The key is stable for the life of the process, so it is cached. A serving process only
-    reads the key since provisioning is what generates it
+    The key is stable for the life of the process, so it is cached. That cache is also why
+    a key rotation runs with the app stopped: a serving process would keep writing new
+    secrets under the key it resolved at startup, onto rows the rotation has already
+    rewritten, and nothing could read them afterwards
     """
     return Fernet(resolve_encryption_key(generate=False).encode())
 
@@ -81,17 +105,3 @@ def encrypt(plaintext: str) -> str:
 def decrypt(token: str) -> str:
     """Return the plaintext for a Fernet token read from storage"""
     return _fernet().decrypt(token.encode()).decode()
-
-
-def main() -> None:
-    """Generate and persist the encryption key when a deployment has none yet"""
-    key_present = bool(os.getenv(_KEY_ENV_VAR)) or _KEY_FILE.exists()
-    resolve_encryption_key(generate=True)
-    if key_present:
-        print("Application encryption key already configured", file=sys.stderr)
-    else:
-        print(f"Generated application encryption key at {_KEY_FILE}", file=sys.stderr)
-
-
-if __name__ == "__main__":
-    main()

--- a/backend/app/encryption.py
+++ b/backend/app/encryption.py
@@ -54,7 +54,13 @@ def resolve_encryption_key(*, generate: bool) -> str:
         RuntimeError: The configured and persisted keys conflict, or no key is configured
             or persisted and generation is not allowed
     """
-    configured_key = os.getenv(KEY_ENV_VAR)
+    # Both sources are stripped so one key has one spelling everywhere. A key carrying a
+    # trailing newline, which is what an env file or a mounted secret produces, decodes to
+    # the same 32 bytes and decrypts everything, but compares unequal to the same key
+    # without it, which would fail the fingerprint check and defeat the rotation's
+    # refusal to rotate onto the key already in use
+    configured = os.getenv(KEY_ENV_VAR)
+    configured_key = configured.strip() if configured else None
     persisted_key = KEY_FILE.read_text().strip() if KEY_FILE.exists() else None
 
     # A configured key that differs from the persisted one would silently win and every

--- a/backend/app/encryption.py
+++ b/backend/app/encryption.py
@@ -38,6 +38,22 @@ def key_fingerprint(key: str) -> str:
     return hashlib.sha256(key.encode()).hexdigest()
 
 
+def read_configured_key() -> str | None:
+    """Return the key configured through the environment, or None when none is set
+
+    Every caller asking whether a key is configured goes through this, so an all-whitespace
+    value counts as unset everywhere rather than as a key in one place and not in another.
+    A key carrying a trailing newline, which is what an env file or a mounted secret
+    produces, decodes to the same 32 bytes and decrypts everything, but compares unequal to
+    the same key without it, which would fail the fingerprint check and defeat the
+    rotation's refusal to rotate onto the key already in use
+
+    Returns:
+        The configured key with surrounding whitespace removed, or None
+    """
+    return os.getenv(KEY_ENV_VAR, "").strip() or None
+
+
 def resolve_encryption_key(*, generate: bool) -> str:
     """Return the application symmetric encryption key
 
@@ -54,13 +70,7 @@ def resolve_encryption_key(*, generate: bool) -> str:
         RuntimeError: The configured and persisted keys conflict, or no key is configured
             or persisted and generation is not allowed
     """
-    # Both sources are stripped so one key has one spelling everywhere. A key carrying a
-    # trailing newline, which is what an env file or a mounted secret produces, decodes to
-    # the same 32 bytes and decrypts everything, but compares unequal to the same key
-    # without it, which would fail the fingerprint check and defeat the rotation's
-    # refusal to rotate onto the key already in use
-    configured = os.getenv(KEY_ENV_VAR)
-    configured_key = configured.strip() if configured else None
+    configured_key = read_configured_key()
     persisted_key = KEY_FILE.read_text().strip() if KEY_FILE.exists() else None
 
     # A configured key that differs from the persisted one would silently win and every

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,7 +8,8 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config.oidc import OIDC_PROVIDER_CONFIGS
 from app.config.runtime import ALLOWED_ORIGINS, RUNTIME
-from app.database import async_session, verify_app_role_is_unprivileged
+from app.database import async_session, engine, verify_app_role_is_unprivileged
+from app.db.encryption_key import verify_key_matches_data
 from app.request_security import RequestBodySizeLimitMiddleware
 from app.routes.accounts import router as account_router
 from app.routes.app_version import router as app_version_router
@@ -35,8 +36,14 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def _lifespan(_app: FastAPI):
-    """Verify the runtime cannot bypass row-level security, then seed OIDC providers before serving"""
+    """Verify the runtime and its encryption key, then seed OIDC providers before serving"""
     await verify_app_role_is_unprivileged()
+
+    # The seeding below rewrites the OIDC client secret under whatever key resolved, so a
+    # process holding the wrong one would mix two keys inside that column. The container
+    # entrypoint checks this too, and this covers every other way the app starts
+    async with engine.connect() as connection:
+        await verify_key_matches_data(connection)
 
     # Reconcile the provider table with the environment on every boot so credential
     # rotations and removals apply without a migration

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,1 +1,16 @@
 """SQLAlchemy model package"""
+
+import importlib
+import pkgutil
+
+
+def import_all_models() -> None:
+    """Import every model module so the metadata holds the full schema
+
+    Alembic autogenerate, the test schema build, the seed scripts and the encrypted column
+    discovery all read the metadata, and a model module nothing imports is absent from it.
+    Walking the package is what keeps a new model file from having to be added to a
+    separate list in each of them, where one list omitting it goes unnoticed
+    """
+    for module in pkgutil.iter_modules(__path__):
+        importlib.import_module(f"{__name__}.{module.name}")

--- a/backend/app/models/auth.py
+++ b/backend/app/models/auth.py
@@ -18,6 +18,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import AuthProvider, Base
+from app.models.types import EncryptedText
 
 
 class AuthIdentity(Base):
@@ -54,7 +55,7 @@ class TotpCredential(Base):
     __tablename__ = "totp_credentials"
 
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id"), primary_key=True)
-    secret_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    secret_encrypted: Mapped[str] = mapped_column(EncryptedText, nullable=False)
     confirmed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))  # Non-null once a code is verified
 
     # Highest TOTP time step already accepted, so a code cannot be replayed within its validity window

--- a/backend/app/models/encryption_key.py
+++ b/backend/app/models/encryption_key.py
@@ -25,7 +25,10 @@ class EncryptionKeyFingerprint(Base):
         CheckConstraint(f"id = {SINGLETON_ID}", name="ck_encryption_key_fingerprint_singleton"),
     )
 
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=SINGLETON_ID)
+    # autoincrement is stated rather than inferred, so the metadata and the migration build
+    # the same column. An integer primary key is a sequence by default, and only the
+    # client-side default above would otherwise suppress it here but not in the migration
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False, default=SINGLETON_ID)
 
     # SHA-256 hex of the key rather than the key, so the row discloses nothing on its own
     fingerprint: Mapped[str] = mapped_column(Text, nullable=False)

--- a/backend/app/models/encryption_key.py
+++ b/backend/app/models/encryption_key.py
@@ -26,8 +26,9 @@ class EncryptionKeyFingerprint(Base):
     )
 
     # autoincrement is stated rather than inferred, so the metadata and the migration build
-    # the same column. An integer primary key is a sequence by default, and only the
-    # client-side default above would otherwise suppress it here but not in the migration
+    # the same column. An integer primary key is a sequence by default, and the default
+    # given here would otherwise suppress that on this side only, leaving the migration to
+    # build a sequence the models never declare
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False, default=SINGLETON_ID)
 
     # SHA-256 hex of the key rather than the key, so the row discloses nothing on its own

--- a/backend/app/models/encryption_key.py
+++ b/backend/app/models/encryption_key.py
@@ -1,0 +1,34 @@
+"""Record of which encryption key the stored secrets are under"""
+
+from datetime import datetime
+
+from sqlalchemy import CheckConstraint, DateTime, Integer, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base
+
+# The table holds one row, and this is its id. A fixed primary key with a check constraint
+# is what keeps a second row from ever being inserted alongside it
+SINGLETON_ID = 1
+
+
+class EncryptionKeyFingerprint(Base):
+    """Binds the database to the encryption key its stored secrets were written under
+
+    Without this, a deployment that loses its key file cannot tell a first run from a
+    removed key, so it mints a fresh key, starts cleanly, and leaves every stored secret
+    unreadable with nothing reporting it
+    """
+
+    __tablename__ = "encryption_key_fingerprint"
+    __table_args__ = (
+        CheckConstraint(f"id = {SINGLETON_ID}", name="ck_encryption_key_fingerprint_singleton"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=SINGLETON_ID)
+
+    # SHA-256 hex of the key rather than the key, so the row discloses nothing on its own
+    fingerprint: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now()
+    )

--- a/backend/app/models/oidc.py
+++ b/backend/app/models/oidc.py
@@ -7,6 +7,7 @@ from sqlalchemy import VARCHAR, Boolean, DateTime, ForeignKey, Text, UniqueConst
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.models.base import Base
+from app.models.types import EncryptedText
 
 
 class OidcProvider(Base):
@@ -25,7 +26,7 @@ class OidcProvider(Base):
     client_id: Mapped[str] = mapped_column(Text, nullable=False)
 
     # Encrypted at rest so a leaked table cannot impersonate this client to the provider
-    client_secret_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    client_secret_encrypted: Mapped[str] = mapped_column(EncryptedText, nullable=False)
     scopes: Mapped[str] = mapped_column(Text, nullable=False)  # space-separated OAuth scopes
 
     # Providers removed from the environment are disabled rather than deleted, so linked

--- a/backend/app/models/types.py
+++ b/backend/app/models/types.py
@@ -1,0 +1,41 @@
+"""Column types carrying meaning the rotation and the guards read"""
+
+from sqlalchemy import MetaData, Text
+from sqlalchemy.types import TypeDecorator
+
+
+class EncryptedText(TypeDecorator):
+    """Text holding a Fernet token, labelled so the key rotation can find it
+
+    This deliberately performs no encryption. Call sites encrypt and decrypt through
+    app.encryption, and the type exists so that a column holding a secret is recognizable
+    from the schema whatever it is called. Moving encryption in here would rewrite every
+    call site and leave the rotation having to bypass its own column type to hold two keys
+    at once, so the label stays inert
+
+    Any column declared with this type is re-encrypted by the rotation, so a new column
+    holding a Fernet token must use it rather than plain Text
+    """
+
+    impl = Text
+
+    # The type carries no parameters, so SQLAlchemy can safely cache statements using it
+    cache_ok = True
+
+
+def find_encrypted_columns(metadata: MetaData) -> list[tuple[str, str]]:
+    """Return every encrypted column in a schema as table and column name pairs
+
+    Args:
+        metadata: Schema to read, passed in rather than read from the shared metadata so
+            a caller can probe a throwaway schema without registering a table globally
+
+    Returns:
+        Table and column name pairs, ordered by table then column
+    """
+    return sorted(
+        (table.name, column.name)
+        for table in metadata.tables.values()
+        for column in table.columns
+        if isinstance(column.type, EncryptedText)
+    )

--- a/backend/scripts/generate_app_encryption_key.py
+++ b/backend/scripts/generate_app_encryption_key.py
@@ -1,0 +1,16 @@
+"""Print a new application encryption key for an operator to store"""
+
+from app.encryption import generate_encryption_key
+
+
+def main() -> None:
+    """Print a new key without persisting it or touching the database
+
+    Printing is safe here because the key protects nothing yet, unlike the rotation, which
+    prints no secret at all. An operator who loses this one simply generates another
+    """
+    print(generate_encryption_key())
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -259,10 +259,7 @@ async def _run_rotation(new_key: str) -> None:
     _print_banner(
         [
             f"Set {encryption.KEY_ENV_VAR} to the new key",
-            "before starting the app again.",
-            "",
-            "The app cannot read any stored secret",
-            "until you do, and refuses to start.",
+            "before starting the app again!",
         ]
     )
 

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -61,8 +61,8 @@ async def _refuse_while_the_app_is_running(connection: AsyncConnection) -> None:
     if await _count_app_connections(connection):
         raise RotationError(
             "Refusing to rotate: the main app appears to be running. Main app must be stopped "
-            "before rotating any keys. If you are seeing this after stopping the app, restart "
-            "the pg database and try again with key rotation"
+            "before rotating any keys. If you are seeing this after stopping the app, please "
+            "restart the pg database and try again with key rotation"
         )
 
 

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -1,0 +1,228 @@
+"""Re-encrypt every stored secret under a new application encryption key"""
+
+import asyncio
+import sys
+
+from cryptography.fernet import Fernet
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
+
+from app import encryption
+from app.config.database import APP_DB_USER, migration_database_url
+from app.db.encryption_key import decrypts, read_fingerprint, read_stored_secret, record_fingerprint
+from app.models import import_all_models
+from app.models.base import Base
+from app.models.types import find_encrypted_columns
+
+# Proves a key both encrypts and decrypts before any stored secret depends on it
+_ROUND_TRIP_PROBE = "encryption key round trip"
+
+
+class RotationError(RuntimeError):
+    """A rotation was refused before anything was written"""
+
+
+async def _count_app_connections(connection: AsyncConnection) -> int:
+    """Return how many other connections the app role holds on this database
+
+    Both predicates matter. pg_stat_activity is cluster-wide, so counting without the
+    database would refuse on any cluster hosting a second deployment using these role names
+    """
+    return await connection.scalar(
+        text(
+            "SELECT count(*) FROM pg_stat_activity "
+            "WHERE usename = :app_user AND datname = current_database() AND pid <> pg_backend_pid()"
+        ),
+        {"app_user": APP_DB_USER},
+    )
+
+
+async def _refuse_while_the_app_is_running(connection: AsyncConnection) -> None:
+    """Raise while the app role still holds a connection to this database
+
+    Raises:
+        RotationError: The app is still connected, so a secret written during the rotation
+            would be encrypted under the old key onto a row already rewritten
+    """
+    open_connections = await _count_app_connections(connection)
+    if open_connections:
+        raise RotationError(
+            f"Refusing to rotate: {open_connections} connection(s) open as {APP_DB_USER}. "
+            f"A secret written while this runs would be encrypted under the old key and "
+            f"lost. Run `docker compose stop app`, then try again"
+        )
+
+
+async def _rewrite_column(
+    connection: AsyncConnection,
+    table: str,
+    column: str,
+    current: Fernet,
+    replacement: Fernet,
+) -> int:
+    """Re-encrypt every value in one column, returning how many rows were rewritten
+
+    Args:
+        connection: Open connection inside the rotation transaction
+        table: Table holding the column
+        column: Column holding Fernet tokens
+        current: Fernet built from the key the values are under
+        replacement: Fernet built from the key to write them under
+
+    Returns:
+        The number of rows rewritten
+    """
+    # Table and column come from the model metadata rather than any caller, so they are
+    # safe to interpolate. FOR UPDATE holds the rows for the life of the transaction, and
+    # ctid identifies each one without the rotation needing to know its primary key
+    rows = (
+        await connection.execute(
+            text(f"SELECT ctid, {column} AS value FROM public.{table} WHERE {column} IS NOT NULL FOR UPDATE")
+        )
+    ).all()
+
+    for row in rows:
+        plaintext = current.decrypt(row.value.encode())
+        await connection.execute(
+            text(f"UPDATE public.{table} SET {column} = :value WHERE ctid = :ctid"),
+            {"value": replacement.encrypt(plaintext).decode(), "ctid": row.ctid},
+        )
+    return len(rows)
+
+
+def _check_replacement_key(new_key: str, current_key: str) -> Fernet:
+    """Return the Fernet for a new key once it is known to be usable
+
+    Args:
+        new_key: The key supplied by the operator
+        current_key: The key the stored secrets are under today
+
+    Returns:
+        A Fernet built from the new key
+
+    Raises:
+        RotationError: The key is malformed, is the current key, or fails a round trip
+    """
+    if new_key == current_key:
+        raise RotationError(
+            "Refusing to rotate: the new key is the key already in use, so this would report "
+            "success while changing nothing"
+        )
+
+    try:
+        replacement = Fernet(new_key.encode())
+    except (ValueError, TypeError) as error:
+        raise RotationError(f"Refusing to rotate: the new key is not a valid Fernet key ({error})") from error
+
+    round_tripped = replacement.decrypt(replacement.encrypt(_ROUND_TRIP_PROBE.encode())).decode()
+    if round_tripped != _ROUND_TRIP_PROBE:
+        raise RotationError("Refusing to rotate: the new key did not survive a round trip")
+
+    return replacement
+
+
+async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple[str, str], int]:
+    """Re-encrypt every stored secret under a new key, in one transaction
+
+    Args:
+        engine: Engine connected as the role owning the encrypted tables
+        new_key: The url-safe base64 Fernet key to re-encrypt under
+
+    Returns:
+        How many rows were rewritten, keyed by table and column name. An empty mapping
+        means the rotation had already been applied and only the stale key file was cleared
+
+    Raises:
+        RotationError: The rotation was refused, with nothing written
+    """
+    current_key = encryption.resolve_encryption_key(generate=False)
+    replacement = _check_replacement_key(new_key, current_key)
+    current = Fernet(current_key.encode())
+
+    import_all_models()
+    columns = find_encrypted_columns(Base.metadata)
+
+    async with engine.connect() as connection:
+        await _refuse_while_the_app_is_running(connection)
+
+        stored_secret = await read_stored_secret(connection)
+        if stored_secret is not None and not decrypts(current_key, stored_secret):
+
+            # An interrupted rotation commits the data and then fails to clear the stale key
+            # file, so the key resolving now is the old one and cannot read anything. Where
+            # the new key reads it instead, the work is done and only the file is left
+            if decrypts(new_key, stored_secret) and await read_fingerprint(connection) == encryption.key_fingerprint(
+                new_key
+            ):
+                _delete_stale_key_file()
+                return {}
+
+            raise RotationError(
+                f"Refusing to rotate: the key resolved from {encryption.KEY_ENV_VAR} or "
+                f"{encryption.KEY_FILE} does not decrypt the stored secrets, so it is not the "
+                f"key they are under"
+            )
+
+    async with engine.begin() as connection:
+
+        # Re-checked inside the transaction, since the app can reconnect between the first
+        # count and here. It narrows the window rather than closing it
+        await _refuse_while_the_app_is_running(connection)
+
+        rewritten = {
+            (table, column): await _rewrite_column(connection, table, column, current, replacement)
+            for table, column in columns
+        }
+        await record_fingerprint(connection, new_key)
+
+    _delete_stale_key_file()
+    return rewritten
+
+
+def _delete_stale_key_file() -> None:
+    """Remove the persisted key, which the rotation has just made the old one
+
+    Nothing writes the new key back. The operator holds it and configures it through the
+    environment, so leaving the old file behind would only conflict with what they set
+    """
+    encryption.KEY_FILE.unlink(missing_ok=True)
+
+
+async def _run_rotation(new_key: str) -> None:
+    """Rotate against the migrator role and report what was rewritten"""
+    engine = create_async_engine(migration_database_url())
+    try:
+        rewritten = await rotate_encryption_key(engine, new_key)
+    finally:
+        await engine.dispose()
+
+    if not rewritten:
+        print("The rotation had already been applied. Removed the stale key file", file=sys.stderr)
+        return
+
+    for (table, column), count in sorted(rewritten.items()):
+        print(f"{table}.{column}: {count} row(s) re-encrypted")
+    print(
+        f"Set {encryption.KEY_ENV_VAR} to the new key before starting the app again",
+        file=sys.stderr,
+    )
+
+
+def main() -> None:
+    """Read the new key from stdin and rotate every stored secret onto it
+
+    The key arrives on stdin rather than as an argument, which would sit in the container's
+    command for anything reading `docker inspect` or /proc to find
+    """
+    new_key = sys.stdin.read().strip()
+    if not new_key:
+        sys.exit("No key on stdin. Pipe the new key in, as `... | rotate-app-encryption-key`")
+
+    try:
+        asyncio.run(_run_rotation(new_key))
+    except RotationError as error:
+        sys.exit(str(error))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -25,10 +25,7 @@ from app.models.types import find_encrypted_columns
 _ROUND_TRIP_PROBE = "encryption key round trip"
 
 # Shown whenever the key does not arrive, since the command reads it from nowhere else
-_STDIN_USAGE = (
-    "No key on standard input. Pipe the new key in, as "
-    "`printf '%s' \"<key>\" | docker compose run --rm -T app rotate-app-encryption-key`"
-)
+_USAGE = "Usage: docker compose run --rm app rotate-app-encryption-key <new-key>"
 
 
 class RotationError(RuntimeError):
@@ -251,24 +248,15 @@ async def _run_rotation(new_key: str) -> None:
 
 
 def main() -> None:
-    """Read the new key from stdin and rotate every stored secret onto it
+    """Rotate every stored secret onto the new key given as the single argument
 
-    The key arrives on stdin rather than as an argument, which would sit in the container's
-    command for anything reading `docker inspect` or /proc to find
+    The key is visible in the process list while this runs, and in the container's recorded
+    command until the container is removed, which `docker compose run --rm` does on exit
     """
-    # Run with a terminal attached, the read below would wait for the operator to type a
-    # key and press Ctrl-D, showing nothing meanwhile. Refusing outright says what to do
-    if sys.stdin.isatty():
-        sys.exit(_STDIN_USAGE)
+    if len(sys.argv) != 2 or not sys.argv[1].strip():
+        sys.exit(_USAGE)
 
-    # Docker attaches stdin as an open pipe even with nothing feeding it, so a run with no
-    # input blocks here until the operator gives up. Saying what it waits for is what makes
-    # that a wait rather than a hang, since the empty check below is only reached on EOF
-    print("Reading the new encryption key from standard input", file=sys.stderr)
-
-    new_key = sys.stdin.read().strip()
-    if not new_key:
-        sys.exit(_STDIN_USAGE)
+    new_key = sys.argv[1].strip()
 
     try:
         asyncio.run(_run_rotation(new_key))

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import sys
+import textwrap
 
 from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import text
@@ -23,6 +24,9 @@ from app.models.types import find_encrypted_columns
 
 # Proves a key both encrypts and decrypts before any stored secret depends on it
 _ROUND_TRIP_PROBE = "encryption key round trip"
+
+# Wide enough to read as a paragraph, narrow enough to fit a default terminal
+_BANNER_TEXT_WIDTH = 68
 
 # Shown whenever the key does not arrive, since the command reads it from nowhere else
 _USAGE = "Usage: docker compose run --rm app rotate-app-encryption-key <new-key>"
@@ -227,17 +231,22 @@ def _delete_stale_key_file() -> None:
 
 
 def _print_banner(lines: list[str]) -> None:
-    """Print lines inside a block of hashes, so the step left to do is hard to scroll past
+    """Print lines inside a block of hashes, so what the operator must read is hard to miss
 
-    The rotation prints a row count per column, and the one instruction the operator still
-    has to act on would otherwise read as one more line among them
+    The rotation prints a row count per column, and both the instruction left to act on and
+    any refusal would otherwise read as one more line among them
 
     Args:
-        lines: Text to frame, one line each, with an empty string for a blank line
+        lines: Text to frame. Each is wrapped to the block width, and an empty string is
+            kept as a blank line
     """
-    width = max(len(line) for line in lines) + 4
-    print("#" * width, file=sys.stderr)
+    wrapped: list[str] = []
     for line in lines:
+        wrapped.extend(textwrap.wrap(line, _BANNER_TEXT_WIDTH) or [""])
+
+    width = max(len(line) for line in wrapped) + 4
+    print("#" * width, file=sys.stderr)
+    for line in wrapped:
         print(f"# {line.ljust(width - 4)} #", file=sys.stderr)
     print("#" * width, file=sys.stderr)
 
@@ -278,7 +287,11 @@ def main() -> None:
     try:
         asyncio.run(_run_rotation(new_key))
     except RotationError as error:
-        sys.exit(str(error))
+
+        # Framed for the same reason as the closing instruction: a refusal arriving among
+        # the compose output is the one thing the operator has to act on
+        _print_banner([str(error)])
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -9,7 +9,13 @@ from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_en
 
 from app import encryption
 from app.config.database import APP_DB_USER, migration_database_url
-from app.db.encryption_key import decrypts, read_fingerprint, read_stored_secret, record_fingerprint
+from app.db.encryption_key import (
+    decrypts,
+    fingerprint_table_exists,
+    read_fingerprint,
+    read_stored_secret,
+    record_fingerprint,
+)
 from app.models import import_all_models
 from app.models.base import Base
 from app.models.types import find_encrypted_columns
@@ -121,7 +127,7 @@ def _check_replacement_key(new_key: str, current_key: str) -> Fernet:
     return replacement
 
 
-async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple[str, str], int]:
+async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple[str, str], int] | None:
     """Re-encrypt every stored secret under a new key, in one transaction
 
     Args:
@@ -129,8 +135,9 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
         new_key: The url-safe base64 Fernet key to re-encrypt under
 
     Returns:
-        How many rows were rewritten, keyed by table and column name. An empty mapping
-        means the rotation had already been applied and only the stale key file was cleared
+        How many rows were rewritten, keyed by table and column name, or None when the
+        rotation had already been applied and only the stale key file was cleared. A
+        rotation over empty tables returns a count of zero for each rather than None
 
     Raises:
         RotationError: The rotation was refused, with nothing written
@@ -145,6 +152,14 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
     async with engine.connect() as connection:
         await _refuse_while_the_app_is_running(connection)
 
+        # Checked here rather than at the write, where a missing table would abort the
+        # transaction with a bare database error after every row had been re-encrypted
+        if not await fingerprint_table_exists(connection):
+            raise RotationError(
+                "Refusing to rotate: this database has no encryption key record. Start the app "
+                "once so the migrations run, then rotate"
+            )
+
         stored_secret = await read_stored_secret(connection)
         if stored_secret is not None and not decrypts(current_key, stored_secret):
 
@@ -155,7 +170,7 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
                 new_key
             ):
                 _delete_stale_key_file()
-                return {}
+                return None
 
             raise RotationError(
                 f"Refusing to rotate: the key resolved from {encryption.KEY_ENV_VAR} or "
@@ -196,7 +211,7 @@ async def _run_rotation(new_key: str) -> None:
     finally:
         await engine.dispose()
 
-    if not rewritten:
+    if rewritten is None:
         print("The rotation had already been applied. Removed the stale key file", file=sys.stderr)
         return
 

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -26,7 +26,11 @@ _ROUND_TRIP_PROBE = "encryption key round trip"
 
 
 class RotationError(RuntimeError):
-    """A rotation was refused before anything was written"""
+    """A rotation was refused, leaving nothing committed
+
+    Most of these are raised before the transaction opens. The one raised on a value the
+    current key cannot read comes from inside it, after rewrites the rollback takes back
+    """
 
 
 async def _count_app_connections(connection: AsyncConnection) -> int:
@@ -98,7 +102,8 @@ async def _rewrite_column(
             # transaction takes every other rewrite back with it
             raise RotationError(
                 f"Refusing to rotate: a value in {table}.{column} is not readable with the "
-                f"current key, so that column holds more than one key. Nothing was written"
+                f"current key, so it is either encrypted under a different key or is not a "
+                f"Fernet token at all. Nothing was written"
             ) from error
 
         await connection.execute(
@@ -152,7 +157,7 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
         rotation over empty tables returns a count of zero for each rather than None
 
     Raises:
-        RotationError: The rotation was refused, with nothing written
+        RotationError: The rotation was refused, leaving nothing committed
     """
     current_key = encryption.resolve_encryption_key(generate=False)
     replacement = _check_replacement_key(new_key, current_key)
@@ -206,18 +211,17 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
     return rewritten
 
 
-def _delete_stale_key_file() -> bool:
+def _delete_stale_key_file() -> None:
     """Remove the persisted key, which the rotation has just made the old one
 
     Nothing writes the new key back. The operator holds it and configures it through the
     environment, so leaving the old file behind would only conflict with what they set
-
-    Returns:
-        Whether a key file was there to remove
     """
-    existed = encryption.KEY_FILE.exists()
-    encryption.KEY_FILE.unlink(missing_ok=True)
-    return existed
+    if not encryption.KEY_FILE.exists():
+        return
+
+    encryption.KEY_FILE.unlink()
+    print(f"Removed the stale key file at {encryption.KEY_FILE}", file=sys.stderr)
 
 
 async def _run_rotation(new_key: str) -> None:

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -58,12 +58,11 @@ async def _refuse_while_the_app_is_running(connection: AsyncConnection) -> None:
         RotationError: The app is still connected, so a secret written during the rotation
             would be encrypted under the old key onto a row already rewritten
     """
-    open_connections = await _count_app_connections(connection)
-    if open_connections:
+    if await _count_app_connections(connection):
         raise RotationError(
-            f"Refusing to rotate: {open_connections} connection(s) open as {APP_DB_USER}. "
-            f"A secret written while this runs would be encrypted under the old key and "
-            f"lost. Run `docker compose stop app`, then try again"
+            "Refusing to rotate: the main app appears to be running. Main app must be stopped "
+            "before rotating any keys. If you are seeing this after stopping the app, restart "
+            "the pg database and try again with key rotation"
         )
 
 
@@ -227,6 +226,22 @@ def _delete_stale_key_file() -> None:
     print(f"Removed the stale key file at {encryption.KEY_FILE}", file=sys.stderr)
 
 
+def _print_banner(lines: list[str]) -> None:
+    """Print lines inside a block of hashes, so the step left to do is hard to scroll past
+
+    The rotation prints a row count per column, and the one instruction the operator still
+    has to act on would otherwise read as one more line among them
+
+    Args:
+        lines: Text to frame, one line each, with an empty string for a blank line
+    """
+    width = max(len(line) for line in lines) + 4
+    print("#" * width, file=sys.stderr)
+    for line in lines:
+        print(f"# {line.ljust(width - 4)} #", file=sys.stderr)
+    print("#" * width, file=sys.stderr)
+
+
 async def _run_rotation(new_key: str) -> None:
     """Rotate against the migrator role and report what was rewritten"""
     engine = create_async_engine(migration_database_url())
@@ -241,9 +256,14 @@ async def _run_rotation(new_key: str) -> None:
         for (table, column), count in sorted(rewritten.items()):
             print(f"{table}.{column}: {count} row(s) re-encrypted")
 
-    print(
-        f"Set {encryption.KEY_ENV_VAR} to the new key before starting the app again",
-        file=sys.stderr,
+    _print_banner(
+        [
+            f"Set {encryption.KEY_ENV_VAR} to the new key",
+            "before starting the app again.",
+            "",
+            "The app cannot read any stored secret",
+            "until you do, and refuses to start.",
+        ]
     )
 
 

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -88,7 +88,7 @@ async def _rewrite_column(
     # ctid identifies each one without the rotation needing to know its primary key
     rows = (
         await connection.execute(
-            text(f"SELECT ctid, {column} AS value FROM public.{table} WHERE {column} IS NOT NULL FOR UPDATE")
+            text(f"SELECT ctid, {column} AS value FROM public.{table} WHERE {column} IS NOT NULL FOR UPDATE")  # noqa: S608
         )
     ).all()
 
@@ -107,7 +107,7 @@ async def _rewrite_column(
             ) from error
 
         await connection.execute(
-            text(f"UPDATE public.{table} SET {column} = :value WHERE ctid = :ctid"),
+            text(f"UPDATE public.{table} SET {column} = :value WHERE ctid = :ctid"),  # noqa: S608
             {"value": replacement.encrypt(plaintext).decode(), "ctid": row.ctid},
         )
     return len(rows)

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -3,18 +3,19 @@
 import asyncio
 import sys
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncConnection, AsyncEngine, create_async_engine
 
 from app import encryption
 from app.config.database import APP_DB_USER, migration_database_url
 from app.db.encryption_key import (
+    FINGERPRINT_TABLE,
     decrypts,
-    fingerprint_table_exists,
     read_fingerprint,
     read_stored_secret,
     record_fingerprint,
+    table_exists,
 )
 from app.models import import_all_models
 from app.models.base import Base
@@ -88,7 +89,18 @@ async def _rewrite_column(
     ).all()
 
     for row in rows:
-        plaintext = current.decrypt(row.value.encode())
+        try:
+            plaintext = current.decrypt(row.value.encode())
+        except InvalidToken as error:
+
+            # InvalidToken carries no message, so raising it as it stands would give the
+            # operator a traceback naming neither the column nor the fact that the
+            # transaction takes every other rewrite back with it
+            raise RotationError(
+                f"Refusing to rotate: a value in {table}.{column} is not readable with the "
+                f"current key, so that column holds more than one key. Nothing was written"
+            ) from error
+
         await connection.execute(
             text(f"UPDATE public.{table} SET {column} = :value WHERE ctid = :ctid"),
             {"value": replacement.encrypt(plaintext).decode(), "ctid": row.ctid},
@@ -136,7 +148,7 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
 
     Returns:
         How many rows were rewritten, keyed by table and column name, or None when the
-        rotation had already been applied and only the stale key file was cleared. A
+        secrets were already under the new key and there was nothing to rewrite. A
         rotation over empty tables returns a count of zero for each rather than None
 
     Raises:
@@ -154,7 +166,7 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
 
         # Checked here rather than at the write, where a missing table would abort the
         # transaction with a bare database error after every row had been re-encrypted
-        if not await fingerprint_table_exists(connection):
+        if not await table_exists(connection, FINGERPRINT_TABLE):
             raise RotationError(
                 "Refusing to rotate: this database has no encryption key record. Start the app "
                 "once so the migrations run, then rotate"
@@ -194,13 +206,18 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
     return rewritten
 
 
-def _delete_stale_key_file() -> None:
+def _delete_stale_key_file() -> bool:
     """Remove the persisted key, which the rotation has just made the old one
 
     Nothing writes the new key back. The operator holds it and configures it through the
     environment, so leaving the old file behind would only conflict with what they set
+
+    Returns:
+        Whether a key file was there to remove
     """
+    existed = encryption.KEY_FILE.exists()
     encryption.KEY_FILE.unlink(missing_ok=True)
+    return existed
 
 
 async def _run_rotation(new_key: str) -> None:
@@ -212,11 +229,11 @@ async def _run_rotation(new_key: str) -> None:
         await engine.dispose()
 
     if rewritten is None:
-        print("The rotation had already been applied. Removed the stale key file", file=sys.stderr)
-        return
+        print("The stored secrets were already under this key, so nothing was re-encrypted", file=sys.stderr)
+    else:
+        for (table, column), count in sorted(rewritten.items()):
+            print(f"{table}.{column}: {count} row(s) re-encrypted")
 
-    for (table, column), count in sorted(rewritten.items()):
-        print(f"{table}.{column}: {count} row(s) re-encrypted")
     print(
         f"Set {encryption.KEY_ENV_VAR} to the new key before starting the app again",
         file=sys.stderr,

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -24,6 +24,12 @@ from app.models.types import find_encrypted_columns
 # Proves a key both encrypts and decrypts before any stored secret depends on it
 _ROUND_TRIP_PROBE = "encryption key round trip"
 
+# Shown whenever the key does not arrive, since the command reads it from nowhere else
+_STDIN_USAGE = (
+    "No key on standard input. Pipe the new key in, as "
+    "`printf '%s' \"<key>\" | docker compose run --rm -T app rotate-app-encryption-key`"
+)
+
 
 class RotationError(RuntimeError):
     """A rotation was refused, leaving nothing committed
@@ -250,9 +256,19 @@ def main() -> None:
     The key arrives on stdin rather than as an argument, which would sit in the container's
     command for anything reading `docker inspect` or /proc to find
     """
+    # Run with a terminal attached, the read below would wait for the operator to type a
+    # key and press Ctrl-D, showing nothing meanwhile. Refusing outright says what to do
+    if sys.stdin.isatty():
+        sys.exit(_STDIN_USAGE)
+
+    # Docker attaches stdin as an open pipe even with nothing feeding it, so a run with no
+    # input blocks here until the operator gives up. Saying what it waits for is what makes
+    # that a wait rather than a hang, since the empty check below is only reached on EOF
+    print("Reading the new encryption key from standard input", file=sys.stderr)
+
     new_key = sys.stdin.read().strip()
     if not new_key:
-        sys.exit("No key on stdin. Pipe the new key in, as `... | rotate-app-encryption-key`")
+        sys.exit(_STDIN_USAGE)
 
     try:
         asyncio.run(_run_rotation(new_key))

--- a/backend/scripts/rotate_app_encryption_key.py
+++ b/backend/scripts/rotate_app_encryption_key.py
@@ -119,25 +119,21 @@ async def _rewrite_column(
     return len(rows)
 
 
-def _check_replacement_key(new_key: str, current_key: str) -> Fernet:
-    """Return the Fernet for a new key once it is known to be usable
+def _check_key_format(new_key: str) -> Fernet:
+    """Return the Fernet for a new key once it is known to work
+
+    Checked before anything reads the current key, so a mistyped key is refused without
+    depending on the deployment resolving a key at all
 
     Args:
         new_key: The key supplied by the operator
-        current_key: The key the stored secrets are under today
 
     Returns:
         A Fernet built from the new key
 
     Raises:
-        RotationError: The key is malformed, is the current key, or fails a round trip
+        RotationError: The key is malformed or fails a round trip
     """
-    if new_key == current_key:
-        raise RotationError(
-            "Refusing to rotate: the new key is the key already in use, so this would report "
-            "success while changing nothing"
-        )
-
     try:
         replacement = Fernet(new_key.encode())
     except (ValueError, TypeError) as error:
@@ -148,6 +144,67 @@ def _check_replacement_key(new_key: str, current_key: str) -> Fernet:
         raise RotationError("Refusing to rotate: the new key did not survive a round trip")
 
     return replacement
+
+
+def _resolve_current_key() -> str | None:
+    """Return the key the deployment resolves, or None when it cannot resolve one
+
+    A missing key, or a variable and a file that disagree, is not reported here. An
+    interrupted rotation leaves exactly that state, and the run may still be the one that
+    finishes it, which is decided against the database rather than against the key sources
+
+    Returns:
+        The resolved key, or None when no single key resolves
+    """
+    try:
+        return encryption.resolve_encryption_key(generate=False)
+    except RuntimeError:
+        return None
+
+
+async def _refuse_unless_the_schema_is_ready(connection: AsyncConnection, columns: list[tuple[str, str]]) -> None:
+    """Raise unless every table the rotation writes to is present
+
+    Checked before the transaction, where a missing table would otherwise abort it with a
+    bare database error after every other column had already been re-encrypted
+
+    Args:
+        connection: Open connection to the application database
+        columns: Table and column name pairs the rotation intends to rewrite
+
+    Raises:
+        RotationError: The key record or an encrypted table is missing
+    """
+    missing = [FINGERPRINT_TABLE] if not await table_exists(connection, FINGERPRINT_TABLE) else []
+    for table, _ in columns:
+        if table not in missing and not await table_exists(connection, table):
+            missing.append(table)
+
+    if missing:
+        raise RotationError(
+            f"Refusing to rotate: this database is missing {', '.join(sorted(missing))}, so its "
+            f"schema is behind this version. Start the app once so the migrations run, then rotate"
+        )
+
+
+async def _rotation_already_applied(connection: AsyncConnection, new_key: str) -> bool:
+    """Whether the stored secrets and the key record are already under the new key
+
+    An interrupted rotation commits and then fails to clear the stale key file, so re-running
+    it finds the work done. Deciding that from the database rather than from the resolved key
+    is what lets the operator finish the cleanup after they have already set the new key
+
+    Args:
+        connection: Open connection to the application database
+        new_key: The key the operator is rotating to
+
+    Returns:
+        Whether there is nothing left to re-encrypt
+    """
+    stored_secret = await read_stored_secret(connection)
+    if stored_secret is None or not decrypts(new_key, stored_secret):
+        return False
+    return await read_fingerprint(connection) == encryption.key_fingerprint(new_key)
 
 
 async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple[str, str], int] | None:
@@ -165,42 +222,41 @@ async def rotate_encryption_key(engine: AsyncEngine, new_key: str) -> dict[tuple
     Raises:
         RotationError: The rotation was refused, leaving nothing committed
     """
-    current_key = encryption.resolve_encryption_key(generate=False)
-    replacement = _check_replacement_key(new_key, current_key)
-    current = Fernet(current_key.encode())
+    replacement = _check_key_format(new_key)
+    current_key = _resolve_current_key()
+
+    if current_key is not None and current_key == new_key:
+        raise RotationError(
+            "Refusing to rotate: the new key is the key already in use, so this would report "
+            "success while changing nothing"
+        )
 
     import_all_models()
     columns = find_encrypted_columns(Base.metadata)
 
     async with engine.connect() as connection:
         await _refuse_while_the_app_is_running(connection)
+        await _refuse_unless_the_schema_is_ready(connection, columns)
 
-        # Checked here rather than at the write, where a missing table would abort the
-        # transaction with a bare database error after every row had been re-encrypted
-        if not await table_exists(connection, FINGERPRINT_TABLE):
-            raise RotationError(
-                "Refusing to rotate: this database has no encryption key record. Start the app "
-                "once so the migrations run, then rotate"
-            )
+        if await _rotation_already_applied(connection, new_key):
+            _delete_stale_key_file()
+            return None
+
+        if current_key is None:
+
+            # Reported here rather than where the key was resolved, so a run that turned out
+            # to be finishing an interrupted rotation is never stopped by it
+            encryption.resolve_encryption_key(generate=False)
 
         stored_secret = await read_stored_secret(connection)
         if stored_secret is not None and not decrypts(current_key, stored_secret):
-
-            # An interrupted rotation commits the data and then fails to clear the stale key
-            # file, so the key resolving now is the old one and cannot read anything. Where
-            # the new key reads it instead, the work is done and only the file is left
-            if decrypts(new_key, stored_secret) and await read_fingerprint(connection) == encryption.key_fingerprint(
-                new_key
-            ):
-                _delete_stale_key_file()
-                return None
-
             raise RotationError(
                 f"Refusing to rotate: the key resolved from {encryption.KEY_ENV_VAR} or "
                 f"{encryption.KEY_FILE} does not decrypt the stored secrets, so it is not the "
                 f"key they are under"
             )
 
+    current = Fernet(current_key.encode())
     async with engine.begin() as connection:
 
         # Re-checked inside the transaction, since the app can reconnect between the first
@@ -223,10 +279,19 @@ def _delete_stale_key_file() -> None:
     Nothing writes the new key back. The operator holds it and configures it through the
     environment, so leaving the old file behind would only conflict with what they set
     """
-    if not encryption.KEY_FILE.exists():
+    try:
+        encryption.KEY_FILE.unlink()
+    except FileNotFoundError:
+
+        # The deployment configures its key through the environment, so there is no file
+        return
+    except OSError as error:
+
+        # The rotation has already committed, so a file that cannot be removed is a note for
+        # the operator rather than a failure. Raising would report the whole run as failed
+        print(f"Could not remove the stale key file at {encryption.KEY_FILE}: {error}", file=sys.stderr)
         return
 
-    encryption.KEY_FILE.unlink()
     print(f"Removed the stale key file at {encryption.KEY_FILE}", file=sys.stderr)
 
 
@@ -286,10 +351,11 @@ def main() -> None:
 
     try:
         asyncio.run(_run_rotation(new_key))
-    except RotationError as error:
+    except RuntimeError as error:
 
-        # Framed for the same reason as the closing instruction: a refusal arriving among
-        # the compose output is the one thing the operator has to act on
+        # RotationError and the errors raised while resolving a key are both RuntimeError,
+        # and an operator has to act on either. Framed for the same reason as the closing
+        # instruction: a bare traceback among the compose output is the thing they miss
         _print_banner([str(error)])
         sys.exit(1)
 

--- a/backend/scripts/seed_categories.py
+++ b/backend/scripts/seed_categories.py
@@ -3,9 +3,11 @@
 import asyncio
 
 from app.database import create_migration_sessionmaker
-from app.models import group as _group  # noqa: F401
-from app.models import user as _user  # noqa: F401
+from app.models import import_all_models
 from app.services.categories.defaults import SYSTEM_CATEGORY_DEFAULTS, seed_system_categories
+
+# Import all models so every mapper the seeded rows relate to is configured
+import_all_models()
 
 
 async def seed_categories() -> None:

--- a/backend/scripts/seed_merchants.py
+++ b/backend/scripts/seed_merchants.py
@@ -3,10 +3,11 @@
 import asyncio
 
 from app.database import create_migration_sessionmaker
-from app.models import category as _category  # noqa: F401
-from app.models import group as _group  # noqa: F401
-from app.models import user as _user  # noqa: F401
+from app.models import import_all_models
 from app.services.merchants.defaults import seed_system_merchants
+
+# Import all models so every mapper the seeded rows relate to is configured
+import_all_models()
 
 
 async def seed_merchants() -> None:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -10,29 +10,13 @@ from app.config.env import require
 from app.database import stamp_request_identity
 from app.db.credentials import resolve_role_password
 from app.db.rls import apply_rls
-
-# Import all models so Base.metadata has the full schema
-from app.models import (  # noqa: F401
-    account,
-    auth,
-    auth_session,
-    auth_token,
-    budget,
-    cache_state,
-    category,
-    currency,
-    group,
-    import_run,
-    institution,
-    merchant,
-    saved_insights_range,
-    tag,
-    transaction,
-    user,
-)
+from app.models import import_all_models
 from app.models.base import Base
 from app.services.categories.defaults import seed_system_categories
 from app.services.merchants.defaults import seed_system_merchants
+
+# Import all models so Base.metadata has the full schema
+import_all_models()
 
 # Database credentials come from .env.test, which points at the isolated test database
 DB_HOST = require("DB_HOST")

--- a/backend/tests/db/test_encryption_key.py
+++ b/backend/tests/db/test_encryption_key.py
@@ -1,0 +1,164 @@
+"""Encryption key provisioning and data binding tests"""
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import text
+
+from app import encryption
+from app.db.encryption_key import (
+    ensure_key,
+    read_fingerprint,
+    read_stored_secret,
+    record_fingerprint,
+    verify_fingerprint,
+    verify_key_matches_data,
+)
+from app.encryption import generate_encryption_key, key_fingerprint
+from tests.conftest import engine
+
+_TOTP_SECRET = "JBSWY3DPEHPK3PXP"
+
+
+@pytest.fixture
+def key_file(tmp_path, monkeypatch):
+    """Point the key file and its directory at a temporary path"""
+    monkeypatch.setattr(encryption, "_SECRETS_DIR", tmp_path)
+    monkeypatch.setattr(encryption, "KEY_FILE", tmp_path / "app_encryption_key")
+    return encryption.KEY_FILE
+
+
+@pytest.fixture
+def configured_key(key_file, monkeypatch):
+    """Configure a key through the environment and return it"""
+    key = generate_encryption_key()
+    monkeypatch.setenv(encryption.KEY_ENV_VAR, key)
+    return key
+
+
+async def _store_totp_secret(connection, key: str) -> None:
+    """Write one TOTP credential encrypted under a given key"""
+    # The suite truncates reference data between tests, so the user's currency is inserted here
+    await connection.execute(
+        text(
+            "INSERT INTO currencies (id, name, symbol, minor_unit_exponent) "
+            "VALUES ('CAD', 'Canadian Dollar', '$', 2) ON CONFLICT (id) DO NOTHING"
+        )
+    )
+    user_id = await connection.scalar(
+        text(
+            "INSERT INTO users (id, email, first_name, tz, base_currency) "
+            "VALUES (gen_random_uuid(), 'rotation@example.com', 'Rotation', 'America/Toronto', 'CAD') "
+            "RETURNING id"
+        )
+    )
+    await connection.execute(
+        text("INSERT INTO totp_credentials (user_id, secret_encrypted) VALUES (:user_id, :secret)"),
+        {"user_id": user_id, "secret": Fernet(key.encode()).encrypt(_TOTP_SECRET.encode()).decode()},
+    )
+
+
+async def test_read_stored_secret_returns_none_when_nothing_is_encrypted():
+    """An empty database has no secret to check a key against"""
+    async with engine.begin() as connection:
+        assert await read_stored_secret(connection) is None
+
+
+async def test_read_stored_secret_finds_a_token_in_any_encrypted_column():
+    """A stored token is found through the column label rather than a hard-coded table"""
+    key = generate_encryption_key()
+    async with engine.begin() as connection:
+        await _store_totp_secret(connection, key)
+
+        stored = await read_stored_secret(connection)
+        assert stored is not None
+        assert Fernet(key.encode()).decrypt(stored.encode()).decode() == _TOTP_SECRET
+
+
+async def test_ensure_key_generates_a_key_on_a_first_install(key_file, monkeypatch):
+    """With no schema and no key anywhere, provisioning mints and persists one"""
+    monkeypatch.delenv(encryption.KEY_ENV_VAR, raising=False)
+
+    async with engine.begin() as connection:
+        # A connection whose schema has no alembic_version stands in for a first install
+        await connection.execute(text("DROP TABLE IF EXISTS alembic_version"))
+        await ensure_key(connection)
+
+    assert key_file.exists()
+    assert key_file.read_text().strip()
+
+
+async def test_ensure_key_refuses_to_mint_over_existing_secrets(key_file, monkeypatch):
+    """A removed key file on a deployment with data is refused rather than replaced"""
+    monkeypatch.delenv(encryption.KEY_ENV_VAR, raising=False)
+
+    async with engine.begin() as connection:
+        await connection.execute(text("CREATE TABLE IF NOT EXISTS alembic_version (version_num varchar(32))"))
+        await _store_totp_secret(connection, generate_encryption_key())
+
+        with pytest.raises(RuntimeError, match="already holds secrets"):
+            await ensure_key(connection)
+
+    assert not key_file.exists()
+
+
+async def test_verify_fingerprint_records_the_key_on_an_upgrading_deployment(configured_key):
+    """A deployment arriving without a record gets the key it can actually read recorded"""
+    async with engine.begin() as connection:
+        await _store_totp_secret(connection, configured_key)
+
+        await verify_fingerprint(connection)
+
+        assert await read_fingerprint(connection) == key_fingerprint(configured_key)
+
+
+async def test_verify_fingerprint_refuses_to_record_a_key_that_reads_nothing(configured_key):
+    """A wrong key configured during an upgrade is refused rather than blessed as correct"""
+    async with engine.begin() as connection:
+        await _store_totp_secret(connection, generate_encryption_key())
+
+        with pytest.raises(RuntimeError, match="does not decrypt"):
+            await verify_fingerprint(connection)
+
+        assert await read_fingerprint(connection) is None
+
+
+async def test_verify_fingerprint_records_on_a_database_with_no_secrets(configured_key):
+    """With nothing encrypted there is nothing to prove, so the key is recorded"""
+    async with engine.begin() as connection:
+        await verify_fingerprint(connection)
+
+        assert await read_fingerprint(connection) == key_fingerprint(configured_key)
+
+
+async def test_verify_key_matches_data_refuses_a_key_the_data_is_not_under(configured_key):
+    """Serving under a key the secrets were not written with is refused at startup"""
+    async with engine.begin() as connection:
+        await record_fingerprint(connection, generate_encryption_key())
+
+        with pytest.raises(RuntimeError, match="different key"):
+            await verify_key_matches_data(connection)
+
+
+async def test_verify_key_matches_data_accepts_the_recorded_key(configured_key):
+    """The key the data is under passes, so a correct deployment starts"""
+    async with engine.begin() as connection:
+        await record_fingerprint(connection, configured_key)
+
+        await verify_key_matches_data(connection)
+
+
+async def test_verify_key_matches_data_allows_a_database_with_no_record(configured_key):
+    """A deployment that has never recorded a fingerprint is not treated as a mismatch"""
+    async with engine.begin() as connection:
+        await verify_key_matches_data(connection)
+
+
+async def test_record_fingerprint_replaces_the_previous_key(configured_key):
+    """Recording after a rotation replaces the record rather than adding a second row"""
+    rotated_key = generate_encryption_key()
+    async with engine.begin() as connection:
+        await record_fingerprint(connection, configured_key)
+        await record_fingerprint(connection, rotated_key)
+
+        assert await read_fingerprint(connection) == key_fingerprint(rotated_key)
+        assert await connection.scalar(text("SELECT count(*) FROM encryption_key_fingerprint")) == 1

--- a/backend/tests/db/test_encryption_key.py
+++ b/backend/tests/db/test_encryption_key.py
@@ -35,6 +35,21 @@ def configured_key(key_file, monkeypatch):
     return key
 
 
+@pytest.fixture
+async def built_schema():
+    """Add and then remove the table whose presence marks an already-built schema
+
+    Alembic creates this table outside the model metadata, so the suite's truncate
+    fixture never clears it and leaving it behind would make every later test in this
+    worker look like a deployment that has already been migrated
+    """
+    async with engine.begin() as connection:
+        await connection.execute(text("CREATE TABLE IF NOT EXISTS alembic_version (version_num varchar(32))"))
+    yield
+    async with engine.begin() as connection:
+        await connection.execute(text("DROP TABLE IF EXISTS alembic_version"))
+
+
 async def _store_totp_secret(connection, key: str) -> None:
     """Write one TOTP credential encrypted under a given key"""
     # The suite truncates reference data between tests, so the user's currency is inserted here
@@ -79,20 +94,17 @@ async def test_ensure_key_generates_a_key_on_a_first_install(key_file, monkeypat
     monkeypatch.delenv(encryption.KEY_ENV_VAR, raising=False)
 
     async with engine.begin() as connection:
-        # A connection whose schema has no alembic_version stands in for a first install
-        await connection.execute(text("DROP TABLE IF EXISTS alembic_version"))
         await ensure_key(connection)
 
     assert key_file.exists()
     assert key_file.read_text().strip()
 
 
-async def test_ensure_key_refuses_to_mint_over_existing_secrets(key_file, monkeypatch):
+async def test_ensure_key_refuses_to_mint_over_existing_secrets(key_file, monkeypatch, built_schema):
     """A removed key file on a deployment with data is refused rather than replaced"""
     monkeypatch.delenv(encryption.KEY_ENV_VAR, raising=False)
 
     async with engine.begin() as connection:
-        await connection.execute(text("CREATE TABLE IF NOT EXISTS alembic_version (version_num varchar(32))"))
         await _store_totp_secret(connection, generate_encryption_key())
 
         with pytest.raises(RuntimeError, match="already holds secrets"):

--- a/backend/tests/db/test_encryption_key.py
+++ b/backend/tests/db/test_encryption_key.py
@@ -3,6 +3,7 @@
 import pytest
 from cryptography.fernet import Fernet
 from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
 
 from app import encryption
 from app.db.encryption_key import (
@@ -103,6 +104,44 @@ async def test_ensure_key_generates_a_key_on_a_first_install(key_file, monkeypat
 async def test_ensure_key_refuses_to_mint_over_existing_secrets(key_file, monkeypatch, built_schema):
     """A removed key file on a deployment with data is refused rather than replaced"""
     monkeypatch.delenv(encryption.KEY_ENV_VAR, raising=False)
+
+    async with engine.begin() as connection:
+        await _store_totp_secret(connection, generate_encryption_key())
+
+        with pytest.raises(RuntimeError, match="already holds secrets"):
+            await ensure_key(connection)
+
+    assert not key_file.exists()
+
+
+async def test_ensure_key_refuses_when_the_database_cannot_be_checked(key_file, monkeypatch, built_schema):
+    """A read the admin role is not allowed to make refuses rather than minting a key
+
+    The check runs as the admin role, which owns none of the tables it reads, so a
+    deployment whose admin role is not a superuser gets an error rather than an answer.
+    Minting is the destructive act, so an unanswerable check has to refuse
+    """
+    monkeypatch.delenv(encryption.KEY_ENV_VAR, raising=False)
+
+    async def refuse_the_read(_connection):
+        raise ProgrammingError("SELECT secret_encrypted FROM totp_credentials", {}, Exception("permission denied"))
+
+    monkeypatch.setattr("app.db.encryption_key.read_stored_secret", refuse_the_read)
+
+    async with engine.begin() as connection:
+        with pytest.raises(RuntimeError, match="could not be checked"):
+            await ensure_key(connection)
+
+    assert not key_file.exists()
+
+
+async def test_ensure_key_treats_a_whitespace_only_variable_as_unset(key_file, monkeypatch, built_schema):
+    """A blank value from an empty mounted secret must not count as a configured key
+
+    Reading the variable raw here while the resolver strips it would take the already
+    configured path, mint a key anyway, and skip the guard against minting over data
+    """
+    monkeypatch.setenv(encryption.KEY_ENV_VAR, "\n")
 
     async with engine.begin() as connection:
         await _store_totp_secret(connection, generate_encryption_key())

--- a/backend/tests/migrations/test_schema_parity.py
+++ b/backend/tests/migrations/test_schema_parity.py
@@ -16,6 +16,7 @@ from sqlalchemy.pool import NullPool
 
 from app.config.database import MIGRATOR_DB_USER
 from app.models.base import Base
+from app.models.types import find_encrypted_columns
 from app.services.merchants.defaults import (
     SELF_MERCHANT_NAME,
     SYSTEM_MERCHANT_NAMES,
@@ -38,6 +39,7 @@ _ALEMBIC_SYSTEM_MERCHANT_DB_NAME = f"{WORKER_DB_NAME}_alembic_system_merchant"
 _BEFORE_SYSTEM_MERCHANTS_REVISION = "cbf7ada87de3"
 _ALEMBIC_UNKNOWN_MERCHANT_DB_NAME = f"{WORKER_DB_NAME}_alembic_unknown_merchant"
 _BEFORE_UNKNOWN_MERCHANT_REVISION = "93e7aa96d2ae"
+_ALEMBIC_ENCRYPTED_DB_NAME = f"{WORKER_DB_NAME}_alembic_encrypted_columns"
 _ALEMBIC_FOLDED_CATEGORY_DB_NAME = f"{WORKER_DB_NAME}_alembic_folded_categories"
 _ALEMBIC_FOLDED_MERCHANT_DB_NAME = f"{WORKER_DB_NAME}_alembic_folded_merchants"
 _BEFORE_FOLDED_NAMES_REVISION = "6a1f132b9da2"
@@ -53,6 +55,25 @@ async def test_alembic_schema_columns_match_model_metadata() -> None:
         assert actual_columns == expected_columns
     finally:
         await _drop_database(_ALEMBIC_TEST_DB_NAME)
+
+
+async def test_alembic_builds_encrypted_columns_as_text() -> None:
+    """Verify labelling a column as encrypted changes nothing about the built column type
+
+    EncryptedText decorates Text, so a database Alembic builds must still hold plain text
+    there and applying the label to an existing column needs no migration. The column
+    comparison above reads names only, so it cannot see a label that altered the DDL
+    """
+    expected_columns = find_encrypted_columns(Base.metadata)
+    assert expected_columns, "No encrypted columns found, so this test would prove nothing"
+
+    await _recreate_database(_ALEMBIC_ENCRYPTED_DB_NAME)
+    try:
+        _run_alembic_upgrade(_ALEMBIC_ENCRYPTED_DB_NAME)
+        built_types = await _get_column_types(_ALEMBIC_ENCRYPTED_DB_NAME, expected_columns)
+        assert built_types == dict.fromkeys(expected_columns, "text")
+    finally:
+        await _drop_database(_ALEMBIC_ENCRYPTED_DB_NAME)
 
 
 async def test_alembic_enum_labels_match_model_metadata() -> None:
@@ -261,6 +282,44 @@ async def _get_database_columns(database_name: str) -> dict[str, set[str]]:
             for row in result:
                 columns_by_table.setdefault(row.table_name, set()).add(row.column_name)
             return columns_by_table
+    finally:
+        await engine.dispose()
+
+
+async def _get_column_types(
+    database_name: str,
+    columns: list[tuple[str, str]],
+) -> dict[tuple[str, str], str]:
+    """Return the built type of each named column from a generated parity database
+
+    Args:
+        database_name: Parity database to read
+        columns: Table and column name pairs to look up
+
+    Returns:
+        The data type each pair resolves to, keyed by that pair
+    """
+    engine = _create_engine_for_database(database_name)
+    try:
+        async with engine.connect() as conn:
+
+            # Fetch every public column type, then keep the named pairs. Filtering here
+            # rather than in SQL avoids casting a pair of arrays into the predicate
+            result = await conn.execute(
+                text(
+                    """
+                    SELECT table_name, column_name, data_type
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                    """,
+                ),
+            )
+            wanted = set(columns)
+            return {
+                (row.table_name, row.column_name): row.data_type
+                for row in result
+                if (row.table_name, row.column_name) in wanted
+            }
     finally:
         await engine.dispose()
 

--- a/backend/tests/migrations/test_schema_parity.py
+++ b/backend/tests/migrations/test_schema_parity.py
@@ -57,21 +57,30 @@ async def test_alembic_schema_columns_match_model_metadata() -> None:
         await _drop_database(_ALEMBIC_TEST_DB_NAME)
 
 
-async def test_alembic_builds_encrypted_columns_as_text() -> None:
-    """Verify labelling a column as encrypted changes nothing about the built column type
+async def test_alembic_column_types_and_defaults_match_model_metadata() -> None:
+    """Verify Alembic builds every column with the type and default the models declare
 
-    EncryptedText decorates Text, so a database Alembic builds must still hold plain text
-    there and applying the label to an existing column needs no migration. The column
-    comparison above reads names only, so it cannot see a label that altered the DDL
+    The column comparison above reads names only, so a column whose migration and model
+    disagree on its type or its default passes there while the two schemas diverge. An
+    integer primary key is the usual way in: it builds as a sequence unless something
+    suppresses that, and a client-side default suppresses it on one side only
+
+    The encrypted columns are asserted by name as well, since EncryptedText decorating
+    Text is what lets an existing column be labelled with no migration at all
     """
-    expected_columns = find_encrypted_columns(Base.metadata)
-    assert expected_columns, "No encrypted columns found, so this test would prove nothing"
+    encrypted_columns = find_encrypted_columns(Base.metadata)
+    assert encrypted_columns, "No encrypted columns found, so this test would prove nothing"
 
     await _recreate_database(_ALEMBIC_ENCRYPTED_DB_NAME)
     try:
         _run_alembic_upgrade(_ALEMBIC_ENCRYPTED_DB_NAME)
-        built_types = await _get_column_types(_ALEMBIC_ENCRYPTED_DB_NAME, expected_columns)
-        assert built_types == dict.fromkeys(expected_columns, "text")
+        from_alembic = await _get_column_definitions(_ALEMBIC_ENCRYPTED_DB_NAME)
+        from_metadata = await _get_column_definitions(WORKER_DB_NAME)
+
+        assert from_alembic == from_metadata
+        assert {column: from_alembic[column][0] for column in encrypted_columns} == dict.fromkeys(
+            encrypted_columns, "text"
+        )
     finally:
         await _drop_database(_ALEMBIC_ENCRYPTED_DB_NAME)
 
@@ -286,40 +295,31 @@ async def _get_database_columns(database_name: str) -> dict[str, set[str]]:
         await engine.dispose()
 
 
-async def _get_column_types(
-    database_name: str,
-    columns: list[tuple[str, str]],
-) -> dict[tuple[str, str], str]:
-    """Return the built type of each named column from a generated parity database
+async def _get_column_definitions(database_name: str) -> dict[tuple[str, str], tuple[str, str | None]]:
+    """Return the built type and default of every public column in a database
 
     Args:
-        database_name: Parity database to read
-        columns: Table and column name pairs to look up
+        database_name: Database to read, either a parity database or the worker's own
 
     Returns:
-        The data type each pair resolves to, keyed by that pair
+        The data type and column default of each column, keyed by table and column name
     """
     engine = _create_engine_for_database(database_name)
     try:
         async with engine.connect() as conn:
 
-            # Fetch every public column type, then keep the named pairs. Filtering here
-            # rather than in SQL avoids casting a pair of arrays into the predicate
+            # Fetch what the database actually built, rather than what either side declared
             result = await conn.execute(
                 text(
                     """
-                    SELECT table_name, column_name, data_type
+                    SELECT table_name, column_name, data_type, column_default
                     FROM information_schema.columns
                     WHERE table_schema = 'public'
+                      AND table_name <> 'alembic_version'
                     """,
                 ),
             )
-            wanted = set(columns)
-            return {
-                (row.table_name, row.column_name): row.data_type
-                for row in result
-                if (row.table_name, row.column_name) in wanted
-            }
+            return {(row.table_name, row.column_name): (row.data_type, row.column_default) for row in result}
     finally:
         await engine.dispose()
 

--- a/backend/tests/models/test_encrypted_text.py
+++ b/backend/tests/models/test_encrypted_text.py
@@ -1,0 +1,47 @@
+"""Encrypted column label and discovery tests"""
+
+from sqlalchemy import Column, Integer, MetaData, Table, Text
+from sqlalchemy.dialects import postgresql
+
+from app.models.base import Base
+from app.models.types import EncryptedText, find_encrypted_columns
+
+# The columns holding a Fernet token today. A new one belongs here and in the model
+_EXPECTED_ENCRYPTED_COLUMNS = [
+    ("oidc_providers", "client_secret_encrypted"),
+    ("totp_credentials", "secret_encrypted"),
+]
+
+
+def test_encrypted_text_renders_as_text():
+    """The label changes no DDL, so applying it to an existing column needs no migration"""
+    assert EncryptedText().compile(dialect=postgresql.dialect()) == "TEXT"
+
+
+def test_find_encrypted_columns_returns_the_real_encrypted_columns():
+    """Discovery over the application schema finds every column holding a Fernet token"""
+    assert find_encrypted_columns(Base.metadata) == _EXPECTED_ENCRYPTED_COLUMNS
+
+
+def test_find_encrypted_columns_ignores_the_column_name():
+    """A labelled column is found whatever it is called, which a naming rule could not do"""
+    # A throwaway schema rather than Base, so this probe never reaches the real metadata
+    # that the row-level security and schema parity guards read
+    probe = MetaData()
+    Table(
+        "connections",
+        probe,
+        Column("id", Integer, primary_key=True),
+        Column("credentials", EncryptedText, nullable=False),
+        Column("provider", Text, nullable=False),
+    )
+
+    assert find_encrypted_columns(probe) == [("connections", "credentials")]
+
+
+def test_find_encrypted_columns_skips_plain_text_columns():
+    """A plain text column is left alone, so the rotation never rewrites a non-secret"""
+    probe = MetaData()
+    Table("notes", probe, Column("id", Integer, primary_key=True), Column("body", Text))
+
+    assert find_encrypted_columns(probe) == []

--- a/backend/tests/models/test_model_registration.py
+++ b/backend/tests/models/test_model_registration.py
@@ -1,0 +1,62 @@
+"""Guard test ensuring every model module reaches the shared metadata"""
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import app.models
+
+_MODELS_DIR = Path(app.models.__file__).parent
+_BACKEND_DIR = _MODELS_DIR.parents[1]
+
+# Matches the table name a model declares, so the expectation is read from the source
+# rather than from an import this test performs itself
+_TABLENAME_PATTERN = re.compile(r'^\s*__tablename__\s*=\s*"([^"]+)"', re.MULTILINE)
+
+# Prints the tables import_all_models registers, as JSON for the assertion to compare
+_REGISTERED_TABLES_SCRIPT = (
+    "import json;"
+    "from app.models import import_all_models;"
+    "from app.models.base import Base;"
+    "import_all_models();"
+    "print(json.dumps(sorted(Base.metadata.tables)))"
+)
+
+
+def _declared_table_names() -> set[str]:
+    """Return every table name declared across the model package source"""
+    declared: set[str] = set()
+    for module_path in _MODELS_DIR.glob("*.py"):
+        declared.update(_TABLENAME_PATTERN.findall(module_path.read_text()))
+    return declared
+
+
+def _registered_table_names() -> set[str]:
+    """Return the tables import_all_models registers, read from a clean interpreter
+
+    A subprocess is what makes this meaningful. Pytest imports every test module during
+    collection, so in this process the model modules are already imported by whatever
+    else needed them, and a gap in import_all_models would be invisible
+    """
+    completed = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", _REGISTERED_TABLES_SCRIPT],
+        cwd=_BACKEND_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, completed.stdout + completed.stderr
+    return set(json.loads(completed.stdout))
+
+
+def test_import_all_models_registers_every_declared_table():
+    """Fail when a model module is left out, which would hide its tables from the metadata"""
+    missing = _declared_table_names() - _registered_table_names()
+    assert not missing, f"Tables declared in app/models but absent from the metadata: {sorted(missing)}"
+
+
+def test_model_package_declares_at_least_one_table():
+    """Fail when the source scan finds nothing, which would make the guard above vacuous"""
+    assert _declared_table_names(), "No __tablename__ declarations found under app/models"

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -1,5 +1,7 @@
 """Encryption key rotation tests"""
 
+import re
+
 import pytest
 from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import text
@@ -77,7 +79,7 @@ async def _store_secrets(key: str) -> None:
 async def _read_stored(table: str, column: str) -> str:
     """Return the single stored token from a column"""
     async with engine.begin() as connection:
-        return await connection.scalar(text(f"SELECT {column} FROM {table} LIMIT 1"))
+        return await connection.scalar(text(f"SELECT {column} FROM {table} LIMIT 1"))  # noqa: S608
 
 
 async def test_rotation_re_encrypts_every_labelled_column(current_key):
@@ -146,7 +148,7 @@ async def test_a_failure_part_way_through_rewrites_nothing(current_key):
         )
     oidc_before = await _read_stored("oidc_providers", "client_secret_encrypted")
 
-    with pytest.raises(RotationError, match="totp_credentials.secret_encrypted"):
+    with pytest.raises(RotationError, match=re.escape("totp_credentials.secret_encrypted")):
         await rotate_encryption_key(engine, generate_encryption_key())
 
     assert await _read_stored("oidc_providers", "client_secret_encrypted") == oidc_before
@@ -283,4 +285,4 @@ async def test_rotation_refuses_a_database_with_no_key_record(current_key):
     # Startup reads the record as the app role, so prove the rebuild restored that read
     # rather than leaving the table unreadable for the rest of this worker's run
     async with ScopedSession() as app_session:
-        await app_session.execute(text(f"SELECT fingerprint FROM {FINGERPRINT_TABLE}"))
+        await app_session.execute(text(f"SELECT fingerprint FROM {FINGERPRINT_TABLE}"))  # noqa: S608

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -12,7 +12,7 @@ from app.db.encryption_key import FINGERPRINT_TABLE, read_fingerprint, record_fi
 from app.db.rls import grant_global_read_table
 from app.encryption import generate_encryption_key, key_fingerprint
 from app.models.encryption_key import EncryptionKeyFingerprint
-from scripts.rotate_app_encryption_key import RotationError, rotate_encryption_key
+from scripts.rotate_app_encryption_key import RotationError, main, rotate_encryption_key
 from tests.conftest import ScopedSession, engine
 
 _TOTP_SECRET = "JBSWY3DPEHPK3PXP"
@@ -286,3 +286,55 @@ async def test_rotation_refuses_a_database_with_no_key_record(current_key):
     # rather than leaving the table unreadable for the rest of this worker's run
     async with ScopedSession() as app_session:
         await app_session.execute(text(f"SELECT fingerprint FROM {FINGERPRINT_TABLE}"))  # noqa: S608
+
+
+class _FakeStdin:
+    """Stands in for standard input, reporting whether a terminal is attached"""
+
+    def __init__(self, text: str, *, tty: bool):
+        self._text = text
+        self._tty = tty
+
+    def isatty(self) -> bool:
+        """Whether a terminal is attached"""
+        return self._tty
+
+    def read(self) -> str:
+        """Return everything on standard input
+
+        A real terminal blocks here until the operator presses Ctrl-D, so reading one at
+        all is the defect. Raising is what makes a test notice it rather than seeing the
+        empty string a stand-in would otherwise hand back
+        """
+        if self._tty:
+            raise AssertionError("read from a terminal, which would block with no output")
+        return self._text
+
+
+def test_the_command_refuses_a_terminal_rather_than_waiting(monkeypatch, capsys):
+    """Run with a terminal attached, it says what to do instead of waiting silently
+
+    sys.stdin.read() on a terminal blocks until the operator presses Ctrl-D, showing
+    nothing at all, which reads as the command having hung
+    """
+    monkeypatch.setattr("sys.stdin", _FakeStdin("", tty=True))
+
+    with pytest.raises(SystemExit) as raised:
+        main()
+
+    assert "No key on standard input" in str(raised.value)
+
+
+def test_the_command_says_what_it_is_waiting_for(monkeypatch, capsys):
+    """With no terminal and no input, it names what it wants before reading
+
+    Docker attaches standard input as an open pipe even with nothing feeding it, so the
+    read blocks with no output. The line printed first is what makes that a wait rather
+    than a hang
+    """
+    monkeypatch.setattr("sys.stdin", _FakeStdin("", tty=False))
+
+    with pytest.raises(SystemExit):
+        main()
+
+    assert "Reading the new encryption key from standard input" in capsys.readouterr().err

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -8,8 +8,9 @@ from sqlalchemy import text
 
 from app import encryption
 from app.db.encryption_key import FINGERPRINT_TABLE, read_fingerprint, record_fingerprint
-from app.db.rls import grant_global_read_table
+from app.db.rls import grant_auth_table, grant_global_read_table
 from app.encryption import generate_encryption_key, key_fingerprint
+from app.models.auth import TotpCredential
 from app.models.encryption_key import EncryptionKeyFingerprint
 from scripts.rotate_app_encryption_key import RotationError, main, rotate_encryption_key
 from tests.conftest import ScopedSession, engine
@@ -268,7 +269,7 @@ async def test_rotation_refuses_a_database_with_no_key_record(current_key):
     async with engine.begin() as connection:
         await connection.execute(text(f"DROP TABLE {FINGERPRINT_TABLE}"))
     try:
-        with pytest.raises(RotationError, match="no encryption key record"):
+        with pytest.raises(RotationError, match="schema is behind this version"):
             await rotate_encryption_key(engine, generate_encryption_key())
 
         assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
@@ -319,3 +320,167 @@ def test_the_command_refuses_more_than_one_argument(monkeypatch):
         main()
 
     assert "Usage:" in str(raised.value)
+
+
+def _stand_in_rotation(recorder: dict, result=None, error: Exception | None = None):
+    """Return a stand-in for the rotation that records its key and returns a fixed result
+
+    Args:
+        recorder: Mapping the stand-in writes the key it received into
+        result: What the stand-in returns, standing for the rows it rewrote
+        error: Raised instead of returning, standing for a refused rotation
+    """
+
+    async def rotation(_engine, new_key):
+        recorder["key"] = new_key
+        if error is not None:
+            raise error
+        return result
+
+    return rotation
+
+
+def test_the_command_forwards_a_real_key_unchanged(monkeypatch, capsys):
+    """A real key reaches the rotation exactly as given
+
+    The placeholder arguments the refusal tests use would not catch a parse that mishandled
+    the url-safe base64 a Fernet key is made of, or its trailing padding
+    """
+    key = generate_encryption_key()
+    recorder: dict[str, str] = {}
+    monkeypatch.setattr(
+        "scripts.rotate_app_encryption_key.rotate_encryption_key",
+        _stand_in_rotation(recorder, result={}),
+    )
+    monkeypatch.setattr("sys.argv", ["rotate_app_encryption_key", key])
+
+    main()
+
+    assert recorder["key"] == key
+
+
+def test_a_successful_rotation_reports_the_counts_and_the_step_left(monkeypatch, capsys):
+    """The operator sees what changed, then the instruction framed so it is hard to miss"""
+    recorder: dict[str, str] = {}
+    monkeypatch.setattr(
+        "scripts.rotate_app_encryption_key.rotate_encryption_key",
+        _stand_in_rotation(recorder, result={("totp_credentials", "secret_encrypted"): 3}),
+    )
+    monkeypatch.setattr("sys.argv", ["rotate_app_encryption_key", generate_encryption_key()])
+
+    main()
+
+    printed = capsys.readouterr()
+    assert "totp_credentials.secret_encrypted: 3 row(s) re-encrypted" in printed.out
+    assert "Set APP_ENCRYPTION_KEY to the new key" in printed.err
+    assert "####" in printed.err
+
+
+def test_an_already_applied_rotation_says_nothing_was_re_encrypted(monkeypatch, capsys):
+    """Re-running after an interrupted rotation reports that, rather than a row count"""
+    recorder: dict[str, str] = {}
+    monkeypatch.setattr(
+        "scripts.rotate_app_encryption_key.rotate_encryption_key",
+        _stand_in_rotation(recorder, result=None),
+    )
+    monkeypatch.setattr("sys.argv", ["rotate_app_encryption_key", generate_encryption_key()])
+
+    main()
+
+    printed = capsys.readouterr()
+    assert "already under this key" in printed.err
+    assert "row(s) re-encrypted" not in printed.out
+
+
+def test_a_refused_rotation_is_framed_and_exits_nonzero(monkeypatch, capsys):
+    """A refusal is framed like the reminder, and the command fails rather than reporting success
+
+    The exit code is what a script wrapping this reads, so reporting zero here would make a
+    refused rotation look like a completed one
+    """
+    recorder: dict[str, str] = {}
+    monkeypatch.setattr(
+        "scripts.rotate_app_encryption_key.rotate_encryption_key",
+        _stand_in_rotation(recorder, error=RotationError("Refusing to rotate: a stated reason")),
+    )
+    monkeypatch.setattr("sys.argv", ["rotate_app_encryption_key", generate_encryption_key()])
+
+    with pytest.raises(SystemExit) as raised:
+        main()
+
+    assert raised.value.code == 1
+    printed = capsys.readouterr()
+    assert "Refusing to rotate: a stated reason" in printed.err
+    assert "####" in printed.err
+
+
+async def test_rotation_finishes_an_interrupted_run_after_the_new_key_is_set(key_file, monkeypatch):
+    """The cleanup is reachable once the operator has already set the new key
+
+    That is the state the instructions leave them in: the rotation committed, the stale key
+    file survived, and setting the variable makes the two key sources disagree. Deciding the
+    resume from the key sources rather than the database would refuse here
+    """
+    new_key = generate_encryption_key()
+    await _store_secrets(new_key)
+    async with engine.begin() as connection:
+        await record_fingerprint(connection, new_key)
+
+    key_file.write_text(generate_encryption_key())
+    monkeypatch.setenv(encryption.KEY_ENV_VAR, new_key)
+    encryption._fernet.cache_clear()
+    stored_before = await _read_stored("totp_credentials", "secret_encrypted")
+
+    rewritten = await rotate_encryption_key(engine, new_key)
+
+    assert rewritten is None
+    assert not key_file.exists()
+    assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
+    encryption._fernet.cache_clear()
+
+
+async def test_rotation_refuses_a_schema_missing_an_encrypted_table(current_key):
+    """A database behind this version is refused rather than aborting mid-transaction
+
+    Every other column would already have been re-encrypted by the time the missing one
+    raised, so the failure would arrive as a bare database error rather than a refusal
+    """
+    await _store_secrets(current_key)
+    stored_before = await _read_stored("oidc_providers", "client_secret_encrypted")
+    async with engine.begin() as connection:
+        await connection.execute(text("DROP TABLE totp_credentials"))
+    try:
+        with pytest.raises(RotationError, match="schema is behind this version"):
+            await rotate_encryption_key(engine, generate_encryption_key())
+
+        assert await _read_stored("oidc_providers", "client_secret_encrypted") == stored_before
+    finally:
+        async with engine.begin() as connection:
+            await connection.run_sync(TotpCredential.__table__.create)
+            await connection.run_sync(grant_auth_table, "totp_credentials")
+
+    # Startup and the auth flows read this table as the app role, so prove the rebuild
+    # restored that access rather than leaving it unreadable for the rest of this worker
+    async with ScopedSession() as app_session:
+        await app_session.execute(text("SELECT user_id FROM totp_credentials"))
+
+
+async def test_a_key_file_that_cannot_be_removed_still_reports_the_rotation(current_key, key_file, monkeypatch):
+    """A rotation that committed is reported even when the stale key file survives
+
+    Raising instead would lose the row counts and the closing instruction, and tell the
+    operator the run failed when the data has already moved
+    """
+    await _store_secrets(current_key)
+
+    def refuse_the_unlink(_self, **_kwargs):
+        raise PermissionError(13, "Permission denied")
+
+    monkeypatch.setattr("pathlib.Path.unlink", refuse_the_unlink)
+
+    rewritten = await rotate_encryption_key(engine, generate_encryption_key())
+
+    assert rewritten == {
+        ("oidc_providers", "client_secret_encrypted"): 1,
+        ("totp_credentials", "secret_encrypted"): 1,
+    }

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -222,8 +222,24 @@ async def test_rotation_finishes_an_interrupted_run(current_key, key_file):
 
     rewritten = await rotate_encryption_key(engine, new_key)
 
-    assert rewritten == {}
+    assert rewritten is None
     assert not key_file.exists()
+    assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
+
+
+async def test_rotation_refuses_a_key_that_only_differs_by_whitespace(current_key, key_file, monkeypatch):
+    """The same key with a trailing newline is the same key, so rotating onto it is refused
+
+    An env file or a mounted secret supplies the key that way, and the newline decodes to
+    the same bytes, so accepting it would re-encrypt everything under the key already in use
+    """
+    await _store_secrets(current_key)
+    monkeypatch.setenv(encryption.KEY_ENV_VAR, f"{current_key}\n")
+    stored_before = await _read_stored("totp_credentials", "secret_encrypted")
+
+    with pytest.raises(RotationError, match="already in use"):
+        await rotate_encryption_key(engine, current_key)
+
     assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
 
 

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -6,8 +6,9 @@ from sqlalchemy import text
 
 from app import encryption
 from app.config.database import APP_DB_USER
-from app.db.encryption_key import read_fingerprint, record_fingerprint
+from app.db.encryption_key import FINGERPRINT_TABLE, read_fingerprint, record_fingerprint
 from app.encryption import generate_encryption_key, key_fingerprint
+from app.models.encryption_key import EncryptionKeyFingerprint
 from scripts.rotate_app_encryption_key import RotationError, rotate_encryption_key
 from tests.conftest import ScopedSession, engine
 
@@ -144,7 +145,7 @@ async def test_a_failure_part_way_through_rewrites_nothing(current_key):
         )
     oidc_before = await _read_stored("oidc_providers", "client_secret_encrypted")
 
-    with pytest.raises(InvalidToken):
+    with pytest.raises(RotationError, match="totp_credentials.secret_encrypted"):
         await rotate_encryption_key(engine, generate_encryption_key())
 
     assert await _read_stored("oidc_providers", "client_secret_encrypted") == oidc_before
@@ -227,20 +228,25 @@ async def test_rotation_finishes_an_interrupted_run(current_key, key_file):
     assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
 
 
-async def test_rotation_refuses_a_key_that_only_differs_by_whitespace(current_key, key_file, monkeypatch):
+async def test_rotation_refuses_a_key_that_only_differs_by_whitespace(key_file, monkeypatch):
     """The same key with a trailing newline is the same key, so rotating onto it is refused
 
     An env file or a mounted secret supplies the key that way, and the newline decodes to
-    the same bytes, so accepting it would re-encrypt everything under the key already in use
+    the same bytes, so accepting it would re-encrypt everything under the key already in
+    use. The deployment here configures the key through the environment alone, which is
+    the one that reaches this refusal rather than the resolver's conflict check
     """
-    await _store_secrets(current_key)
-    monkeypatch.setenv(encryption.KEY_ENV_VAR, f"{current_key}\n")
+    key = generate_encryption_key()
+    monkeypatch.setenv(encryption.KEY_ENV_VAR, f"{key}\n")
+    encryption._fernet.cache_clear()
+    await _store_secrets(key)
     stored_before = await _read_stored("totp_credentials", "secret_encrypted")
 
     with pytest.raises(RotationError, match="already in use"):
-        await rotate_encryption_key(engine, current_key)
+        await rotate_encryption_key(engine, key)
 
     assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
+    encryption._fernet.cache_clear()
 
 
 async def test_rotation_rewrites_nothing_on_an_empty_database(current_key):
@@ -251,3 +257,19 @@ async def test_rotation_rewrites_nothing_on_an_empty_database(current_key):
         ("oidc_providers", "client_secret_encrypted"): 0,
         ("totp_credentials", "secret_encrypted"): 0,
     }
+
+
+async def test_rotation_refuses_a_database_with_no_key_record(current_key):
+    """Rotating before the migrations run is refused rather than dying at the last write"""
+    await _store_secrets(current_key)
+    stored_before = await _read_stored("totp_credentials", "secret_encrypted")
+    async with engine.begin() as connection:
+        await connection.execute(text(f"DROP TABLE {FINGERPRINT_TABLE}"))
+    try:
+        with pytest.raises(RotationError, match="no encryption key record"):
+            await rotate_encryption_key(engine, generate_encryption_key())
+
+        assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
+    finally:
+        async with engine.begin() as connection:
+            await connection.run_sync(EncryptionKeyFingerprint.__table__.create)

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -7,6 +7,7 @@ from sqlalchemy import text
 from app import encryption
 from app.config.database import APP_DB_USER
 from app.db.encryption_key import FINGERPRINT_TABLE, read_fingerprint, record_fingerprint
+from app.db.rls import grant_global_read_table
 from app.encryption import generate_encryption_key, key_fingerprint
 from app.models.encryption_key import EncryptionKeyFingerprint
 from scripts.rotate_app_encryption_key import RotationError, rotate_encryption_key
@@ -271,5 +272,15 @@ async def test_rotation_refuses_a_database_with_no_key_record(current_key):
 
         assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
     finally:
+        # Postgres drops a table's privileges with the table, and creating it back from the
+        # model restores no grant, so the app role's read is re-granted the way the
+        # migration grants it. Without this the table stays unreadable to that role for
+        # every later test in this worker
         async with engine.begin() as connection:
             await connection.run_sync(EncryptionKeyFingerprint.__table__.create)
+            await connection.run_sync(grant_global_read_table, FINGERPRINT_TABLE)
+
+    # Startup reads the record as the app role, so prove the rebuild restored that read
+    # rather than leaving the table unreadable for the rest of this worker's run
+    async with ScopedSession() as app_session:
+        await app_session.execute(text(f"SELECT fingerprint FROM {FINGERPRINT_TABLE}"))

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -7,7 +7,6 @@ from cryptography.fernet import Fernet, InvalidToken
 from sqlalchemy import text
 
 from app import encryption
-from app.config.database import APP_DB_USER
 from app.db.encryption_key import FINGERPRINT_TABLE, read_fingerprint, record_fingerprint
 from app.db.rls import grant_global_read_table
 from app.encryption import generate_encryption_key, key_fingerprint
@@ -206,7 +205,7 @@ async def test_rotation_refuses_while_the_app_role_is_connected(current_key):
     async with ScopedSession() as app_session:
         await app_session.execute(text("SELECT 1"))
 
-        with pytest.raises(RotationError, match=f"open as {APP_DB_USER}"):
+        with pytest.raises(RotationError, match="the main app appears to be running"):
             await rotate_encryption_key(engine, generate_encryption_key())
 
     assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -119,12 +119,49 @@ async def test_rotation_removes_the_stale_key_file(current_key, key_file):
     assert not key_file.exists()
 
 
+async def test_a_failure_part_way_through_rewrites_nothing(current_key):
+    """A column rewritten before the failure is rolled back with the rest
+
+    Columns are rewritten in sorted order, so the OIDC secret is already re-encrypted
+    inside the transaction by the time an unreadable TOTP row stops it. That is the case
+    the single transaction exists for, and the earlier refusals cannot reach it because
+    they all happen before the transaction opens
+    """
+    await _store_secrets(current_key)
+    async with engine.begin() as connection:
+        # A row the current key cannot read, which fails the rewrite rather than the checks
+        await connection.execute(
+            text(
+                "INSERT INTO users (id, email, first_name, tz, base_currency) "
+                "VALUES (gen_random_uuid(), 'corrupt@example.com', 'Corrupt', 'America/Toronto', 'CAD')"
+            )
+        )
+        await connection.execute(
+            text(
+                "INSERT INTO totp_credentials (user_id, secret_encrypted) "
+                "SELECT id, 'not-a-fernet-token' FROM users WHERE email = 'corrupt@example.com'"
+            )
+        )
+    oidc_before = await _read_stored("oidc_providers", "client_secret_encrypted")
+
+    with pytest.raises(InvalidToken):
+        await rotate_encryption_key(engine, generate_encryption_key())
+
+    assert await _read_stored("oidc_providers", "client_secret_encrypted") == oidc_before
+    assert Fernet(current_key.encode()).decrypt(oidc_before.encode()).decode() == _OIDC_SECRET
+    async with engine.begin() as connection:
+        assert await read_fingerprint(connection) is None
+
+
 async def test_rotation_refuses_a_key_equal_to_the_current_one(current_key):
     """Rotating onto the same key would report success while changing nothing"""
     await _store_secrets(current_key)
+    stored_before = await _read_stored("totp_credentials", "secret_encrypted")
 
     with pytest.raises(RotationError, match="already in use"):
         await rotate_encryption_key(engine, current_key)
+
+    assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
 
 
 async def test_rotation_refuses_a_malformed_key(current_key):

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -1,0 +1,200 @@
+"""Encryption key rotation tests"""
+
+import pytest
+from cryptography.fernet import Fernet, InvalidToken
+from sqlalchemy import text
+
+from app import encryption
+from app.config.database import APP_DB_USER
+from app.db.encryption_key import read_fingerprint, record_fingerprint
+from app.encryption import generate_encryption_key, key_fingerprint
+from scripts.rotate_app_encryption_key import RotationError, rotate_encryption_key
+from tests.conftest import ScopedSession, engine
+
+_TOTP_SECRET = "JBSWY3DPEHPK3PXP"
+_OIDC_SECRET = "oidc-secret-1"
+
+
+@pytest.fixture
+def key_file(tmp_path, monkeypatch):
+    """Point the key file and its directory at a temporary path"""
+    monkeypatch.setattr(encryption, "_SECRETS_DIR", tmp_path)
+    monkeypatch.setattr(encryption, "KEY_FILE", tmp_path / "app_encryption_key")
+    return encryption.KEY_FILE
+
+
+@pytest.fixture
+def current_key(key_file, monkeypatch):
+    """Persist a key to the key file and clear the environment, returning that key
+
+    The rotation resolves the key the app would, so the file standing alone is the default
+    deployment: a key generated on first start with no environment variable set
+    """
+    key = generate_encryption_key()
+    key_file.write_text(key)
+    monkeypatch.delenv(encryption.KEY_ENV_VAR, raising=False)
+
+    # The cached Fernet outlives a single test, so clear it whenever the key moves
+    encryption._fernet.cache_clear()
+    yield key
+    encryption._fernet.cache_clear()
+
+
+async def _store_secrets(key: str) -> None:
+    """Write one TOTP secret and one OIDC client secret encrypted under a key"""
+    fernet = Fernet(key.encode())
+    async with engine.begin() as connection:
+        await connection.execute(
+            text(
+                "INSERT INTO currencies (id, name, symbol, minor_unit_exponent) "
+                "VALUES ('CAD', 'Canadian Dollar', '$', 2) ON CONFLICT (id) DO NOTHING"
+            )
+        )
+        user_id = await connection.scalar(
+            text(
+                "INSERT INTO users (id, email, first_name, tz, base_currency) "
+                "VALUES (gen_random_uuid(), 'rotation@example.com', 'Rotation', 'America/Toronto', 'CAD') "
+                "RETURNING id"
+            )
+        )
+        await connection.execute(
+            text("INSERT INTO totp_credentials (user_id, secret_encrypted) VALUES (:user_id, :secret)"),
+            {"user_id": user_id, "secret": fernet.encrypt(_TOTP_SECRET.encode()).decode()},
+        )
+        await connection.execute(
+            text(
+                "INSERT INTO oidc_providers "
+                "(id, slug, display_name, issuer, client_id, client_secret_encrypted, scopes, enabled) "
+                "VALUES (gen_random_uuid(), 'generic', 'OIDC', 'https://issuer.example', "
+                "'client-1', :secret, 'openid email', true)"
+            ),
+            {"secret": fernet.encrypt(_OIDC_SECRET.encode()).decode()},
+        )
+
+
+async def _read_stored(table: str, column: str) -> str:
+    """Return the single stored token from a column"""
+    async with engine.begin() as connection:
+        return await connection.scalar(text(f"SELECT {column} FROM {table} LIMIT 1"))
+
+
+async def test_rotation_re_encrypts_every_labelled_column(current_key):
+    """Both stored secrets read under the new key afterwards and neither under the old one"""
+    await _store_secrets(current_key)
+    new_key = generate_encryption_key()
+
+    rewritten = await rotate_encryption_key(engine, new_key)
+
+    assert rewritten == {
+        ("oidc_providers", "client_secret_encrypted"): 1,
+        ("totp_credentials", "secret_encrypted"): 1,
+    }
+    for table, column, expected in (
+        ("totp_credentials", "secret_encrypted", _TOTP_SECRET),
+        ("oidc_providers", "client_secret_encrypted", _OIDC_SECRET),
+    ):
+        stored = await _read_stored(table, column)
+        assert Fernet(new_key.encode()).decrypt(stored.encode()).decode() == expected
+        with pytest.raises(InvalidToken):
+            Fernet(current_key.encode()).decrypt(stored.encode())
+
+
+async def test_rotation_moves_the_recorded_fingerprint(current_key):
+    """The record follows the data, so the app knows which key to expect afterwards"""
+    await _store_secrets(current_key)
+    new_key = generate_encryption_key()
+
+    await rotate_encryption_key(engine, new_key)
+
+    async with engine.begin() as connection:
+        assert await read_fingerprint(connection) == key_fingerprint(new_key)
+
+
+async def test_rotation_removes_the_stale_key_file(current_key, key_file):
+    """The old key is cleared from the volume, leaving the environment as the only source"""
+    await _store_secrets(current_key)
+
+    await rotate_encryption_key(engine, generate_encryption_key())
+
+    assert not key_file.exists()
+
+
+async def test_rotation_refuses_a_key_equal_to_the_current_one(current_key):
+    """Rotating onto the same key would report success while changing nothing"""
+    await _store_secrets(current_key)
+
+    with pytest.raises(RotationError, match="already in use"):
+        await rotate_encryption_key(engine, current_key)
+
+
+async def test_rotation_refuses_a_malformed_key(current_key):
+    """A truncated or mistyped key fails before anything is written"""
+    await _store_secrets(current_key)
+    stored_before = await _read_stored("totp_credentials", "secret_encrypted")
+
+    with pytest.raises(RotationError, match="not a valid Fernet key"):
+        await rotate_encryption_key(engine, "not-a-key")
+
+    assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
+
+
+async def test_rotation_refuses_when_the_current_key_reads_nothing(key_file, monkeypatch):
+    """A deployment whose resolved key is not the one the data is under fails up front"""
+    data_key = generate_encryption_key()
+    await _store_secrets(data_key)
+
+    # Resolve a third key, which is neither the one the data is under nor the target
+    key_file.write_text(generate_encryption_key())
+    monkeypatch.delenv(encryption.KEY_ENV_VAR, raising=False)
+    encryption._fernet.cache_clear()
+    stored_before = await _read_stored("totp_credentials", "secret_encrypted")
+
+    with pytest.raises(RotationError, match="does not decrypt the stored secrets"):
+        await rotate_encryption_key(engine, generate_encryption_key())
+
+    assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
+    encryption._fernet.cache_clear()
+
+
+async def test_rotation_refuses_while_the_app_role_is_connected(current_key):
+    """A serving app would write secrets under the old key mid-rotation, so this refuses"""
+    await _store_secrets(current_key)
+    stored_before = await _read_stored("totp_credentials", "secret_encrypted")
+
+    # An open session as the app role is what a running app looks like from the database
+    async with ScopedSession() as app_session:
+        await app_session.execute(text("SELECT 1"))
+
+        with pytest.raises(RotationError, match=f"open as {APP_DB_USER}"):
+            await rotate_encryption_key(engine, generate_encryption_key())
+
+    assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
+
+
+async def test_rotation_finishes_an_interrupted_run(current_key, key_file):
+    """Re-running after a crash between the commit and the file removal clears the file
+
+    The data and the record are already under the new key, so there is nothing to rewrite
+    and the stale key file is all that is left of the interrupted run
+    """
+    new_key = generate_encryption_key()
+    await _store_secrets(new_key)
+    async with engine.begin() as connection:
+        await record_fingerprint(connection, new_key)
+    stored_before = await _read_stored("totp_credentials", "secret_encrypted")
+
+    rewritten = await rotate_encryption_key(engine, new_key)
+
+    assert rewritten == {}
+    assert not key_file.exists()
+    assert await _read_stored("totp_credentials", "secret_encrypted") == stored_before
+
+
+async def test_rotation_rewrites_nothing_on_an_empty_database(current_key):
+    """A deployment with no secrets yet rotates to a zero count rather than failing"""
+    rewritten = await rotate_encryption_key(engine, generate_encryption_key())
+
+    assert rewritten == {
+        ("oidc_providers", "client_secret_encrypted"): 0,
+        ("totp_credentials", "secret_encrypted"): 0,
+    }

--- a/backend/tests/scripts/test_rotate_app_encryption_key.py
+++ b/backend/tests/scripts/test_rotate_app_encryption_key.py
@@ -288,53 +288,35 @@ async def test_rotation_refuses_a_database_with_no_key_record(current_key):
         await app_session.execute(text(f"SELECT fingerprint FROM {FINGERPRINT_TABLE}"))  # noqa: S608
 
 
-class _FakeStdin:
-    """Stands in for standard input, reporting whether a terminal is attached"""
-
-    def __init__(self, text: str, *, tty: bool):
-        self._text = text
-        self._tty = tty
-
-    def isatty(self) -> bool:
-        """Whether a terminal is attached"""
-        return self._tty
-
-    def read(self) -> str:
-        """Return everything on standard input
-
-        A real terminal blocks here until the operator presses Ctrl-D, so reading one at
-        all is the defect. Raising is what makes a test notice it rather than seeing the
-        empty string a stand-in would otherwise hand back
-        """
-        if self._tty:
-            raise AssertionError("read from a terminal, which would block with no output")
-        return self._text
-
-
-def test_the_command_refuses_a_terminal_rather_than_waiting(monkeypatch, capsys):
-    """Run with a terminal attached, it says what to do instead of waiting silently
-
-    sys.stdin.read() on a terminal blocks until the operator presses Ctrl-D, showing
-    nothing at all, which reads as the command having hung
-    """
-    monkeypatch.setattr("sys.stdin", _FakeStdin("", tty=True))
+def test_the_command_refuses_no_key(monkeypatch):
+    """Run with nothing after the command name, it says how to call it"""
+    monkeypatch.setattr("sys.argv", ["rotate_app_encryption_key"])
 
     with pytest.raises(SystemExit) as raised:
         main()
 
-    assert "No key on standard input" in str(raised.value)
+    assert "Usage:" in str(raised.value)
 
 
-def test_the_command_says_what_it_is_waiting_for(monkeypatch, capsys):
-    """With no terminal and no input, it names what it wants before reading
+def test_the_command_refuses_a_blank_key(monkeypatch):
+    """An empty or whitespace argument is refused rather than treated as a key
 
-    Docker attaches standard input as an open pipe even with nothing feeding it, so the
-    read blocks with no output. The line printed first is what makes that a wait rather
-    than a hang
+    A shell expanding an unset variable produces exactly this, so it reaches the command
+    as an argument that is present but holds nothing
     """
-    monkeypatch.setattr("sys.stdin", _FakeStdin("", tty=False))
+    monkeypatch.setattr("sys.argv", ["rotate_app_encryption_key", "   "])
 
-    with pytest.raises(SystemExit):
+    with pytest.raises(SystemExit) as raised:
         main()
 
-    assert "Reading the new encryption key from standard input" in capsys.readouterr().err
+    assert "Usage:" in str(raised.value)
+
+
+def test_the_command_refuses_more_than_one_argument(monkeypatch):
+    """An unquoted key that the shell split is refused rather than half used"""
+    monkeypatch.setattr("sys.argv", ["rotate_app_encryption_key", "one", "two"])
+
+    with pytest.raises(SystemExit) as raised:
+        main()
+
+    assert "Usage:" in str(raised.value)

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -3,7 +3,19 @@
 import pytest
 
 from app import encryption
-from app.encryption import decrypt, encrypt, generate_encryption_key, resolve_encryption_key
+from app.encryption import decrypt, encrypt, generate_encryption_key, key_fingerprint, resolve_encryption_key
+
+
+@pytest.fixture
+def key_file(tmp_path, monkeypatch):
+    """Point the key file and its directory at a temporary path
+
+    Both are patched, since generating a key creates the directory and the real one is
+    /data/secrets, which the test host neither has nor should gain
+    """
+    monkeypatch.setattr(encryption, "_SECRETS_DIR", tmp_path)
+    monkeypatch.setattr(encryption, "KEY_FILE", tmp_path / "app_encryption_key")
+    return encryption.KEY_FILE
 
 
 def test_encrypt_round_trips_to_the_original_plaintext():
@@ -22,34 +34,49 @@ def test_encrypt_is_non_deterministic():
     assert encrypt(secret) != encrypt(secret)
 
 
-def test_resolve_raises_when_configured_and_persisted_keys_conflict(tmp_path, monkeypatch):
+def test_key_fingerprint_identifies_a_key_without_disclosing_it():
+    """The digest is stable for one key, differs between keys, and is not the key"""
+    key = generate_encryption_key()
+    other_key = generate_encryption_key()
+
+    assert key_fingerprint(key) == key_fingerprint(key)
+    assert key_fingerprint(key) != key_fingerprint(other_key)
+    assert key not in key_fingerprint(key)
+
+
+def test_resolve_raises_when_configured_and_persisted_keys_conflict(key_file, monkeypatch):
     """A configured key that differs from the persisted key aborts instead of silently winning"""
-    key_file = tmp_path / "app_encryption_key"
     key_file.write_text(generate_encryption_key())
-    monkeypatch.setattr(encryption, "_KEY_FILE", key_file)
     monkeypatch.setenv("APP_ENCRYPTION_KEY", generate_encryption_key())
 
     with pytest.raises(RuntimeError, match="does not match"):
         resolve_encryption_key(generate=False)
 
 
-def test_resolve_returns_the_key_when_configured_and_persisted_keys_match(tmp_path, monkeypatch):
+def test_conflict_message_does_not_advise_removing_either_key(key_file, monkeypatch):
+    """Removing the live key of the two loses the stored secrets, so it is never the advice"""
+    key_file.write_text(generate_encryption_key())
+    monkeypatch.setenv("APP_ENCRYPTION_KEY", generate_encryption_key())
+
+    with pytest.raises(RuntimeError) as raised:
+        resolve_encryption_key(generate=False)
+
+    assert "Remove" not in str(raised.value)
+
+
+def test_resolve_returns_the_key_when_configured_and_persisted_keys_match(key_file, monkeypatch):
     """Supplying the same key through both sources is not a conflict"""
     key = generate_encryption_key()
-    key_file = tmp_path / "app_encryption_key"
     key_file.write_text(key)
-    monkeypatch.setattr(encryption, "_KEY_FILE", key_file)
     monkeypatch.setenv("APP_ENCRYPTION_KEY", key)
 
     assert resolve_encryption_key(generate=False) == key
 
 
-def test_resolve_returns_the_persisted_key_without_a_configured_key(tmp_path, monkeypatch):
+def test_resolve_returns_the_persisted_key_without_a_configured_key(key_file, monkeypatch):
     """The persisted key resolves on its own when the environment variable is absent"""
     key = generate_encryption_key()
-    key_file = tmp_path / "app_encryption_key"
     key_file.write_text(key)
-    monkeypatch.setattr(encryption, "_KEY_FILE", key_file)
     monkeypatch.delenv("APP_ENCRYPTION_KEY", raising=False)
 
     assert resolve_encryption_key(generate=False) == key

--- a/backend/tests/test_encryption.py
+++ b/backend/tests/test_encryption.py
@@ -73,6 +73,27 @@ def test_resolve_returns_the_key_when_configured_and_persisted_keys_match(key_fi
     assert resolve_encryption_key(generate=False) == key
 
 
+def test_resolve_strips_whitespace_around_a_configured_key(key_file, monkeypatch):
+    """An env file or a mounted secret adds a trailing newline, which must not change the key
+
+    The newline decodes to the same 32 bytes, so every stored secret still reads, but the
+    key would compare unequal to itself and fail the fingerprint check
+    """
+    key = generate_encryption_key()
+    monkeypatch.setenv("APP_ENCRYPTION_KEY", f"{key}\n")
+
+    assert resolve_encryption_key(generate=False) == key
+
+
+def test_a_configured_key_with_whitespace_is_not_a_conflict(key_file, monkeypatch):
+    """The same key through both sources stays one key when one copy carries a newline"""
+    key = generate_encryption_key()
+    key_file.write_text(key)
+    monkeypatch.setenv("APP_ENCRYPTION_KEY", f"  {key}\n")
+
+    assert resolve_encryption_key(generate=False) == key
+
+
 def test_resolve_returns_the_persisted_key_without_a_configured_key(key_file, monkeypatch):
     """The persisted key resolves on its own when the environment variable is absent"""
     key = generate_encryption_key()

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,26 @@ export RUNTIME="${RUNTIME:-server}"
 export JWT_ACCESS_PRIVATE_KEY_PATH="${JWT_ACCESS_PRIVATE_KEY_PATH:-/data/keys/access_private.pem}"
 export JWT_REFRESH_PRIVATE_KEY_PATH="${JWT_REFRESH_PRIVATE_KEY_PATH:-/data/keys/refresh_private.pem}"
 
+# Maintenance commands an operator runs against a stopped stack, as
+# `docker compose run --rm app <command>`. Matched against a fixed list rather than run as
+# given, since this container holds the admin database credentials and the data volume, and
+# passing arbitrary arguments through would make it a shell on both
+if [ "$#" -gt 0 ]; then
+	case "$1" in
+	generate-app-encryption-key)
+		exec python -m scripts.generate_app_encryption_key
+		;;
+	rotate-app-encryption-key)
+		exec python -m scripts.rotate_app_encryption_key
+		;;
+	*)
+		echo "Unknown command: $1" >&2
+		echo "Available: generate-app-encryption-key, rotate-app-encryption-key" >&2
+		exit 64
+		;;
+	esac
+fi
+
 ensure_private_key() {
 	key_name="$1"
 	key_path="$2"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -15,7 +15,10 @@ if [ "$#" -gt 0 ]; then
 		exec python -m scripts.generate_app_encryption_key
 		;;
 	rotate-app-encryption-key)
-		exec python -m scripts.rotate_app_encryption_key
+		# Forwards what follows the command name, which is the new key, and only for
+		# this one command so the others still take no arguments
+		shift
+		exec python -m scripts.rotate_app_encryption_key "$@"
 		;;
 	*)
 		echo "Unknown command: $1" >&2

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -48,8 +48,9 @@ ensure_private_key "Access" "$JWT_ACCESS_PRIVATE_KEY_PATH"
 ensure_private_key "Refresh" "$JWT_REFRESH_PRIVATE_KEY_PATH"
 
 # The encryption key protects TOTP secrets and OIDC client secrets at rest, generated
-# and persisted next to the role secrets when absent
-python -m app.encryption
+# and persisted next to the role secrets when absent. A database that already holds
+# encrypted secrets refuses here rather than starting under a key that cannot read them
+python -m app.db.encryption_key ensure-key
 
 # Create the migrator and app roles and hand them schema ownership while still
 # connected as the admin role, before migrations run as the migrator
@@ -64,6 +65,10 @@ alembic upgrade head
 # It is also what installs any policy that reads a column added after the bootstrap, since the
 # bootstrap replays against a schema without it, so a freshly migrated database needs this too
 python -m app.db.provision apply-rls
+
+# Bind the database to its encryption key, which an upgrading deployment records here for
+# the first time, and refuse to serve when the key in hand is not the one the data is under
+python -m app.db.encryption_key verify-fingerprint
 
 python -m scripts.seed_currencies
 python -m scripts.seed_categories

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,6 +12,12 @@ export JWT_REFRESH_PRIVATE_KEY_PATH="${JWT_REFRESH_PRIVATE_KEY_PATH:-/data/keys/
 if [ "$#" -gt 0 ]; then
 	case "$1" in
 	generate-app-encryption-key)
+		# Rejects anything after the command name rather than dropping it, so a mistyped
+		# invocation does not print a fresh key and exit as though it had worked
+		if [ "$#" -gt 1 ]; then
+			echo "generate-app-encryption-key takes no arguments" >&2
+			exit 64
+		fi
 		exec python -m scripts.generate_app_encryption_key
 		;;
 	rotate-app-encryption-key)


### PR DESCRIPTION
Implemented a maintenance command that rotates the encryption key by re-encrypting every stored secret in a single transaction. The command refuses to operate while the app is connected, refuses a malformed key, and refuses a key already in use. The app also stores a fingerprint of the key and checks it at startup, refusing to start on a mismatch. This enables storing bank credentials under the same encryption key.
