### PR TITLE
fix: remove layout animations from modals

### DIFF
--- a/frontend/src/components/dropdown/hooks/usePosition.ts
+++ b/frontend/src/components/dropdown/hooks/usePosition.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef, useState, type RefObject } from 'react'
 import {
   DEFAULT_DROPDOWN_BOX_POSITION,
   getDropdownBoxPosition,
+  isSameDropdownBoxPosition,
   type DropdownBoxDirection,
   type DropdownBoxPosition,
   type DropdownViewport,
@@ -74,7 +75,10 @@ export function useDropdownPosition({
     })
 
     heldDirection.current = { openAbove: next.openAbove, openLeftward: next.openLeftward }
-    setBoxPosition(next)
+
+    // Kept as it is where the measurement landed in the same place, so a frame that found nothing
+    // moved costs a measurement rather than a render of the whole control and its list
+    setBoxPosition((current) => isSameDropdownBoxPosition(current, next) ? current : next)
   }, [searchable, wrapperRef])
 
   useEffect(() => {
@@ -86,24 +90,19 @@ export function useDropdownPosition({
       return
     }
 
-    let frame = 0
-    const updateOnFrame = () => {
-      window.cancelAnimationFrame(frame)
-      frame = window.requestAnimationFrame(updateBoxPosition)
-    }
+    // Measured every frame the box is open rather than on scroll and resize, because those two
+    // events miss the case that moves the box furthest: a modal growing around it re-centres itself
+    // and slides the head, without the page scrolling or the window changing size. A box that opened
+    // upward is pinned by its lower edge and one that opened downward by its upper edge, so the two
+    // drift apart from their head in opposite directions, and neither corrects itself until the next
+    // scroll. The measurement is one getBoundingClientRect, and a frame that finds nothing moved
+    // re-renders nothing
+    let frame = window.requestAnimationFrame(function track() {
+      updateBoxPosition()
+      frame = window.requestAnimationFrame(track)
+    })
 
-    updateOnFrame()
-    window.addEventListener('resize', updateOnFrame)
-    window.addEventListener('scroll', updateOnFrame, true)
-    window.visualViewport?.addEventListener('resize', updateOnFrame)
-    window.visualViewport?.addEventListener('scroll', updateOnFrame)
-    return () => {
-      window.cancelAnimationFrame(frame)
-      window.removeEventListener('resize', updateOnFrame)
-      window.removeEventListener('scroll', updateOnFrame, true)
-      window.visualViewport?.removeEventListener('resize', updateOnFrame)
-      window.visualViewport?.removeEventListener('scroll', updateOnFrame)
-    }
+    return () => window.cancelAnimationFrame(frame)
   }, [placed, updateBoxPosition])
 
   return { boxPosition, updateBoxPosition }

--- a/frontend/src/components/dropdown/position.ts
+++ b/frontend/src/components/dropdown/position.ts
@@ -71,6 +71,30 @@ export interface DropdownBoxPosition {
   width: number
 }
 
+/**
+ * Whether two placements would put the box in exactly the same spot at exactly the same size
+ *
+ * The box is re-measured on every frame it is open, because the page under it can move without
+ * scrolling or resizing: a modal that grows re-centres itself, which slides every field in it. Most
+ * of those frames find nothing changed, and this is what lets the drop-down keep the placement
+ * object it already has rather than re-rendering the whole control sixty times a second.
+ */
+export function isSameDropdownBoxPosition(
+  a: DropdownBoxPosition,
+  b: DropdownBoxPosition,
+): boolean {
+  return a.bottom === b.bottom
+    && a.boxMaxHeight === b.boxMaxHeight
+    && a.left === b.left
+    && a.listMaxHeight === b.listMaxHeight
+    && a.openAbove === b.openAbove
+    && a.openLeftward === b.openLeftward
+    && a.openWidth === b.openWidth
+    && a.right === b.right
+    && a.top === b.top
+    && a.width === b.width
+}
+
 /** Which way the box is growing, held for as long as one opening lasts */
 export interface DropdownBoxDirection {
   openAbove: boolean

--- a/frontend/src/components/modal/Shell.tsx
+++ b/frontend/src/components/modal/Shell.tsx
@@ -7,10 +7,6 @@ import { useBodyScrollLock } from '@/hooks/useBodyScrollLock'
 
 const EASE = [0.25, 0.1, 0.25, 1] as const
 
-// Slightly quicker than the panel's own entrance, so a height change that happens while the modal is open
-// reads as the content settling rather than as the panel animating again
-const LAYOUT_TRANSITION = { duration: 0.22, ease: EASE } as const
-
 // A modal opened from the page and a modal opened from another modal. Both take their stacking level from
 // the named scale in constants/stackingLevels.ts, where the stacked one sits above every page-level modal
 // and above the full-screen filter sheet. It also settles a little faster, so the second modal never feels
@@ -50,8 +46,6 @@ interface ModalShellProps {
   closeDisabled?: boolean
   /** Runs once the exit animation has finished, for work that must wait until the modal is fully gone */
   onExitComplete?: () => void
-  /** Animates the panel's height as its content grows, for a form that reveals whole rows as it is filled in */
-  animateHeight?: boolean
   /** Keeps tooltips opened inside the panel within its edges, for one whose content would otherwise push them off */
   boundsTooltips?: boolean
   children: ReactNode
@@ -70,7 +64,6 @@ export function ModalShell({
   level = 'page',
   closeDisabled = false,
   onExitComplete,
-  animateHeight = false,
   boundsTooltips = false,
   children,
 }: ModalShellProps) {
@@ -187,11 +180,17 @@ export function ModalShell({
             data-tooltip-bounds={boundsTooltips ? true : undefined}
             className={`app-modal-panel ${covered ? 'app-modal-panel-covered' : ''} ${panelClassName}`}
             onClick={(event) => event.stopPropagation()}
-            layout={animateHeight}
+            // No layout animation, and nothing else may put a settled transform or a filter on this
+            // panel either. Motion animates a layout change by scaling the element, and a scaled or
+            // filtered box becomes what its `position: fixed` descendants measure themselves from,
+            // which throws the open drop-down box hundreds of pixels out of place and clips it to
+            // the panel for as long as the animation runs. The panel is sized by its content, so it
+            // follows anything inside it that animates its own height, which is how a form that
+            // reveals whole rows grows
             initial={appearance.panelOffset}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={appearance.panelOffset}
-            transition={animateHeight ? { ...appearance.panelTransition, layout: LAYOUT_TRANSITION } : appearance.panelTransition}
+            transition={appearance.panelTransition}
           >
             {children}
           </motion.div>

--- a/frontend/src/components/modal/TitledPanel.tsx
+++ b/frontend/src/components/modal/TitledPanel.tsx
@@ -53,8 +53,6 @@ interface ModalTitledPanelProps {
   closeDisabled?: boolean
   /** Runs once the exit animation has finished, for work that must wait until the modal is fully gone */
   onExitComplete?: () => void
-  /** Animates the panel's height as the form grows, for one that reveals whole rows as it is filled in */
-  animateHeight?: boolean
   footer: ReactNode
   children: ReactNode
 }
@@ -77,7 +75,6 @@ export function ModalTitledPanel({
   level = 'page',
   closeDisabled = false,
   onExitComplete,
-  animateHeight = false,
   footer,
   children,
 }: ModalTitledPanelProps) {
@@ -133,7 +130,6 @@ export function ModalTitledPanel({
       level={level}
       closeDisabled={closeDisabled}
       onExitComplete={onExitComplete}
-      animateHeight={animateHeight}
     >
       {RailIcon && railLabel && (
         <div className={chrome.railClassName} style={chrome.railStyle} aria-hidden>

--- a/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
+++ b/frontend/src/pages/accounts/detail/components/edit-identity/Modal.tsx
@@ -19,7 +19,6 @@ import {
   fromMinorUnits,
 } from '@/utils/moneyInput'
 import { waitForMilliseconds } from '@/utils/timing'
-import { EASE } from '@/pages/accounts/detail/constants/accountDetail'
 import {
   createIdentityFormValues,
   getIdentityFieldErrors,
@@ -283,16 +282,16 @@ export default function EditAccountIdentityModal({
         titleId={EDIT_ACCOUNT_IDENTITY_TITLE_ID}
         panelClassName="flex max-h-[84vh] w-full max-w-2xl overflow-hidden"
         level="stacked"
-        animateHeight
       >
         <EditModalSideRail />
 
-        <motion.form
-          layout
+        {/* No layout animation here, for the reason given beside the panel in components/modal/Shell.tsx.
+            The sections that appear and disappear animate their own height instead, and this form follows
+            them because it is sized by what it holds */}
+        <form
           onSubmit={handleSubmit}
           className="flex min-h-0 w-full flex-col"
           noValidate
-          transition={{ layout: { duration: 0.28, ease: EASE } }}
         >
           <EditModalHeader
             accountType={account.account_type}
@@ -379,7 +378,7 @@ export default function EditAccountIdentityModal({
             onCancel={requestClose}
             onStartDelete={handleStartDeleteAccount}
           />
-        </motion.form>
+        </form>
       </ModalShell>
       <InstitutionModal
         key={institutionModal.key}

--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -251,7 +251,6 @@ export default function CreateTransactionModal({
         headerStatus={readOnly ? 'Archived account' : undefined}
         RailIcon={ReceiptText}
         railLabel="Transaction"
-        animateHeight
         onClose={closeModal}
         onExitComplete={applyPendingDeletion}
         onSubmit={handleSubmit}

--- a/frontend/tests/components/dropdown/position.test.ts
+++ b/frontend/tests/components/dropdown/position.test.ts
@@ -4,7 +4,7 @@
  * clipped by its own box
  */
 import { describe, expect, it } from 'vitest'
-import { getDropdownBoxPosition } from '@/components/dropdown/position'
+import { getDropdownBoxPosition, isSameDropdownBoxPosition } from '@/components/dropdown/position'
 
 const viewport = {
   height: 600,
@@ -295,5 +295,92 @@ describe('drop-down box placement', () => {
 
     // Still 54px short of the far edge, so a grown box on a phone is nowhere near it
     expect(390 - (compact.left + compact.openWidth)).toBe(54)
+  })
+
+  describe('a box following its head while the page moves under it', () => {
+    // A modal that grows re-centres itself, which slides every field in it without the page
+    // scrolling. These pin that the placement actually changes when that happens, since the box is
+    // re-measured every frame precisely to catch it
+    const downward = { openAbove: false, openLeftward: false }
+    const upward = { openAbove: true, openLeftward: false }
+
+    it('moves the upper edge of a box that opened downward when its head rises', () => {
+      const before = getDropdownBoxPosition({
+        ...head,
+        held: downward,
+        anchorRect: { bottom: 140, left: 20, top: 100, width: 200 },
+        viewport,
+      })
+      const after = getDropdownBoxPosition({
+        ...head,
+        held: downward,
+        anchorRect: { bottom: 130, left: 20, top: 90, width: 200 },
+        viewport,
+      })
+
+      expect(before.top).toBe(100)
+      expect(after.top).toBe(90)
+      expect(isSameDropdownBoxPosition(before, after)).toBe(false)
+    })
+
+    it('moves the lower edge of a box that opened upward when its head rises', () => {
+      const before = getDropdownBoxPosition({
+        ...head,
+        held: upward,
+        anchorRect: { bottom: 140, left: 20, top: 100, width: 200 },
+        viewport,
+      })
+      const after = getDropdownBoxPosition({
+        ...head,
+        held: upward,
+        anchorRect: { bottom: 130, left: 20, top: 90, width: 200 },
+        viewport,
+      })
+
+      // Measured from the bottom of the page, so a head that rises by 10 puts this edge 10 further up
+      expect(before.bottom).toBe(460)
+      expect(after.bottom).toBe(470)
+      expect(isSameDropdownBoxPosition(before, after)).toBe(false)
+    })
+
+    it('reports a head that has not moved as the same placement', () => {
+      const anchorRect = { bottom: 140, left: 20, top: 100, width: 200 }
+      const first = getDropdownBoxPosition({ ...head, held: downward, anchorRect, viewport })
+      const second = getDropdownBoxPosition({ ...head, held: downward, anchorRect, viewport })
+
+      expect(first).not.toBe(second)
+      expect(isSameDropdownBoxPosition(first, second)).toBe(true)
+    })
+
+    // Every field, one at a time. A comparison left out of isSameDropdownBoxPosition would let the
+    // box keep a placement that has actually moved, and nothing else in the suite would notice
+    it('reports a difference in any single field', () => {
+      const base = getDropdownBoxPosition({
+        ...head,
+        held: downward,
+        anchorRect: { bottom: 140, left: 20, top: 100, width: 200 },
+        viewport,
+      })
+
+      const changes: Array<Partial<typeof base>> = [
+        { bottom: base.bottom + 1 },
+        { boxMaxHeight: base.boxMaxHeight + 1 },
+        { left: base.left + 1 },
+        { listMaxHeight: base.listMaxHeight + 1 },
+        { openAbove: !base.openAbove },
+        { openLeftward: !base.openLeftward },
+        { openWidth: base.openWidth + 1 },
+        { right: base.right + 1 },
+        { top: base.top + 1 },
+        { width: base.width + 1 },
+      ]
+
+      // One entry per field, so a field added to the placement without being compared shows up here
+      expect(changes).toHaveLength(Object.keys(base).length)
+
+      for (const change of changes) {
+        expect(isSameDropdownBoxPosition(base, { ...base, ...change })).toBe(false)
+      }
+    })
   })
 })


### PR DESCRIPTION
Removed layout animations that were moving drop-down boxes out of place from the modal shell and the panels built on it. Motion animates layout changes by scaling the element, and a scaled element becomes the containing block for `position: fixed` descendants, so the open box measured itself from the transformed panel instead of the viewport. The drop-down now re-measures its position on every frame while open to catch the case where the modal re-centres and slides the fields underneath without scrolling the page.
