### PR TITLE
feat: warn when debt payment may be a credit repayment

### DIFF
--- a/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/Modal.tsx
@@ -107,6 +107,7 @@ export default function CreateTransactionModal({
 
   const categoryField = useCategoryField({
     categories,
+    readOnly,
     form,
     applyKindChange,
     clearError,
@@ -309,6 +310,7 @@ export default function CreateTransactionModal({
             categoryValue={form.category_id}
             categoryError={showError('category_id')}
             isBalanceAdjustmentCategory={categoryField.isBalanceAdjustmentCategory}
+            creditRepaymentSteer={categoryField.creditRepaymentSteer}
             showMerchantDefaultCategoryAction={merchantField.showMerchantDefaultCategoryAction}
             merchantDefaultCategoryActionLabel={merchantField.merchantDefaultCategoryActionLabel}
             merchantDefaultCategoryPending={merchantField.merchantDefaultCategoryPending}

--- a/frontend/src/pages/transactions/components/transaction-modal/controls/CategoryNoticeLine.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/controls/CategoryNoticeLine.tsx
@@ -1,0 +1,46 @@
+import { useState, type ReactNode } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
+
+type CategoryNoticeLineProps = {
+  show: boolean
+  children: ReactNode
+}
+
+/**
+ * One line of explanation under the category dropdown, expanding and collapsing with the choice
+ * that produces it
+ *
+ * The wrapper clips only while its height is moving. Clipping is what lets the height animate
+ * without the content spilling, and leaving it on afterwards would cut off a tooltip panel, which
+ * is positioned outside the line's own box
+ */
+export default function CategoryNoticeLine({ show, children }: CategoryNoticeLineProps) {
+  // Starts clipped so the first frame of the expansion cannot spill, and goes back to clipped as
+  // the collapse begins
+  const [clipWhileMoving, setClipWhileMoving] = useState(true)
+
+  return (
+    <AnimatePresence initial={false}>
+      {show && (
+        <motion.div
+          key="category-notice-line"
+          initial={{ opacity: 0, height: 0 }}
+          animate={{ opacity: 1, height: 'auto' }}
+          exit={{ opacity: 0, height: 0 }}
+          transition={{ duration: 0.2, ease: EASE }}
+          className={clipWhileMoving ? 'overflow-hidden' : undefined}
+          onAnimationStart={() => setClipWhileMoving(true)}
+          onAnimationComplete={() => setClipWhileMoving(!show)}
+        >
+          <div
+            className="flex flex-wrap items-center gap-x-2 gap-y-1 px-0.5 pt-2 text-xs leading-5"
+            style={{ color: 'var(--app-warning-text)' }}
+          >
+            {children}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/pages/transactions/components/transaction-modal/controls/CreditRepaymentNotice.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/controls/CreditRepaymentNotice.tsx
@@ -1,0 +1,72 @@
+import { CircleHelp } from 'lucide-react'
+import { AnimatePresence, motion } from 'motion/react'
+import IconTooltip from '@/components/tooltips/IconTooltip'
+import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
+
+type CreditRepaymentNoticeProps = {
+  show: boolean
+
+  // Sets the category to Credit Card Payment. Left out where the modal is read-only or that
+  // category has not loaded, and the button is then not rendered at all
+  onUseCreditCardPayment?: () => void
+}
+
+/**
+ * Asks the user to check that a payment filed under Debt Payment really is an expense, with the
+ * reasoning behind the question in a tooltip and the common correction as a button
+ *
+ * The line fades in rather than expanding, because the tooltip panel is positioned outside the
+ * line's own box and a wrapper animating its height has to clip, which clips the panel too
+ */
+export default function CreditRepaymentNotice({
+  show,
+  onUseCreditCardPayment,
+}: CreditRepaymentNoticeProps) {
+  return (
+    <AnimatePresence initial={false}>
+      {show && (
+        <motion.div
+          key="credit-repayment-notice"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2, ease: EASE }}
+        >
+          <div
+            className="flex flex-wrap items-center gap-x-2 gap-y-1 px-0.5 pt-2 text-xs leading-5"
+            style={{ color: 'var(--app-warning-text)' }}
+          >
+            <span className="inline-flex items-center gap-1">
+              Make sure this payment is really an expense.
+              <IconTooltip
+                label="When a debt payment is not an expense"
+                icon={CircleHelp}
+                placement="bottom"
+                widthClassName="w-72"
+                size={13}
+                iconColor="var(--app-warning-text)"
+                modalFieldTabStop
+              >
+                Purchases on a credit card, line of credit or HELOC were already recorded as
+                expenses when you made them. Recording the repayment (excluding interest charges) as
+                an expense counts that spending twice, so use a transfer category instead. Debt
+                Payment is for repaying something you do not own until it is paid in full, such as a
+                car loan or a mortgage.
+              </IconTooltip>
+            </span>
+            {onUseCreditCardPayment && (
+              <button
+                type="button"
+                className="font-medium underline underline-offset-2"
+                style={{ color: 'var(--app-accent)' }}
+                onClick={onUseCreditCardPayment}
+              >
+                Use Credit Card Payment
+              </button>
+            )}
+          </div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
+}

--- a/frontend/src/pages/transactions/components/transaction-modal/controls/CreditRepaymentNotice.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/controls/CreditRepaymentNotice.tsx
@@ -1,7 +1,6 @@
 import { CircleHelp } from 'lucide-react'
-import { AnimatePresence, motion } from 'motion/react'
 import IconTooltip from '@/components/tooltips/IconTooltip'
-import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
+import CategoryNoticeLine from '@/pages/transactions/components/transaction-modal/controls/CategoryNoticeLine'
 
 type CreditRepaymentNoticeProps = {
   show: boolean
@@ -14,59 +13,41 @@ type CreditRepaymentNoticeProps = {
 /**
  * Asks the user to check that a payment filed under Debt Payment really is an expense, with the
  * reasoning behind the question in a tooltip and the common correction as a button
- *
- * The line fades in rather than expanding, because the tooltip panel is positioned outside the
- * line's own box and a wrapper animating its height has to clip, which clips the panel too
  */
 export default function CreditRepaymentNotice({
   show,
   onUseCreditCardPayment,
 }: CreditRepaymentNoticeProps) {
   return (
-    <AnimatePresence initial={false}>
-      {show && (
-        <motion.div
-          key="credit-repayment-notice"
-          initial={{ opacity: 0 }}
-          animate={{ opacity: 1 }}
-          exit={{ opacity: 0 }}
-          transition={{ duration: 0.2, ease: EASE }}
+    <CategoryNoticeLine show={show}>
+      <span className="inline-flex items-center gap-1">
+        Make sure this payment is really an expense.
+        <IconTooltip
+          label="When a debt payment is not an expense"
+          icon={CircleHelp}
+          placement="bottom"
+          widthClassName="w-72"
+          size={13}
+          iconColor="var(--app-warning-text)"
+          modalFieldTabStop
         >
-          <div
-            className="flex flex-wrap items-center gap-x-2 gap-y-1 px-0.5 pt-2 text-xs leading-5"
-            style={{ color: 'var(--app-warning-text)' }}
-          >
-            <span className="inline-flex items-center gap-1">
-              Make sure this payment is really an expense.
-              <IconTooltip
-                label="When a debt payment is not an expense"
-                icon={CircleHelp}
-                placement="bottom"
-                widthClassName="w-72"
-                size={13}
-                iconColor="var(--app-warning-text)"
-                modalFieldTabStop
-              >
-                Purchases on a credit card, line of credit or HELOC were already recorded as
-                expenses when you made them. Recording the repayment (excluding interest charges) as
-                an expense counts that spending twice, so use a transfer category instead. Debt
-                Payment is for repaying something you do not own until it is paid in full, such as a
-                car loan or a mortgage.
-              </IconTooltip>
-            </span>
-            {onUseCreditCardPayment && (
-              <button
-                type="button"
-                className="font-medium underline underline-offset-2"
-                style={{ color: 'var(--app-accent)' }}
-                onClick={onUseCreditCardPayment}
-              >
-                Use Credit Card Payment
-              </button>
-            )}
-          </div>
-        </motion.div>
+          Purchases on a credit card, line of credit or HELOC were already recorded as expenses
+          when you made them. Recording the repayment (excluding interest charges) as an expense
+          counts that spending twice, so use a transfer category instead. Debt Payment is for
+          repaying something you do not own until it is paid in full, such as a car loan or a
+          mortgage.
+        </IconTooltip>
+      </span>
+      {onUseCreditCardPayment && (
+        <button
+          type="button"
+          className="font-medium underline underline-offset-2"
+          style={{ color: 'var(--app-accent)' }}
+          onClick={onUseCreditCardPayment}
+        >
+          Use Credit Card Payment
+        </button>
       )}
-    </AnimatePresence>
+    </CategoryNoticeLine>
   )
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/controls/TransferCashFlowNotice.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/controls/TransferCashFlowNotice.tsx
@@ -1,60 +1,22 @@
-import { AlertTriangle } from 'lucide-react'
-import { AnimatePresence, motion } from 'motion/react'
-import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
+import CategoryNoticeLine from '@/pages/transactions/components/transaction-modal/controls/CategoryNoticeLine'
 
 type TransferCashFlowNoticeProps = {
   show: boolean
 }
 
 /**
- * Reminds the user that balance adjustments never count toward cash flow and that a
- * transfer is the right way to record money actually moving between their accounts
+ * Explains that balance adjustments never count toward cash flow and that a transfer is the right
+ * way to record money actually moving between accounts
  */
 export default function TransferCashFlowNotice({
   show,
 }: TransferCashFlowNoticeProps) {
   return (
-    <AnimatePresence initial={false}>
-      {show && (
-        <motion.div
-          key="transfer-cash-flow-notice"
-          initial={{ opacity: 0, height: 0 }}
-          animate={{ opacity: 1, height: 'auto' }}
-          exit={{ opacity: 0, height: 0 }}
-          transition={{ duration: 0.2, ease: EASE }}
-          className="overflow-hidden"
-        >
-          <div
-            className="mt-3 rounded-lg px-3 py-2.5"
-            style={{
-              background: 'var(--app-warning-soft)',
-              border: '1px solid var(--app-border)',
-            }}
-          >
-            <div className="flex gap-2.5">
-              <div
-                className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-md"
-                style={{ background: 'var(--app-bg)', color: 'var(--app-warning)' }}
-              >
-                <AlertTriangle size={13} aria-hidden />
-              </div>
-              <div className="min-w-0">
-                <p className="text-sm font-semibold leading-5">
-                  Balance adjustments are not cash flow
-                </p>
-                <p
-                  className="mt-0.5 text-sm leading-5"
-                  style={{ color: 'var(--app-text-muted)' }}
-                >
-                  A balance adjustment only corrects an account&apos;s balance, so it is left
-                  out of cash flow. If money actually moved between your accounts, pick a
-                  regular transfer category instead.
-                </p>
-              </div>
-            </div>
-          </div>
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <CategoryNoticeLine show={show}>
+      <span>
+        A balance adjustment only corrects an account&apos;s balance, so it is left out of cash
+        flow. Pick a regular transfer category if money actually moved.
+      </span>
+    </CategoryNoticeLine>
   )
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/hooks/useCategoryField.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/hooks/useCategoryField.ts
@@ -2,6 +2,10 @@ import { useMemo } from 'react'
 import type { Category } from '@/api/categories'
 import { BALANCE_ADJUSTMENT_CATEGORY_NAME, doesTransferRecordCounterpartyAccount } from '@/utils/transfers'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
+import {
+  getCreditRepaymentSteer,
+  type CreditRepaymentSteer,
+} from '@/pages/transactions/components/transaction-modal/utils/creditRepayment'
 import type {
   TransactionFormFieldErrors,
   TransactionFormValues,
@@ -10,6 +14,7 @@ import type {
 
 interface UseCategoryFieldOptions {
   categories: Category[]
+  readOnly: boolean
   form: TransactionFormValues
   applyKindChange: (nextKind: TransactionModalKind, fields?: Partial<TransactionFormValues>) => void
   clearError: (field: keyof TransactionFormFieldErrors) => void
@@ -21,6 +26,7 @@ interface CategoryFieldState {
   categoryOptions: ReturnType<typeof buildCategoryOptions>
   selectedCategory: Category | undefined
   isBalanceAdjustmentCategory: boolean
+  creditRepaymentSteer: CreditRepaymentSteer
   handleCategoryChange: (categoryId: string) => void
   handleCategoryCreated: (category: Category) => void
 }
@@ -30,6 +36,7 @@ interface CategoryFieldState {
  */
 export function useCategoryField({
   categories,
+  readOnly,
   form,
   applyKindChange,
   clearError,
@@ -53,6 +60,8 @@ export function useCategoryField({
     selectedCategory?.is_system &&
     selectedCategory.name === BALANCE_ADJUSTMENT_CATEGORY_NAME
   )
+
+  const creditRepaymentSteer = getCreditRepaymentSteer(selectedCategory, categories, readOnly)
 
   const handleCategoryChange = (categoryId: string) => {
     const category = categoryById.get(categoryId)
@@ -81,6 +90,7 @@ export function useCategoryField({
     categoryOptions,
     selectedCategory,
     isBalanceAdjustmentCategory,
+    creditRepaymentSteer,
     handleCategoryChange,
     handleCategoryCreated,
   }

--- a/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
+++ b/frontend/src/pages/transactions/components/transaction-modal/sections/ReferencesSection.tsx
@@ -8,7 +8,9 @@ import {
   EASE,
   TRANSACTION_MODAL_FIELD_IDS,
 } from '@/pages/transactions/components/transaction-modal/constants'
+import CreditRepaymentNotice from '@/pages/transactions/components/transaction-modal/controls/CreditRepaymentNotice'
 import TransferCashFlowNotice from '@/pages/transactions/components/transaction-modal/controls/TransferCashFlowNotice'
+import type { CreditRepaymentSteer } from '@/pages/transactions/components/transaction-modal/utils/creditRepayment'
 import { doesTransferRecordCounterpartyAccount } from '@/utils/transfers'
 import type {
   TransactionDirection,
@@ -67,6 +69,10 @@ interface TransactionReferencesSectionProps {
 
   // True when the chosen category is the synthetic balance adjustment, which is excluded from cash flow
   isBalanceAdjustmentCategory: boolean
+
+  // Whether to ask the user to check that a payment filed under Debt Payment is really an expense,
+  // and which category the offered switch sets
+  creditRepaymentSteer: CreditRepaymentSteer
   showMerchantDefaultCategoryAction: boolean
   merchantDefaultCategoryActionLabel: string
   merchantDefaultCategoryPending: boolean
@@ -163,6 +169,7 @@ export default function TransactionReferencesSection({
   categoryValue,
   categoryError,
   isBalanceAdjustmentCategory,
+  creditRepaymentSteer,
   showMerchantDefaultCategoryAction,
   merchantDefaultCategoryActionLabel,
   merchantDefaultCategoryPending,
@@ -196,6 +203,13 @@ export default function TransactionReferencesSection({
   // Every transfer-kind category except Balance Adjustment records which counterparty account the
   // money touched
   const recordsCounterpartyAccount = doesTransferRecordCounterpartyAccount(kind, isBalanceAdjustmentCategory)
+
+  // Goes through the same handler the dropdown does, so the switch behaves exactly as picking the
+  // category by hand. Left undefined where no switch is offered, which is what hides the button
+  const switchTargetId = creditRepaymentSteer.switchTargetId
+  const useCreditCardPayment = switchTargetId
+    ? () => onCategoryChange(switchTargetId)
+    : undefined
 
   // Ticking the checkbox writes a transaction in both accounts, so neither one is the single account
   // it was recorded in. The two fields then read source first, which is why the one below says the
@@ -390,6 +404,10 @@ export default function TransactionReferencesSection({
           disabled={readOnly}
         />
         <TransferCashFlowNotice show={isBalanceAdjustmentCategory} />
+        <CreditRepaymentNotice
+          show={creditRepaymentSteer.show}
+          onUseCreditCardPayment={useCreditCardPayment}
+        />
       </div>
 
       <div>

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/creditRepayment.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/creditRepayment.ts
@@ -1,0 +1,40 @@
+import type { Category } from '@/api/categories'
+import { CREDIT_CARD_PAYMENT_CATEGORY_NAME, DEBT_PAYMENT_CATEGORY_NAME } from '@/utils/transfers'
+
+export interface CreditRepaymentSteer {
+  /** Whether to show the line asking the user to check that the payment really is an expense */
+  show: boolean
+
+  /** Category the offered switch sets, or null when no switch is offered */
+  switchTargetId: string | null
+}
+
+/**
+ * Reports whether the chosen category may be recording a credit repayment as an expense, and which
+ * category the offered switch sets
+ *
+ * Both categories are matched by name and the system flag, the way Balance Adjustment already is,
+ * so a personal category sharing either name is left alone. The whole decision lives here rather
+ * than in the component, so every case it has to get right is reachable from a test
+ *
+ * @param selectedCategory Category currently chosen on the form, if any
+ * @param categories Every category the user can pick from
+ * @param readOnly Whether the modal is showing a transaction that cannot be changed
+ */
+export function getCreditRepaymentSteer(
+  selectedCategory: Category | undefined,
+  categories: Category[],
+  readOnly: boolean,
+): CreditRepaymentSteer {
+  const isDebtPayment = !!selectedCategory?.is_system
+    && selectedCategory.name === DEBT_PAYMENT_CATEGORY_NAME
+  if (!isDebtPayment) return { show: false, switchTargetId: null }
+
+  // A read-only transaction still explains itself, but there is nothing to switch it to
+  if (readOnly) return { show: true, switchTargetId: null }
+
+  const creditCardPayment = categories.find(
+    (category) => category.is_system && category.name === CREDIT_CARD_PAYMENT_CATEGORY_NAME,
+  )
+  return { show: true, switchTargetId: creditCardPayment?.id ?? null }
+}

--- a/frontend/src/utils/transfers.ts
+++ b/frontend/src/utils/transfers.ts
@@ -4,6 +4,13 @@ import type { Category } from '@/api/categories'
 // excludes them from cash flow
 export const BALANCE_ADJUSTMENT_CATEGORY_NAME = 'Balance Adjustment'
 
+// The system expense category a repayment is most often filed under. Correct for a loan or a
+// mortgage, and a double count for a credit account, whose purchases were expensed when they were made
+export const DEBT_PAYMENT_CATEGORY_NAME = 'Debt Payment'
+
+// The system transfer category that records a credit account repayment without expensing it again
+export const CREDIT_CARD_PAYMENT_CATEGORY_NAME = 'Credit Card Payment'
+
 // Sentinel dropdown value for money that left the tracked accounts, distinct from any real account
 // id, and the one label every dropdown offering that answer uses
 export const OUTSIDE_ACCOUNT_VALUE = '__outside__'

--- a/frontend/tests/pages/transactions/components/transaction-modal/utils/creditRepayment.test.ts
+++ b/frontend/tests/pages/transactions/components/transaction-modal/utils/creditRepayment.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests the steer shown when Debt Payment is chosen, so the line cannot start appearing for a
+ * category it was never meant for, and the offered switch cannot point at a category that is not
+ * the system one or be offered where the transaction cannot be changed
+ */
+import { describe, expect, it } from 'vitest'
+import { getCreditRepaymentSteer } from '@/pages/transactions/components/transaction-modal/utils/creditRepayment'
+import { createCategory } from './fixtures'
+
+const debtPayment = createCategory({ id: 'debt-payment', name: 'Debt Payment', is_system: true })
+const creditCardPayment = createCategory({
+  id: 'credit-card-payment',
+  name: 'Credit Card Payment',
+  kind: 'transfer',
+  is_system: true,
+})
+const everyCategory = [debtPayment, creditCardPayment]
+
+describe('credit repayment steer', () => {
+  it('shows the line and offers the system Credit Card Payment category', () => {
+    expect(getCreditRepaymentSteer(debtPayment, everyCategory, false))
+      .toEqual({ show: true, switchTargetId: 'credit-card-payment' })
+  })
+
+  it('offers no switch on a transaction that cannot be changed', () => {
+    expect(getCreditRepaymentSteer(debtPayment, everyCategory, true))
+      .toEqual({ show: true, switchTargetId: null })
+  })
+
+  it('still shows the line when Credit Card Payment has not loaded yet', () => {
+    expect(getCreditRepaymentSteer(debtPayment, [debtPayment], false))
+      .toEqual({ show: true, switchTargetId: null })
+  })
+
+  it('ignores a personal category sharing either name', () => {
+    const personalDebtPayment = createCategory({ id: 'mine', name: 'Debt Payment' })
+    const personalCreditCardPayment = createCategory({
+      id: 'also-mine',
+      name: 'Credit Card Payment',
+      kind: 'transfer',
+    })
+
+    expect(getCreditRepaymentSteer(personalDebtPayment, everyCategory, false))
+      .toEqual({ show: false, switchTargetId: null })
+    expect(getCreditRepaymentSteer(debtPayment, [debtPayment, personalCreditCardPayment], false))
+      .toEqual({ show: true, switchTargetId: null })
+  })
+
+  it('shows nothing for another system expense category', () => {
+    const groceries = createCategory({ id: 'groceries', name: 'Groceries', is_system: true })
+
+    expect(getCreditRepaymentSteer(groceries, everyCategory, false))
+      .toEqual({ show: false, switchTargetId: null })
+  })
+
+  it('shows nothing while no category is chosen', () => {
+    expect(getCreditRepaymentSteer(undefined, everyCategory, false))
+      .toEqual({ show: false, switchTargetId: null })
+  })
+})


### PR DESCRIPTION
Implemented a warning when the Debt Payment category is chosen, explaining that this double-counts spending because purchases were already recorded as expenses when made. Choosing Debt Payment shows a line under the category dropdown asking the user to verify the payment is really an expense, with a tooltip explaining the issue and a button to switch to Credit Card Payment. The Balance Adjustment notice changes from a warning panel to a single line of text in the same style.