### PR TITLE
Hold card heights when a request fails

### DIFF
--- a/frontend/src/components/errors/FailureBlock.tsx
+++ b/frontend/src/components/errors/FailureBlock.tsx
@@ -85,11 +85,12 @@ interface FailureBlockProps {
  * block, so the controls exist once. What differs is the heading the caller passes, how large the
  * block is drawn, and whether reloading keeps this browser's storage
  *
- * A caller whose container cannot grow asks for the compact wording instead. The usual sentence
- * runs to five lines in a dashboard widget, which would leave no room for the Reload button, and
- * the compact one drops the bug report link with it. That is asked for rather than taken from the
- * size, since every caller of the inline size asks for the same size while only the dashboard sits
- * somewhere with a height decided before the wording is known
+ * A caller whose container is too short for the usual sentence asks for the compact wording
+ * instead. That sentence runs to five lines in a dashboard widget, which would leave no room for
+ * the Reload button, and the compact one drops the bug report link with it. It is asked for rather
+ * than taken from the size, since every caller of the inline size asks for the same size while the
+ * space each of them has differs: a dashboard widget gives the box about 174px, while an insights
+ * card, which holds a height too, has 360px or more and takes the usual wording
  *
  * It returns a fragment rather than its own container, since the three callers each need a
  * different one: a full window, a centred card, or a strip inside a section that is already there

--- a/frontend/src/components/errors/FailureBlock.tsx
+++ b/frontend/src/components/errors/FailureBlock.tsx
@@ -44,6 +44,11 @@ const CONTROLS_SPACING_CLASS: Record<FailureBlockSize, string> = {
   inline: 'mt-4',
 };
 
+// Two lines is what the shortest widget on the dashboard has room for once its heading and its
+// Reload button are placed. A server message runs to whatever length the server chose, so without
+// this the button is pushed out of a card that cannot grow to follow it
+const COMPACT_MESSAGE_CAP_CLASS = 'line-clamp-2';
+
 interface FailureBlockProps {
   componentStack?: string | null;
 
@@ -52,6 +57,14 @@ interface FailureBlockProps {
 
   error: unknown;
   heading: ReactNode;
+
+  // Set by the container rather than taken from the size, because every caller of the inline size
+  // asks for the same size while only some of them sit somewhere that cannot grow
+  /**
+   * Draws the box for a container whose height is fixed before its contents are known: shorter
+   * wording, and a quoted server message cut off after two lines
+   */
+  compact?: boolean;
 
   // Keeps the reload from emptying this browser's storage. Set it where the failure is known to be a
   // request that failed rather than saved state that broke a render, since the wipe exists to clear
@@ -69,13 +82,20 @@ interface FailureBlockProps {
  * The heading, explanation and recovery controls shown wherever something did not load
  *
  * The crash screen and the smaller box a working page puts beside a failed list render the same
- * block, so the wording and the controls exist once. What differs is the heading the caller passes,
- * how large the block is drawn, and whether reloading keeps this browser's storage
+ * block, so the controls exist once. What differs is the heading the caller passes, how large the
+ * block is drawn, and whether reloading keeps this browser's storage
+ *
+ * A caller whose container cannot grow asks for the compact wording instead. The usual sentence
+ * runs to five lines in a dashboard widget, which would leave no room for the Reload button, and
+ * the compact one drops the bug report link with it. That is asked for rather than taken from the
+ * size, since every caller of the inline size asks for the same size while only the dashboard sits
+ * somewhere with a height decided before the wording is known
  *
  * It returns a fragment rather than its own container, since the three callers each need a
  * different one: a full window, a centred card, or a strip inside a section that is already there
  */
 export default function FailureBlock({
+  compact = false,
   componentStack = null,
   detail = null,
   error,
@@ -143,18 +163,21 @@ export default function FailureBlock({
       </div>
 
       <p
-        className={`${MESSAGE_SPACING_CLASS[size]} text-sm leading-relaxed`}
+        className={`${MESSAGE_SPACING_CLASS[size]} text-sm leading-relaxed ${compact && detail ? COMPACT_MESSAGE_CAP_CLASS : ''}`}
         style={{ color: 'var(--app-text-muted)' }}
       >
-        {detail ?? (serverUnreachable ? (
+        {detail ?? (compact ? (
+          serverUnreachable
+            ? <>The app can&apos;t reach the server right now.</>
+            : <>Something went wrong. Please try reloading the application.</>
+        ) : serverUnreachable ? (
           <>
-            The app can&apos;t reach the server right now. Your data is fine. Reload once your
-            connection is back.
+            The app can&apos;t reach the server right now. Reload once your connection is back.
           </>
         ) : (
           <>
-            The app ran into an issue while trying to respond to your request. Your data is fine,
-            and reloading usually fixes it. If it persists, please try again in a bit and submit a{' '}
+            Something went wrong while the app was responding to your request. Reloading usually
+            fixes it. If it keeps happening, please submit a{' '}
             <a
               href={BUG_REPORT_URL}
               target="_blank"
@@ -163,8 +186,7 @@ export default function FailureBlock({
               style={{ color: 'var(--app-accent)' }}
             >
               bug report
-            </a>{' '}
-            if it still doesn&apos;t resolve.
+            </a>.
           </>
         ))}
       </p>

--- a/frontend/src/components/errors/LoadFailure.tsx
+++ b/frontend/src/components/errors/LoadFailure.tsx
@@ -19,11 +19,19 @@ const STANDALONE_WIDTH_CLASS = 'w-full max-w-sm';
  */
 export default function LoadFailure({
   className = 'py-3',
+  compact = false,
   error,
   standalone = false,
   subject,
 }: {
   className?: string
+
+  /**
+   * Draws the box for a container whose height is fixed before its contents are known: shorter
+   * wording, and a quoted server message cut off after two lines
+   */
+  compact?: boolean
+
   error: unknown
   standalone?: boolean
   subject: string
@@ -35,6 +43,7 @@ export default function LoadFailure({
 
   const block = (
     <FailureBlock
+      compact={compact}
       detail={serverAnswered ? error.detail ?? null : null}
       error={error}
       heading={`${subject} could not load`}
@@ -49,10 +58,16 @@ export default function LoadFailure({
 
   // The wording stays left-aligned, so the width is capped and that capped block is what moves to
   // the middle. A block spanning the whole card would start at the left edge with nothing to centre
+  //
+  // The middle is found with an automatic margin rather than by centring the column, because a
+  // container that cannot grow can be shorter than the block. An automatic margin falls back to
+  // zero once there is no space left over, which leaves the block at the top and loses only its
+  // tail. Centring divides the shortfall between both ends instead, cutting the heading off the top
+  // and the Reload button off the bottom and leaving the middle of a sentence with no way to retry
   if (standalone) {
     return (
-      <div className="flex h-full w-full flex-1 flex-col items-center justify-center py-3" role="alert">
-        <div className={STANDALONE_WIDTH_CLASS}>{block}</div>
+      <div className="flex h-full w-full flex-1 flex-col items-center py-3" role="alert">
+        <div className={`my-auto ${STANDALONE_WIDTH_CLASS}`}>{block}</div>
       </div>
     )
   }

--- a/frontend/src/pages/dashboard/components/WidgetLoadingBody.tsx
+++ b/frontend/src/pages/dashboard/components/WidgetLoadingBody.tsx
@@ -8,16 +8,18 @@ import { LoadingContent, LoadingOverlay } from '@/components/loading/Transition'
  *
  * A widget holding nothing does not render blank: net worth renders $0.00, and runway, credit and
  * spending comparison each render a zero of their own. So the box takes the place of the content
- * where the widget has nothing to show, rather than sitting over a confident figure no request
- * produced. Where something did load earlier the box sits above it and that reading stays, since the
- * query cache is persisted and a failure that passes must not throw away a figure worth seeing
+ * rather than sitting over a confident figure no request produced. It takes the place of a figure
+ * that did load earlier too. Every widget holds a height its row sets and clips to it, and on the
+ * shortest row the box fills that height, so a figure kept underneath would render where nobody
+ * could see it. The two taller rows have room for both and drop the figure anyway, since one rule
+ * across the eight is what keeps a failed widget reading the same wherever it sits. The figure is
+ * still in the cache and comes back with the next request that succeeds
  */
 export function DashboardWidgetLoadingBody({
   children,
   contentConcealed,
   error,
   failed,
-  hasContent,
   loadingVisible,
   shouldReduceMotion,
   label,
@@ -33,11 +35,6 @@ export function DashboardWidgetLoadingBody({
 
   failed: boolean
 
-  // Read from the snapshot the reveal is held against rather than from the live query, or the box
-  // and the content would disagree for as long as that hold lasts
-  /** Whether the widget has a figure or a list to show */
-  hasContent: boolean
-
   loadingVisible: boolean
   shouldReduceMotion: boolean
   label: string
@@ -48,25 +45,16 @@ export function DashboardWidgetLoadingBody({
   className?: string
   contentClassName?: string
 }) {
-  // Clipping and the zero minimum height are what stop the content stretching a widget whose height
-  // is otherwise the one its row sets. Both come off while the box is up, so the widget grows to
-  // hold it and the rest of its row grows with it
-  const containment = failed ? '' : 'min-h-0 overflow-hidden'
-
-  // With nothing else in the widget the box sits in the middle of the space. Where a figure survived
-  // the failure it stays full width above that figure, since moving it to the middle would put it
-  // over the figure it belongs above
-  const boxAlone = failed && !hasContent
-
   return (
-    <div className={`relative ${containment} ${className}`}>
+    <div className={`relative min-h-0 overflow-hidden ${className}`}>
       <LoadingContent
         concealed={contentConcealed}
         shouldReduceMotion={shouldReduceMotion}
-        className={boxAlone ? 'flex h-full flex-col' : contentClassName}
+        className={failed ? 'flex h-full flex-col' : contentClassName}
       >
-        {failed && <LoadFailure error={error} standalone={boxAlone} subject={subject} />}
-        {(!failed || hasContent) && children}
+        {failed ? (
+          <LoadFailure compact error={error} standalone subject={subject} />
+        ) : children}
       </LoadingContent>
       <LoadingOverlay
         visible={loadingVisible}

--- a/frontend/src/pages/dashboard/widgets/credit/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/credit/Widget.tsx
@@ -43,7 +43,7 @@ export function CreditWidget({ displayCurrency }: CreditWidgetProps) {
   const creditSummary = getCreditUsageSummary(dashboardCredit, creditMode)
 
   return (
-    <div className="app-card min-h-[14rem] flex flex-col">
+    <div className="app-card h-[15.5rem] flex flex-col">
       <CreditHeader
         creditMode={creditMode}
         hasCredit={creditSummary.hasCredit}
@@ -57,7 +57,6 @@ export function CreditWidget({ displayCurrency }: CreditWidgetProps) {
         contentConcealed={contentConcealed}
         error={creditError}
         failed={creditFailed}
-        hasContent={dashboardCredit !== undefined}
         subject="Credit usage"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}

--- a/frontend/src/pages/dashboard/widgets/net-worth/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/net-worth/Widget.tsx
@@ -47,13 +47,12 @@ export function NetWorthWidget({ displayCurrency }: NetWorthWidgetProps) {
   const fxStatus = dashboardNetWorth?.fx_status
 
   return (
-    <div className="app-card min-h-[14rem] pb-2 flex flex-col">
+    <div className="app-card h-[15.5rem] pb-2 flex flex-col">
       <NetWorthHeader fxStatus={fxStatus} />
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
         error={netWorthError}
         failed={netWorthFailed}
-        hasContent={dashboardNetWorth !== undefined}
         subject="Net worth"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}

--- a/frontend/src/pages/dashboard/widgets/recent-activity/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/recent-activity/Widget.tsx
@@ -47,14 +47,13 @@ export function RecentActivityWidget() {
   )
 
   return (
-    <div className="app-card min-h-[410px] flex flex-col">
+    <div className="app-card h-[410px] flex flex-col">
       <RecentActivityHeader />
 
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
         error={recentActivityError ?? categoriesError}
         failed={recentActivityFailed || categoriesFailed}
-        hasContent={dashboardRecentActivity !== undefined}
         subject="Recent activity"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}

--- a/frontend/src/pages/dashboard/widgets/runway/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/runway/Widget.tsx
@@ -67,7 +67,7 @@ export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
   )
 
   return (
-    <div ref={runwayCardRef} className="app-card relative min-h-[14rem] flex flex-col">
+    <div ref={runwayCardRef} className="app-card relative h-[15.5rem] flex flex-col">
       <RunwayHeader
         fxStatus={fxStatus}
         runwayStyle={runwayStyle}
@@ -76,7 +76,6 @@ export function RunwayWidget({ displayCurrency }: RunwayWidgetProps) {
         contentConcealed={contentConcealed}
         error={runwayError ?? runwayAccountsError ?? accountsError}
         failed={runwayFailed || runwayAccountsFailed || accountsFailed}
-        hasContent={runway !== undefined}
         subject="Runway"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}

--- a/frontend/src/pages/dashboard/widgets/savings-rate/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/savings-rate/Widget.tsx
@@ -44,7 +44,7 @@ export function SavingsRateWidget() {
   )
 
   return (
-    <div className="app-card min-h-[14rem] pb-2 flex flex-col">
+    <div className="app-card h-[15.5rem] pb-2 flex flex-col">
       <SavingsRateHeader
         fxStatus={fxStatus}
         capSavingsRateChart={capSavingsRateChart}
@@ -54,7 +54,6 @@ export function SavingsRateWidget() {
         contentConcealed={contentConcealed}
         error={savingsRateError}
         failed={savingsRateFailed}
-        hasContent={dashboardSavingsRate !== undefined}
         subject="Savings rate"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}

--- a/frontend/src/pages/dashboard/widgets/spending-breakdown/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-breakdown/Widget.tsx
@@ -56,7 +56,7 @@ export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWi
   } = breakdownSummary
 
   return (
-    <div className="app-card min-h-[470px] flex flex-col">
+    <div className="app-card h-[470px] flex flex-col">
       <SpendingBreakdownHeader
         breakdownMode={breakdownMode}
         breakdownRange={breakdownRange}
@@ -69,7 +69,6 @@ export function SpendingBreakdownWidget({ displayCurrency }: SpendingBreakdownWi
         contentConcealed={contentConcealed}
         error={spendingBreakdownError}
         failed={spendingBreakdownFailed}
-        hasContent={spendingBreakdown !== undefined}
         subject="Spending breakdown"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}

--- a/frontend/src/pages/dashboard/widgets/spending-comparison/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/spending-comparison/Widget.tsx
@@ -61,7 +61,7 @@ export function SpendingComparisonWidget({ displayCurrency }: SpendingComparison
     [displaySpendingRange, spendingComparison],
   )
   return (
-    <div className="app-card min-h-[470px] flex flex-col">
+    <div className="app-card h-[470px] flex flex-col">
       <SpendingComparisonHeader
         spendingRange={spendingRange}
         fxStatus={fxStatus}
@@ -71,7 +71,6 @@ export function SpendingComparisonWidget({ displayCurrency }: SpendingComparison
         contentConcealed={contentConcealed}
         error={spendingComparisonError}
         failed={spendingComparisonFailed}
-        hasContent={spendingComparison !== undefined}
         subject="Spending comparison"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}

--- a/frontend/src/pages/dashboard/widgets/top-budgets/Widget.tsx
+++ b/frontend/src/pages/dashboard/widgets/top-budgets/Widget.tsx
@@ -42,14 +42,13 @@ export function TopBudgetsWidget() {
   )
 
   return (
-    <div className="app-card min-h-[410px] flex flex-col">
+    <div className="app-card h-[410px] flex flex-col">
       <TopBudgetsHeader fxStatus={fxStatus} />
 
       <DashboardWidgetLoadingBody
         contentConcealed={contentConcealed}
         error={budgetsError}
         failed={budgetsFailed}
-        hasContent={latestBudgetUtilizations !== undefined}
         subject="Top budgets"
         loadingVisible={loadingVisible}
         shouldReduceMotion={shouldReduceMotion}

--- a/frontend/src/pages/insights/InsightsPage.tsx
+++ b/frontend/src/pages/insights/InsightsPage.tsx
@@ -126,7 +126,6 @@ export default function InsightsPage() {
             displayCurrency={displayCurrency}
             error={queries.periodGlance.error}
             failed={queries.periodGlance.isError}
-            hasContent={queries.periodGlance.data !== undefined}
             loading={queries.periodGlance.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -145,7 +144,6 @@ export default function InsightsPage() {
             displayCurrency={displayCurrency}
             error={queries.fundFlow.error}
             failed={queries.fundFlow.isError}
-            hasContent={queries.fundFlow.data !== undefined}
             loading={queries.fundFlow.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -163,7 +161,6 @@ export default function InsightsPage() {
             animationKey={`${breakdownMode}-${range.cardTransitionKey}`}
             error={queries.incomeExpenseBreakdown.error}
             failed={queries.incomeExpenseBreakdown.isError}
-            hasContent={queries.incomeExpenseBreakdown.data !== undefined}
             loading={queries.incomeExpenseBreakdown.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -180,7 +177,6 @@ export default function InsightsPage() {
             displayCurrency={displayCurrency}
             error={queries.netWorth.error}
             failed={queries.netWorth.isError}
-            hasContent={queries.netWorth.data !== undefined}
             loading={queries.netWorth.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -194,7 +190,6 @@ export default function InsightsPage() {
             displayCurrency={displayCurrency}
             error={queries.cashFlow.error}
             failed={queries.cashFlow.isError}
-            hasContent={queries.cashFlow.data !== undefined}
             loading={queries.cashFlow.isFetching}
             transitionKey={range.cardTransitionKey}
           />
@@ -209,7 +204,6 @@ export default function InsightsPage() {
             onCapRatesToggle={() => setCapSavingsRateChart((current) => !current)}
             error={queries.savingsRateTrend.error}
             failed={queries.savingsRateTrend.isError}
-            hasContent={queries.savingsRateTrend.data !== undefined}
             loading={queries.savingsRateTrend.isFetching}
             transitionKey="savings-rate-trend"
           />
@@ -223,7 +217,6 @@ export default function InsightsPage() {
               currency={displayCurrency}
               error={queries.merchants.error}
               failed={queries.merchants.isError}
-              hasContent={queries.merchants.data !== undefined}
               loading={queries.merchants.isFetching}
               transitionKey={range.cardTransitionKey}
             />
@@ -236,7 +229,6 @@ export default function InsightsPage() {
               currency={displayCurrency}
               error={queries.merchants.error}
               failed={queries.merchants.isError}
-              hasContent={queries.merchants.data !== undefined}
               loading={queries.merchants.isFetching}
               transitionKey={range.cardTransitionKey}
             />

--- a/frontend/src/pages/insights/components/cash-flow-card/Card.tsx
+++ b/frontend/src/pages/insights/components/cash-flow-card/Card.tsx
@@ -27,9 +27,6 @@ type CashFlowCardProps = {
 
   failed: boolean
 
-  /** Whether the request has ever come back, since the net figure reads zero either way */
-  hasContent: boolean
-
   loading?: boolean
   transitionKey: string
 }
@@ -41,8 +38,11 @@ type CashFlowSnapshot = {
   displayCurrency: string
   error: unknown
   failed: boolean
-  hasContent: boolean
 }
+
+// The card holds this height whether it is drawing the chart or saying the request failed, so a
+// failure does not resize it
+const BODY_CLASS = 'flex h-[390px] flex-col'
 
 const cashFlowCalculation = 'Bars group money moving in and out by period. Net equals inflow minus outflow. Transfers are included. Balance adjustments are excluded'
 const netCashFlowCalculation = 'The cumulative net cash flow at the end of the chosen time range'
@@ -57,7 +57,6 @@ export function CashFlowCard({
   displayCurrency,
   error,
   failed,
-  hasContent,
   loading = false,
   transitionKey,
 }: CashFlowCardProps) {
@@ -71,8 +70,7 @@ export function CashFlowCard({
     displayCurrency,
     error,
     failed,
-    hasContent,
-  }), [buckets, displayCurrency, error, failed, fxStatus, granularity, hasContent])
+  }), [buckets, displayCurrency, error, failed, fxStatus, granularity])
   const {
     displaySnapshot,
     contentConcealed,
@@ -112,15 +110,17 @@ export function CashFlowCard({
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           {displaySnapshot.failed && (
-            <LoadFailure
-              error={displaySnapshot.error}
-              standalone={!displaySnapshot.hasContent}
-              subject="Cash flow"
-            />
+            <div className={BODY_CLASS}>
+              <LoadFailure
+                error={displaySnapshot.error}
+                standalone
+                subject="Cash flow"
+              />
+            </div>
           )}
 
-          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
-            <div className="flex h-[390px] flex-col">
+          {!displaySnapshot.failed && (
+            <div className={BODY_CLASS}>
               <div className="mb-3">
                 <p className="app-label app-label-compact inline-flex items-center gap-2">
                   Net Cash Flow

--- a/frontend/src/pages/insights/components/fund-flow-card/Card.tsx
+++ b/frontend/src/pages/insights/components/fund-flow-card/Card.tsx
@@ -3,7 +3,7 @@ import { Network } from 'lucide-react'
 import type { InsightsFlowEntry } from '@/api/insights'
 import type { FxStatus } from '@/api/shared/fx'
 import LoadFailure from '@/components/errors/LoadFailure'
-import { LoadingContent } from '@/components/loading/Transition'
+import { LoadingContent, LoadingOverlay } from '@/components/loading/Transition'
 import { useLoadingSnapshot } from '@/hooks/useLoadingSnapshot'
 import type { FundFlowData } from '@/pages/insights/types/fundFlow'
 import { getFundFlowChartHeight } from '@/pages/insights/utils/fundFlowChart'
@@ -29,7 +29,6 @@ type FundFlowSnapshot = {
   chartHeight: number
   error: unknown
   failed: boolean
-  hasContent: boolean
 }
 
 type FundFlowCardProps = {
@@ -47,9 +46,6 @@ type FundFlowCardProps = {
   error: unknown
 
   failed: boolean
-
-  /** Whether the request has ever come back, since an empty chart looks the same either way */
-  hasContent: boolean
 
   loading?: boolean
   transitionKey: string
@@ -70,7 +66,6 @@ export function FundFlowCard({
   displayCurrency,
   error,
   failed,
-  hasContent,
   loading = false,
   transitionKey,
 }: FundFlowCardProps) {
@@ -90,7 +85,6 @@ export function FundFlowCard({
     chartHeight: getFundFlowChartHeight(incomeSourceCount, expenseCategoryCount),
     error,
     failed,
-    hasContent,
   }), [
     displayCurrency,
     error,
@@ -100,7 +94,6 @@ export function FundFlowCard({
     failed,
     fxStatus,
     flowData,
-    hasContent,
     incomeOutflows,
     incomeSourceCount,
     incomeSources,
@@ -148,19 +141,28 @@ export function FundFlowCard({
           </span>
         )}
       />
-      {/* Its own concealment, since this card hands the loading transition down to the chart rather
-          than wrapping the whole body in one */}
+      {/* Its own concealment and its own spinner, since this card hands the loading transition down
+          to the chart rather than wrapping the whole body in one, and the chart is not rendered
+          while the box is up. Without the spinner here, retrying a failed range would sit on a
+          blank card until the answer came back */}
       {displaySnapshot.failed && (
-        <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
-          <LoadFailure
-            error={displaySnapshot.error}
-            standalone={!displaySnapshot.hasContent}
-            subject="Fund flow"
+        <div className="relative">
+          <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
+            <LoadFailure
+              error={displaySnapshot.error}
+              standalone
+              subject="Fund flow"
+            />
+          </LoadingContent>
+          <LoadingOverlay
+            visible={loadingVisible}
+            shouldReduceMotion={shouldReduceMotion}
+            label="Loading fund flow"
           />
-        </LoadingContent>
+        </div>
       )}
 
-      {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+      {!displaySnapshot.failed && (
         <>
         <div className="mb-3 grid items-start gap-3 min-[720px]:grid-cols-2">
           <FundFlowCategoryList

--- a/frontend/src/pages/insights/components/income-expense-breakdown-card/Card.tsx
+++ b/frontend/src/pages/insights/components/income-expense-breakdown-card/Card.tsx
@@ -39,9 +39,6 @@ type IncomeExpenseBreakdownCardProps = {
 
   failed: boolean
 
-  /** Whether the request has ever come back, since the chart reads empty either way */
-  hasContent: boolean
-
   loading?: boolean
   transitionKey: string
 }
@@ -56,7 +53,6 @@ type IncomeExpenseBreakdownSnapshot = {
   animationKey: string
   error: unknown
   failed: boolean
-  hasContent: boolean
 }
 
 /**
@@ -73,7 +69,6 @@ export function IncomeExpenseBreakdownCard({
   animationKey,
   error,
   failed,
-  hasContent,
   loading = false,
   transitionKey,
 }: IncomeExpenseBreakdownCardProps) {
@@ -89,8 +84,7 @@ export function IncomeExpenseBreakdownCard({
     animationKey,
     error,
     failed,
-    hasContent,
-  }), [animationKey, displayCurrency, entries, error, failed, fxStatus, hasContent, mode, total, trendSections])
+  }), [animationKey, displayCurrency, entries, error, failed, fxStatus, mode, total, trendSections])
   const {
     displaySnapshot,
     contentConcealed,
@@ -140,12 +134,12 @@ export function IncomeExpenseBreakdownCard({
           {displaySnapshot.failed && (
             <LoadFailure
               error={displaySnapshot.error}
-              standalone={!displaySnapshot.hasContent}
+              standalone
               subject={displaySnapshot.mode === 'expense' ? 'Expense breakdown' : 'Income breakdown'}
             />
           )}
 
-          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+          {!displaySnapshot.failed && (
             <div className="grid gap-6 min-[1350px]:grid-cols-[minmax(0,0.95fr)_minmax(360px,1.05fr)]">
               <IncomeExpensePieChart
                 mode={displaySnapshot.mode}

--- a/frontend/src/pages/insights/components/merchant-distribution-card/Card.tsx
+++ b/frontend/src/pages/insights/components/merchant-distribution-card/Card.tsx
@@ -25,9 +25,6 @@ type MerchantDistributionCardProps = {
 
   failed: boolean
 
-  /** Whether the request has ever come back, since an empty map looks the same either way */
-  hasContent: boolean
-
   loading?: boolean
   transitionKey: string
 }
@@ -39,7 +36,6 @@ type MerchantDistributionSnapshot = {
   emptyLabel: string
   error: unknown
   failed: boolean
-  hasContent: boolean
 }
 
 /**
@@ -51,7 +47,6 @@ export function MerchantDistributionCard({
   currency,
   error,
   failed,
-  hasContent,
   loading = false,
   transitionKey,
 }: MerchantDistributionCardProps) {
@@ -64,8 +59,7 @@ export function MerchantDistributionCard({
     emptyLabel: loading ? 'Loading merchant spending...' : 'No merchant spending in this range',
     error,
     failed,
-    hasContent,
-  }), [currency, error, failed, fxStatus, hasContent, loading, merchants])
+  }), [currency, error, failed, fxStatus, loading, merchants])
   const {
     displaySnapshot,
     contentConcealed,
@@ -107,12 +101,12 @@ export function MerchantDistributionCard({
           {displaySnapshot.failed && (
             <LoadFailure
               error={displaySnapshot.error}
-              standalone={!displaySnapshot.hasContent}
+              standalone
               subject="Spending distribution by merchant"
             />
           )}
 
-          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+          {!displaySnapshot.failed && (
             <>
               {displaySnapshot.merchants.length > 0 ? (
                 <MerchantMarketMap merchants={displaySnapshot.merchants} currency={displaySnapshot.currency} />

--- a/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
+++ b/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
@@ -24,9 +24,6 @@ type MerchantRankingCardProps = {
 
   failed: boolean
 
-  /** Whether the request has ever come back, since an empty ranking looks the same either way */
-  hasContent: boolean
-
   loading?: boolean
   transitionKey: string
 }
@@ -38,7 +35,6 @@ type MerchantRankingSnapshot = {
   emptyLabel: string
   error: unknown
   failed: boolean
-  hasContent: boolean
 }
 
 function getChangeColor(changePct: number | null) {
@@ -63,7 +59,6 @@ export function MerchantRankingCard({
   currency,
   error,
   failed,
-  hasContent,
   loading = false,
   transitionKey,
 }: MerchantRankingCardProps) {
@@ -77,8 +72,7 @@ export function MerchantRankingCard({
     emptyLabel: loading ? 'Loading merchant ranking...' : 'No merchant spending in this range',
     error,
     failed,
-    hasContent,
-  }), [currency, error, failed, fxStatus, hasContent, loading, merchants])
+  }), [currency, error, failed, fxStatus, loading, merchants])
   const {
     displaySnapshot,
     contentConcealed,
@@ -90,9 +84,11 @@ export function MerchantRankingCard({
     transitionKey,
   })
 
-  // Nothing else is left in the card, so the body has to fill the card's height for the box to have
-  // a middle to sit in. The ranking's own layout is left alone, since it sizes to its rows
-  const boxAlone = displaySnapshot.failed && !displaySnapshot.hasContent
+  // The box takes the place of the ranking, so the body has to fill the card's height for the box
+  // to have a middle to sit in. Content-sized, it would sit at the top of a card still holding
+  // 560px above 1300px, with the rest of that height empty beneath it. The ranking's own layout is
+  // left alone, since it sizes to its rows
+  const boxAlone = displaySnapshot.failed
 
   return (
     <div className="app-card flex flex-col min-[1300px]:h-[560px]">
@@ -124,12 +120,12 @@ export function MerchantRankingCard({
           {displaySnapshot.failed && (
             <LoadFailure
               error={displaySnapshot.error}
-              standalone={!displaySnapshot.hasContent}
+              standalone
               subject="Merchant ranking"
             />
           )}
 
-          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+          {!displaySnapshot.failed && (
             displaySnapshot.merchants.length > 0 ? (
               <div className="space-y-3">
                 {displaySnapshot.merchants.map((merchant, index) => (

--- a/frontend/src/pages/insights/components/net-worth-card/Card.tsx
+++ b/frontend/src/pages/insights/components/net-worth-card/Card.tsx
@@ -39,9 +39,6 @@ type NetWorthCardProps = {
 
   failed: boolean
 
-  /** Whether the request has ever come back, since the ending figure reads zero either way */
-  hasContent: boolean
-
   loading?: boolean
   transitionKey: string
 }
@@ -56,8 +53,11 @@ type NetWorthSnapshot = {
   emptyLabel: string
   error: unknown
   failed: boolean
-  hasContent: boolean
 }
+
+// The card holds this height whether it is drawing the chart or saying the request failed, so a
+// failure does not resize it
+const BODY_CLASS = 'flex h-[360px] flex-col'
 
 /**
  * Describes the calculation currently shown by the net-worth card mode
@@ -81,7 +81,6 @@ export function NetWorthCard({
   displayCurrency,
   error,
   failed,
-  hasContent,
   loading = false,
   transitionKey,
 }: NetWorthCardProps) {
@@ -98,8 +97,7 @@ export function NetWorthCard({
     emptyLabel: loading ? 'Loading net worth history...' : 'No net worth history in this range.',
     error,
     failed,
-    hasContent,
-  }), [baseline, displayCurrency, error, failed, fxStatus, groups, hasContent, loading, mode, series])
+  }), [baseline, displayCurrency, error, failed, fxStatus, groups, loading, mode, series])
   const {
     displaySnapshot,
     contentConcealed,
@@ -160,15 +158,17 @@ export function NetWorthCard({
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           {displaySnapshot.failed && (
-            <LoadFailure
-              error={displaySnapshot.error}
-              standalone={!displaySnapshot.hasContent}
-              subject="Net worth"
-            />
+            <div className={BODY_CLASS}>
+              <LoadFailure
+                error={displaySnapshot.error}
+                standalone
+                subject="Net worth"
+              />
+            </div>
           )}
 
-          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
-            <div className="flex h-[360px] flex-col">
+          {!displaySnapshot.failed && (
+            <div className={BODY_CLASS}>
               <div className="mb-3 flex flex-wrap items-end justify-between gap-3">
                 <div>
                   <p className="app-label app-label-compact inline-flex items-center gap-2">

--- a/frontend/src/pages/insights/components/period-glance-card/Card.tsx
+++ b/frontend/src/pages/insights/components/period-glance-card/Card.tsx
@@ -24,7 +24,6 @@ type PeriodGlanceSnapshot = {
   displayCurrency: string
   error: unknown
   failed: boolean
-  hasContent: boolean
 }
 
 type PeriodGlanceCardProps = {
@@ -39,9 +38,6 @@ type PeriodGlanceCardProps = {
   error: unknown
 
   failed: boolean
-
-  /** Whether the request has ever come back, since the metrics read zero either way */
-  hasContent: boolean
 
   loading?: boolean
   transitionKey: string
@@ -59,7 +55,6 @@ export function PeriodGlanceCard({
   displayCurrency,
   error,
   failed,
-  hasContent,
   loading = false,
   transitionKey,
 }: PeriodGlanceCardProps) {
@@ -74,8 +69,7 @@ export function PeriodGlanceCard({
     displayCurrency,
     error,
     failed,
-    hasContent,
-  }), [displayCurrency, error, expenses, failed, hasContent, income, incomeExpenseFxStatus, primaryMetric, supportItems])
+  }), [displayCurrency, error, expenses, failed, income, incomeExpenseFxStatus, primaryMetric, supportItems])
   const {
     displaySnapshot,
     contentConcealed,
@@ -96,12 +90,12 @@ export function PeriodGlanceCard({
           {displaySnapshot.failed && (
             <LoadFailure
               error={displaySnapshot.error}
-              standalone={!displaySnapshot.hasContent}
+              standalone
               subject="This period at a glance"
             />
           )}
 
-          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
+          {!displaySnapshot.failed && (
             <div className="grid gap-4 min-[1500px]:grid-cols-[minmax(0,40fr)_minmax(0,60fr)]">
               <PeriodGlancePrimaryPanel
                 primaryMetric={displaySnapshot.primaryMetric}

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
@@ -30,9 +30,6 @@ type SavingsRateTrendCardProps = {
 
   failed: boolean
 
-  /** Whether the request has ever come back, since the summary metrics read empty either way */
-  hasContent: boolean
-
   loading?: boolean
   transitionKey: string
 }
@@ -45,8 +42,11 @@ type SavingsRateTrendSnapshot = {
   emptyLabel: string
   error: unknown
   failed: boolean
-  hasContent: boolean
 }
+
+// Above 750px the card holds this height whether it is drawing the chart or saying the request
+// failed, so a failure does not resize it. Below that the card sizes to whichever is showing
+const BODY_CLASS = 'flex flex-col min-[750px]:h-[430px]'
 
 const savingsRateCalculation = 'Monthly savings rate is income minus expenses, divided by income. Income and expense categories are netted first. Transfers are excluded'
 const latestSavingsRateCalculation = 'Savings rate for the latest available month. The current month may be partial. Shows −∞% when expenses exist without income because the calculation divides by zero'
@@ -67,7 +67,6 @@ export function SavingsRateTrendCard({
   onCapRatesToggle,
   error,
   failed,
-  hasContent,
   loading = false,
   transitionKey,
 }: SavingsRateTrendCardProps) {
@@ -81,8 +80,7 @@ export function SavingsRateTrendCard({
     emptyLabel: loading ? 'Loading savings-rate history...' : 'No savings-rate history available',
     error,
     failed,
-    hasContent,
-  }), [capRates, displayCurrency, error, failed, fxStatus, hasContent, loading, series])
+  }), [capRates, displayCurrency, error, failed, fxStatus, loading, series])
   const {
     displaySnapshot,
     contentConcealed,
@@ -136,15 +134,17 @@ export function SavingsRateTrendCard({
       <div className="relative overflow-visible" data-tooltip-bounds>
         <LoadingContent concealed={contentConcealed} shouldReduceMotion={shouldReduceMotion}>
           {displaySnapshot.failed && (
-            <LoadFailure
-              error={displaySnapshot.error}
-              standalone={!displaySnapshot.hasContent}
-              subject="Savings rate trend"
-            />
+            <div className={BODY_CLASS}>
+              <LoadFailure
+                error={displaySnapshot.error}
+                standalone
+                subject="Savings rate trend"
+              />
+            </div>
           )}
 
-          {(!displaySnapshot.failed || displaySnapshot.hasContent) && (
-            <div className="flex flex-col min-[750px]:h-[430px]">
+          {!displaySnapshot.failed && (
+            <div className={BODY_CLASS}>
               <div className="mb-4 grid gap-4 border-b border-[var(--app-border)] pb-4 min-[750px]:grid-cols-[minmax(0,1.15fr)_minmax(0,1.85fr)] min-[750px]:items-center min-[750px]:gap-6">
                 <div className="min-w-0">
                   <p className="app-label inline-flex items-center gap-2">


### PR DESCRIPTION
Fixed a bug where cards stretched to fit their contents, whether requests succeeded or failed. Now the cards hold a set size in all states. The failure box fits inside them: the wording is shorter and a server message is capped at two lines. On the insights page, the box takes the place of the card's contents instead of being added above them.
