### PR TITLE
fix: show why a request failed instead of an empty state

### DIFF
--- a/frontend/src/api/auth/errors.ts
+++ b/frontend/src/api/auth/errors.ts
@@ -20,6 +20,9 @@ export class ApiError extends Error {
 
   constructor(message: string, status: number, options: ApiErrorOptions = {}) {
     super(message);
+    // Without this the class inherits the plain Error name, so a copied bug report cannot tell a
+    // request the server refused from a render that threw
+    this.name = 'ApiError';
     this.status = status;
     this.attemptsRemaining = options.attemptsRemaining;
     this.detail = options.detail;

--- a/frontend/src/api/auth/errors.ts
+++ b/frontend/src/api/auth/errors.ts
@@ -1,16 +1,28 @@
 export const REFRESH_ALREADY_ROTATED_STATUS = 409;
 export const REFRESH_ALREADY_ROTATED_DETAIL = 'Refresh token was already rotated';
 
+interface ApiErrorOptions {
+  attemptsRemaining?: number;
+  detail?: string;
+}
+
 export class ApiError extends Error {
   status: number;
 
   /** Step-up attempts left before the shared lockout signs the user out, when the response reports it */
   attemptsRemaining?: number;
 
-  constructor(message: string, status: number, attemptsRemaining?: number) {
+  // Set only where the response body carried a `detail`, so an empty one is the app's own way of
+  // knowing the backend offered no explanation. `message` cannot answer that: it falls back to a
+  // sentence the client invents from the status
+  /** The backend's own explanation of the failure, where the response carried one */
+  detail?: string;
+
+  constructor(message: string, status: number, options: ApiErrorOptions = {}) {
     super(message);
     this.status = status;
-    this.attemptsRemaining = attemptsRemaining;
+    this.attemptsRemaining = options.attemptsRemaining;
+    this.detail = options.detail;
   }
 }
 

--- a/frontend/src/api/auth/requests.ts
+++ b/frontend/src/api/auth/requests.ts
@@ -121,7 +121,7 @@ async function requestAuth<T>(path: string, options: RequestInit): Promise<T> {
   if (!res.ok) {
     const body = await res.json().catch(() => null);
     const message = body?.detail ?? `Request failed (${res.status})`;
-    throw new ApiError(message, res.status);
+    throw new ApiError(message, res.status, { detail: body?.detail });
   }
 
   // The forgot and reset endpoints return 204 with no body, so res.json would throw

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -85,7 +85,10 @@ export async function authenticatedFetch<T>(path: string, options: RequestInit =
     const message = body?.detail ?? `Request failed (${res.status})`;
     const attemptsHeader = res.headers.get(ATTEMPTS_REMAINING_HEADER);
     const attemptsRemaining = attemptsHeader !== null ? Number(attemptsHeader) : undefined;
-    throw new ApiError(message, res.status, Number.isNaN(attemptsRemaining) ? undefined : attemptsRemaining);
+    throw new ApiError(message, res.status, {
+      attemptsRemaining: Number.isNaN(attemptsRemaining) ? undefined : attemptsRemaining,
+      detail: body?.detail,
+    });
   }
 
   // 204 No Content responses have an empty body, so res.json would fail

--- a/frontend/src/api/oidc/requests.ts
+++ b/frontend/src/api/oidc/requests.ts
@@ -40,7 +40,9 @@ async function requestOidc<T>(path: string, options: RequestInit = {}): Promise<
       throw new OidcEmailConflictError(detail.email);
     }
     const message = typeof detail === 'string' ? detail : `Request failed (${response.status})`;
-    throw new ApiError(message, response.status);
+    throw new ApiError(message, response.status, {
+      detail: typeof detail === 'string' ? detail : undefined,
+    });
   }
 
   return response.json() as Promise<T>;

--- a/frontend/src/api/passkeys/requests.ts
+++ b/frontend/src/api/passkeys/requests.ts
@@ -54,7 +54,11 @@ export async function authenticatePasskey(credential: AuthenticationResponseJSON
   });
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { detail?: string } | null;
-    throw new ApiError(body?.detail ?? `Passkey sign-in failed (${response.status})`, response.status);
+    throw new ApiError(
+      body?.detail ?? `Passkey sign-in failed (${response.status})`,
+      response.status,
+      { detail: body?.detail },
+    );
   }
   return response.json();
 }
@@ -90,7 +94,11 @@ export async function fetchPasskeyMfaOptions(mfaToken: string): Promise<PublicKe
   });
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { detail?: string } | null;
-    throw new ApiError(body?.detail ?? `Failed to start passkey verification (${response.status})`, response.status);
+    throw new ApiError(
+      body?.detail ?? `Failed to start passkey verification (${response.status})`,
+      response.status,
+      { detail: body?.detail },
+    );
   }
   return response.json();
 }
@@ -110,7 +118,11 @@ export async function verifyPasskeyMfa(
   });
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { detail?: string } | null;
-    throw new ApiError(body?.detail ?? `Passkey verification failed (${response.status})`, response.status);
+    throw new ApiError(
+      body?.detail ?? `Passkey verification failed (${response.status})`,
+      response.status,
+      { detail: body?.detail },
+    );
   }
   return response.json();
 }
@@ -127,7 +139,11 @@ export async function fetchPasskeyResetOptions(mfaToken: string): Promise<Public
   });
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { detail?: string } | null;
-    throw new ApiError(body?.detail ?? `Failed to start passkey verification (${response.status})`, response.status);
+    throw new ApiError(
+      body?.detail ?? `Failed to start passkey verification (${response.status})`,
+      response.status,
+      { detail: body?.detail },
+    );
   }
   return response.json();
 }
@@ -147,7 +163,11 @@ export async function verifyPasskeyReset(
   });
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { detail?: string } | null;
-    throw new ApiError(body?.detail ?? `Passkey verification failed (${response.status})`, response.status);
+    throw new ApiError(
+      body?.detail ?? `Passkey verification failed (${response.status})`,
+      response.status,
+      { detail: body?.detail },
+    );
   }
 }
 

--- a/frontend/src/components/errors/FailureBlock.tsx
+++ b/frontend/src/components/errors/FailureBlock.tsx
@@ -1,0 +1,194 @@
+import { AlertTriangle, Check, Copy, RefreshCw } from 'lucide-react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { copyText } from '@/utils/clipboard';
+import { buildErrorReport } from '@/utils/errorReport';
+import { clearStoredData } from '@/utils/storedData';
+
+/** How much of the app the block stands in for: the whole window, a page area, or one card's contents */
+export type FailureBlockSize = 'card' | 'inline' | 'screen';
+
+type CopyStatus = 'idle' | 'copied' | 'failed';
+
+const COPY_LABELS: Record<CopyStatus, string> = {
+  idle: 'Copy error details',
+  copied: 'Copied',
+  failed: 'Could not copy',
+};
+
+// The issue list rather than a blank new issue, so the repository's own template picker is what
+// the user lands on
+const BUG_REPORT_URL = 'https://github.com/Lumina-Finance/lumina-finance/issues';
+
+// How long the copy button confirms before returning to its usual label
+const COPY_CONFIRMATION_MS = 2000;
+
+const ICON_SIZE: Record<FailureBlockSize, number> = { screen: 26, card: 22, inline: 18 };
+
+const HEADING_CLASS: Record<FailureBlockSize, string> = {
+  screen: 'text-3xl',
+  card: 'text-2xl',
+  inline: 'text-lg',
+};
+
+// The inline size sits inside a card that has its own padding around it, so it closes the gaps the
+// two standalone sizes need to fill a window
+const MESSAGE_SPACING_CLASS: Record<FailureBlockSize, string> = {
+  screen: 'mt-4',
+  card: 'mt-4',
+  inline: 'mt-2',
+};
+
+const CONTROLS_SPACING_CLASS: Record<FailureBlockSize, string> = {
+  screen: 'mt-6',
+  card: 'mt-6',
+  inline: 'mt-4',
+};
+
+interface FailureBlockProps {
+  componentStack?: string | null;
+
+  /** The API's own explanation, quoted in place of the app's wording where the response carried one */
+  detail?: string | null;
+
+  error: unknown;
+  heading: ReactNode;
+
+  // Keeps the reload from emptying this browser's storage. Set it where the failure is known to be a
+  // request that failed rather than saved state that broke a render, since the wipe exists to clear
+  // that state, and it otherwise takes the theme, the sidebar width and the whole cached query data
+  // with it for nothing
+  preserveStoredData?: boolean;
+
+  /** Chooses the lost-connection wording over the general one, the caller having decided which fits */
+  serverUnreachable: boolean;
+
+  size: FailureBlockSize;
+}
+
+/**
+ * The heading, explanation and recovery controls shown wherever something did not load
+ *
+ * The crash screen and the smaller box a working page puts beside a failed list render the same
+ * block, so the wording and the controls exist once. What differs is the heading the caller passes,
+ * how large the block is drawn, and whether reloading keeps this browser's storage
+ *
+ * It returns a fragment rather than its own container, since the three callers each need a
+ * different one: a full window, a centred card, or a strip inside a section that is already there
+ */
+export default function FailureBlock({
+  componentStack = null,
+  detail = null,
+  error,
+  heading,
+  preserveStoredData = false,
+  serverUnreachable,
+  size,
+}: FailureBlockProps) {
+  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
+  const copyResetTimer = useRef<number | null>(null);
+
+  useEffect(() => () => {
+    if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
+  }, []);
+
+  /**
+   * Reloads, by default onto empty storage, because state saved in this browser can be what broke the
+   * render and a plain reload would restore it
+   *
+   * A caller that knows the failure was a request rather than saved state keeps the storage, since
+   * wiping it then costs the user their theme, their sidebar width and every cached response without
+   * making the reload any likelier to work
+   */
+  const handleReload = () => {
+    if (!preserveStoredData) clearStoredData();
+    window.location.reload();
+  };
+
+  /**
+   * Puts the technical detail on the clipboard for a bug report, keeping it off the screen
+   *
+   * The report is built here rather than when the error was caught so the time reflects the moment
+   * the user asked for it, which is what they will have seen in the app
+   */
+  const handleCopy = async () => {
+    const report = buildErrorReport({
+      componentStack,
+      error,
+      // The query string is left out on purpose. A password reset link carries its token there and
+      // the provider callback carries an authorization code, and this text is written to be pasted
+      // into a public bug report
+      path: window.location.pathname,
+      occurredAt: new Date(),
+      userAgent: navigator.userAgent,
+    });
+
+    setCopyStatus((await copyText(report)) ? 'copied' : 'failed');
+
+    if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
+    copyResetTimer.current = window.setTimeout(() => setCopyStatus('idle'), COPY_CONFIRMATION_MS);
+  };
+
+  return (
+    <>
+      <div className="flex items-center gap-3">
+        <AlertTriangle
+          size={ICON_SIZE[size]}
+          strokeWidth={2}
+          className="shrink-0"
+          style={{ color: 'var(--app-accent)' }}
+          aria-hidden
+        />
+
+        <h1 className={`font-serif font-normal tracking-tight ${HEADING_CLASS[size]}`}>{heading}</h1>
+      </div>
+
+      <p
+        className={`${MESSAGE_SPACING_CLASS[size]} text-sm leading-relaxed`}
+        style={{ color: 'var(--app-text-muted)' }}
+      >
+        {detail ?? (serverUnreachable ? (
+          <>
+            The app can&apos;t reach the server right now. Your data is fine. Reload once your
+            connection is back.
+          </>
+        ) : (
+          <>
+            The app ran into an issue while trying to respond to your request. Your data is fine,
+            and reloading usually fixes it. If it persists, please try again in a bit and submit a{' '}
+            <a
+              href={BUG_REPORT_URL}
+              target="_blank"
+              rel="noreferrer"
+              className="underline underline-offset-2"
+              style={{ color: 'var(--app-accent)' }}
+            >
+              bug report
+            </a>{' '}
+            if it still doesn&apos;t resolve.
+          </>
+        ))}
+      </p>
+
+      <div className={`${CONTROLS_SPACING_CLASS[size]} flex flex-wrap items-center gap-4`}>
+        <button type="button" className="app-primary-button" onClick={handleReload}>
+          <RefreshCw size={15} strokeWidth={2} aria-hidden />
+          Reload
+        </button>
+
+        <button
+          type="button"
+          className="inline-flex items-center gap-1.5 text-xs font-medium underline underline-offset-2 transition-colors duration-200"
+          style={{ color: 'var(--app-text-muted)' }}
+          onClick={handleCopy}
+        >
+          {copyStatus === 'copied' ? (
+            <Check size={14} strokeWidth={2.5} style={{ color: 'var(--app-positive)' }} aria-hidden />
+          ) : (
+            <Copy size={14} strokeWidth={2} aria-hidden />
+          )}
+          {COPY_LABELS[copyStatus]}
+        </button>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/errors/Fallback.tsx
+++ b/frontend/src/components/errors/Fallback.tsx
@@ -1,26 +1,7 @@
-import { AlertTriangle, Check, Copy, RefreshCw } from 'lucide-react';
-import { useEffect, useRef, useState } from 'react';
+import FailureBlock from '@/components/errors/FailureBlock';
 import { useServerReachability } from '@/hooks/useServerReachability';
-import { copyText } from '@/utils/clipboard';
-import { buildErrorReport } from '@/utils/errorReport';
-import { clearStoredData } from '@/utils/storedData';
 
 export type FallbackVariant = 'card' | 'screen';
-
-type CopyStatus = 'idle' | 'copied' | 'failed';
-
-const COPY_LABELS: Record<CopyStatus, string> = {
-  idle: 'Copy error details',
-  copied: 'Copied',
-  failed: 'Could not copy',
-};
-
-// The issue list rather than a blank new issue, so the repository's own template picker is what
-// the user lands on
-const BUG_REPORT_URL = 'https://github.com/Lumina-Finance/lumina-finance/issues';
-
-// How long the copy button confirms before returning to its usual label
-const COPY_CONFIRMATION_MS = 2000;
 
 interface FallbackProps {
   componentStack: string | null;
@@ -42,116 +23,19 @@ interface FallbackProps {
  * from the user's side the difference is only how much of the app is still there
  */
 export default function Fallback({ componentStack, error, preserveStoredData = false, variant }: FallbackProps) {
-  const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle');
-  const copyResetTimer = useRef<number | null>(null);
   // Until the probe comes back the message assumes a bug, since that is the only thing the user
   // can act on. An unreachable server rewrites it rather than the other way round
   const serverUnreachable = useServerReachability() === 'unreachable';
 
-  useEffect(() => () => {
-    if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
-  }, []);
-
-  /**
-   * Reloads, by default onto empty storage, because state saved in this browser can be what broke the
-   * render and a plain reload would restore it
-   *
-   * A caller that knows the failure was a network one keeps the storage, since wiping it then costs
-   * the user their theme, their sidebar width and every cached response without making the reload any
-   * likelier to work
-   */
-  const handleReload = () => {
-    if (!preserveStoredData) clearStoredData();
-    window.location.reload();
-  };
-
-  /**
-   * Puts the technical detail on the clipboard for a bug report, keeping it off the screen
-   *
-   * The report is built here rather than when the error was caught so the time reflects the moment
-   * the user asked for it, which is what they will have seen in the app
-   */
-  const handleCopy = async () => {
-    const report = buildErrorReport({
-      componentStack,
-      error,
-      // The query string is left out on purpose. A password reset link carries its token there and
-      // the provider callback carries an authorization code, and this text is written to be pasted
-      // into a public bug report
-      path: window.location.pathname,
-      occurredAt: new Date(),
-      userAgent: navigator.userAgent,
-    });
-
-    setCopyStatus((await copyText(report)) ? 'copied' : 'failed');
-
-    if (copyResetTimer.current !== null) window.clearTimeout(copyResetTimer.current);
-    copyResetTimer.current = window.setTimeout(() => setCopyStatus('idle'), COPY_CONFIRMATION_MS);
-  };
-
   const content = (
-    <>
-      <div className="flex items-center gap-3">
-        <AlertTriangle
-          size={variant === 'screen' ? 26 : 22}
-          strokeWidth={2}
-          className="shrink-0"
-          style={{ color: 'var(--app-accent)' }}
-          aria-hidden
-        />
-
-        <h1
-          className={`font-serif font-normal tracking-tight ${variant === 'screen' ? 'text-3xl' : 'text-2xl'}`}
-        >
-          OK this was not in the plan <span aria-hidden>:(</span>
-        </h1>
-      </div>
-
-      <p className="mt-4 text-sm leading-relaxed" style={{ color: 'var(--app-text-muted)' }}>
-        {serverUnreachable ? (
-          <>
-            The app can&apos;t reach the server right now. Your data is fine. Reload once your
-            connection is back.
-          </>
-        ) : (
-          <>
-            The app ran into an issue while trying to respond to your request. Your data is fine,
-            and reloading usually fixes it. If it persists, please try again in a bit and submit a{' '}
-            <a
-              href={BUG_REPORT_URL}
-              target="_blank"
-              rel="noreferrer"
-              className="underline underline-offset-2"
-              style={{ color: 'var(--app-accent)' }}
-            >
-              bug report
-            </a>{' '}
-            if it still doesn&apos;t resolve.
-          </>
-        )}
-      </p>
-
-      <div className="mt-6 flex flex-wrap items-center gap-4">
-        <button type="button" className="app-primary-button" onClick={handleReload}>
-          <RefreshCw size={15} strokeWidth={2} aria-hidden />
-          Reload
-        </button>
-
-        <button
-          type="button"
-          className="inline-flex items-center gap-1.5 text-xs font-medium underline underline-offset-2 transition-colors duration-200"
-          style={{ color: 'var(--app-text-muted)' }}
-          onClick={handleCopy}
-        >
-          {copyStatus === 'copied' ? (
-            <Check size={14} strokeWidth={2.5} style={{ color: 'var(--app-positive)' }} aria-hidden />
-          ) : (
-            <Copy size={14} strokeWidth={2} aria-hidden />
-          )}
-          {COPY_LABELS[copyStatus]}
-        </button>
-      </div>
-    </>
+    <FailureBlock
+      componentStack={componentStack}
+      error={error}
+      heading={<>OK this was not in the plan <span aria-hidden>:(</span></>}
+      preserveStoredData={preserveStoredData}
+      serverUnreachable={serverUnreachable}
+      size={variant}
+    />
   );
 
   if (variant === 'screen') {

--- a/frontend/src/components/errors/Fallback.tsx
+++ b/frontend/src/components/errors/Fallback.tsx
@@ -31,7 +31,16 @@ export default function Fallback({ componentStack, error, preserveStoredData = f
     <FailureBlock
       componentStack={componentStack}
       error={error}
-      heading={<>OK this was not in the plan <span aria-hidden>:(</span></>}
+      // The last word and the face are held together, or a narrow screen breaks between them and
+      // leaves the bracket opening the next line as stray punctuation
+      heading={(
+        <>
+          OK this was not in the{' '}
+          <span className="whitespace-nowrap">
+            plan <span aria-hidden>:(</span>
+          </span>
+        </>
+      )}
       preserveStoredData={preserveStoredData}
       serverUnreachable={serverUnreachable}
       size={variant}

--- a/frontend/src/components/errors/LoadFailure.tsx
+++ b/frontend/src/components/errors/LoadFailure.tsx
@@ -1,0 +1,44 @@
+import { ApiError } from '@/api/auth';
+import FailureBlock from '@/components/errors/FailureBlock';
+
+/**
+ * Says why part of a working page is missing, in place of an empty state that would otherwise tell
+ * the reader there is nothing to show
+ *
+ * It carries the same wording and the same controls as the crash screen, drawn small enough to sit
+ * inside a section or a card. Where the response carried the backend's own explanation, that is
+ * quoted instead of the app's general wording
+ *
+ * @param error - The rejection the query reported, read for the backend's explanation and the status
+ * @param subject - What failed, in the words the page uses for it, as in "Categories" or "Net worth"
+ */
+export default function LoadFailure({
+  className = 'py-3',
+  error,
+  subject,
+}: {
+  className?: string
+  error: unknown
+  subject: string
+}) {
+  // A request that never reached the server rejects from fetch itself, so nothing is an ApiError,
+  // while an ApiError proves the server answered. Reading the distinction off the error is what lets
+  // a page carrying eight of these say the right thing without each one probing the server
+  const serverAnswered = error instanceof ApiError
+
+  return (
+    <div className={className} role="alert">
+      <FailureBlock
+        detail={serverAnswered ? error.detail ?? null : null}
+        error={error}
+        heading={`${subject} could not load`}
+        // The failure is a request that failed rather than saved state that broke a render, so
+        // wiping this browser's storage would cost the reader their theme, their sidebar width and
+        // every cached response for nothing
+        preserveStoredData
+        serverUnreachable={!serverAnswered}
+        size="inline"
+      />
+    </div>
+  )
+}

--- a/frontend/src/components/errors/LoadFailure.tsx
+++ b/frontend/src/components/errors/LoadFailure.tsx
@@ -1,6 +1,10 @@
 import { ApiError } from '@/api/auth';
 import FailureBlock from '@/components/errors/FailureBlock';
 
+// Wide enough for the sentence to break in a readable place, narrow enough that a card has room
+// left to centre it in. Below this width the box simply fills what it is given
+const STANDALONE_WIDTH_CLASS = 'w-full max-w-sm';
+
 /**
  * Says why part of a working page is missing, in place of an empty state that would otherwise tell
  * the reader there is nothing to show
@@ -10,15 +14,18 @@ import FailureBlock from '@/components/errors/FailureBlock';
  * quoted instead of the app's general wording
  *
  * @param error - The rejection the query reported, read for the backend's explanation and the status
+ * @param standalone - Set where nothing else is left in the card, which sits the box in the middle
  * @param subject - What failed, in the words the page uses for it, as in "Categories" or "Net worth"
  */
 export default function LoadFailure({
   className = 'py-3',
   error,
+  standalone = false,
   subject,
 }: {
   className?: string
   error: unknown
+  standalone?: boolean
   subject: string
 }) {
   // A request that never reached the server rejects from fetch itself, so nothing is an ApiError,
@@ -26,19 +33,33 @@ export default function LoadFailure({
   // a page carrying eight of these say the right thing without each one probing the server
   const serverAnswered = error instanceof ApiError
 
+  const block = (
+    <FailureBlock
+      detail={serverAnswered ? error.detail ?? null : null}
+      error={error}
+      heading={`${subject} could not load`}
+      // The failure is a request that failed rather than saved state that broke a render, so
+      // wiping this browser's storage would cost the reader their theme, their sidebar width and
+      // every cached response for nothing
+      preserveStoredData
+      serverUnreachable={!serverAnswered}
+      size="inline"
+    />
+  )
+
+  // The wording stays left-aligned, so the width is capped and that capped block is what moves to
+  // the middle. A block spanning the whole card would start at the left edge with nothing to centre
+  if (standalone) {
+    return (
+      <div className="flex h-full w-full flex-1 flex-col items-center justify-center py-3" role="alert">
+        <div className={STANDALONE_WIDTH_CLASS}>{block}</div>
+      </div>
+    )
+  }
+
   return (
     <div className={className} role="alert">
-      <FailureBlock
-        detail={serverAnswered ? error.detail ?? null : null}
-        error={error}
-        heading={`${subject} could not load`}
-        // The failure is a request that failed rather than saved state that broke a render, so
-        // wiping this browser's storage would cost the reader their theme, their sidebar width and
-        // every cached response for nothing
-        preserveStoredData
-        serverUnreachable={!serverAnswered}
-        size="inline"
-      />
+      {block}
     </div>
   )
 }

--- a/frontend/src/pages/accounts/AccountsPage.tsx
+++ b/frontend/src/pages/accounts/AccountsPage.tsx
@@ -29,7 +29,11 @@ export default function AccountsPage() {
   const [createModalKey, setCreateModalKey] = useState(0)
   const { user } = useAuth()
   const { data: accounts, isFetching, error } = useAccounts()
-  const { data: taxAdvantagedCategories } = useTaxAdvantagedCategories()
+  const {
+    data: taxAdvantagedCategories,
+    error: taxAdvantagedCategoriesError,
+    isError: taxAdvantagedCategoriesFailed,
+  } = useTaxAdvantagedCategories()
 
   const allRows = useMemo(() => accounts ?? [], [accounts])
 
@@ -84,7 +88,14 @@ export default function AccountsPage() {
 
         <div>
           <MetricsBand metrics={accountMetrics} displayCurrency={displayCurrency} />
-          <TaxAdvantagedLimitsSection summaries={taxAdvantagedLimitSummaries} />
+          {/* The limits are built from the same accounts the statement above reports on, so a failed
+              accounts request already says so there and a second message here would report one
+              outage twice in two voices */}
+          <TaxAdvantagedLimitsSection
+            categoriesError={taxAdvantagedCategoriesError}
+            categoriesFailed={taxAdvantagedCategoriesFailed && !error}
+            summaries={taxAdvantagedLimitSummaries}
+          />
         </div>
       </div>
 

--- a/frontend/src/pages/accounts/components/create-account-modal/Modal.tsx
+++ b/frontend/src/pages/accounts/components/create-account-modal/Modal.tsx
@@ -1,6 +1,7 @@
 import { useState, useMemo, type FormEvent } from 'react';
 import { motion, AnimatePresence } from 'motion/react';
 import Dropdown from '@/components/dropdown/Dropdown';
+import LoadFailure from '@/components/errors/LoadFailure';
 import IconTooltip from '@/components/tooltips/IconTooltip';
 import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow';
 import CreateModalSectionFrame from '@/components/create-modal/SectionFrame';
@@ -62,7 +63,11 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
   const mutation = useCreateAccount();
   const { data: currencies = [] } = useCurrencies();
   const { data: institutions = [] } = useInstitutions();
-  const { data: taxAdvantagedCategories = [] } = useTaxAdvantagedCategories();
+  const {
+    data: taxAdvantagedCategories = [],
+    error: taxAdvantagedCategoriesError,
+    isError: taxAdvantagedCategoriesFailed,
+  } = useTaxAdvantagedCategories();
 
   const [form, setForm] = useState(() => buildInitialCreateAccountForm(user?.base_currency));
   const [fieldErrors, setFieldErrors] = useState<CreateAccountFieldErrors>({});
@@ -318,6 +323,15 @@ export default function CreateAccountModal({ open, onClose }: CreateAccountModal
                           searchable
                           searchPlaceholder="Search categories..."
                         />
+                        {/* Beside the drop-down rather than in place of the form, since the
+                            category is optional and the account can still be created without one */}
+                        {taxAdvantagedCategoriesFailed && (
+                          <LoadFailure
+                            className="pt-3"
+                            error={taxAdvantagedCategoriesError}
+                            subject="Tax-advantaged categories"
+                          />
+                        )}
                       </div>
                     ) : (
                       <div>

--- a/frontend/src/pages/accounts/components/tax-advantaged-limits/Section.tsx
+++ b/frontend/src/pages/accounts/components/tax-advantaged-limits/Section.tsx
@@ -1,43 +1,68 @@
+import LoadFailure from '@/components/errors/LoadFailure'
 import type { TaxAdvantagedLimitSummary } from '@/pages/accounts/types/accounts'
 import { hasTaxAdvantagedLimitTracking } from '@/pages/accounts/utils/taxAdvantagedLimits'
 import { TaxAdvantagedLimitMeterStack } from './LimitMeterStack'
 
 /**
  * Renders tax-advantaged limit summaries for linked active accounts
+ *
+ * @param categoriesError - The rejection the category request reported, shown where it failed
+ * @param categoriesFailed - Whether the category list failed, which leaves no summaries to build
+ * @param summaries - One entry per category an active account is linked to
  */
 export default function TaxAdvantagedLimitsSection({
+  categoriesError,
+  categoriesFailed,
   summaries,
 }: {
+  categoriesError: unknown
+  categoriesFailed: boolean
   summaries: TaxAdvantagedLimitSummary[]
 }) {
+  // Summaries cached from an earlier session survive a failed request, since the query cache is
+  // persisted, so the message sits above them rather than throwing readable limits away
+  if (categoriesFailed) {
+    return (
+      <section>
+        <LoadFailure error={categoriesError} subject="Contribution limits" />
+        {summaries.length > 0 && renderSummaries(summaries)}
+      </section>
+    )
+  }
+
   if (summaries.length === 0) return null
 
-  return (
-    <section>
-      <div className="grid gap-x-10 gap-y-0 min-[1100px]:grid-cols-2 min-[1500px]:grid-cols-3">
-        {summaries.map(({ plan, linkedAccountCount }) => {
-          return (
-            <div
-              key={plan.id}
-              className="min-w-0 py-3"
-              data-tooltip-bounds
-            >
-              <div className="mb-2 flex min-w-0 items-baseline justify-between gap-3">
-                <div className="flex min-w-0 items-baseline gap-2">
-                  <p className="truncate font-medium">{plan.name}</p>
-                  <p className="shrink-0 text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                    {plan.currency} · {linkedAccountCount} linked account{linkedAccountCount !== 1 ? 's' : ''}
-                  </p>
-                </div>
-              </div>
+  return <section>{renderSummaries(summaries)}</section>
+}
 
-              <div className="space-y-3">
-                {hasTaxAdvantagedLimitTracking(plan) && <TaxAdvantagedLimitMeterStack plan={plan} />}
+/**
+ * Lays the summaries out in the responsive grid both the loaded and the failed case share
+ */
+function renderSummaries(summaries: TaxAdvantagedLimitSummary[]) {
+  return (
+    <div className="grid gap-x-10 gap-y-0 min-[1100px]:grid-cols-2 min-[1500px]:grid-cols-3">
+      {summaries.map(({ plan, linkedAccountCount }) => {
+        return (
+          <div
+            key={plan.id}
+            className="min-w-0 py-3"
+            data-tooltip-bounds
+          >
+            <div className="mb-2 flex min-w-0 items-baseline justify-between gap-3">
+              <div className="flex min-w-0 items-baseline gap-2">
+                <p className="truncate font-medium">{plan.name}</p>
+                <p className="shrink-0 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                  {plan.currency} · {linkedAccountCount} linked account{linkedAccountCount !== 1 ? 's' : ''}
+                </p>
               </div>
             </div>
-          )
-        })}
-      </div>
-    </section>
+
+            <div className="space-y-3">
+              {hasTaxAdvantagedLimitTracking(plan) && <TaxAdvantagedLimitMeterStack plan={plan} />}
+            </div>
+          </div>
+        )
+      })}
+    </div>
   )
 }

--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -74,7 +74,11 @@ export default function EditAccountIdentityModal({
   const updateAccount = useUpdateAccount()
   const deleteAccount = useDeleteAccount({ minimumPendingMs: MIN_DELETE_SPINNER_MS })
   const { data: institutions = [] } = useInstitutions()
-  const { data: taxAdvantagedCategories = [] } = useTaxAdvantagedCategories()
+  const {
+    data: taxAdvantagedCategories = [],
+    error: taxAdvantagedCategoriesError,
+    isError: taxAdvantagedCategoriesFailed,
+  } = useTaxAdvantagedCategories()
   const [form, setForm] = useState<IdentityFormValues>(() => (
     createIdentityFormValues(account, currencies)
   ))
@@ -317,6 +321,8 @@ export default function EditAccountIdentityModal({
                   selectedCurrencySymbol={selectedCurrencySymbol}
                   creditLimitExponent={knownCreditLimitExponent ?? DEFAULT_MINOR_UNIT_EXPONENT}
                   taxAdvantagedCategoryOptions={taxAdvantagedCategoryOptions}
+                  taxAdvantagedCategoriesError={taxAdvantagedCategoriesError}
+                  taxAdvantagedCategoriesFailed={taxAdvantagedCategoriesFailed}
                   setField={setField}
                 />
               )}

--- a/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/sections/DetailsSection.tsx
@@ -1,5 +1,6 @@
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
 import Dropdown from '@/components/dropdown/Dropdown'
+import LoadFailure from '@/components/errors/LoadFailure'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { useMoneyInput } from '@/hooks/useMoneyInput'
 import {
@@ -29,6 +30,8 @@ type AccountDetailsSectionProps = {
   // Decimal places of the account's currency, used to settle the credit limit field on blur
   creditLimitExponent: number
   taxAdvantagedCategoryOptions: DropdownOption[]
+  taxAdvantagedCategoriesError: unknown
+  taxAdvantagedCategoriesFailed: boolean
   setField: SetIdentityFormField
 }
 
@@ -44,6 +47,8 @@ export function AccountDetailsSection({
   selectedCurrencySymbol,
   creditLimitExponent,
   taxAdvantagedCategoryOptions,
+  taxAdvantagedCategoriesError,
+  taxAdvantagedCategoriesFailed,
   setField,
 }: AccountDetailsSectionProps) {
   const isCreditLimitLocked = currencyState !== 'ready'
@@ -67,6 +72,15 @@ export function AccountDetailsSection({
             searchable
             searchPlaceholder="Search categories..."
           />
+          {/* Beside the drop-down rather than in place of the form, since the category is optional
+              and the rest of the account can still be edited without it */}
+          {taxAdvantagedCategoriesFailed && (
+            <LoadFailure
+              className="pt-3"
+              error={taxAdvantagedCategoriesError}
+              subject="Tax-advantaged categories"
+            />
+          )}
         </div>
       )}
 

--- a/frontend/src/pages/dashboard/components/WidgetLoadingBody.tsx
+++ b/frontend/src/pages/dashboard/components/WidgetLoadingBody.tsx
@@ -53,14 +53,28 @@ export function DashboardWidgetLoadingBody({
   // hold it and the rest of its row grows with it
   const containment = failed ? '' : 'min-h-0 overflow-hidden'
 
+  // With nothing else in the widget the box sits in the middle of the space rather than in the top
+  // corner of it. Its own wording stays left-aligned, so the width is capped: a block spanning the
+  // whole widget would start at the left edge and there would be nothing to centre
+  //
+  // Where a figure survived the failure the box stays full width above that figure, since moving it
+  // to the middle would put it over the figure it belongs above
+  const boxAlone = failed && !hasContent
+
   return (
     <div className={`relative ${containment} ${className}`}>
       <LoadingContent
         concealed={contentConcealed}
         shouldReduceMotion={shouldReduceMotion}
-        className={contentClassName}
+        className={boxAlone ? 'flex h-full flex-col items-center justify-center' : contentClassName}
       >
-        {failed && <LoadFailure error={error} subject={subject} />}
+        {failed && (
+          <LoadFailure
+            className={boxAlone ? 'w-full max-w-sm py-3' : 'py-3'}
+            error={error}
+            subject={subject}
+          />
+        )}
         {(!failed || hasContent) && children}
       </LoadingContent>
       <LoadingOverlay

--- a/frontend/src/pages/dashboard/components/WidgetLoadingBody.tsx
+++ b/frontend/src/pages/dashboard/components/WidgetLoadingBody.tsx
@@ -53,12 +53,9 @@ export function DashboardWidgetLoadingBody({
   // hold it and the rest of its row grows with it
   const containment = failed ? '' : 'min-h-0 overflow-hidden'
 
-  // With nothing else in the widget the box sits in the middle of the space rather than in the top
-  // corner of it. Its own wording stays left-aligned, so the width is capped: a block spanning the
-  // whole widget would start at the left edge and there would be nothing to centre
-  //
-  // Where a figure survived the failure the box stays full width above that figure, since moving it
-  // to the middle would put it over the figure it belongs above
+  // With nothing else in the widget the box sits in the middle of the space. Where a figure survived
+  // the failure it stays full width above that figure, since moving it to the middle would put it
+  // over the figure it belongs above
   const boxAlone = failed && !hasContent
 
   return (
@@ -66,15 +63,9 @@ export function DashboardWidgetLoadingBody({
       <LoadingContent
         concealed={contentConcealed}
         shouldReduceMotion={shouldReduceMotion}
-        className={boxAlone ? 'flex h-full flex-col items-center justify-center' : contentClassName}
+        className={boxAlone ? 'flex h-full flex-col' : contentClassName}
       >
-        {failed && (
-          <LoadFailure
-            className={boxAlone ? 'w-full max-w-sm py-3' : 'py-3'}
-            error={error}
-            subject={subject}
-          />
-        )}
+        {failed && <LoadFailure error={error} standalone={boxAlone} subject={subject} />}
         {(!failed || hasContent) && children}
       </LoadingContent>
       <LoadingOverlay

--- a/frontend/src/pages/dashboard/components/WidgetLoadingBody.tsx
+++ b/frontend/src/pages/dashboard/components/WidgetLoadingBody.tsx
@@ -1,34 +1,67 @@
 import type { ReactNode } from 'react'
+import LoadFailure from '@/components/errors/LoadFailure'
 import { LoadingContent, LoadingOverlay } from '@/components/loading/Transition'
 
 /**
- * Wraps dashboard widget content with the shared loading conceal and overlay behaviour
+ * Wraps dashboard widget content with the shared loading conceal and overlay behaviour, and says
+ * why the widget is missing where its request did not come back
+ *
+ * A widget holding nothing does not render blank: net worth renders $0.00, and runway, credit and
+ * spending comparison each render a zero of their own. So the box takes the place of the content
+ * where the widget has nothing to show, rather than sitting over a confident figure no request
+ * produced. Where something did load earlier the box sits above it and that reading stays, since the
+ * query cache is persisted and a failure that passes must not throw away a figure worth seeing
  */
 export function DashboardWidgetLoadingBody({
   children,
   contentConcealed,
+  error,
+  failed,
+  hasContent,
   loadingVisible,
   shouldReduceMotion,
   label,
+  subject,
   className = '',
   contentClassName = 'h-full',
 }: {
   children: ReactNode
   contentConcealed: boolean
+
+  /** The rejection the widget's request reported, or the first of them where the widget reads several */
+  error: unknown
+
+  failed: boolean
+
+  // Read from the snapshot the reveal is held against rather than from the live query, or the box
+  // and the content would disagree for as long as that hold lasts
+  /** Whether the widget has a figure or a list to show */
+  hasContent: boolean
+
   loadingVisible: boolean
   shouldReduceMotion: boolean
   label: string
+
+  /** What did not load, in the words the widget's own header uses for it */
+  subject: string
+
   className?: string
   contentClassName?: string
 }) {
+  // Clipping and the zero minimum height are what stop the content stretching a widget whose height
+  // is otherwise the one its row sets. Both come off while the box is up, so the widget grows to
+  // hold it and the rest of its row grows with it
+  const containment = failed ? '' : 'min-h-0 overflow-hidden'
+
   return (
-    <div className={`relative min-h-0 overflow-hidden ${className}`}>
+    <div className={`relative ${containment} ${className}`}>
       <LoadingContent
         concealed={contentConcealed}
         shouldReduceMotion={shouldReduceMotion}
         className={contentClassName}
       >
-        {children}
+        {failed && <LoadFailure error={error} subject={subject} />}
+        {(!failed || hasContent) && children}
       </LoadingContent>
       <LoadingOverlay
         visible={loadingVisible}

--- a/frontend/src/pages/dashboard/widgets/credit/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/credit/Widget.tsx
@@ -17,7 +17,12 @@ type CreditWidgetProps = {
  * Loads credit utilization data and composes the active mode, header, progress ring, and amount
  */
 export function CreditWidget({ displayCurrency }: CreditWidgetProps) {
-  const { data: incomingDashboardCredit, isFetching: dashboardCreditLoading } = useDashboardCredit()
+  const {
+    data: incomingDashboardCredit,
+    error: creditError,
+    isError: creditFailed,
+    isFetching: dashboardCreditLoading,
+  } = useDashboardCredit()
   const [creditMode, setCreditMode] = useState<CreditMode>('used')
   const loadingSnapshot = useMemo(
     () => ({ dashboardCredit: incomingDashboardCredit }),
@@ -38,7 +43,7 @@ export function CreditWidget({ displayCurrency }: CreditWidgetProps) {
   const creditSummary = getCreditUsageSummary(dashboardCredit, creditMode)
 
   return (
-    <div className="app-card h-[14rem] flex flex-col">
+    <div className="app-card min-h-[14rem] flex flex-col">
       <CreditHeader
         creditMode={creditMode}
         hasCredit={creditSummary.hasCredit}
@@ -50,6 +55,10 @@ export function CreditWidget({ displayCurrency }: CreditWidgetProps) {
 
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
+        error={creditError}
+        failed={creditFailed}
+        hasContent={dashboardCredit !== undefined}
+        subject="Credit usage"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}
         label="Loading credit"

--- a/frontend/src/pages/dashboard/widgets/net-worth/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/net-worth/Widget.tsx
@@ -17,7 +17,12 @@ type NetWorthWidgetProps = {
  */
 export function NetWorthWidget({ displayCurrency }: NetWorthWidgetProps) {
   const { user } = useAuth()
-  const { data: incomingDashboardNetWorth, isFetching: dashboardNetWorthLoading } = useDashboardNetWorth()
+  const {
+    data: incomingDashboardNetWorth,
+    error: netWorthError,
+    isError: netWorthFailed,
+    isFetching: dashboardNetWorthLoading,
+  } = useDashboardNetWorth()
   const loadingSnapshot = useMemo(
     () => ({ dashboardNetWorth: incomingDashboardNetWorth }),
     [incomingDashboardNetWorth],
@@ -42,10 +47,14 @@ export function NetWorthWidget({ displayCurrency }: NetWorthWidgetProps) {
   const fxStatus = dashboardNetWorth?.fx_status
 
   return (
-    <div className="app-card h-[14rem] pb-2 flex flex-col">
+    <div className="app-card min-h-[14rem] pb-2 flex flex-col">
       <NetWorthHeader fxStatus={fxStatus} />
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
+        error={netWorthError}
+        failed={netWorthFailed}
+        hasContent={dashboardNetWorth !== undefined}
+        subject="Net worth"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}
         label="Loading net worth"

--- a/frontend/src/pages/dashboard/widgets/recent-activity/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/recent-activity/Widget.tsx
@@ -11,8 +11,18 @@ import { getRecentActivityRows } from '@/pages/dashboard/utils/getRecentActivity
  * Loads recent transactions and category metadata for the dashboard activity list
  */
 export function RecentActivityWidget() {
-  const { data: incomingDashboardRecentActivity, isFetching: recentActivityLoading } = useDashboardRecentActivity()
-  const { data: incomingCategories, isFetching: categoriesLoading } = useCategories()
+  const {
+    data: incomingDashboardRecentActivity,
+    error: recentActivityError,
+    isError: recentActivityFailed,
+    isFetching: recentActivityLoading,
+  } = useDashboardRecentActivity()
+  const {
+    data: incomingCategories,
+    error: categoriesError,
+    isError: categoriesFailed,
+    isFetching: categoriesLoading,
+  } = useCategories()
   const loadingSnapshot = useMemo(
     () => ({
       categories: incomingCategories,
@@ -37,11 +47,15 @@ export function RecentActivityWidget() {
   )
 
   return (
-    <div className="app-card h-[410px] flex flex-col">
+    <div className="app-card min-h-[410px] flex flex-col">
       <RecentActivityHeader />
 
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
+        error={recentActivityError ?? categoriesError}
+        failed={recentActivityFailed || categoriesFailed}
+        hasContent={dashboardRecentActivity !== undefined}
+        subject="Recent activity"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}
         label="Loading recent activity"

--- a/frontend/src/pages/dashboard/widgets/runway/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/runway/Widget.tsx
@@ -24,9 +24,19 @@ type RunwayWidgetProps = {
 export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
   const runwayCardRef = useRef<HTMLDivElement>(null)
   const { currencies } = useMoneyFormatters()
-  const { data: incomingRunway, isFetching: runwayLoading } = useRunway()
-  const { data: incomingRunwayAccountIds, isFetching: runwayAccountsLoading } = useRunwayAccounts()
-  const { data: incomingAccounts, isFetching: accountsLoading } = useAccounts()
+  const { data: incomingRunway, error: runwayError, isError: runwayFailed, isFetching: runwayLoading } = useRunway()
+  const {
+    data: incomingRunwayAccountIds,
+    error: runwayAccountsError,
+    isError: runwayAccountsFailed,
+    isFetching: runwayAccountsLoading,
+  } = useRunwayAccounts()
+  const {
+    data: incomingAccounts,
+    error: accountsError,
+    isError: accountsFailed,
+    isFetching: accountsLoading,
+  } = useAccounts()
   const loadingSnapshot = useMemo(
     () => ({
       accounts: incomingAccounts,
@@ -57,13 +67,17 @@ export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
   )
 
   return (
-    <div ref={runwayCardRef} className="app-card relative h-[14rem] flex flex-col">
+    <div ref={runwayCardRef} className="app-card relative min-h-[14rem] flex flex-col">
       <RunwayHeader
         fxStatus={fxStatus}
         runwayStyle={runwayStyle}
       />
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
+        error={runwayError ?? runwayAccountsError ?? accountsError}
+        failed={runwayFailed || runwayAccountsFailed || accountsFailed}
+        hasContent={runway !== undefined}
+        subject="Runway"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}
         label="Loading runway"

--- a/frontend/src/pages/dashboard/widgets/savings-rate/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/savings-rate/Widget.tsx
@@ -12,7 +12,12 @@ import { getSavingsRateSeries } from '@/pages/dashboard/utils/getSavingsRateSeri
  */
 export function SavingsRateWidget() {
   const [capSavingsRateChart, setCapSavingsRateChart] = useState(false)
-  const { data: incomingDashboardSavingsRate, isFetching: dashboardSavingsRateLoading } = useDashboardSavingsRate()
+  const {
+    data: incomingDashboardSavingsRate,
+    error: savingsRateError,
+    isError: savingsRateFailed,
+    isFetching: dashboardSavingsRateLoading,
+  } = useDashboardSavingsRate()
   const loadingSnapshot = useMemo(
     () => ({ dashboardSavingsRate: incomingDashboardSavingsRate }),
     [incomingDashboardSavingsRate],
@@ -39,7 +44,7 @@ export function SavingsRateWidget() {
   )
 
   return (
-    <div className="app-card h-[14rem] pb-2 flex flex-col">
+    <div className="app-card min-h-[14rem] pb-2 flex flex-col">
       <SavingsRateHeader
         fxStatus={fxStatus}
         capSavingsRateChart={capSavingsRateChart}
@@ -47,6 +52,10 @@ export function SavingsRateWidget() {
       />
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
+        error={savingsRateError}
+        failed={savingsRateFailed}
+        hasContent={dashboardSavingsRate !== undefined}
+        subject="Savings rate"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}
         label="Loading savings rate"

--- a/frontend/src/pages/dashboard/widgets/spending-breakdown/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-breakdown/Widget.tsx
@@ -23,7 +23,12 @@ type SpendingBreakdownWidgetProps = {
 export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWidgetProps) {
   const [breakdownMode, setBreakdownMode] = useState<BreakdownMode>('spending')
   const [breakdownRange, setBreakdownRange] = useState<SpendingRange>('MTD')
-  const { data: incomingSpendingBreakdown, isFetching: spendingBreakdownLoading } = useSpendingBreakdown(breakdownRange)
+  const {
+    data: incomingSpendingBreakdown,
+    error: spendingBreakdownError,
+    isError: spendingBreakdownFailed,
+    isFetching: spendingBreakdownLoading,
+  } = useSpendingBreakdown(breakdownRange)
   const loadingSnapshot = useMemo(
     () => ({ spendingBreakdown: incomingSpendingBreakdown }),
     [incomingSpendingBreakdown],
@@ -51,7 +56,7 @@ export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWi
   } = breakdownSummary
 
   return (
-    <div className="app-card h-[470px] flex flex-col">
+    <div className="app-card min-h-[470px] flex flex-col">
       <SpendingBreakdownHeader
         breakdownMode={breakdownMode}
         breakdownRange={breakdownRange}
@@ -62,6 +67,10 @@ export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWi
 
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
+        error={spendingBreakdownError}
+        failed={spendingBreakdownFailed}
+        hasContent={spendingBreakdown !== undefined}
+        subject="Spending breakdown"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}
         label="Loading spending breakdown"

--- a/frontend/src/pages/dashboard/widgets/spending-comparison/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-comparison/Widget.tsx
@@ -20,7 +20,12 @@ type SpendingComparisonWidgetProps = {
  */
 export function SpendingComparisonWidget({ displayCurrency }: SpendingComparisonWidgetProps) {
   const [spendingRange, setSpendingRange] = useState<SpendingRange>('MTD')
-  const { data: incomingSpendingComparison, isFetching: spendingComparisonLoading } = useSpendingComparison(spendingRange)
+  const {
+    data: incomingSpendingComparison,
+    error: spendingComparisonError,
+    isError: spendingComparisonFailed,
+    isFetching: spendingComparisonLoading,
+  } = useSpendingComparison(spendingRange)
   const loadingSnapshot = useMemo(
     () => ({
       spendingComparison: incomingSpendingComparison,
@@ -56,7 +61,7 @@ export function SpendingComparisonWidget({ displayCurrency }: SpendingComparison
     [displaySpendingRange, spendingComparison],
   )
   return (
-    <div className="app-card h-[470px] flex flex-col">
+    <div className="app-card min-h-[470px] flex flex-col">
       <SpendingComparisonHeader
         spendingRange={spendingRange}
         fxStatus={fxStatus}
@@ -64,6 +69,10 @@ export function SpendingComparisonWidget({ displayCurrency }: SpendingComparison
       />
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
+        error={spendingComparisonError}
+        failed={spendingComparisonFailed}
+        hasContent={spendingComparison !== undefined}
+        subject="Spending comparison"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}
         label="Loading spending comparison"

--- a/frontend/src/pages/dashboard/widgets/top-budgets/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/top-budgets/Widget.tsx
@@ -11,7 +11,12 @@ import { getTopBudgets } from '@/pages/dashboard/utils/getTopBudgets'
  * Loads recent budget utilization data and composes the dashboard top budgets list
  */
 export function TopBudgetsWidget() {
-  const { data: incomingLatestBudgetUtilizations, isFetching: loading } = useLatestBudgetUtilizations()
+  const {
+    data: incomingLatestBudgetUtilizations,
+    error: budgetsError,
+    isError: budgetsFailed,
+    isFetching: loading,
+  } = useLatestBudgetUtilizations()
   const loadingSnapshot = useMemo(
     () => ({ latestBudgetUtilizations: incomingLatestBudgetUtilizations }),
     [incomingLatestBudgetUtilizations],
@@ -37,11 +42,15 @@ export function TopBudgetsWidget() {
   )
 
   return (
-    <div className="app-card h-[410px] flex flex-col">
+    <div className="app-card min-h-[410px] flex flex-col">
       <TopBudgetsHeader fxStatus={fxStatus} />
 
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
+        error={budgetsError}
+        failed={budgetsFailed}
+        hasContent={latestBudgetUtilizations !== undefined}
+        subject="Top budgets"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}
         label="Loading top budgets"

--- a/frontend/src/pages/insights/InsightsPage.tsx
+++ b/frontend/src/pages/insights/InsightsPage.tsx
@@ -102,6 +102,8 @@ export default function InsightsPage() {
         draftFrom={range.draftInputDates.from}
         draftTo={range.draftInputDates.to}
         savedRanges={savedRangesQuery.data ?? []}
+        savedRangesError={savedRangesQuery.error}
+        savedRangesFailed={savedRangesQuery.isError}
         onSelectPreset={range.selectPreset}
         onRevertSelection={range.revertSelection}
         onDraftAmountChange={range.setDraftAmount}

--- a/frontend/src/pages/insights/InsightsPage.tsx
+++ b/frontend/src/pages/insights/InsightsPage.tsx
@@ -122,6 +122,9 @@ export default function InsightsPage() {
             expenses={cardData.periodGlanceData.expenses}
             incomeExpenseFxStatus={queries.periodGlance.data?.income_expense_fx_status}
             displayCurrency={displayCurrency}
+            error={queries.periodGlance.error}
+            failed={queries.periodGlance.isError}
+            hasContent={queries.periodGlance.data !== undefined}
             loading={queries.periodGlance.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -138,6 +141,9 @@ export default function InsightsPage() {
             expenseCategoryCount={cardData.fundFlowData.expenseCategoryCount}
             fxStatus={queries.fundFlow.data?.fx_status}
             displayCurrency={displayCurrency}
+            error={queries.fundFlow.error}
+            failed={queries.fundFlow.isError}
+            hasContent={queries.fundFlow.data !== undefined}
             loading={queries.fundFlow.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -153,6 +159,9 @@ export default function InsightsPage() {
             fxStatus={queries.incomeExpenseBreakdown.data?.fx_status}
             displayCurrency={displayCurrency}
             animationKey={`${breakdownMode}-${range.cardTransitionKey}`}
+            error={queries.incomeExpenseBreakdown.error}
+            failed={queries.incomeExpenseBreakdown.isError}
+            hasContent={queries.incomeExpenseBreakdown.data !== undefined}
             loading={queries.incomeExpenseBreakdown.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -167,6 +176,9 @@ export default function InsightsPage() {
             series={cardData.netWorthCardData.series}
             fxStatus={queries.netWorth.data?.fx_status}
             displayCurrency={displayCurrency}
+            error={queries.netWorth.error}
+            failed={queries.netWorth.isError}
+            hasContent={queries.netWorth.data !== undefined}
             loading={queries.netWorth.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -178,6 +190,9 @@ export default function InsightsPage() {
             buckets={cardData.cashFlowBars.buckets}
             fxStatus={queries.cashFlow.data?.fx_status}
             displayCurrency={displayCurrency}
+            error={queries.cashFlow.error}
+            failed={queries.cashFlow.isError}
+            hasContent={queries.cashFlow.data !== undefined}
             loading={queries.cashFlow.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -190,6 +205,9 @@ export default function InsightsPage() {
             displayCurrency={displayCurrency}
             capRates={capSavingsRateChart}
             onCapRatesToggle={() => setCapSavingsRateChart((current) => !current)}
+            error={queries.savingsRateTrend.error}
+            failed={queries.savingsRateTrend.isError}
+            hasContent={queries.savingsRateTrend.data !== undefined}
             loading={queries.savingsRateTrend.isFetching}
             transitionKey="savings-rate-trend"
           />
@@ -201,6 +219,9 @@ export default function InsightsPage() {
               merchants={cardData.merchantDistributionMerchants}
               fxStatus={queries.merchants.data?.fx_status}
               currency={displayCurrency}
+              error={queries.merchants.error}
+              failed={queries.merchants.isError}
+              hasContent={queries.merchants.data !== undefined}
               loading={queries.merchants.isFetching}
               transitionKey={range.cardTransitionKey}
             />
@@ -211,6 +232,9 @@ export default function InsightsPage() {
               merchants={cardData.rankedMerchants}
               fxStatus={queries.merchants.data?.fx_status}
               currency={displayCurrency}
+              error={queries.merchants.error}
+              failed={queries.merchants.isError}
+              hasContent={queries.merchants.data !== undefined}
               loading={queries.merchants.isFetching}
               transitionKey={range.cardTransitionKey}
             />

--- a/frontend/src/pages/insights/components/FloatingRangeControl.tsx
+++ b/frontend/src/pages/insights/components/FloatingRangeControl.tsx
@@ -50,6 +50,12 @@ type InsightsFloatingRangeControlProps = {
   draftFrom: string
   draftTo: string
   savedRanges: SavedInsightsRange[]
+
+  /** The rejection the saved-ranges request reported */
+  savedRangesError: unknown
+
+  savedRangesFailed: boolean
+
   onSelectPreset: (value: InsightsRangePreset) => void
   onRevertSelection: () => void
   onDraftAmountChange: (value: number) => void
@@ -87,6 +93,8 @@ function GlassRangeSelector({
   draftFrom,
   draftTo,
   savedRanges,
+  savedRangesError,
+  savedRangesFailed,
   onSelectPreset,
   onRevertSelection,
   onDraftAmountChange,
@@ -293,6 +301,8 @@ function GlassRangeSelector({
                 </motion.button>
                 <SavedRanges
                   savedRanges={savedRanges}
+                  savedRangesError={savedRangesError}
+                  savedRangesFailed={savedRangesFailed}
                   onSaveCurrentRange={handleSaveCurrentRange}
                   onApplySavedRange={handleApplySavedRange}
                   onDeleteSavedRange={onDeleteSavedRange}

--- a/frontend/src/pages/insights/components/SavedRanges.tsx
+++ b/frontend/src/pages/insights/components/SavedRanges.tsx
@@ -2,6 +2,7 @@ import { useState, type FormEvent } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { BookmarkPlus, X } from 'lucide-react'
 import type { SavedInsightsRange } from '@/api/insights'
+import LoadFailure from '@/components/errors/LoadFailure'
 import { getRelativeRangeLabel } from '@/pages/insights/utils/range'
 
 const SAVED_RANGE_NAME_MAX_LENGTH = 64
@@ -11,6 +12,12 @@ const savedRangeSpring = { type: 'spring', stiffness: 420, damping: 34, mass: 0.
 
 type SavedRangesProps = {
   savedRanges: SavedInsightsRange[]
+
+  /** The rejection the saved-ranges request reported */
+  savedRangesError: unknown
+
+  savedRangesFailed: boolean
+
   onSaveCurrentRange: (name: string) => Promise<void>
   onApplySavedRange: (range: SavedInsightsRange) => void
   onDeleteSavedRange: (rangeId: string) => void
@@ -21,6 +28,8 @@ type SavedRangesProps = {
  */
 export function SavedRanges({
   savedRanges,
+  savedRangesError,
+  savedRangesFailed,
   onSaveCurrentRange,
   onApplySavedRange,
   onDeleteSavedRange,
@@ -83,6 +92,12 @@ export function SavedRanges({
           Save
         </button>
       </form>
+
+      {/* Ranges cached from an earlier session survive a failed request, since the query cache is
+          persisted, so the message sits above them rather than throwing a readable list away. The
+          name field stays usable either way, because saving a new range is a write the failed read
+          says nothing about */}
+      {savedRangesFailed && <LoadFailure className="pt-2" error={savedRangesError} subject="Saved ranges" />}
 
       <ul className={savedRanges.length > 0 ? 'mt-2' : ''}>
         <AnimatePresence initial={false}>

--- a/frontend/src/pages/insights/components/cash-flow-card/Card.tsx
+++ b/frontend/src/pages/insights/components/cash-flow-card/Card.tsx
@@ -112,7 +112,11 @@ export function CashFlowCard({
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           {displaySnapshot.failed && (
-            <LoadFailure error={displaySnapshot.error} subject="Cash flow" />
+            <LoadFailure
+              error={displaySnapshot.error}
+              standalone={!displaySnapshot.hasContent}
+              subject="Cash flow"
+            />
           )}
 
           {(!displaySnapshot.failed || displaySnapshot.hasContent) && (

--- a/frontend/src/pages/insights/components/cash-flow-card/Card.tsx
+++ b/frontend/src/pages/insights/components/cash-flow-card/Card.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { CalendarDays } from 'lucide-react'
 import type { FxStatus } from '@/api/shared/fx'
+import LoadFailure from '@/components/errors/LoadFailure'
 import {
   LoadingContent,
   LoadingOverlay,
@@ -20,6 +21,15 @@ type CashFlowCardProps = {
   buckets: CashFlowBarBucket[]
   fxStatus: FxStatus | undefined
   displayCurrency: string
+
+  /** The rejection this card's request reported */
+  error: unknown
+
+  failed: boolean
+
+  /** Whether the request has ever come back, since the net figure reads zero either way */
+  hasContent: boolean
+
   loading?: boolean
   transitionKey: string
 }
@@ -29,6 +39,9 @@ type CashFlowSnapshot = {
   buckets: CashFlowBarBucket[]
   fxStatus: FxStatus | undefined
   displayCurrency: string
+  error: unknown
+  failed: boolean
+  hasContent: boolean
 }
 
 const cashFlowCalculation = 'Bars group money moving in and out by period. Net equals inflow minus outflow. Transfers are included. Balance adjustments are excluded'
@@ -42,16 +55,24 @@ export function CashFlowCard({
   buckets,
   fxStatus,
   displayCurrency,
+  error,
+  failed,
+  hasContent,
   loading = false,
   transitionKey,
 }: CashFlowCardProps) {
   const { currencies } = useMoneyFormatters()
+  // The failure travels in the snapshot rather than beside it, so the box arrives with the reveal
+  // instead of growing the card while the spinner is still turning
   const incomingSnapshot = useMemo<CashFlowSnapshot>(() => ({
     granularity,
     buckets,
     fxStatus,
     displayCurrency,
-  }), [buckets, displayCurrency, fxStatus, granularity])
+    error,
+    failed,
+    hasContent,
+  }), [buckets, displayCurrency, error, failed, fxStatus, granularity, hasContent])
   const {
     displaySnapshot,
     contentConcealed,
@@ -90,43 +111,49 @@ export function CashFlowCard({
       />
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
-          <div className="flex h-[390px] flex-col">
-            <div className="mb-3">
-              <p className="app-label app-label-compact inline-flex items-center gap-2">
-                Net Cash Flow
-                <InsightCalculationTooltip
-                  label="Net Cash Flow"
-                  calculation={netCashFlowCalculation}
-                />
-              </p>
-              <p
-                className="mt-1 font-financial text-3xl leading-none tracking-tight"
-                style={{ color: getSignedAmountColor(totalNet) }}
-              >
-                {formatSignedCurrency(totalNet, displaySnapshot.displayCurrency, currencies)}
-              </p>
-            </div>
-            <CashFlowBarChart
-              buckets={displaySnapshot.buckets}
-              displayCurrency={displaySnapshot.displayCurrency}
-              emptyLabel="No cash flow in this range"
-            />
-            <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-[var(--app-border)] pt-3">
-              <p className="text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                {label} net cash flow. Hover a bar for inflow, outflow, and net
-              </p>
-              <div className="flex items-center gap-4 text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                <span className="flex items-center gap-1.5">
-                  <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-positive)' }} />
-                  Net positive
-                </span>
-                <span className="flex items-center gap-1.5">
-                  <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-negative)' }} />
-                  Net negative
-                </span>
+          {displaySnapshot.failed && (
+            <LoadFailure error={displaySnapshot.error} subject="Cash flow" />
+          )}
+
+          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+            <div className="flex h-[390px] flex-col">
+              <div className="mb-3">
+                <p className="app-label app-label-compact inline-flex items-center gap-2">
+                  Net Cash Flow
+                  <InsightCalculationTooltip
+                    label="Net Cash Flow"
+                    calculation={netCashFlowCalculation}
+                  />
+                </p>
+                <p
+                  className="mt-1 font-financial text-3xl leading-none tracking-tight"
+                  style={{ color: getSignedAmountColor(totalNet) }}
+                >
+                  {formatSignedCurrency(totalNet, displaySnapshot.displayCurrency, currencies)}
+                </p>
+              </div>
+              <CashFlowBarChart
+                buckets={displaySnapshot.buckets}
+                displayCurrency={displaySnapshot.displayCurrency}
+                emptyLabel="No cash flow in this range"
+              />
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-[var(--app-border)] pt-3">
+                <p className="text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                  {label} net cash flow. Hover a bar for inflow, outflow, and net
+                </p>
+                <div className="flex items-center gap-4 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-positive)' }} />
+                    Net positive
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-negative)' }} />
+                    Net negative
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
+          )}
         </LoadingContent>
 
         <LoadingOverlay

--- a/frontend/src/pages/insights/components/fund-flow-card/Card.tsx
+++ b/frontend/src/pages/insights/components/fund-flow-card/Card.tsx
@@ -2,6 +2,8 @@ import { useMemo, useState } from 'react'
 import { Network } from 'lucide-react'
 import type { InsightsFlowEntry } from '@/api/insights'
 import type { FxStatus } from '@/api/shared/fx'
+import LoadFailure from '@/components/errors/LoadFailure'
+import { LoadingContent } from '@/components/loading/Transition'
 import { useLoadingSnapshot } from '@/hooks/useLoadingSnapshot'
 import type { FundFlowData } from '@/pages/insights/types/fundFlow'
 import { getFundFlowChartHeight } from '@/pages/insights/utils/fundFlowChart'
@@ -25,6 +27,9 @@ type FundFlowSnapshot = {
   displayCurrency: string
   emptyLabel: string
   chartHeight: number
+  error: unknown
+  failed: boolean
+  hasContent: boolean
 }
 
 type FundFlowCardProps = {
@@ -37,6 +42,15 @@ type FundFlowCardProps = {
   expenseCategoryCount: number
   fxStatus: FxStatus | undefined
   displayCurrency: string
+
+  /** The rejection this card's request reported */
+  error: unknown
+
+  failed: boolean
+
+  /** Whether the request has ever come back, since an empty chart looks the same either way */
+  hasContent: boolean
+
   loading?: boolean
   transitionKey: string
 }
@@ -54,9 +68,14 @@ export function FundFlowCard({
   expenseCategoryCount,
   fxStatus,
   displayCurrency,
+  error,
+  failed,
+  hasContent,
   loading = false,
   transitionKey,
 }: FundFlowCardProps) {
+  // The failure travels in the snapshot rather than beside it, so the box arrives with the reveal
+  // instead of growing the card while the spinner is still turning
   const incomingSnapshot = useMemo<FundFlowSnapshot>(() => ({
     flowData,
     incomeSources,
@@ -69,13 +88,19 @@ export function FundFlowCard({
     displayCurrency,
     emptyLabel: loading ? 'Loading fund flow...' : 'No income or expenses in this range.',
     chartHeight: getFundFlowChartHeight(incomeSourceCount, expenseCategoryCount),
+    error,
+    failed,
+    hasContent,
   }), [
     displayCurrency,
+    error,
     expenseCategories,
     expenseCategoryCount,
     expenseInflows,
+    failed,
     fxStatus,
     flowData,
+    hasContent,
     incomeOutflows,
     incomeSourceCount,
     incomeSources,
@@ -123,39 +148,51 @@ export function FundFlowCard({
           </span>
         )}
       />
-      <div className="mb-3 grid items-start gap-3 min-[720px]:grid-cols-2">
-        <FundFlowCategoryList
-          title="Income Sources"
-          normalEntries={normalIncomeSources}
-          flippedEntries={displaySnapshot.expenseInflows}
-          flippedLabel="Expense Inflow"
-          normalLabel="Income Source"
-          calculation="Refunds reduce spending first before flipping into an income source. +x means categories that flipped"
+      {/* Its own concealment, since this card hands the loading transition down to the chart rather
+          than wrapping the whole body in one */}
+      {displaySnapshot.failed && (
+        <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
+          <LoadFailure error={displaySnapshot.error} subject="Fund flow" />
+        </LoadingContent>
+      )}
+
+      {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+        <>
+        <div className="mb-3 grid items-start gap-3 min-[720px]:grid-cols-2">
+          <FundFlowCategoryList
+            title="Income Sources"
+            normalEntries={normalIncomeSources}
+            flippedEntries={displaySnapshot.expenseInflows}
+            flippedLabel="Expense Inflow"
+            normalLabel="Income Source"
+            calculation="Refunds reduce spending first before flipping into an income source. +x means categories that flipped"
+            displayCurrency={displaySnapshot.displayCurrency}
+            open={incomeListOpen}
+            onToggle={() => setIncomeListOpen((current) => !current)}
+          />
+          <FundFlowCategoryList
+            title="Expense Categories"
+            normalEntries={normalExpenseCategories}
+            flippedEntries={displaySnapshot.incomeOutflows}
+            flippedLabel="Income Outflow"
+            normalLabel="Expense Category"
+            calculation="Reversals reduce income first before flipping into an expense category. +x means categories that flipped"
+            displayCurrency={displaySnapshot.displayCurrency}
+            open={expenseListOpen}
+            onToggle={() => setExpenseListOpen((current) => !current)}
+          />
+        </div>
+        <FundFlowChart
+          flowData={displaySnapshot.flowData}
+          chartHeight={displaySnapshot.chartHeight}
           displayCurrency={displaySnapshot.displayCurrency}
-          open={incomeListOpen}
-          onToggle={() => setIncomeListOpen((current) => !current)}
+          emptyLabel={displaySnapshot.emptyLabel}
+          contentConcealed={contentConcealed}
+          loadingVisible={loadingVisible}
+          shouldReduceMotion={shouldReduceMotion}
         />
-        <FundFlowCategoryList
-          title="Expense Categories"
-          normalEntries={normalExpenseCategories}
-          flippedEntries={displaySnapshot.incomeOutflows}
-          flippedLabel="Income Outflow"
-          normalLabel="Expense Category"
-          calculation="Reversals reduce income first before flipping into an expense category. +x means categories that flipped"
-          displayCurrency={displaySnapshot.displayCurrency}
-          open={expenseListOpen}
-          onToggle={() => setExpenseListOpen((current) => !current)}
-        />
-      </div>
-      <FundFlowChart
-        flowData={displaySnapshot.flowData}
-        chartHeight={displaySnapshot.chartHeight}
-        displayCurrency={displaySnapshot.displayCurrency}
-        emptyLabel={displaySnapshot.emptyLabel}
-        contentConcealed={contentConcealed}
-        loadingVisible={loadingVisible}
-        shouldReduceMotion={shouldReduceMotion}
-      />
+        </>
+      )}
     </section>
   )
 }

--- a/frontend/src/pages/insights/components/fund-flow-card/Card.tsx
+++ b/frontend/src/pages/insights/components/fund-flow-card/Card.tsx
@@ -152,7 +152,11 @@ export function FundFlowCard({
           than wrapping the whole body in one */}
       {displaySnapshot.failed && (
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
-          <LoadFailure error={displaySnapshot.error} subject="Fund flow" />
+          <LoadFailure
+            error={displaySnapshot.error}
+            standalone={!displaySnapshot.hasContent}
+            subject="Fund flow"
+          />
         </LoadingContent>
       )}
 

--- a/frontend/src/pages/insights/components/income-expense-breakdown-card/Card.tsx
+++ b/frontend/src/pages/insights/components/income-expense-breakdown-card/Card.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { PieChart as PieChartIcon, Repeat } from 'lucide-react'
 import type { InsightsBreakdownCategoryKind } from '@/api/insights'
 import type { FxStatus } from '@/api/shared/fx'
+import LoadFailure from '@/components/errors/LoadFailure'
 import {
   LoadingContent,
   LoadingOverlay,
@@ -32,6 +33,15 @@ type IncomeExpenseBreakdownCardProps = {
   fxStatus: FxStatus | undefined
   displayCurrency: string
   animationKey: string
+
+  /** The rejection this card's request reported */
+  error: unknown
+
+  failed: boolean
+
+  /** Whether the request has ever come back, since the chart reads empty either way */
+  hasContent: boolean
+
   loading?: boolean
   transitionKey: string
 }
@@ -44,6 +54,9 @@ type IncomeExpenseBreakdownSnapshot = {
   fxStatus: FxStatus | undefined
   displayCurrency: string
   animationKey: string
+  error: unknown
+  failed: boolean
+  hasContent: boolean
 }
 
 /**
@@ -58,9 +71,14 @@ export function IncomeExpenseBreakdownCard({
   fxStatus,
   displayCurrency,
   animationKey,
+  error,
+  failed,
+  hasContent,
   loading = false,
   transitionKey,
 }: IncomeExpenseBreakdownCardProps) {
+  // The failure travels in the snapshot rather than beside it, so the box arrives with the reveal
+  // instead of growing the card while the spinner is still turning
   const incomingSnapshot = useMemo<IncomeExpenseBreakdownSnapshot>(() => ({
     mode,
     entries,
@@ -69,7 +87,10 @@ export function IncomeExpenseBreakdownCard({
     fxStatus,
     displayCurrency,
     animationKey,
-  }), [animationKey, displayCurrency, entries, fxStatus, mode, total, trendSections])
+    error,
+    failed,
+    hasContent,
+  }), [animationKey, displayCurrency, entries, error, failed, fxStatus, hasContent, mode, total, trendSections])
   const {
     displaySnapshot,
     contentConcealed,
@@ -116,23 +137,32 @@ export function IncomeExpenseBreakdownCard({
       />
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
-          <div className="grid gap-6 min-[1350px]:grid-cols-[minmax(0,0.95fr)_minmax(360px,1.05fr)]">
-            <IncomeExpensePieChart
-              mode={displaySnapshot.mode}
-              entries={displaySnapshot.entries}
-              total={displaySnapshot.total}
-              displayCurrency={displaySnapshot.displayCurrency}
-              animationKey={displaySnapshot.animationKey}
-              shouldReduceMotion={shouldReduceMotion}
+          {displaySnapshot.failed && (
+            <LoadFailure
+              error={displaySnapshot.error}
+              subject={displaySnapshot.mode === 'expense' ? 'Expense breakdown' : 'Income breakdown'}
             />
-            <IncomeExpenseTrendSections
-              mode={displaySnapshot.mode}
-              sections={displaySnapshot.trendSections}
-              displayCurrency={displaySnapshot.displayCurrency}
-              animationKey={displaySnapshot.animationKey}
-              shouldReduceMotion={shouldReduceMotion}
-            />
-          </div>
+          )}
+
+          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+            <div className="grid gap-6 min-[1350px]:grid-cols-[minmax(0,0.95fr)_minmax(360px,1.05fr)]">
+              <IncomeExpensePieChart
+                mode={displaySnapshot.mode}
+                entries={displaySnapshot.entries}
+                total={displaySnapshot.total}
+                displayCurrency={displaySnapshot.displayCurrency}
+                animationKey={displaySnapshot.animationKey}
+                shouldReduceMotion={shouldReduceMotion}
+              />
+              <IncomeExpenseTrendSections
+                mode={displaySnapshot.mode}
+                sections={displaySnapshot.trendSections}
+                displayCurrency={displaySnapshot.displayCurrency}
+                animationKey={displaySnapshot.animationKey}
+                shouldReduceMotion={shouldReduceMotion}
+              />
+            </div>
+          )}
         </LoadingContent>
 
         <LoadingOverlay

--- a/frontend/src/pages/insights/components/income-expense-breakdown-card/Card.tsx
+++ b/frontend/src/pages/insights/components/income-expense-breakdown-card/Card.tsx
@@ -140,6 +140,7 @@ export function IncomeExpenseBreakdownCard({
           {displaySnapshot.failed && (
             <LoadFailure
               error={displaySnapshot.error}
+              standalone={!displaySnapshot.hasContent}
               subject={displaySnapshot.mode === 'expense' ? 'Expense breakdown' : 'Income breakdown'}
             />
           )}

--- a/frontend/src/pages/insights/components/merchant-distribution-card/Card.tsx
+++ b/frontend/src/pages/insights/components/merchant-distribution-card/Card.tsx
@@ -105,7 +105,11 @@ export function MerchantDistributionCard({
           shouldReduceMotion={shouldReduceMotion}
         >
           {displaySnapshot.failed && (
-            <LoadFailure error={displaySnapshot.error} subject="Spending distribution by merchant" />
+            <LoadFailure
+              error={displaySnapshot.error}
+              standalone={!displaySnapshot.hasContent}
+              subject="Spending distribution by merchant"
+            />
           )}
 
           {(!displaySnapshot.failed || displaySnapshot.hasContent) && (

--- a/frontend/src/pages/insights/components/merchant-distribution-card/Card.tsx
+++ b/frontend/src/pages/insights/components/merchant-distribution-card/Card.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { Store } from 'lucide-react'
 import type { FxStatus } from '@/api/shared/fx'
+import LoadFailure from '@/components/errors/LoadFailure'
 import {
   LoadingContent,
   LoadingOverlay,
@@ -18,6 +19,15 @@ type MerchantDistributionCardProps = {
   merchants: MerchantMarketMerchant[]
   fxStatus: FxStatus | undefined
   currency: string
+
+  /** The rejection this card's request reported */
+  error: unknown
+
+  failed: boolean
+
+  /** Whether the request has ever come back, since an empty map looks the same either way */
+  hasContent: boolean
+
   loading?: boolean
   transitionKey: string
 }
@@ -27,6 +37,9 @@ type MerchantDistributionSnapshot = {
   fxStatus: FxStatus | undefined
   currency: string
   emptyLabel: string
+  error: unknown
+  failed: boolean
+  hasContent: boolean
 }
 
 /**
@@ -36,15 +49,23 @@ export function MerchantDistributionCard({
   merchants,
   fxStatus,
   currency,
+  error,
+  failed,
+  hasContent,
   loading = false,
   transitionKey,
 }: MerchantDistributionCardProps) {
+  // The failure travels in the snapshot rather than beside it, so the box arrives with the reveal
+  // instead of replacing the map while the spinner is still turning
   const incomingSnapshot = useMemo<MerchantDistributionSnapshot>(() => ({
     merchants,
     fxStatus,
     currency,
     emptyLabel: loading ? 'Loading merchant spending...' : 'No merchant spending in this range',
-  }), [currency, fxStatus, loading, merchants])
+    error,
+    failed,
+    hasContent,
+  }), [currency, error, failed, fxStatus, hasContent, loading, merchants])
   const {
     displaySnapshot,
     contentConcealed,
@@ -83,17 +104,25 @@ export function MerchantDistributionCard({
           concealed={contentConcealed}
           shouldReduceMotion={shouldReduceMotion}
         >
-          {displaySnapshot.merchants.length > 0 ? (
-            <MerchantMarketMap merchants={displaySnapshot.merchants} currency={displaySnapshot.currency} />
-          ) : (
-            <div className="flex min-h-0 flex-1 items-center justify-center rounded-lg border border-dashed border-[var(--app-border)] text-sm" style={{ color: 'var(--app-text-muted)' }}>
-              {displaySnapshot.emptyLabel}
-            </div>
+          {displaySnapshot.failed && (
+            <LoadFailure error={displaySnapshot.error} subject="Spending distribution by merchant" />
           )}
-          <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs" style={{ color: 'var(--app-text-muted)' }}>
-            <span>Tile size shows total spend. Dots mark tiny tiles with details available on hover</span>
-            <MerchantDistributionLegend />
-          </div>
+
+          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+            <>
+              {displaySnapshot.merchants.length > 0 ? (
+                <MerchantMarketMap merchants={displaySnapshot.merchants} currency={displaySnapshot.currency} />
+              ) : (
+                <div className="flex min-h-0 flex-1 items-center justify-center rounded-lg border border-dashed border-[var(--app-border)] text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                  {displaySnapshot.emptyLabel}
+                </div>
+              )}
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-3 text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                <span>Tile size shows total spend. Dots mark tiny tiles with details available on hover</span>
+                <MerchantDistributionLegend />
+              </div>
+            </>
+          )}
         </LoadingContent>
 
         <LoadingOverlay

--- a/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
+++ b/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
@@ -90,8 +90,12 @@ export function MerchantRankingCard({
     transitionKey,
   })
 
+  // Nothing else is left in the card, so the body has to fill the card's height for the box to have
+  // a middle to sit in. The ranking's own layout is left alone, since it sizes to its rows
+  const boxAlone = displaySnapshot.failed && !displaySnapshot.hasContent
+
   return (
-    <div className="app-card min-[1300px]:h-[560px]">
+    <div className="app-card flex flex-col min-[1300px]:h-[560px]">
       <InsightSectionHeader
         icon={ListChecks}
         label={(
@@ -111,10 +115,18 @@ export function MerchantRankingCard({
           </span>
         )}
       />
-      <div className="relative overflow-hidden">
-        <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
+      <div className={`relative overflow-hidden ${boxAlone ? 'flex min-h-0 flex-1 flex-col' : ''}`}>
+        <LoadingContent
+          className={boxAlone ? 'flex min-h-0 flex-1 flex-col' : undefined}
+          concealed={contentConcealed}
+          shouldReduceMotion={shouldReduceMotion}
+        >
           {displaySnapshot.failed && (
-            <LoadFailure error={displaySnapshot.error} subject="Merchant ranking" />
+            <LoadFailure
+              error={displaySnapshot.error}
+              standalone={!displaySnapshot.hasContent}
+              subject="Merchant ranking"
+            />
           )}
 
           {(!displaySnapshot.failed || displaySnapshot.hasContent) && (

--- a/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
+++ b/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { ListChecks } from 'lucide-react'
 import type { FxStatus } from '@/api/shared/fx'
+import LoadFailure from '@/components/errors/LoadFailure'
 import {
   LoadingContent,
   LoadingOverlay,
@@ -17,6 +18,15 @@ type MerchantRankingCardProps = {
   merchants: MerchantRankingRow[]
   fxStatus: FxStatus | undefined
   currency: string
+
+  /** The rejection this card's request reported */
+  error: unknown
+
+  failed: boolean
+
+  /** Whether the request has ever come back, since an empty ranking looks the same either way */
+  hasContent: boolean
+
   loading?: boolean
   transitionKey: string
 }
@@ -26,6 +36,9 @@ type MerchantRankingSnapshot = {
   fxStatus: FxStatus | undefined
   currency: string
   emptyLabel: string
+  error: unknown
+  failed: boolean
+  hasContent: boolean
 }
 
 function getChangeColor(changePct: number | null) {
@@ -48,16 +61,24 @@ export function MerchantRankingCard({
   merchants,
   fxStatus,
   currency,
+  error,
+  failed,
+  hasContent,
   loading = false,
   transitionKey,
 }: MerchantRankingCardProps) {
   const { formatCurrency } = useMoneyFormatters()
+  // The failure travels in the snapshot rather than beside it, so the box arrives with the reveal
+  // instead of replacing the list while the spinner is still turning
   const incomingSnapshot = useMemo<MerchantRankingSnapshot>(() => ({
     merchants,
     fxStatus,
     currency,
     emptyLabel: loading ? 'Loading merchant ranking...' : 'No merchant spending in this range',
-  }), [currency, fxStatus, loading, merchants])
+    error,
+    failed,
+    hasContent,
+  }), [currency, error, failed, fxStatus, hasContent, loading, merchants])
   const {
     displaySnapshot,
     contentConcealed,
@@ -92,42 +113,48 @@ export function MerchantRankingCard({
       />
       <div className="relative overflow-hidden">
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
-          {displaySnapshot.merchants.length > 0 ? (
-            <div className="space-y-3">
-              {displaySnapshot.merchants.map((merchant, index) => (
-                <div key={merchant.id} className="flex items-center gap-3">
-                  <span
-                    className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold"
-                    style={{ background: 'var(--app-accent-soft)', color: 'var(--app-accent)' }}
-                  >
-                    {index + 1}
-                  </span>
-                  <div className="min-w-0 flex-1">
-                    <p className="truncate text-sm font-semibold">
-                      {merchant.name}
-                    </p>
-                    <p className="text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                      {merchant.transactionCount} transactions | avg {formatCurrency(merchant.averageAmount, displaySnapshot.currency)}
-                    </p>
-                  </div>
-                  <div className="text-right">
-                    <p className="font-financial text-sm">
-                      {formatCurrency(merchant.totalAmount, displaySnapshot.currency)}
-                    </p>
-                    <p
-                      className="font-financial text-xs"
-                      style={{ color: getChangeColor(merchant.changePct) }}
+          {displaySnapshot.failed && (
+            <LoadFailure error={displaySnapshot.error} subject="Merchant ranking" />
+          )}
+
+          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+            displaySnapshot.merchants.length > 0 ? (
+              <div className="space-y-3">
+                {displaySnapshot.merchants.map((merchant, index) => (
+                  <div key={merchant.id} className="flex items-center gap-3">
+                    <span
+                      className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-bold"
+                      style={{ background: 'var(--app-accent-soft)', color: 'var(--app-accent)' }}
                     >
-                      {getChangeLabel(merchant.changePct)}
-                    </p>
+                      {index + 1}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-semibold">
+                        {merchant.name}
+                      </p>
+                      <p className="text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                        {merchant.transactionCount} transactions | avg {formatCurrency(merchant.averageAmount, displaySnapshot.currency)}
+                      </p>
+                    </div>
+                    <div className="text-right">
+                      <p className="font-financial text-sm">
+                        {formatCurrency(merchant.totalAmount, displaySnapshot.currency)}
+                      </p>
+                      <p
+                        className="font-financial text-xs"
+                        style={{ color: getChangeColor(merchant.changePct) }}
+                      >
+                        {getChangeLabel(merchant.changePct)}
+                      </p>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <div className="flex min-h-24 items-center justify-center rounded-lg border border-dashed border-[var(--app-border)] text-sm" style={{ color: 'var(--app-text-muted)' }}>
-              {displaySnapshot.emptyLabel}
-            </div>
+                ))}
+              </div>
+            ) : (
+              <div className="flex min-h-24 items-center justify-center rounded-lg border border-dashed border-[var(--app-border)] text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                {displaySnapshot.emptyLabel}
+              </div>
+            )
           )}
         </LoadingContent>
 

--- a/frontend/src/pages/insights/components/net-worth-card/Card.tsx
+++ b/frontend/src/pages/insights/components/net-worth-card/Card.tsx
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { ArrowLeftRight, Minus, TrendingDown, TrendingUp, Wallet } from 'lucide-react'
 import type { FxStatus } from '@/api/shared/fx'
+import LoadFailure from '@/components/errors/LoadFailure'
 import {
   LoadingContent,
   LoadingOverlay,
@@ -32,6 +33,15 @@ type NetWorthCardProps = {
   series: NetWorthPoint[]
   fxStatus: FxStatus | undefined
   displayCurrency: string
+
+  /** The rejection this card's request reported */
+  error: unknown
+
+  failed: boolean
+
+  /** Whether the request has ever come back, since the ending figure reads zero either way */
+  hasContent: boolean
+
   loading?: boolean
   transitionKey: string
 }
@@ -44,6 +54,9 @@ type NetWorthSnapshot = {
   fxStatus: FxStatus | undefined
   displayCurrency: string
   emptyLabel: string
+  error: unknown
+  failed: boolean
+  hasContent: boolean
 }
 
 /**
@@ -66,10 +79,15 @@ export function NetWorthCard({
   series,
   fxStatus,
   displayCurrency,
+  error,
+  failed,
+  hasContent,
   loading = false,
   transitionKey,
 }: NetWorthCardProps) {
   const { currencies, formatCurrency } = useMoneyFormatters()
+  // The failure travels in the snapshot rather than beside it, so the box arrives with the reveal
+  // instead of growing the card while the spinner is still turning
   const incomingSnapshot = useMemo<NetWorthSnapshot>(() => ({
     mode,
     groups,
@@ -78,7 +96,10 @@ export function NetWorthCard({
     fxStatus,
     displayCurrency,
     emptyLabel: loading ? 'Loading net worth history...' : 'No net worth history in this range.',
-  }), [baseline, displayCurrency, fxStatus, groups, loading, mode, series])
+    error,
+    failed,
+    hasContent,
+  }), [baseline, displayCurrency, error, failed, fxStatus, groups, hasContent, loading, mode, series])
   const {
     displaySnapshot,
     contentConcealed,
@@ -138,38 +159,44 @@ export function NetWorthCard({
       />
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
-          <div className="flex h-[360px] flex-col">
-            <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
-              <div>
-                <p className="app-label app-label-compact inline-flex items-center gap-2">
-                  Ending Net Worth
-                  <InsightCalculationTooltip
-                    label="Ending Net Worth"
-                    calculation="Ending net worth value as of the last date in the chosen time period"
-                  />
-                </p>
-                <div className="mt-1 flex flex-wrap items-end gap-x-2 gap-y-1">
-                  <p className="font-financial text-3xl leading-none tracking-tight">
-                    {formatCurrency(latest?.total ?? 0, displaySnapshot.displayCurrency)}
+          {displaySnapshot.failed && (
+            <LoadFailure error={displaySnapshot.error} subject="Net worth" />
+          )}
+
+          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+            <div className="flex h-[360px] flex-col">
+              <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
+                <div>
+                  <p className="app-label app-label-compact inline-flex items-center gap-2">
+                    Ending Net Worth
+                    <InsightCalculationTooltip
+                      label="Ending Net Worth"
+                      calculation="Ending net worth value as of the last date in the chosen time period"
+                    />
                   </p>
-                  <div className="flex items-center gap-1.5 text-sm font-medium leading-none" style={{ color: netWorthTrendColor }}>
-                    <NetWorthTrendIcon size={14} aria-hidden />
-                    <span className="font-financial">{formatSignedNetWorthCurrency(latestChange, displaySnapshot.displayCurrency, currencies)}</span>
-                    <span style={{ color: 'var(--app-text-subtle)' }}>since start</span>
+                  <div className="mt-1 flex flex-wrap items-end gap-x-2 gap-y-1">
+                    <p className="font-financial text-3xl leading-none tracking-tight">
+                      {formatCurrency(latest?.total ?? 0, displaySnapshot.displayCurrency)}
+                    </p>
+                    <div className="flex items-center gap-1.5 text-sm font-medium leading-none" style={{ color: netWorthTrendColor }}>
+                      <NetWorthTrendIcon size={14} aria-hidden />
+                      <span className="font-financial">{formatSignedNetWorthCurrency(latestChange, displaySnapshot.displayCurrency, currencies)}</span>
+                      <span style={{ color: 'var(--app-text-subtle)' }}>since start</span>
+                    </div>
                   </div>
                 </div>
               </div>
+              <NetWorthChart
+                mode={displaySnapshot.mode}
+                groups={displaySnapshot.groups}
+                chartItems={chartItems}
+                deltaSeries={deltaSeries}
+                displayCurrency={displaySnapshot.displayCurrency}
+                emptyLabel={displaySnapshot.emptyLabel}
+                shouldReduceMotion={shouldReduceMotion}
+              />
             </div>
-            <NetWorthChart
-              mode={displaySnapshot.mode}
-              groups={displaySnapshot.groups}
-              chartItems={chartItems}
-              deltaSeries={deltaSeries}
-              displayCurrency={displaySnapshot.displayCurrency}
-              emptyLabel={displaySnapshot.emptyLabel}
-              shouldReduceMotion={shouldReduceMotion}
-            />
-          </div>
+          )}
         </LoadingContent>
 
         <LoadingOverlay

--- a/frontend/src/pages/insights/components/net-worth-card/Card.tsx
+++ b/frontend/src/pages/insights/components/net-worth-card/Card.tsx
@@ -160,7 +160,11 @@ export function NetWorthCard({
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           {displaySnapshot.failed && (
-            <LoadFailure error={displaySnapshot.error} subject="Net worth" />
+            <LoadFailure
+              error={displaySnapshot.error}
+              standalone={!displaySnapshot.hasContent}
+              subject="Net worth"
+            />
           )}
 
           {(!displaySnapshot.failed || displaySnapshot.hasContent) && (

--- a/frontend/src/pages/insights/components/period-glance-card/Card.tsx
+++ b/frontend/src/pages/insights/components/period-glance-card/Card.tsx
@@ -94,7 +94,11 @@ export function PeriodGlanceCard({
       <div className="relative overflow-hidden" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           {displaySnapshot.failed && (
-            <LoadFailure error={displaySnapshot.error} subject="This period at a glance" />
+            <LoadFailure
+              error={displaySnapshot.error}
+              standalone={!displaySnapshot.hasContent}
+              subject="This period at a glance"
+            />
           )}
 
           {(!displaySnapshot.failed || displaySnapshot.hasContent) && (

--- a/frontend/src/pages/insights/components/period-glance-card/Card.tsx
+++ b/frontend/src/pages/insights/components/period-glance-card/Card.tsx
@@ -5,6 +5,7 @@ import type {
   PeriodGlancePrimaryMetric,
   PeriodGlanceSupportItem,
 } from '@/pages/insights/types/periodGlance'
+import LoadFailure from '@/components/errors/LoadFailure'
 import {
   LoadingContent,
   LoadingOverlay,
@@ -21,6 +22,9 @@ type PeriodGlanceSnapshot = {
   expenses: number
   incomeExpenseFxStatus: FxStatus | undefined
   displayCurrency: string
+  error: unknown
+  failed: boolean
+  hasContent: boolean
 }
 
 type PeriodGlanceCardProps = {
@@ -30,6 +34,15 @@ type PeriodGlanceCardProps = {
   expenses: number
   incomeExpenseFxStatus: FxStatus | undefined
   displayCurrency: string
+
+  /** The rejection this card's request reported */
+  error: unknown
+
+  failed: boolean
+
+  /** Whether the request has ever come back, since the metrics read zero either way */
+  hasContent: boolean
+
   loading?: boolean
   transitionKey: string
 }
@@ -44,9 +57,14 @@ export function PeriodGlanceCard({
   expenses,
   incomeExpenseFxStatus,
   displayCurrency,
+  error,
+  failed,
+  hasContent,
   loading = false,
   transitionKey,
 }: PeriodGlanceCardProps) {
+  // The failure travels in the snapshot rather than beside it, so the box arrives with the reveal
+  // instead of growing the card while the spinner is still turning
   const incomingSnapshot = useMemo<PeriodGlanceSnapshot>(() => ({
     primaryMetric,
     supportItems,
@@ -54,7 +72,10 @@ export function PeriodGlanceCard({
     expenses,
     incomeExpenseFxStatus,
     displayCurrency,
-  }), [displayCurrency, expenses, income, incomeExpenseFxStatus, primaryMetric, supportItems])
+    error,
+    failed,
+    hasContent,
+  }), [displayCurrency, error, expenses, failed, hasContent, income, incomeExpenseFxStatus, primaryMetric, supportItems])
   const {
     displaySnapshot,
     contentConcealed,
@@ -72,16 +93,22 @@ export function PeriodGlanceCard({
 
       <div className="relative overflow-hidden" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
-          <div className="grid gap-4 min-[1500px]:grid-cols-[minmax(0,40fr)_minmax(0,60fr)]">
-            <PeriodGlancePrimaryPanel
-              primaryMetric={displaySnapshot.primaryMetric}
-              income={displaySnapshot.income}
-              expenses={displaySnapshot.expenses}
-              incomeExpenseFxStatus={displaySnapshot.incomeExpenseFxStatus}
-              displayCurrency={displaySnapshot.displayCurrency}
-            />
-            <PeriodGlanceSupportGrid supportItems={displaySnapshot.supportItems} />
-          </div>
+          {displaySnapshot.failed && (
+            <LoadFailure error={displaySnapshot.error} subject="This period at a glance" />
+          )}
+
+          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+            <div className="grid gap-4 min-[1500px]:grid-cols-[minmax(0,40fr)_minmax(0,60fr)]">
+              <PeriodGlancePrimaryPanel
+                primaryMetric={displaySnapshot.primaryMetric}
+                income={displaySnapshot.income}
+                expenses={displaySnapshot.expenses}
+                incomeExpenseFxStatus={displaySnapshot.incomeExpenseFxStatus}
+                displayCurrency={displaySnapshot.displayCurrency}
+              />
+              <PeriodGlanceSupportGrid supportItems={displaySnapshot.supportItems} />
+            </div>
+          )}
         </LoadingContent>
 
         <LoadingOverlay

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { ArrowUpToLine, Repeat } from 'lucide-react'
 import type { FxStatus } from '@/api/shared/fx'
+import LoadFailure from '@/components/errors/LoadFailure'
 import {
   LoadingContent,
   LoadingOverlay,
@@ -23,6 +24,15 @@ type SavingsRateTrendCardProps = {
   displayCurrency: string
   capRates: boolean
   onCapRatesToggle: () => void
+
+  /** The rejection this card's request reported */
+  error: unknown
+
+  failed: boolean
+
+  /** Whether the request has ever come back, since the summary metrics read empty either way */
+  hasContent: boolean
+
   loading?: boolean
   transitionKey: string
 }
@@ -33,6 +43,9 @@ type SavingsRateTrendSnapshot = {
   displayCurrency: string
   capRates: boolean
   emptyLabel: string
+  error: unknown
+  failed: boolean
+  hasContent: boolean
 }
 
 const savingsRateCalculation = 'Monthly savings rate is income minus expenses, divided by income. Income and expense categories are netted first. Transfers are excluded'
@@ -52,16 +65,24 @@ export function SavingsRateTrendCard({
   displayCurrency,
   capRates,
   onCapRatesToggle,
+  error,
+  failed,
+  hasContent,
   loading = false,
   transitionKey,
 }: SavingsRateTrendCardProps) {
+  // The failure travels in the snapshot rather than beside it, so the box arrives with the reveal
+  // instead of growing the card while the spinner is still turning
   const incomingSnapshot = useMemo<SavingsRateTrendSnapshot>(() => ({
     series,
     fxStatus,
     displayCurrency,
     capRates,
     emptyLabel: loading ? 'Loading savings-rate history...' : 'No savings-rate history available',
-  }), [capRates, displayCurrency, fxStatus, loading, series])
+    error,
+    failed,
+    hasContent,
+  }), [capRates, displayCurrency, error, failed, fxStatus, hasContent, loading, series])
   const {
     displaySnapshot,
     contentConcealed,
@@ -114,118 +135,124 @@ export function SavingsRateTrendCard({
       />
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
-          <div className="flex flex-col min-[750px]:h-[430px]">
-            <div className="mb-4 grid gap-4 border-b border-[var(--app-border)] pb-4 min-[750px]:grid-cols-[minmax(0,1.15fr)_minmax(0,1.85fr)] min-[750px]:items-center min-[750px]:gap-6">
-              <div className="min-w-0">
-                <p className="app-label inline-flex items-center gap-2">
-                  Latest Savings Rate
-                  <InsightCalculationTooltip
-                    label="Latest Savings Rate"
-                    calculation={latestSavingsRateCalculation}
-                  />
-                </p>
-                <p className="mt-1 font-financial text-4xl leading-none tracking-tight">
-                  {formatSavingsRateValue(latestPoint?.rate ?? null)}
-                </p>
-                <p className="mt-2 text-sm leading-6" style={{ color: 'var(--app-text-muted)' }}>
-                  {latestPoint?.fullLabel ?? 'No recent month'}
-                </p>
+          {displaySnapshot.failed && (
+            <LoadFailure error={displaySnapshot.error} subject="Savings rate trend" />
+          )}
+
+          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+            <div className="flex flex-col min-[750px]:h-[430px]">
+              <div className="mb-4 grid gap-4 border-b border-[var(--app-border)] pb-4 min-[750px]:grid-cols-[minmax(0,1.15fr)_minmax(0,1.85fr)] min-[750px]:items-center min-[750px]:gap-6">
+                <div className="min-w-0">
+                  <p className="app-label inline-flex items-center gap-2">
+                    Latest Savings Rate
+                    <InsightCalculationTooltip
+                      label="Latest Savings Rate"
+                      calculation={latestSavingsRateCalculation}
+                    />
+                  </p>
+                  <p className="mt-1 font-financial text-4xl leading-none tracking-tight">
+                    {formatSavingsRateValue(latestPoint?.rate ?? null)}
+                  </p>
+                  <p className="mt-2 text-sm leading-6" style={{ color: 'var(--app-text-muted)' }}>
+                    {latestPoint?.fullLabel ?? 'No recent month'}
+                  </p>
+                </div>
+                <div className="grid min-w-0 gap-2 min-[750px]:grid-cols-3 min-[750px]:gap-4">
+                  <div className="min-w-0 rounded-md border border-[var(--app-border)] px-2.5 py-2 min-[750px]:px-3 min-[750px]:py-2.5">
+                    <p className={savingsRateStatLabelClass}>
+                      Average
+                      <InsightCalculationTooltip
+                        label="Average Savings Rate"
+                        calculation={averageSavingsRateCalculation}
+                      />
+                    </p>
+                    <div className="mt-1 flex items-baseline justify-between gap-3 min-[750px]:block">
+                      <p className="font-financial text-xl leading-none tracking-tight min-[750px]:text-2xl">
+                        {formatSavingsRateValue(averageRate)}
+                      </p>
+                      <p className={savingsRateStatCaptionClass} style={{ color: 'var(--app-text-muted)' }}>
+                        Completed months with income
+                      </p>
+                    </div>
+                  </div>
+                  <div className="min-w-0 rounded-md border border-[var(--app-border)] px-2.5 py-2 min-[750px]:px-3 min-[750px]:py-2.5">
+                    <p className={savingsRateStatLabelClass}>
+                      Best
+                      <InsightCalculationTooltip
+                        label="Best Savings Rate"
+                        calculation={bestSavingsRateCalculation}
+                      />
+                    </p>
+                    <div className="mt-1 flex items-baseline justify-between gap-3 min-[750px]:block">
+                      <p className="font-financial text-xl leading-none tracking-tight min-[750px]:text-2xl">
+                        {formatSavingsRateValue(bestPoint?.rate ?? null)}
+                      </p>
+                      <p className={savingsRateStatCaptionClass} style={{ color: 'var(--app-text-muted)' }}>
+                        {bestPoint?.fullLabel ?? 'N/A'}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="min-w-0 rounded-md border border-[var(--app-border)] px-2.5 py-2 min-[750px]:px-3 min-[750px]:py-2.5">
+                    <p className={savingsRateStatLabelClass}>
+                      Worst
+                      <InsightCalculationTooltip
+                        label="Worst Savings Rate"
+                        calculation={worstSavingsRateCalculation}
+                      />
+                    </p>
+                    <div className="mt-1 flex items-baseline justify-between gap-3 min-[750px]:block">
+                      <p className="font-financial text-xl leading-none tracking-tight min-[750px]:text-2xl">
+                        {formatSavingsRateValue(worstPoint?.rate ?? null)}
+                      </p>
+                      <p className={savingsRateStatCaptionClass} style={{ color: 'var(--app-text-muted)' }}>
+                        {worstPoint?.fullLabel ?? 'N/A'}
+                      </p>
+                    </div>
+                  </div>
+                </div>
               </div>
-              <div className="grid min-w-0 gap-2 min-[750px]:grid-cols-3 min-[750px]:gap-4">
-                <div className="min-w-0 rounded-md border border-[var(--app-border)] px-2.5 py-2 min-[750px]:px-3 min-[750px]:py-2.5">
-                  <p className={savingsRateStatLabelClass}>
-                    Average
-                    <InsightCalculationTooltip
-                      label="Average Savings Rate"
-                      calculation={averageSavingsRateCalculation}
-                    />
-                  </p>
-                  <div className="mt-1 flex items-baseline justify-between gap-3 min-[750px]:block">
-                    <p className="font-financial text-xl leading-none tracking-tight min-[750px]:text-2xl">
-                      {formatSavingsRateValue(averageRate)}
-                    </p>
-                    <p className={savingsRateStatCaptionClass} style={{ color: 'var(--app-text-muted)' }}>
-                      Completed months with income
-                    </p>
-                  </div>
-                </div>
-                <div className="min-w-0 rounded-md border border-[var(--app-border)] px-2.5 py-2 min-[750px]:px-3 min-[750px]:py-2.5">
-                  <p className={savingsRateStatLabelClass}>
-                    Best
-                    <InsightCalculationTooltip
-                      label="Best Savings Rate"
-                      calculation={bestSavingsRateCalculation}
-                    />
-                  </p>
-                  <div className="mt-1 flex items-baseline justify-between gap-3 min-[750px]:block">
-                    <p className="font-financial text-xl leading-none tracking-tight min-[750px]:text-2xl">
-                      {formatSavingsRateValue(bestPoint?.rate ?? null)}
-                    </p>
-                    <p className={savingsRateStatCaptionClass} style={{ color: 'var(--app-text-muted)' }}>
-                      {bestPoint?.fullLabel ?? 'N/A'}
-                    </p>
-                  </div>
-                </div>
-                <div className="min-w-0 rounded-md border border-[var(--app-border)] px-2.5 py-2 min-[750px]:px-3 min-[750px]:py-2.5">
-                  <p className={savingsRateStatLabelClass}>
-                    Worst
-                    <InsightCalculationTooltip
-                      label="Worst Savings Rate"
-                      calculation={worstSavingsRateCalculation}
-                    />
-                  </p>
-                  <div className="mt-1 flex items-baseline justify-between gap-3 min-[750px]:block">
-                    <p className="font-financial text-xl leading-none tracking-tight min-[750px]:text-2xl">
-                      {formatSavingsRateValue(worstPoint?.rate ?? null)}
-                    </p>
-                    <p className={savingsRateStatCaptionClass} style={{ color: 'var(--app-text-muted)' }}>
-                      {worstPoint?.fullLabel ?? 'N/A'}
-                    </p>
-                  </div>
+              <SavingsRateChart
+                series={displaySnapshot.series}
+                averageRate={averageRate}
+                displayCurrency={displaySnapshot.displayCurrency}
+                capRates={displaySnapshot.capRates}
+                emptyLabel={displaySnapshot.emptyLabel}
+              />
+              <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-[var(--app-border)] pt-3">
+                <p className="text-xs" style={{ color: 'var(--app-text-muted)' }}>
+                  <span>Latest 12 months, up to available data</span>
+                  {' '}
+                  <AnimatePresence initial={false}>
+                    {displaySnapshot.capRates && (
+                      <motion.span
+                        className="inline-block font-semibold"
+                        initial={shouldReduceMotion ? false : { opacity: 0, y: 4 }}
+                        animate={{ opacity: 1, y: 0 }}
+                        exit={shouldReduceMotion ? undefined : { opacity: 0, y: -4 }}
+                        transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
+                      >
+                        Chart scale is capped at 100%
+                      </motion.span>
+                    )}
+                  </AnimatePresence>
+                </p>
+                <div className="flex w-full items-center justify-center gap-4 text-xs min-[750px]:w-auto" style={{ color: 'var(--app-text-muted)' }}>
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-positive)' }} />
+                    20%+
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-accent)' }} />
+                    1-19%
+                  </span>
+                  <span className="flex items-center gap-1.5">
+                    <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-negative)' }} />
+                    0% or less
+                  </span>
                 </div>
               </div>
             </div>
-            <SavingsRateChart
-              series={displaySnapshot.series}
-              averageRate={averageRate}
-              displayCurrency={displaySnapshot.displayCurrency}
-              capRates={displaySnapshot.capRates}
-              emptyLabel={displaySnapshot.emptyLabel}
-            />
-            <div className="mt-3 flex flex-wrap items-center justify-between gap-3 border-t border-[var(--app-border)] pt-3">
-              <p className="text-xs" style={{ color: 'var(--app-text-muted)' }}>
-                <span>Latest 12 months, up to available data</span>
-                {' '}
-                <AnimatePresence initial={false}>
-                  {displaySnapshot.capRates && (
-                    <motion.span
-                      className="inline-block font-semibold"
-                      initial={shouldReduceMotion ? false : { opacity: 0, y: 4 }}
-                      animate={{ opacity: 1, y: 0 }}
-                      exit={shouldReduceMotion ? undefined : { opacity: 0, y: -4 }}
-                      transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.2, ease: [0.16, 1, 0.3, 1] }}
-                    >
-                      Chart scale is capped at 100%
-                    </motion.span>
-                  )}
-                </AnimatePresence>
-              </p>
-              <div className="flex w-full items-center justify-center gap-4 text-xs min-[750px]:w-auto" style={{ color: 'var(--app-text-muted)' }}>
-                <span className="flex items-center gap-1.5">
-                  <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-positive)' }} />
-                  20%+
-                </span>
-                <span className="flex items-center gap-1.5">
-                  <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-accent)' }} />
-                  1-19%
-                </span>
-                <span className="flex items-center gap-1.5">
-                  <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-negative)' }} />
-                  0% or less
-                </span>
-              </div>
-            </div>
-          </div>
+          )}
         </LoadingContent>
 
         <LoadingOverlay

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
@@ -136,7 +136,11 @@ export function SavingsRateTrendCard({
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           {displaySnapshot.failed && (
-            <LoadFailure error={displaySnapshot.error} subject="Savings rate trend" />
+            <LoadFailure
+              error={displaySnapshot.error}
+              standalone={!displaySnapshot.hasContent}
+              subject="Savings rate trend"
+            />
           )}
 
           {(!displaySnapshot.failed || displaySnapshot.hasContent) && (

--- a/frontend/src/pages/settings/components/category-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/category-settings-section/Section.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Plus } from 'lucide-react'
 import { ApiError } from '@/api/auth'
+import LoadFailure from '@/components/errors/LoadFailure'
 import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import {
   useCategories,
@@ -29,7 +30,7 @@ import { waitForMilliseconds } from '@/utils/timing'
  * transactions should move instead
  */
 export default function CategorySettingsSection() {
-  const { data: categories = [], isLoading } = useCategories()
+  const { data: categories = [], isLoading, isError, error } = useCategories()
   const deleteCategory = useDeleteCategory()
   const forgetCategory = useForgetCategory()
   const mergeCategory = useMergeCategory()
@@ -132,7 +133,12 @@ export default function CategorySettingsSection() {
             overlayClassName={SETTINGS_LIST_LOADING_OVERLAY_CLASS}
             animateLoadingHeight
           >
-            {categories.length === 0 ? (
+            {/* Categories cached from an earlier session survive a failed request, since the query
+                cache is persisted, so the message sits above them rather than throwing a readable
+                list away */}
+            {isError && <LoadFailure error={error} subject="Categories" />}
+
+            {isError && categories.length === 0 ? null : categories.length === 0 ? (
               <p className="py-3 text-center text-sm italic" style={{ color: 'var(--app-text-subtle)' }}>
                 No categories yet.
               </p>

--- a/frontend/src/pages/settings/components/merchant-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/merchant-settings-section/Section.tsx
@@ -155,6 +155,8 @@ export default function MerchantSettingsSection() {
                 deletingMerchantId={deletingMerchantId}
                 editingMerchantId={editingMerchantId}
                 hasMoreMerchants={shownMerchants.hasMore}
+                listError={merchantList.merchantListError}
+                listFailed={merchantList.merchantListFailed}
                 merchantListRef={merchantList.merchantListRef}
                 shouldScrollMerchants={shownMerchants.shouldScroll}
                 showFetchingMoreMerchants={merchantList.showFetchingMoreMerchants}

--- a/frontend/src/pages/settings/components/merchant-settings-section/hooks/useList.ts
+++ b/frontend/src/pages/settings/components/merchant-settings-section/hooks/useList.ts
@@ -20,9 +20,11 @@ import {
 export function useMerchantSettingsList(locallyDeletedMerchantIds: string[]) {
   const {
     activeSearch,
+    error,
     handleListMoreClick,
     handleListScroll,
     hasMore,
+    isError,
     listRef,
     search,
     setActiveSearch,
@@ -68,6 +70,8 @@ export function useMerchantSettingsList(locallyDeletedMerchantIds: string[]) {
     showInitialMerchantLoading: showInitialLoading,
     showMerchantListEnd: showListEnd,
     showMerchantListMoreIndicator: showListMoreIndicator,
+    merchantListError: error,
+    merchantListFailed: isError,
     merchantListRef: listRef,
     visibleMerchants,
   }

--- a/frontend/src/pages/settings/components/merchant-settings-section/list/List.tsx
+++ b/frontend/src/pages/settings/components/merchant-settings-section/list/List.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, useReducedMotion } from 'motion/react'
 import type { Category } from '@/api/categories'
 import type { Merchant } from '@/api/merchants'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
+import LoadFailure from '@/components/errors/LoadFailure'
 import ScrollableListMoreButton from '@/components/list-controls/MoreButton'
 import MerchantRow from '@/pages/settings/components/merchant-settings-section/list/Row'
 import MobileMerchantRow from '@/pages/settings/components/merchant-settings-section/list/MobileRow'
@@ -20,6 +21,8 @@ export default function MerchantSettingsList({
   deletingMerchantId,
   editingMerchantId,
   hasMoreMerchants,
+  listError,
+  listFailed,
   merchantListRef,
   shouldScrollMerchants,
   showFetchingMoreMerchants,
@@ -42,6 +45,8 @@ export default function MerchantSettingsList({
   deletingMerchantId: string | null
   editingMerchantId: string | null
   hasMoreMerchants: boolean
+  listError: unknown
+  listFailed: boolean
   merchantListRef: RefObject<HTMLDivElement | null>
   shouldScrollMerchants: boolean
   showFetchingMoreMerchants: boolean
@@ -58,9 +63,12 @@ export default function MerchantSettingsList({
   onListScroll: (event: UIEvent<HTMLDivElement>) => void
 }) {
   const shouldReduceMotion = useReducedMotion()
+  const failure = listFailed ? <LoadFailure error={listError} subject="Merchants" /> : null
 
+  // With no rows in hand nothing about the list is known, so the failure takes the place of the
+  // empty text. With rows cached from an earlier session it sits above them and they stay
   if (visibleMerchants.length === 0 && !showInitialMerchantLoading) {
-    return (
+    return failure ?? (
       <p className="py-3 text-center text-sm italic" style={{ color: 'var(--app-text-subtle)' }}>
         {activeSearch.trim() ? 'No merchants match your search.' : 'No merchants yet.'}
       </p>
@@ -68,86 +76,18 @@ export default function MerchantSettingsList({
   }
 
   return (
-    <div className="relative">
-      <div
-        ref={merchantListRef}
-        className={shouldScrollMerchants ? 'max-h-[35rem] min-w-0 overflow-x-auto overflow-y-auto pr-2' : 'min-w-0 overflow-x-auto'}
-        onScroll={shouldScrollMerchants ? onListScroll : undefined}
-      >
-        <div className="min-[750px]:hidden">
-          <AnimatePresence initial={false}>
-            {visibleMerchants.map((merchant, index) => (
-              <MobileMerchantRow
-                key={merchant.id}
-                categoryById={categoryById}
-                categoryOptions={categoryOptions}
-                confirmingDelete={confirmingDeleteMerchantId === merchant.id}
-                deleting={deletingMerchantId === merchant.id}
-                isEditing={editingMerchantId === merchant.id}
-                isLast={!showMerchantListEnd && !hasMoreMerchants && index === visibleMerchants.length - 1}
-                merchant={merchant}
-                shouldReduceMotion={shouldReduceMotion}
-                onDeleteCancel={onDeleteCancel}
-                onDeleteConfirm={onDeleteConfirm}
-                onDeleteRequest={onDeleteRequest}
-                onEdit={onEdit}
-                onEditCancel={onEditCancel}
-              />
-            ))}
-          </AnimatePresence>
-          {showMerchantListEnd && !showFetchingMoreMerchants && !showInitialMerchantLoading && (
-            <p
-              className="py-4 text-center text-sm italic"
-              style={{ color: 'var(--app-text-subtle)' }}
-            >
-              You've reached the end.
-            </p>
-          )}
-          {showFetchingMoreMerchants && visibleMerchants.length > 0 && (
-            <p
-              className="py-4 text-center text-sm italic"
-              style={{ color: 'var(--app-text-subtle)' }}
-            >
-              Fetching more
-            </p>
-          )}
-        </div>
-
-        <table className="hidden w-full table-auto text-left text-[0.9375rem] min-[750px]:table">
-          <colgroup>
-            <col style={{ width: '1%' }} />
-            <col />
-            <col style={{ width: '7rem' }} />
-          </colgroup>
-          <thead>
-            <tr style={{ color: 'var(--app-text-muted)', borderBottom: '1px solid var(--app-border)' }}>
-              <th
-                scope="col"
-                className={`app-label whitespace-nowrap py-3 pl-4 pr-6 ${shouldScrollMerchants ? 'sticky top-0 z-10' : ''}`}
-                style={{ background: 'var(--app-surface-soft)' }}
-              >
-                Merchant
-              </th>
-              <th
-                scope="col"
-                className={`app-label py-3 pr-4 ${shouldScrollMerchants ? 'sticky top-0 z-10' : ''}`}
-                style={{ background: 'var(--app-surface-soft)' }}
-              >
-                Default category
-              </th>
-              <th
-                scope="col"
-                className={`app-label py-3 pr-4 text-right ${shouldScrollMerchants ? 'sticky top-0 z-10' : ''}`}
-                style={{ background: 'var(--app-surface-soft)' }}
-              >
-                Actions
-              </th>
-            </tr>
-          </thead>
-          <tbody>
+    <>
+      {failure}
+      <div className="relative">
+        <div
+          ref={merchantListRef}
+          className={shouldScrollMerchants ? 'max-h-[35rem] min-w-0 overflow-x-auto overflow-y-auto pr-2' : 'min-w-0 overflow-x-auto'}
+          onScroll={shouldScrollMerchants ? onListScroll : undefined}
+        >
+          <div className="min-[750px]:hidden">
             <AnimatePresence initial={false}>
               {visibleMerchants.map((merchant, index) => (
-                <MerchantRow
+                <MobileMerchantRow
                   key={merchant.id}
                   categoryById={categoryById}
                   categoryOptions={categoryOptions}
@@ -166,37 +106,108 @@ export default function MerchantSettingsList({
               ))}
             </AnimatePresence>
             {showMerchantListEnd && !showFetchingMoreMerchants && !showInitialMerchantLoading && (
-              <tr>
-                <td colSpan={3}>
-                  <p
-                    className="py-4 text-center text-sm italic"
-                    style={{ color: 'var(--app-text-subtle)' }}
-                  >
-                    You've reached the end.
-                  </p>
-                </td>
-              </tr>
+              <p
+                className="py-4 text-center text-sm italic"
+                style={{ color: 'var(--app-text-subtle)' }}
+              >
+                You've reached the end.
+              </p>
             )}
             {showFetchingMoreMerchants && visibleMerchants.length > 0 && (
-              <tr>
-                <td colSpan={3}>
-                  <p
-                    className="py-4 text-center text-sm italic"
-                    style={{ color: 'var(--app-text-subtle)' }}
-                  >
-                    Fetching more
-                  </p>
-                </td>
-              </tr>
+              <p
+                className="py-4 text-center text-sm italic"
+                style={{ color: 'var(--app-text-subtle)' }}
+              >
+                Fetching more
+              </p>
             )}
-          </tbody>
-        </table>
+          </div>
+
+          <table className="hidden w-full table-auto text-left text-[0.9375rem] min-[750px]:table">
+            <colgroup>
+              <col style={{ width: '1%' }} />
+              <col />
+              <col style={{ width: '7rem' }} />
+            </colgroup>
+            <thead>
+              <tr style={{ color: 'var(--app-text-muted)', borderBottom: '1px solid var(--app-border)' }}>
+                <th
+                  scope="col"
+                  className={`app-label whitespace-nowrap py-3 pl-4 pr-6 ${shouldScrollMerchants ? 'sticky top-0 z-10' : ''}`}
+                  style={{ background: 'var(--app-surface-soft)' }}
+                >
+                  Merchant
+                </th>
+                <th
+                  scope="col"
+                  className={`app-label py-3 pr-4 ${shouldScrollMerchants ? 'sticky top-0 z-10' : ''}`}
+                  style={{ background: 'var(--app-surface-soft)' }}
+                >
+                  Default category
+                </th>
+                <th
+                  scope="col"
+                  className={`app-label py-3 pr-4 text-right ${shouldScrollMerchants ? 'sticky top-0 z-10' : ''}`}
+                  style={{ background: 'var(--app-surface-soft)' }}
+                >
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <AnimatePresence initial={false}>
+                {visibleMerchants.map((merchant, index) => (
+                  <MerchantRow
+                    key={merchant.id}
+                    categoryById={categoryById}
+                    categoryOptions={categoryOptions}
+                    confirmingDelete={confirmingDeleteMerchantId === merchant.id}
+                    deleting={deletingMerchantId === merchant.id}
+                    isEditing={editingMerchantId === merchant.id}
+                    isLast={!showMerchantListEnd && !hasMoreMerchants && index === visibleMerchants.length - 1}
+                    merchant={merchant}
+                    shouldReduceMotion={shouldReduceMotion}
+                    onDeleteCancel={onDeleteCancel}
+                    onDeleteConfirm={onDeleteConfirm}
+                    onDeleteRequest={onDeleteRequest}
+                    onEdit={onEdit}
+                    onEditCancel={onEditCancel}
+                  />
+                ))}
+              </AnimatePresence>
+              {showMerchantListEnd && !showFetchingMoreMerchants && !showInitialMerchantLoading && (
+                <tr>
+                  <td colSpan={3}>
+                    <p
+                      className="py-4 text-center text-sm italic"
+                      style={{ color: 'var(--app-text-subtle)' }}
+                    >
+                      You've reached the end.
+                    </p>
+                  </td>
+                </tr>
+              )}
+              {showFetchingMoreMerchants && visibleMerchants.length > 0 && (
+                <tr>
+                  <td colSpan={3}>
+                    <p
+                      className="py-4 text-center text-sm italic"
+                      style={{ color: 'var(--app-text-subtle)' }}
+                    >
+                      Fetching more
+                    </p>
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+        <ScrollableListMoreButton
+          show={showMerchantListMoreIndicator}
+          onClick={onListMoreClick}
+          ariaLabel={hasMoreMerchants ? 'Show more merchants' : 'Scroll merchants down'}
+        />
       </div>
-      <ScrollableListMoreButton
-        show={showMerchantListMoreIndicator}
-        onClick={onListMoreClick}
-        ariaLabel={hasMoreMerchants ? 'Show more merchants' : 'Scroll merchants down'}
-      />
-    </div>
+    </>
   )
 }

--- a/frontend/src/pages/settings/components/shared/hooks/usePaginatedSettingsList.ts
+++ b/frontend/src/pages/settings/components/shared/hooks/usePaginatedSettingsList.ts
@@ -16,6 +16,8 @@ const LOAD_MORE_CLICK_SCROLL_FRACTION = 0.45
 
 interface InfiniteListQueryResult<TItem> {
   data?: { pages: TItem[][] }
+  error: unknown
+  isError: boolean
   isLoading: boolean
   isFetchingNextPage: boolean
   hasNextPage?: boolean
@@ -225,9 +227,13 @@ export function usePaginatedSettingsList<TItem extends { id: string }>({
 
   return {
     activeSearch,
+    // Passed out rather than handled here, since the section around the list is what decides
+    // whether the failure replaces the rows or sits above them
+    error: listQuery.error,
     handleListMoreClick,
     handleListScroll,
     hasMore,
+    isError: listQuery.isError,
     listRef,
     search,
     setActiveSearch,

--- a/frontend/src/pages/settings/components/tag-settings-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tag-settings-section/Section.tsx
@@ -149,6 +149,8 @@ export default function TagSettingsSection() {
                 deletingTagId={deletingTagId}
                 editingTagId={editingTagId}
                 hasMoreTags={shownTags.hasMore}
+                listError={tagList.tagListError}
+                listFailed={tagList.tagListFailed}
                 showFetchingMoreTags={tagList.showFetchingMoreTags}
                 showInitialTagLoading={tagList.showInitialTagLoading}
                 showTagListEnd={shownTags.showListEnd}

--- a/frontend/src/pages/settings/components/tag-settings-section/hooks/useList.ts
+++ b/frontend/src/pages/settings/components/tag-settings-section/hooks/useList.ts
@@ -16,9 +16,11 @@ import {
 export function useTagSettingsList(locallyDeletedTagIds: string[]) {
   const {
     activeSearch,
+    error,
     handleListMoreClick,
     handleListScroll,
     hasMore,
+    isError,
     listRef,
     search,
     setActiveSearch,
@@ -54,6 +56,8 @@ export function useTagSettingsList(locallyDeletedTagIds: string[]) {
     showInitialTagLoading: showInitialLoading,
     showTagListEnd: showListEnd,
     showTagListMoreIndicator: showListMoreIndicator,
+    tagListError: error,
+    tagListFailed: isError,
     tagListRef: listRef,
     visibleTags: visibleItems,
   }

--- a/frontend/src/pages/settings/components/tag-settings-section/list/List.tsx
+++ b/frontend/src/pages/settings/components/tag-settings-section/list/List.tsx
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useRef, useState, type RefObject, type UIEvent } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import type { Tag } from '@/api/tags'
+import LoadFailure from '@/components/errors/LoadFailure'
 import ScrollableListMoreButton from '@/components/list-controls/MoreButton'
 import TagRow from '@/pages/settings/components/tag-settings-section/list/Row'
 import { TAG_LIST_HEIGHT_TRANSITION } from '@/pages/settings/components/tag-settings-section/constants'
@@ -15,6 +16,8 @@ export default function TagSettingsList({
   deletingTagId,
   editingTagId,
   hasMoreTags,
+  listError,
+  listFailed,
   showFetchingMoreTags,
   showInitialTagLoading,
   showTagListEnd,
@@ -35,6 +38,8 @@ export default function TagSettingsList({
   deletingTagId: string | null
   editingTagId: string | null
   hasMoreTags: boolean
+  listError: unknown
+  listFailed: boolean
   showFetchingMoreTags: boolean
   showInitialTagLoading: boolean
   showTagListEnd: boolean
@@ -77,10 +82,14 @@ export default function TagSettingsList({
     }
   }, [])
 
-  const content = visibleTags.length === 0 && !showInitialTagLoading ? (
-    <p className="py-3 text-center text-sm italic" style={{ color: 'var(--app-text-subtle)' }}>
-      {activeSearch.trim() ? 'No tags match your search.' : 'No tags yet.'}
-    </p>
+  // With no rows in hand nothing about the list is known, so the failure takes the place of the
+  // empty text. With rows cached from an earlier session it sits above them and they stay
+  const rows = visibleTags.length === 0 && !showInitialTagLoading ? (
+    listFailed ? null : (
+      <p className="py-3 text-center text-sm italic" style={{ color: 'var(--app-text-subtle)' }}>
+        {activeSearch.trim() ? 'No tags match your search.' : 'No tags yet.'}
+      </p>
+    )
   ) : (
     <div className="relative">
       <div
@@ -163,6 +172,13 @@ export default function TagSettingsList({
         ariaLabel={hasMoreTags ? 'Show more tags' : 'Scroll tags down'}
       />
     </div>
+  )
+
+  const content = (
+    <>
+      {listFailed && <LoadFailure error={listError} subject="Tags" />}
+      {rows}
+    </>
   )
 
   return (

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/Section.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { Plus } from 'lucide-react'
 import type { AccountsOverview } from '@/api/accounts'
-import { ApiError } from '@/api/auth'
+import LoadFailure from '@/components/errors/LoadFailure'
 import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import LoadingRegion from '@/components/loading/Region'
 import { useCurrencies } from '@/api/currency'
@@ -14,38 +14,6 @@ import { useCurrencyGuard } from '@/hooks/useCurrencyGuard'
 import TaxAdvantagedCategoriesTable from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/table/CategoriesTable'
 import TaxAdvantagedCategoryModal from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/modals/CategoryModal'
 import { useTaxAdvantagedCategoryList } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/hooks/useCategoryList'
-
-/**
- * Says why the category list is missing, quoting the API's own sentence where it sent one, so a
- * refusal that says which setting is at fault reaches the reader instead of an empty section
- *
- * Where the API sent no sentence, the offer to refresh is a button rather than an anchor, since it
- * acts on the page the reader is already on rather than taking them anywhere
- */
-function CategoriesLoadError({ detail }: { detail: string | null }) {
-  return (
-    <div className="py-3 text-center" role="alert">
-      <p className="text-sm font-semibold" style={{ color: 'var(--app-text)' }}>
-        Categories could not load
-      </p>
-      <p className="mt-1 text-sm leading-6" style={{ color: 'var(--app-text-subtle)' }}>
-        {detail ?? (
-          <>
-            <button
-              type="button"
-              className="underline underline-offset-2"
-              style={{ color: 'var(--app-accent)' }}
-              onClick={() => window.location.reload()}
-            >
-              Refresh the page
-            </button>
-            {' or try again later.'}
-          </>
-        )}
-      </p>
-    </div>
-  )
-}
 
 /**
  * Settings section for managing tax-advantaged categories, combining search, creation and a
@@ -62,9 +30,6 @@ export default function TaxAdvantagedCategoriesSection({
 }) {
   const { data: currencies = [] } = useCurrencies()
   const { data: plans = [], isLoading, isError, error } = useTaxAdvantagedCategories()
-  // Cached categories from an earlier session survive a failed request, since the query cache is
-  // persisted, so the message sits above them rather than throwing a readable list away
-  const listErrorDetail = error instanceof ApiError ? error.message : null
   const [openCategoryId, setOpenCategoryId] = useState<string | null>(null)
   // Held apart from the selection so the panel keeps its contents while it animates out
   const [isCategoryOpen, setIsCategoryOpen] = useState(false)
@@ -131,7 +96,10 @@ export default function TaxAdvantagedCategoriesSection({
             overlayClassName={SETTINGS_LIST_LOADING_OVERLAY_CLASS}
             animateLoadingHeight
           >
-            {isError && <CategoriesLoadError detail={listErrorDetail} />}
+            {/* Cached categories from an earlier session survive a failed request, since the query
+                cache is persisted, so the message sits above them rather than throwing a readable
+                list away */}
+            {isError && <LoadFailure error={error} subject="Tax-advantaged categories" />}
 
             {isError && plans.length === 0 ? null : plans.length === 0 ? (
               <p className="py-3 text-center italic text-sm" style={{ color: 'var(--app-text-subtle)' }}>

--- a/frontend/src/utils/errorReport.ts
+++ b/frontend/src/utils/errorReport.ts
@@ -1,3 +1,5 @@
+import { ApiError } from '@/api/auth';
+
 interface ErrorReportDetails {
   componentStack: string | null;
   error: unknown;
@@ -25,8 +27,17 @@ export function buildErrorReport({ componentStack, error, occurredAt, path, user
     `Time: ${occurredAt.toISOString()}`,
     `Page: ${path}`,
     `Error: ${description}`,
-    `Browser: ${userAgent}`,
   ];
+
+  // A failed request carries its status and the backend's own explanation as fields, and neither is
+  // reliably in the message: the client invents a sentence from the status only when the body had no
+  // explanation, so quoting one hides the other
+  if (error instanceof ApiError) {
+    lines.push(`Status: ${error.status}`);
+    if (error.detail) lines.push(`Server said: ${error.detail}`);
+  }
+
+  lines.push(`Browser: ${userAgent}`);
 
   if (error instanceof Error && error.stack) {
     lines.push('', 'Stack:', error.stack.trim());

--- a/frontend/tests/utils/errorReport.test.ts
+++ b/frontend/tests/utils/errorReport.test.ts
@@ -3,6 +3,7 @@
  * to place the error and nothing that depends on the page still being there
  */
 import { describe, expect, it } from 'vitest'
+import { ApiError } from '@/api/auth'
 import { buildErrorReport } from '@/utils/errorReport'
 
 const OCCURRED_AT = new Date('2026-07-28T12:34:56.000Z')
@@ -27,6 +28,36 @@ describe('buildErrorReport', () => {
     expect(report).toContain(`Browser: ${USER_AGENT}`)
     expect(report).toContain('Stack:\nTypeError: Cannot read properties of undefined\n    at Dashboard')
     expect(report).toContain('Components:\nat Dashboard\n    at Boundary')
+  })
+
+  it('carries the status and the backend sentence a refused request came with', () => {
+    const report = buildErrorReport({
+      componentStack: null,
+      error: new ApiError('Category is still applied to transactions', 409, {
+        detail: 'Category is still applied to transactions',
+      }),
+      occurredAt: OCCURRED_AT,
+      path: '/settings',
+      userAgent: USER_AGENT,
+    })
+
+    expect(report).toContain('Error: ApiError: Category is still applied to transactions')
+    expect(report).toContain('Status: 409')
+    expect(report).toContain('Server said: Category is still applied to transactions')
+  })
+
+  it('carries the status of a failed request the backend gave no sentence for', () => {
+    const report = buildErrorReport({
+      componentStack: null,
+      error: new ApiError('Request failed (500)', 500),
+      occurredAt: OCCURRED_AT,
+      path: '/',
+      userAgent: USER_AGENT,
+    })
+
+    expect(report).toContain('Error: ApiError: Request failed (500)')
+    expect(report).toContain('Status: 500')
+    expect(report).not.toContain('Server said:')
   })
 
   it('describes a thrown value that is not an error and leaves the stack out', () => {

--- a/frontend/tests/utils/lockoutWarning.test.ts
+++ b/frontend/tests/utils/lockoutWarning.test.ts
@@ -7,11 +7,11 @@ import { buildLockoutWarning, describeStepUpFailure, getAttemptsRemaining } from
 
 describe('getAttemptsRemaining', () => {
   it('returns the count from a step-up error that carries it', () => {
-    expect(getAttemptsRemaining(new ApiError('Invalid credentials', 401, 3))).toBe(3)
+    expect(getAttemptsRemaining(new ApiError('Invalid credentials', 401, { attemptsRemaining: 3 }))).toBe(3)
   })
 
   it('returns zero when the failure just tripped the lock', () => {
-    expect(getAttemptsRemaining(new ApiError('Invalid credentials', 401, 0))).toBe(0)
+    expect(getAttemptsRemaining(new ApiError('Invalid credentials', 401, { attemptsRemaining: 0 }))).toBe(0)
   })
 
   it('returns null for an error without the attempts signal', () => {


### PR DESCRIPTION
Added an error message box that shows why a request failed instead of rendering an empty state. Where data was cached, the box sits above those rows rather than replacing them.
