### PR TITLE
fix: clip the dropdown list so no row shows above its heading

### DIFF
--- a/frontend/src/components/dropdown/OptionList.tsx
+++ b/frontend/src/components/dropdown/OptionList.tsx
@@ -136,7 +136,7 @@ export function DropdownOptionList({
       ref={listRef}
       id={listId}
       role="listbox"
-      className="overflow-auto"
+      className="app-dropdown-list"
       style={{ maxHeight: listMaxHeight }}
       onScroll={onScroll}
     >

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -779,6 +779,17 @@
     }
   }
 
+  /* Holds the options and scrolls them, with its height set from position.ts rather than here.
+
+     The clip is stated outright rather than left to the overflow, which is what a scroll container
+     is meant to give on its own. Firefox paints the row straddling the upper edge outside the list
+     while still clipping that row for hit testing, and the sliver it leaves lands in the gap above
+     the pinned group heading, where a reader takes it for part of the list */
+  .app-dropdown-list {
+    overflow: auto;
+    clip-path: inset(0);
+  }
+
   .app-dropdown-row {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Clipped the option list in dropdown groups to hide rows behind their pinned heading. Rows straddling the top edge now stay hidden instead of appearing in the gap above the heading in Firefox, where an explicit clip-path forces the paint clip to take effect.
