### PR TITLE
fix: standardize savings rate and indicator colours

### DIFF
--- a/frontend/src/pages/accounts/components/metrics/Band.tsx
+++ b/frontend/src/pages/accounts/components/metrics/Band.tsx
@@ -10,6 +10,7 @@ import {
   getRunwayFxStatusMessage,
   getSavingsRateFxStatusMessage,
 } from '@/utils/fxTooltipMessages'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 import { MetricPanel } from './Panel'
 
 type MetricsBandProps = {
@@ -53,7 +54,7 @@ export default function MetricsBand({
           value={savingsRateDisplay.value}
           valueColor={savingsRate.color}
           progress={savingsRate.progress}
-          progressColor={savingsRate.color}
+          progressColor={savingsRate.barColor}
           caption={savingsRateDisplay.caption}
         />
 
@@ -68,7 +69,7 @@ export default function MetricsBand({
           value={creditUsageDisplay.value}
           valueColor={creditUsage.color}
           progress={creditUsage.hasCreditData ? Math.max(0, Math.min(creditUsage.utilization, 100)) : 0}
-          progressColor={creditUsage.color}
+          progressColor={creditUsage.barColor}
           caption={creditUsageDisplay.caption}
         />
 
@@ -83,7 +84,7 @@ export default function MetricsBand({
           value={runway.label}
           valueColor={runway.months === null ? 'var(--app-text-subtle)' : 'var(--app-text)'}
           progress={runway.progress}
-          progressColor="linear-gradient(to right, var(--app-positive), var(--app-accent))"
+          progressColor={`linear-gradient(to right, ${getValueMarkColor('positive')}, ${getValueMarkColor('accent')})`}
           caption={runway.caption}
           help={<RunwayHelpTooltip />}
           headerClassName="pr-20"

--- a/frontend/src/pages/accounts/components/tax-advantaged-limits/CompactLimitMeter.tsx
+++ b/frontend/src/pages/accounts/components/tax-advantaged-limits/CompactLimitMeter.tsx
@@ -11,7 +11,7 @@ import {
   clampTaxAdvantagedPercent,
   formatTaxAdvantagedMeterMoney,
   getTaxAdvantagedRemainingColor,
-  getTaxAdvantagedUsageColor,
+  getTaxAdvantagedUsageBarColor,
   getTaxAdvantagedUsagePercent,
 } from '@/pages/accounts/utils/taxAdvantagedLimits'
 import { TaxAdvantagedLimitMeterTooltipContent } from './LimitMeterTooltipContent'
@@ -66,7 +66,7 @@ export function TaxAdvantagedCompactLimitMeter({
     )
   }
 
-  const color = getTaxAdvantagedUsageColor(used, limit)
+  const color = getTaxAdvantagedUsageBarColor(used, limit)
   const barWidth = getTaxAdvantagedUsagePercent(used, limit)
   const usageLabel = `${formatTaxAdvantagedMeterMoney(used, currency, currencies)} / ${formatTaxAdvantagedMeterMoney(limit, currency, currencies)}`
   const remaining = limit - used

--- a/frontend/src/pages/accounts/detail/components/identity/LimitUsage.tsx
+++ b/frontend/src/pages/accounts/detail/components/identity/LimitUsage.tsx
@@ -1,5 +1,6 @@
 import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import {
+  getTaxAdvantagedUsageBarColor,
   getTaxAdvantagedUsageColor,
   getTaxAdvantagedUsagePercent,
 } from '@/pages/accounts/utils/taxAdvantagedLimits'
@@ -38,6 +39,7 @@ export function DetailLimitUsage({
   }
 
   const color = getTaxAdvantagedUsageColor(used, limit)
+  const barColor = getTaxAdvantagedUsageBarColor(used, limit)
   const usageLabel = `${formatCurrency(used, currency)} / ${formatCurrency(limit, currency)}`
   const usagePercent = getTaxAdvantagedUsagePercent(used, limit)
 
@@ -65,7 +67,7 @@ export function DetailLimitUsage({
           <div
             className="h-full rounded-full"
             style={{
-              background: color,
+              background: barColor,
               width: `${usagePercent}%`,
             }}
           />

--- a/frontend/src/pages/accounts/detail/components/monthly-cash-flow/BarChart.tsx
+++ b/frontend/src/pages/accounts/detail/components/monthly-cash-flow/BarChart.tsx
@@ -20,6 +20,7 @@ import {
   useChartEntranceAnimation,
 } from '@/components/charts/useChartEntranceAnimation'
 import type { CashFlowBar } from '@/pages/accounts/detail/utils/cashFlowChartViewModel'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 import { MonthlyCashFlowTooltipContent } from './TooltipContent'
 
 const cashFlowChartMargin = { top: 8, right: 0, bottom: 0, left: 0 } as const
@@ -117,7 +118,7 @@ export function MonthlyCashFlowBarChart({
           <YAxis hide domain={domain} />
           <Bar
             dataKey="income"
-            fill="var(--app-positive)"
+            fill={getValueMarkColor('positive')}
             radius={[4, 4, 0, 0]}
             maxBarSize={24}
             opacity={0.85}
@@ -125,7 +126,7 @@ export function MonthlyCashFlowBarChart({
           />
           <Bar
             dataKey="expense"
-            fill="var(--app-negative)"
+            fill={getValueMarkColor('negative')}
             radius={[4, 4, 0, 0]}
             maxBarSize={24}
             opacity={0.85}

--- a/frontend/src/pages/accounts/detail/components/monthly-cash-flow/Legend.tsx
+++ b/frontend/src/pages/accounts/detail/components/monthly-cash-flow/Legend.tsx
@@ -1,3 +1,5 @@
+import { getValueMarkColor } from '@/utils/valueMarkColor'
+
 /**
  * Renders the inflow and outflow legend for the monthly cash flow card
  */
@@ -8,11 +10,11 @@ export function MonthlyCashFlowLegend() {
       style={{ color: 'var(--app-text-subtle)' }}
     >
       <span className="flex items-center gap-1.5">
-        <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--app-positive)' }} />
+        <span className="w-2 h-2 rounded-sm" style={{ background: getValueMarkColor('positive') }} />
         In
       </span>
       <span className="flex items-center gap-1.5">
-        <span className="w-2 h-2 rounded-sm" style={{ background: 'var(--app-negative)' }} />
+        <span className="w-2 h-2 rounded-sm" style={{ background: getValueMarkColor('negative') }} />
         Out
       </span>
     </div>

--- a/frontend/src/pages/accounts/detail/utils/balanceChartViewModel.ts
+++ b/frontend/src/pages/accounts/detail/utils/balanceChartViewModel.ts
@@ -12,6 +12,7 @@ import {
   type BalanceChartPoint,
 } from '@/pages/accounts/detail/utils/balanceChartSeries'
 import { getTodayDate } from '@/utils/date'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 
 export type BalanceChartDataPoint = BalanceChartPoint & {
   periodBalance?: number
@@ -127,12 +128,18 @@ export function getBalanceChartSnapshot({
   const chartSeries = chartMode === 'balance' ? series : periodSeries
   const periodDelta = getBalancePeriodDelta(series)
   const trendUp = periodDelta !== null && periodDelta.absolute >= 0
-  const lineColor = currentBalance < 0 ? 'var(--app-negative)' : 'var(--app-accent)'
+  const lineColor = currentBalance < 0 ? getValueMarkColor('negative') : getValueMarkColor('accent')
+  const deltaTone = trendUp ? 'positive' : 'negative'
+
+  // The period change is written out as a figure and drawn as the line in change mode, so it
+  // carries a colour for each: the figure keeps the contrast a number needs, the line matches
+  // every other chart
   const deltaColor = periodDelta === null
     ? 'var(--app-text-muted)'
     : trendUp
       ? 'var(--app-positive)'
       : 'var(--app-negative)'
+  const deltaMarkColor = periodDelta === null ? 'var(--app-text-muted)' : getValueMarkColor(deltaTone)
 
   return {
     range,
@@ -142,7 +149,7 @@ export function getBalanceChartSnapshot({
     periodDelta,
     trendUp,
     deltaColor,
-    chartLineColor: chartMode === 'change' && periodDelta !== null ? deltaColor : lineColor,
+    chartLineColor: chartMode === 'change' && periodDelta !== null ? deltaMarkColor : lineColor,
     chartSeries,
     chartDataKey: chartMode === 'balance' ? 'balance' : 'periodBalance',
     axisStartMs: calendarDateMs(fromDate),

--- a/frontend/src/pages/accounts/types/accounts.ts
+++ b/frontend/src/pages/accounts/types/accounts.ts
@@ -21,7 +21,12 @@ export interface AccountsMetricsViewModel {
     net: number
     income: number
     progress: number
+
+    /** Colour of the figure */
     color: string
+
+    /** Colour of the bar under it, drawn from the chart colours rather than the text ones */
+    barColor: string
     fxStatus: FxStatus | undefined
   }
   creditUsage: {
@@ -32,7 +37,12 @@ export interface AccountsMetricsViewModel {
     utilization: number
     totalUsed: number
     totalLimit: number
+
+    /** Colour of the figure */
     color: string
+
+    /** Colour of the bar under it, drawn from the chart colours rather than the text ones */
+    barColor: string
     fxStatus: FxStatus | undefined
   }
   runway: {

--- a/frontend/src/pages/accounts/utils/accountMetrics.ts
+++ b/frontend/src/pages/accounts/utils/accountMetrics.ts
@@ -7,6 +7,8 @@ import type { RunwayResult } from '@/api/user'
 import type { Currency } from '@/api/currency'
 import type { AccountsMetricsViewModel } from '@/pages/accounts/types/accounts'
 import { formatCurrency } from '@/utils/formatCurrency'
+import { getSavingsRateTier } from '@/utils/savingsRateTier'
+import { getValueMarkColor, type ValueMarkTone } from '@/utils/valueMarkColor'
 import {
   RUNWAY_BAND_STYLE,
   RUNWAY_TARGET_MONTHS,
@@ -14,6 +16,31 @@ import {
   formatRunwayBasis,
   runwayBand,
 } from '@/utils/runway'
+
+// Colour of the figure on a metric tile. A number needs more contrast against the tile than the
+// bar under it does, so the two are not drawn from the same pair
+const METRIC_TEXT_COLORS: Record<ValueMarkTone, string> = {
+  positive: 'var(--app-positive)',
+  accent: 'var(--app-accent)',
+  negative: 'var(--app-negative)',
+}
+
+// What a tile shows before its figure arrives, and where there is no figure to show
+const METRIC_UNSET_COLOR = 'var(--app-text-subtle)'
+
+/**
+ * Resolves the colour of a metric tile's figure, or the resting grey when it has none
+ */
+function getMetricTextColor(tone: ValueMarkTone | null) {
+  return tone === null ? METRIC_UNSET_COLOR : METRIC_TEXT_COLORS[tone]
+}
+
+/**
+ * Resolves the colour of a metric tile's bar, or the resting grey when it has no figure
+ */
+function getMetricBarColor(tone: ValueMarkTone | null) {
+  return tone === null ? METRIC_UNSET_COLOR : getValueMarkColor(tone)
+}
 
 /**
  * Builds the savings rate metric from the most recent dashboard savings period
@@ -36,18 +63,15 @@ export function getSavingsRateMetric(
         : value <= 0
           ? 100
           : Math.min(value, 100)
-  const color =
-    isLoading
-      ? 'var(--app-text-subtle)'
-      : value !== null
-      ? value >= 20
-        ? 'var(--app-positive)'
-        : value >= 10
-          ? 'var(--app-accent)'
-          : 'var(--app-negative)'
+  // A month with no income and no expenses has no rate to show, so the tile stays grey rather than
+  // taking the tier a null rate falls in
+  const tone = isLoading
+    ? null
+    : value !== null
+      ? getSavingsRateTier(value)
       : hasExpenses
-        ? 'var(--app-negative)'
-        : 'var(--app-text-subtle)'
+        ? 'negative'
+        : null
 
   return {
     value,
@@ -56,7 +80,8 @@ export function getSavingsRateMetric(
     net,
     income,
     progress,
-    color,
+    color: getMetricTextColor(tone),
+    barColor: getMetricBarColor(tone),
     fxStatus: dashboardSavingsRate?.fx_status,
   }
 }
@@ -75,13 +100,13 @@ export function getCreditUsageMetric(
   const totalLimit = dashboardCredit?.credit_limit_total ?? 0
   const hasCreditData = Boolean(dashboardCredit) && totalLimit > 0
   const utilization = totalLimit > 0 ? Math.round((totalUsed / totalLimit) * 100) : 0
-  const color = isLoading || !hasCreditData
-    ? 'var(--app-text-subtle)'
+  const tone = isLoading || !hasCreditData
+    ? null
     : utilization <= 30
-      ? 'var(--app-positive)'
+      ? 'positive'
       : utilization <= 70
-        ? 'var(--app-accent)'
-        : 'var(--app-negative)'
+        ? 'accent'
+        : 'negative'
 
   return {
     hasCreditAccounts: revolvingAccounts.length > 0,
@@ -91,7 +116,8 @@ export function getCreditUsageMetric(
     utilization,
     totalUsed,
     totalLimit,
-    color,
+    color: getMetricTextColor(tone),
+    barColor: getMetricBarColor(tone),
     fxStatus: dashboardCredit?.fx_status,
   }
 }

--- a/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
+++ b/frontend/src/pages/accounts/utils/taxAdvantagedLimits.ts
@@ -4,16 +4,36 @@ import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import type { TaxAdvantagedLimitSummary } from '@/pages/accounts/types/accounts'
 import { type CompactMoneyRule, formatCompactMoney } from '@/utils/formatCompactMoney'
 import { formatMajorUnits, toMajorUnits } from '@/utils/formatCurrency'
+import { getValueMarkColor, type ValueMarkTone } from '@/utils/valueMarkColor'
 
 /**
- * Chooses the usage colour for tax-advantaged contribution and withdrawal meters
+ * Places tax-advantaged usage in a band, or reports that there is no band to place it in
+ *
+ * Room used up exactly is not over the limit, so it reads as spent rather than as a problem
+ */
+function getTaxAdvantagedUsageTone(used: number, limit: number): ValueMarkTone | null {
+  if (limit <= 0) return used > 0 ? 'negative' : null
+  if (used / limit > 1) return 'negative'
+  if (limit - used === 0) return null
+  return 'accent'
+}
+
+/**
+ * Chooses the colour of the percentage written beside a tax-advantaged meter
  */
 export function getTaxAdvantagedUsageColor(used: number, limit: number): string {
-  if (limit <= 0) return used > 0 ? 'var(--app-negative)' : 'var(--app-text-muted)'
-  const ratio = used / limit
-  if (ratio > 1) return 'var(--app-negative)'
-  if (limit - used === 0) return 'var(--app-text-muted)'
-  return 'var(--app-accent)'
+  const tone = getTaxAdvantagedUsageTone(used, limit)
+  if (tone === null) return 'var(--app-text-muted)'
+  return tone === 'negative' ? 'var(--app-negative)' : 'var(--app-accent)'
+}
+
+/**
+ * Chooses the colour of the meter bar itself, which is a shape rather than a figure
+ */
+export function getTaxAdvantagedUsageBarColor(used: number, limit: number): string {
+  const tone = getTaxAdvantagedUsageTone(used, limit)
+  if (tone === null) return 'var(--app-text-muted)'
+  return getValueMarkColor(tone)
 }
 
 /**

--- a/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/HistoryChart.tsx
@@ -32,10 +32,11 @@ import CurrentPeriodBoundary from '@/pages/budgets/components/budget-details-mod
 import StackedBarSegment from '@/pages/budgets/components/budget-details-modal/StackedBarSegment'
 import BudgetUtilizationBar from '@/pages/budgets/components/budget-details-modal/UtilizationBar'
 import BudgetChartAxisTick from '@/pages/budgets/components/budget-details-modal/XAxisTick'
-import BudgetChartYAxisTick, {
+import BudgetChartYAxisTick from '@/pages/budgets/components/budget-details-modal/YAxisTick'
+import {
   OVER_BUDGET_LIMIT_LINE_COLOR,
   OVER_BUDGET_LIMIT_LINE_PCT,
-} from '@/pages/budgets/components/budget-details-modal/YAxisTick'
+} from '@/pages/budgets/components/budget-details-modal/budgetChartAxis'
 import { MODAL_SURFACE_TRANSITION_MS } from '@/pages/budgets/constants'
 import {
   BUDGET_CHART_HOVER_HIGHLIGHT_WIDTH,

--- a/frontend/src/pages/budgets/components/budget-details-modal/YAxisTick.tsx
+++ b/frontend/src/pages/budgets/components/budget-details-modal/YAxisTick.tsx
@@ -1,20 +1,16 @@
 import { Text, type YAxisTickContentProps } from 'recharts'
-
-// The dashed limit line is drawn across the plot at this utilization percentage to mark the
-// budget, and the Y-axis tick bolds its label at the same value
-export const OVER_BUDGET_LIMIT_LINE_PCT = 100
-
-// Colour of the dashed budget-limit line, reused by the Y-axis tick to colour its label at the
-// same threshold
-export const OVER_BUDGET_LIMIT_LINE_COLOR = 'var(--app-negative)'
+import {
+  OVER_BUDGET_LIMIT_LABEL_COLOR,
+  OVER_BUDGET_LIMIT_LINE_PCT,
+} from '@/pages/budgets/components/budget-details-modal/budgetChartAxis'
 
 // Font size shared by every Y-axis utilization label
 const BUDGET_CHART_Y_AXIS_TICK_FONT_SIZE = 12
 
 /**
  * Renders one Y-axis utilization label, matching the default tick styling unless it is the 100%
- * budget limit, which is drawn in the limit-line colour and bold so the label reads together with
- * the dashed line crossing the plot at the same height
+ * budget limit, which is drawn red and bold so the label reads together with the dashed line
+ * crossing the plot at the same height. The two reds differ, since one is text and one is a mark
  *
  * Recharts' default tick is a `<Text>` positioned from the tick props it computes, so this renders
  * through that same component to keep the label aligned with its gridline. The full tick props are
@@ -27,7 +23,7 @@ export default function BudgetChartYAxisTick(tickProps: YAxisTickContentProps) {
   return (
     <Text
       {...tickProps}
-      fill={isLimit ? OVER_BUDGET_LIMIT_LINE_COLOR : 'var(--app-text-subtle)'}
+      fill={isLimit ? OVER_BUDGET_LIMIT_LABEL_COLOR : 'var(--app-text-subtle)'}
       fontSize={BUDGET_CHART_Y_AXIS_TICK_FONT_SIZE}
       fontWeight={isLimit ? 700 : 400}
     >

--- a/frontend/src/pages/budgets/components/budget-details-modal/budgetChartAxis.ts
+++ b/frontend/src/pages/budgets/components/budget-details-modal/budgetChartAxis.ts
@@ -1,3 +1,15 @@
+import { getValueMarkColor } from '@/utils/valueMarkColor'
+
+// The utilization the dashed limit line is drawn across the plot at, and the tick the label bolds
+export const OVER_BUDGET_LIMIT_LINE_PCT = 100
+
+// Colour of that dashed line
+export const OVER_BUDGET_LIMIT_LINE_COLOR = getValueMarkColor('negative')
+
+// Colour of the label at the same threshold. A label is read rather than measured, so it takes the
+// red that carries contrast against the page instead of the one the line uses
+export const OVER_BUDGET_LIMIT_LABEL_COLOR = 'var(--app-negative)'
+
 // The Y axis always shows at least this much so the 100% budget threshold stays on the visible axis
 const BUDGET_CHART_MIN_AXIS_MAX_PCT = 100
 

--- a/frontend/src/pages/budgets/utils/budgetStatus.ts
+++ b/frontend/src/pages/budgets/utils/budgetStatus.ts
@@ -1,17 +1,20 @@
 import type { Budget, BudgetUtilization } from '@/api/budgets'
 import { getBudgetUtilizationPercent } from '@/pages/budgets/utils/utilization'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 
 /**
  * Classifies the latest budget period into the status used by cards and details summaries
+ *
+ * The badge text and the shapes beside it take different colours: text keeps the contrast a
+ * reader needs, while the strip and the bar match every other shape drawn from a value
  */
 export function attentionState(latestPeriod: Budget | undefined, utilization: BudgetUtilization | undefined) {
   if (!latestPeriod) {
     return {
       label: 'Needs attention',
       background: 'var(--app-negative-soft)',
-      color: 'var(--app-negative)',
       textColor: 'var(--app-negative)',
-      indicatorColor: 'var(--app-negative)',
+      indicatorColor: getValueMarkColor('negative'),
     }
   }
 
@@ -20,16 +23,14 @@ export function attentionState(latestPeriod: Budget | undefined, utilization: Bu
     return {
       label: 'Needs attention',
       background: 'var(--app-negative-soft)',
-      color: 'var(--app-negative)',
       textColor: 'var(--app-negative)',
-      indicatorColor: 'var(--app-negative)',
+      indicatorColor: getValueMarkColor('negative'),
     }
   }
   if (usedPercent >= 80) {
     return {
       label: 'Watch',
       background: 'var(--app-warning-soft)',
-      color: 'var(--app-warning)',
       textColor: 'var(--app-warning-text)',
       indicatorColor: 'var(--app-warning)',
     }
@@ -37,8 +38,7 @@ export function attentionState(latestPeriod: Budget | undefined, utilization: Bu
   return {
     label: 'On track',
     background: 'var(--app-positive-soft)',
-    color: 'var(--app-positive)',
     textColor: 'var(--app-positive)',
-    indicatorColor: 'var(--app-positive)',
+    indicatorColor: getValueMarkColor('positive'),
   }
 }

--- a/frontend/src/pages/dashboard/utils/getSavingsRateChartData.ts
+++ b/frontend/src/pages/dashboard/utils/getSavingsRateChartData.ts
@@ -4,18 +4,6 @@ export type SavingsRateChartPoint = SavingsRateSeriesPoint & {
   chartRate: number | null
 }
 
-export type SavingsRateTier = 'positive' | 'accent' | 'negative'
-
-/**
- * Converts a savings rate into the colour tier used by the dashboard chart
- */
-export function getSavingsRateTier(rate: number | null): SavingsRateTier {
-  if (rate === null) return 'negative'
-  if (rate >= 20) return 'positive'
-  if (rate >= 10) return 'accent'
-  return 'negative'
-}
-
 /**
  * Caps outlier savings rates so the optional bounded chart remains readable
  */

--- a/frontend/src/pages/dashboard/utils/getTopBudgetAttentionState.ts
+++ b/frontend/src/pages/dashboard/utils/getTopBudgetAttentionState.ts
@@ -1,6 +1,12 @@
+import { getValueMarkColor } from '@/utils/valueMarkColor'
+
 export type TopBudgetAttentionState = {
   label: string
+
+  /** Colour of the written status, which needs contrast against the widget behind it */
   textColor: string
+
+  /** Colour of the dot beside it, which is a shape and matches every other shape reading a value */
   indicatorColor: string
 }
 
@@ -12,7 +18,7 @@ export function getTopBudgetAttentionState(usagePct: number): TopBudgetAttention
     return {
       label: 'Needs attention',
       textColor: 'var(--app-negative)',
-      indicatorColor: 'var(--app-negative)',
+      indicatorColor: getValueMarkColor('negative'),
     }
   }
 
@@ -27,6 +33,6 @@ export function getTopBudgetAttentionState(usagePct: number): TopBudgetAttention
   return {
     label: 'On track',
     textColor: 'var(--app-positive)',
-    indicatorColor: 'var(--app-positive)',
+    indicatorColor: getValueMarkColor('positive'),
   }
 }

--- a/frontend/src/pages/dashboard/widgets/net-worth/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/net-worth/Chart.tsx
@@ -24,6 +24,7 @@ import {
   DASHBOARD_X_AXIS_TICK_FONT_SIZE,
 } from '@/pages/dashboard/constants/chart'
 import type { NetWorthSeriesPoint } from '@/pages/dashboard/types/dashboard'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 import {
   getRechartsTooltipPoint,
   getRechartsTooltipPointer,
@@ -111,7 +112,7 @@ function getNetWorthLineColor(data: NetWorthSeriesPoint[]) {
     data.length >= 2 &&
     data[data.length - 1].value >= data[0].value
 
-  return netWorthTrendUp ? 'var(--app-positive)' : 'var(--app-negative)'
+  return getValueMarkColor(netWorthTrendUp ? 'positive' : 'negative')
 }
 
 /**

--- a/frontend/src/pages/dashboard/widgets/savings-rate/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/savings-rate/Chart.tsx
@@ -28,9 +28,9 @@ import {
 } from '@/pages/dashboard/utils/getSavingsRateChartData'
 import {
   getSavingsRateTier,
-  getSavingsRateTierColor,
   SAVINGS_RATE_TIERS,
 } from '@/utils/savingsRateTier'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 import {
   getRechartsTooltipPoint,
   getRechartsTooltipPointer,
@@ -137,7 +137,7 @@ export function SavingsRateChart({
               <rect
                 width={3}
                 height={6}
-                style={{ fill: getSavingsRateTierColor(tier) }}
+                style={{ fill: getValueMarkColor(tier) }}
               />
             </pattern>
           ))}
@@ -178,7 +178,7 @@ export function SavingsRateChart({
                   fill={
                     entry.isCurrent
                       ? `url(#savings-stripes-${tier})`
-                      : getSavingsRateTierColor(tier)
+                      : getValueMarkColor(tier)
                   }
                 />
               )

--- a/frontend/src/pages/dashboard/widgets/savings-rate/Chart.tsx
+++ b/frontend/src/pages/dashboard/widgets/savings-rate/Chart.tsx
@@ -24,9 +24,13 @@ import { SavingsCurrentBoundary } from '@/pages/dashboard/components/SavingsCurr
 import { DASHBOARD_X_AXIS_TICK_FONT_SIZE } from '@/pages/dashboard/constants/chart'
 import {
   getSavingsRateDisplay,
-  getSavingsRateTier,
   type SavingsRateChartPoint,
 } from '@/pages/dashboard/utils/getSavingsRateChartData'
+import {
+  getSavingsRateTier,
+  getSavingsRateTierColor,
+  SAVINGS_RATE_TIERS,
+} from '@/utils/savingsRateTier'
 import {
   getRechartsTooltipPoint,
   getRechartsTooltipPointer,
@@ -121,7 +125,7 @@ export function SavingsRateChart({
       {/* Recharts resolves pattern fills reliably when definitions share the chart SVG context */}
       <svg width={0} height={0} style={{ position: 'absolute' }} aria-hidden>
         <defs>
-          {(['positive', 'accent', 'negative'] as const).map((tier) => (
+          {SAVINGS_RATE_TIERS.map((tier) => (
             <pattern
               key={tier}
               id={`savings-stripes-${tier}`}
@@ -133,7 +137,7 @@ export function SavingsRateChart({
               <rect
                 width={3}
                 height={6}
-                style={{ fill: `var(--app-${tier})` }}
+                style={{ fill: getSavingsRateTierColor(tier) }}
               />
             </pattern>
           ))}
@@ -174,7 +178,7 @@ export function SavingsRateChart({
                   fill={
                     entry.isCurrent
                       ? `url(#savings-stripes-${tier})`
-                      : `var(--app-${tier})`
+                      : getSavingsRateTierColor(tier)
                   }
                 />
               )

--- a/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
+++ b/frontend/src/pages/insights/components/merchant-ranking-card/Card.tsx
@@ -37,10 +37,16 @@ type MerchantRankingSnapshot = {
   failed: boolean
 }
 
+/**
+ * Chooses the colour of a merchant's change figure, where spending more reads as the bad direction
+ *
+ * These are the colours text is written in rather than the ones a chart mark is drawn in, since a
+ * figure has to hold up against the page behind it
+ */
 function getChangeColor(changePct: number | null) {
   if (changePct === null) return 'var(--app-text-muted)'
-  if (changePct > 0) return 'var(--app-chart-negative)'
-  if (changePct < 0) return 'var(--app-chart-positive)'
+  if (changePct > 0) return 'var(--app-negative)'
+  if (changePct < 0) return 'var(--app-positive)'
   return 'var(--app-text-muted)'
 }
 

--- a/frontend/src/pages/insights/components/net-worth-card/Card.tsx
+++ b/frontend/src/pages/insights/components/net-worth-card/Card.tsx
@@ -118,10 +118,12 @@ export function NetWorthCard({
     [chartItems, displaySnapshot.baseline, displaySnapshot.mode, displaySnapshot.series],
   )
   const latestChange = deltaSeries.at(-1)?.totalChange ?? 0
+  // The text colours rather than the chart ones, since this is a figure and its arrow rather than
+  // anything drawn in the plot
   const netWorthTrendColor = latestChange > 0
-    ? 'var(--app-chart-positive)'
+    ? 'var(--app-positive)'
     : latestChange < 0
-      ? 'var(--app-chart-negative)'
+      ? 'var(--app-negative)'
       : 'var(--app-text-muted)'
   const NetWorthTrendIcon = latestChange > 0 ? TrendingUp : latestChange < 0 ? TrendingDown : Minus
 

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
@@ -12,6 +12,11 @@ import type { SavingsRateHistoryPoint } from '@/pages/insights/types/savingsRate
 import { getSavingsRateTrendFxStatusMessage } from '@/pages/insights/utils/fxTooltipMessages'
 import { formatSavingsRateValue } from '@/pages/insights/utils/money'
 import { getSavingsRateSummary } from '@/pages/insights/utils/savingsRateChart'
+import {
+  getSavingsRateTierColor,
+  SAVINGS_RATE_TIER_LABELS,
+  SAVINGS_RATE_TIERS,
+} from '@/utils/savingsRateTier'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import { InsightCalculationTooltip } from '@/pages/insights/components/CalculationTooltip'
 import { InsightActionButton } from '@/pages/insights/components/ActionButton'
@@ -241,18 +246,12 @@ export function SavingsRateTrendCard({
                   </AnimatePresence>
                 </p>
                 <div className="flex w-full items-center justify-center gap-4 text-xs min-[750px]:w-auto" style={{ color: 'var(--app-text-muted)' }}>
-                  <span className="flex items-center gap-1.5">
-                    <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-positive)' }} />
-                    20%+
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-accent)' }} />
-                    1-19%
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <span className="h-2 w-2 rounded-sm" style={{ background: 'var(--app-chart-negative)' }} />
-                    0% or less
-                  </span>
+                  {SAVINGS_RATE_TIERS.map((tier) => (
+                    <span key={tier} className="flex items-center gap-1.5">
+                      <span className="h-2 w-2 rounded-sm" style={{ background: getSavingsRateTierColor(tier) }} />
+                      {SAVINGS_RATE_TIER_LABELS[tier]}
+                    </span>
+                  ))}
                 </div>
               </div>
             </div>

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Card.tsx
@@ -13,10 +13,10 @@ import { getSavingsRateTrendFxStatusMessage } from '@/pages/insights/utils/fxToo
 import { formatSavingsRateValue } from '@/pages/insights/utils/money'
 import { getSavingsRateSummary } from '@/pages/insights/utils/savingsRateChart'
 import {
-  getSavingsRateTierColor,
   SAVINGS_RATE_TIER_LABELS,
   SAVINGS_RATE_TIERS,
 } from '@/utils/savingsRateTier'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 import { FxStatusBadge } from '@/components/tooltips/FxStatusBadge'
 import { InsightCalculationTooltip } from '@/pages/insights/components/CalculationTooltip'
 import { InsightActionButton } from '@/pages/insights/components/ActionButton'
@@ -248,7 +248,7 @@ export function SavingsRateTrendCard({
                 <div className="flex w-full items-center justify-center gap-4 text-xs min-[750px]:w-auto" style={{ color: 'var(--app-text-muted)' }}>
                   {SAVINGS_RATE_TIERS.map((tier) => (
                     <span key={tier} className="flex items-center gap-1.5">
-                      <span className="h-2 w-2 rounded-sm" style={{ background: getSavingsRateTierColor(tier) }} />
+                      <span className="h-2 w-2 rounded-sm" style={{ background: getValueMarkColor(tier) }} />
                       {SAVINGS_RATE_TIER_LABELS[tier]}
                     </span>
                   ))}

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Chart.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Chart.tsx
@@ -28,9 +28,9 @@ import {
 } from '@/pages/insights/utils/savingsRateChart'
 import {
   getSavingsRateTier,
-  getSavingsRateTierColor,
   SAVINGS_RATE_TIERS,
 } from '@/utils/savingsRateTier'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 import { formatSavingsRateValue } from '@/pages/insights/utils/money'
 import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
@@ -226,7 +226,7 @@ export function SavingsRateChart({
                   <rect
                     width={3}
                     height={6}
-                    style={{ fill: getSavingsRateTierColor(tier) }}
+                    style={{ fill: getValueMarkColor(tier) }}
                   />
                 </pattern>
               ))}
@@ -277,7 +277,7 @@ export function SavingsRateChart({
                       fill={
                         entry.isCurrent
                           ? `url(#insights-savings-stripes-${tier})`
-                          : getSavingsRateTierColor(tier)
+                          : getValueMarkColor(tier)
                       }
                     />
                   )

--- a/frontend/src/pages/insights/components/savings-rate-trend-card/Chart.tsx
+++ b/frontend/src/pages/insights/components/savings-rate-trend-card/Chart.tsx
@@ -24,10 +24,13 @@ import type { SavingsRateHistoryPoint } from '@/pages/insights/types/savingsRate
 import {
   getSavingsRateAxisConfig,
   getSavingsRateChartPoints,
-  getSavingsRateTier,
   type SavingsRateChartPoint,
-  type SavingsRateTier,
 } from '@/pages/insights/utils/savingsRateChart'
+import {
+  getSavingsRateTier,
+  getSavingsRateTierColor,
+  SAVINGS_RATE_TIERS,
+} from '@/utils/savingsRateTier'
 import { formatSavingsRateValue } from '@/pages/insights/utils/money'
 import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 
@@ -73,12 +76,6 @@ function getSavingsRateTooltipPointer(
     clientY: event.clientY,
     chartX: typeof state.activeCoordinate?.x === 'number' ? state.activeCoordinate.x : undefined,
   }
-}
-
-function getSavingsRateTierColor(tier: SavingsRateTier) {
-  if (tier === 'positive') return 'var(--app-chart-positive)'
-  if (tier === 'negative') return 'var(--app-chart-negative)'
-  return 'var(--app-accent)'
 }
 
 /**
@@ -217,7 +214,7 @@ export function SavingsRateChart({
         >
           <svg width={0} height={0} style={{ position: 'absolute' }} aria-hidden>
             <defs>
-              {(['positive', 'accent', 'negative'] as const).map((tier) => (
+              {SAVINGS_RATE_TIERS.map((tier) => (
                 <pattern
                   key={tier}
                   id={`insights-savings-stripes-${tier}`}

--- a/frontend/src/pages/insights/utils/savingsRateChart.ts
+++ b/frontend/src/pages/insights/utils/savingsRateChart.ts
@@ -1,7 +1,5 @@
 import type { SavingsRateHistoryPoint } from '@/pages/insights/types/savingsRate'
 
-export type SavingsRateTier = 'positive' | 'accent' | 'negative'
-
 export type SavingsRateSummary = {
   latestPoint: SavingsRateHistoryPoint | undefined
   averageRate: number | null
@@ -26,16 +24,6 @@ function hasFiniteSavingsRate(point: SavingsRateHistoryPoint): point is SavingsR
 function clampSavingsRate(rate: number | null) {
   if (rate === null) return null
   return Math.max(-100, Math.min(100, rate))
-}
-
-/**
- * Returns the display tier used by the savings-rate chart and legend
- */
-export function getSavingsRateTier(rate: number | null): SavingsRateTier {
-  if (rate === null) return 'negative'
-  if (rate >= 20) return 'positive'
-  if (rate > 0) return 'accent'
-  return 'negative'
 }
 
 /**

--- a/frontend/src/pages/transactions/components/top-band/DailyCashFlowChart.tsx
+++ b/frontend/src/pages/transactions/components/top-band/DailyCashFlowChart.tsx
@@ -45,6 +45,7 @@ import {
   type DailyCashFlowPoint,
 } from '@/pages/transactions/utils/dailyCashFlowChart'
 import { getCashFlowFxStatusMessage } from '@/pages/transactions/utils/fxTooltipMessages'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
 
 export type { DailyCashFlowChartMode } from '@/pages/transactions/utils/dailyCashFlowChart'
 
@@ -353,12 +354,12 @@ export default function DailyCashFlowChart({
                 <stop offset="100%" stopColor="var(--app-text-muted)" stopOpacity={0.02} />
               </linearGradient>
               <linearGradient id="inflowGrad" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="0%" stopColor="var(--app-positive)" stopOpacity={0.25} />
-                <stop offset="100%" stopColor="var(--app-positive)" stopOpacity={0.02} />
+                <stop offset="0%" stopColor={getValueMarkColor('positive')} stopOpacity={0.25} />
+                <stop offset="100%" stopColor={getValueMarkColor('positive')} stopOpacity={0.02} />
               </linearGradient>
               <linearGradient id="outflowGrad" x1="0" y1="1" x2="0" y2="0">
-                <stop offset="0%" stopColor="var(--app-negative)" stopOpacity={0.25} />
-                <stop offset="100%" stopColor="var(--app-negative)" stopOpacity={0.02} />
+                <stop offset="0%" stopColor={getValueMarkColor('negative')} stopOpacity={0.25} />
+                <stop offset="100%" stopColor={getValueMarkColor('negative')} stopOpacity={0.02} />
               </linearGradient>
             </defs>
             <XAxis
@@ -393,7 +394,7 @@ export default function DailyCashFlowChart({
                 <Area
                   type="monotone"
                   dataKey="inflow"
-                  stroke="var(--app-positive)"
+                  stroke={getValueMarkColor('positive')}
                   fill="url(#inflowGrad)"
                   strokeWidth={1.5}
                   isAnimationActive={false}
@@ -401,7 +402,7 @@ export default function DailyCashFlowChart({
                 <Area
                   type="monotone"
                   dataKey="outflow"
-                  stroke="var(--app-negative)"
+                  stroke={getValueMarkColor('negative')}
                   fill="url(#outflowGrad)"
                   strokeWidth={1.5}
                   isAnimationActive={false}

--- a/frontend/src/utils/savingsRateTier.ts
+++ b/frontend/src/utils/savingsRateTier.ts
@@ -11,12 +11,6 @@ const SAVINGS_RATE_POSITIVE_TIER_MIN_PERCENT = 20
 // A month that keeps less than this reads the same as one that kept nothing at all
 const SAVINGS_RATE_ACCENT_TIER_MIN_PERCENT = 10
 
-const SAVINGS_RATE_TIER_COLORS: Record<SavingsRateTier, string> = {
-  positive: 'var(--app-chart-positive)',
-  accent: 'var(--app-accent)',
-  negative: 'var(--app-chart-negative)',
-}
-
 /**
  * The band each tier covers, worded the way the legend shows it
  */
@@ -37,11 +31,4 @@ export function getSavingsRateTier(rate: number | null): SavingsRateTier {
   if (rate >= SAVINGS_RATE_POSITIVE_TIER_MIN_PERCENT) return 'positive'
   if (rate >= SAVINGS_RATE_ACCENT_TIER_MIN_PERCENT) return 'accent'
   return 'negative'
-}
-
-/**
- * Resolves the colour a tier is drawn in, the same shade in both themes
- */
-export function getSavingsRateTierColor(tier: SavingsRateTier) {
-  return SAVINGS_RATE_TIER_COLORS[tier]
 }

--- a/frontend/src/utils/savingsRateTier.ts
+++ b/frontend/src/utils/savingsRateTier.ts
@@ -1,0 +1,47 @@
+export type SavingsRateTier = 'positive' | 'accent' | 'negative'
+
+/**
+ * The three tiers in the order the legend lists them and the charts define their stripe patterns
+ */
+export const SAVINGS_RATE_TIERS = ['positive', 'accent', 'negative'] as const
+
+// A month that keeps this share of its income or more reads as a strong result
+const SAVINGS_RATE_POSITIVE_TIER_MIN_PERCENT = 20
+
+// A month that keeps less than this reads the same as one that kept nothing at all
+const SAVINGS_RATE_ACCENT_TIER_MIN_PERCENT = 10
+
+const SAVINGS_RATE_TIER_COLORS: Record<SavingsRateTier, string> = {
+  positive: 'var(--app-chart-positive)',
+  accent: 'var(--app-accent)',
+  negative: 'var(--app-chart-negative)',
+}
+
+/**
+ * The band each tier covers, worded the way the legend shows it
+ */
+export const SAVINGS_RATE_TIER_LABELS: Record<SavingsRateTier, string> = {
+  positive: `${SAVINGS_RATE_POSITIVE_TIER_MIN_PERCENT}%+`,
+  accent: `${SAVINGS_RATE_ACCENT_TIER_MIN_PERCENT}-${SAVINGS_RATE_POSITIVE_TIER_MIN_PERCENT - 1}%`,
+  negative: `Under ${SAVINGS_RATE_ACCENT_TIER_MIN_PERCENT}%`,
+}
+
+/**
+ * Converts a savings rate into the tier every savings rate chart colours it by
+ *
+ * A month with no income and no expenses has no rate to place and takes the lowest tier. Neither
+ * chart draws a bar for such a month, so the tier it holds is never painted
+ */
+export function getSavingsRateTier(rate: number | null): SavingsRateTier {
+  if (rate === null) return 'negative'
+  if (rate >= SAVINGS_RATE_POSITIVE_TIER_MIN_PERCENT) return 'positive'
+  if (rate >= SAVINGS_RATE_ACCENT_TIER_MIN_PERCENT) return 'accent'
+  return 'negative'
+}
+
+/**
+ * Resolves the colour a tier is drawn in, the same shade in both themes
+ */
+export function getSavingsRateTierColor(tier: SavingsRateTier) {
+  return SAVINGS_RATE_TIER_COLORS[tier]
+}

--- a/frontend/src/utils/valueMarkColor.ts
+++ b/frontend/src/utils/valueMarkColor.ts
@@ -1,0 +1,20 @@
+export type ValueMarkTone = 'positive' | 'accent' | 'negative'
+
+// Every shape that reads a value out as a colour draws from this pair, so a bar on one page and a
+// bar on another cannot end up different greens. Text keeps --app-positive and --app-negative,
+// which carry the contrast a figure needs against the page behind it
+const VALUE_MARK_COLORS: Record<ValueMarkTone, string> = {
+  positive: 'var(--app-chart-positive)',
+  accent: 'var(--app-accent)',
+  negative: 'var(--app-chart-negative)',
+}
+
+/**
+ * Resolves the colour a chart mark, meter or progress bar is drawn in
+ *
+ * The green and the red hold their shade in both themes. The amber does not, since it is the same
+ * accent the rest of the interface uses
+ */
+export function getValueMarkColor(tone: ValueMarkTone) {
+  return VALUE_MARK_COLORS[tone]
+}

--- a/frontend/tests/pages/accounts/detail/utils/balanceChartViewModel.test.ts
+++ b/frontend/tests/pages/accounts/detail/utils/balanceChartViewModel.test.ts
@@ -99,6 +99,65 @@ describe('balance chart view model helpers', () => {
     expect(snapshot.chartSeries.map((point) => point.periodBalance)).toEqual([0, 0, 1_500])
     expect(snapshot.periodDelta).toEqual({ absolute: 1_500, pct: 15 })
     expect(snapshot.trendUp).toBe(true)
-    expect(snapshot.chartLineColor).toBe('var(--app-positive)')
+
+    // The same rise is a figure and a line, so it carries the text green and the chart green at once
+    expect(snapshot.deltaColor).toBe('var(--app-positive)')
+    expect(snapshot.chartLineColor).toBe('var(--app-chart-positive)')
+  })
+
+  it('keeps the gold line in balance mode and moves only its red', () => {
+    const snapshots: AccountBalanceSnapshot[] = [
+      { account_id: 'account', dt: '2026-06-01', balance: 10_000 },
+      { account_id: 'account', dt: '2026-06-03', balance: 11_500 },
+    ]
+    const buildBalanceMode = (currentBalance: number) => getBalanceChartSnapshot({
+      snapshots,
+      range: '7D',
+      chartMode: 'balance',
+      currentBalance,
+      currency: 'USD',
+      fromDate: new Date(2026, 5, 1),
+      toDate: new Date(2026, 5, 3),
+      granularity: 'day',
+    })
+
+    expect(buildBalanceMode(11_500).chartLineColor).toBe('var(--app-accent)')
+    expect(buildBalanceMode(-500).chartLineColor).toBe('var(--app-chart-negative)')
+  })
+
+  it('splits a falling period the same way, and colours a period with no movement at all grey', () => {
+    const falling = getBalanceChartSnapshot({
+      snapshots: [
+        { account_id: 'account', dt: '2026-06-01', balance: 11_500 },
+        { account_id: 'account', dt: '2026-06-03', balance: 10_000 },
+      ],
+      range: '7D',
+      chartMode: 'change',
+      currentBalance: 10_000,
+      currency: 'USD',
+      fromDate: new Date(2026, 5, 1),
+      toDate: new Date(2026, 5, 3),
+      granularity: 'day',
+    })
+
+    expect(falling.trendUp).toBe(false)
+    expect(falling.deltaColor).toBe('var(--app-negative)')
+    expect(falling.chartLineColor).toBe('var(--app-chart-negative)')
+
+    // One day of range leaves a single point, so there is no movement to measure between two
+    const singleDay = getBalanceChartSnapshot({
+      snapshots: [{ account_id: 'account', dt: '2026-06-01', balance: 10_000 }],
+      range: '7D',
+      chartMode: 'change',
+      currentBalance: 10_000,
+      currency: 'USD',
+      fromDate: new Date(2026, 5, 1),
+      toDate: new Date(2026, 5, 1),
+      granularity: 'day',
+    })
+
+    expect(singleDay.periodDelta).toBeNull()
+    expect(singleDay.deltaColor).toBe('var(--app-text-muted)')
+    expect(singleDay.chartLineColor).toBe('var(--app-accent)')
   })
 })

--- a/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
+++ b/frontend/tests/pages/accounts/utils/accountMetrics.test.ts
@@ -30,6 +30,7 @@ describe('account metric helpers', () => {
       income: 2_000,
       progress: 25,
       color: 'var(--app-positive)',
+      barColor: 'var(--app-chart-positive)',
     })
 
     expect(getSavingsRateMetric({
@@ -42,6 +43,59 @@ describe('account metric helpers', () => {
       hasExpenses: true,
       progress: 100,
       color: 'var(--app-negative)',
+      barColor: 'var(--app-chart-negative)',
+    })
+  })
+
+  it('places the savings rate tile in the same band as the savings rate charts', () => {
+    const getTileColors = (income: number, expenses: number) => {
+      const metric = getSavingsRateMetric({
+        savings_rate_history: [{ month: '2026-06-01', income, expenses }],
+        fx_status: { state: 'complete', missing_pairs: [] },
+      }, false)
+
+      return { value: metric.value, color: metric.color, barColor: metric.barColor }
+    }
+
+    expect(getTileColors(100, 80)).toEqual({
+      value: 20,
+      color: 'var(--app-positive)',
+      barColor: 'var(--app-chart-positive)',
+    })
+    expect(getTileColors(100, 81)).toEqual({
+      value: 19,
+      color: 'var(--app-accent)',
+      barColor: 'var(--app-accent)',
+    })
+    expect(getTileColors(100, 90)).toEqual({
+      value: 10,
+      color: 'var(--app-accent)',
+      barColor: 'var(--app-accent)',
+    })
+    expect(getTileColors(100, 91)).toEqual({
+      value: 9,
+      color: 'var(--app-negative)',
+      barColor: 'var(--app-chart-negative)',
+    })
+  })
+
+  it('leaves an empty or still-loading savings rate tile grey rather than red', () => {
+    expect(getSavingsRateMetric({
+      savings_rate_history: [{ month: '2026-06-01', income: 0, expenses: 0 }],
+      fx_status: { state: 'none', missing_pairs: [] },
+    }, false)).toMatchObject({
+      value: null,
+      hasExpenses: false,
+      color: 'var(--app-text-subtle)',
+      barColor: 'var(--app-text-subtle)',
+    })
+
+    expect(getSavingsRateMetric({
+      savings_rate_history: [{ month: '2026-06-01', income: 1_000, expenses: 100 }],
+      fx_status: { state: 'complete', missing_pairs: [] },
+    }, true)).toMatchObject({
+      color: 'var(--app-text-subtle)',
+      barColor: 'var(--app-text-subtle)',
     })
   })
 
@@ -72,6 +126,46 @@ describe('account metric helpers', () => {
       totalUsed: 250,
       totalLimit: 1_000,
       color: 'var(--app-positive)',
+      barColor: 'var(--app-chart-positive)',
+    })
+  })
+
+  it('splits the credit usage figure from its bar across all three bands', () => {
+    const rows = [createAccount({
+      id: 'card',
+      account_kind: 'revolving',
+      account_type: 'credit_card',
+      credit_limit: 1_000,
+    })]
+    const getTileColors = (creditUsed: number) => {
+      const metric = getCreditUsageMetric(rows, {
+        credit_used: creditUsed,
+        credit_limit_total: 1_000,
+        fx_status: { state: 'complete', missing_pairs: [] },
+      }, false)
+
+      return { utilization: metric.utilization, color: metric.color, barColor: metric.barColor }
+    }
+
+    expect(getTileColors(300)).toEqual({
+      utilization: 30,
+      color: 'var(--app-positive)',
+      barColor: 'var(--app-chart-positive)',
+    })
+    expect(getTileColors(500)).toEqual({
+      utilization: 50,
+      color: 'var(--app-accent)',
+      barColor: 'var(--app-accent)',
+    })
+    expect(getTileColors(800)).toEqual({
+      utilization: 80,
+      color: 'var(--app-negative)',
+      barColor: 'var(--app-chart-negative)',
+    })
+
+    expect(getCreditUsageMetric(rows, undefined, false)).toMatchObject({
+      color: 'var(--app-text-subtle)',
+      barColor: 'var(--app-text-subtle)',
     })
   })
 

--- a/frontend/tests/pages/accounts/utils/metricDisplay.test.ts
+++ b/frontend/tests/pages/accounts/utils/metricDisplay.test.ts
@@ -20,6 +20,7 @@ describe('account metric display helpers', () => {
       income: 0,
       progress: 0,
       color: 'var(--app-negative)',
+      barColor: 'var(--app-chart-negative)',
       fxStatus: undefined,
     }
 
@@ -39,6 +40,7 @@ describe('account metric display helpers', () => {
       totalUsed: 0,
       totalLimit: 0,
       color: 'var(--app-text-subtle)',
+      barColor: 'var(--app-text-subtle)',
       fxStatus: { state: 'unavailable', missing_pairs: [] },
     }
 

--- a/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
+++ b/frontend/tests/pages/accounts/utils/taxAdvantagedLimits.test.ts
@@ -16,6 +16,7 @@ import {
   getTaxAdvantagedUsageColor,
   getTaxAdvantagedUsagePercent,
   hasTaxAdvantagedLimitTracking,
+  getTaxAdvantagedUsageBarColor,
 } from '@/pages/accounts/utils/taxAdvantagedLimits'
 import { createAccount, createInstitution, createTaxAdvantagedCategory, testCurrencies } from './fixtures'
 
@@ -25,6 +26,19 @@ describe('tax-advantaged limit helpers', () => {
     expect(getTaxAdvantagedUsagePercent(-25, 100)).toBe(0)
     expect(getTaxAdvantagedUsageColor(125, 100)).toBe('var(--app-negative)')
     expect(getTaxAdvantagedUsageColor(100, 100)).toBe('var(--app-text-muted)')
+  })
+
+  it('draws the meter bar in the chart colours while its percentage keeps the text ones', () => {
+    expect(getTaxAdvantagedUsageBarColor(125, 100)).toBe('var(--app-chart-negative)')
+    expect(getTaxAdvantagedUsageBarColor(50, 100)).toBe('var(--app-accent)')
+    expect(getTaxAdvantagedUsageColor(50, 100)).toBe('var(--app-accent)')
+
+    // The two agree on which band the usage is in, so only the shade differs
+    expect(getTaxAdvantagedUsageBarColor(100, 100)).toBe('var(--app-text-muted)')
+    expect(getTaxAdvantagedUsageBarColor(0, 0)).toBe('var(--app-text-muted)')
+    expect(getTaxAdvantagedUsageColor(0, 0)).toBe('var(--app-text-muted)')
+    expect(getTaxAdvantagedUsageBarColor(10, 0)).toBe('var(--app-chart-negative)')
+    expect(getTaxAdvantagedUsageColor(10, 0)).toBe('var(--app-negative)')
   })
 
   it('formats compact meter values without losing the currency sign', () => {

--- a/frontend/tests/pages/budgets/components/budgetChartAxis.test.ts
+++ b/frontend/tests/pages/budgets/components/budgetChartAxis.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Tests the budget limit line and the label at the same height, so the line keeps the red every
+ * chart mark uses while the label keeps the one a reader needs against the page
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  OVER_BUDGET_LIMIT_LABEL_COLOR,
+  OVER_BUDGET_LIMIT_LINE_COLOR,
+  OVER_BUDGET_LIMIT_LINE_PCT,
+} from '@/pages/budgets/components/budget-details-modal/budgetChartAxis'
+
+describe('budget limit line', () => {
+  it('draws the line and writes its label in different reds', () => {
+    expect(OVER_BUDGET_LIMIT_LINE_COLOR).toBe('var(--app-chart-negative)')
+    expect(OVER_BUDGET_LIMIT_LABEL_COLOR).toBe('var(--app-negative)')
+    expect(OVER_BUDGET_LIMIT_LINE_COLOR).not.toBe(OVER_BUDGET_LIMIT_LABEL_COLOR)
+  })
+
+  it('puts both at the utilization a budget is spent up to', () => {
+    expect(OVER_BUDGET_LIMIT_LINE_PCT).toBe(100)
+  })
+})

--- a/frontend/tests/pages/budgets/utils/budgetStatus.test.ts
+++ b/frontend/tests/pages/budgets/utils/budgetStatus.test.ts
@@ -71,4 +71,23 @@ describe('budget attention status', () => {
   it('classifies full utilization as needing attention', () => {
     expect(attentionState(createBudget(), createUtilization(100000)).label).toBe('Needs attention')
   })
+
+  it('colours the strip and the bar apart from the words, and leaves the amber state alone', () => {
+    expect(attentionState(createBudget(), createUtilization(50000))).toMatchObject({
+      textColor: 'var(--app-positive)',
+      indicatorColor: 'var(--app-chart-positive)',
+    })
+    expect(attentionState(createBudget(), createUtilization(100000))).toMatchObject({
+      textColor: 'var(--app-negative)',
+      indicatorColor: 'var(--app-chart-negative)',
+    })
+    expect(attentionState(createBudget(), createUtilization(80000))).toMatchObject({
+      textColor: 'var(--app-warning-text)',
+      indicatorColor: 'var(--app-warning)',
+    })
+  })
+
+  it('returns no colour nothing reads', () => {
+    expect(attentionState(createBudget(), createUtilization(50000))).not.toHaveProperty('color')
+  })
 })

--- a/frontend/tests/pages/dashboard/utils/getTopBudgetAttentionState.test.ts
+++ b/frontend/tests/pages/dashboard/utils/getTopBudgetAttentionState.test.ts
@@ -11,4 +11,19 @@ describe('top budget attention state', () => {
     expect(getTopBudgetAttentionState(80).label).toBe('Watch')
     expect(getTopBudgetAttentionState(100).label).toBe('Needs attention')
   })
+
+  it('colours the dot apart from the words beside it, and leaves the amber state alone', () => {
+    expect(getTopBudgetAttentionState(50)).toMatchObject({
+      textColor: 'var(--app-positive)',
+      indicatorColor: 'var(--app-chart-positive)',
+    })
+    expect(getTopBudgetAttentionState(100)).toMatchObject({
+      textColor: 'var(--app-negative)',
+      indicatorColor: 'var(--app-chart-negative)',
+    })
+    expect(getTopBudgetAttentionState(85)).toMatchObject({
+      textColor: 'var(--app-warning-text)',
+      indicatorColor: 'var(--app-warning)',
+    })
+  })
 })

--- a/frontend/tests/utils/savingsRateTier.test.ts
+++ b/frontend/tests/utils/savingsRateTier.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests the savings rate tier scale, so both charts place a rate in the same band, paint that band
+ * the same colour, and describe it in a legend that moves with the thresholds
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  getSavingsRateTier,
+  getSavingsRateTierColor,
+  SAVINGS_RATE_TIER_LABELS,
+  SAVINGS_RATE_TIERS,
+  type SavingsRateTier,
+} from '@/utils/savingsRateTier'
+
+const WHOLE_RATES_FROM_MINUS_100_TO_100 = Array.from({ length: 201 }, (_, index) => index - 100)
+
+/**
+ * Finds the lowest whole rate the tier function puts in a band, by asking it about every rate
+ *
+ * The labels are checked against this rather than against the thresholds the module holds, since a
+ * label typed out by hand matches those thresholds until one of them moves, which is the day the
+ * label is wrong and the only day the check is worth anything
+ */
+function getLowestRateInTier(tier: SavingsRateTier) {
+  const rate = WHOLE_RATES_FROM_MINUS_100_TO_100.find((candidate) => getSavingsRateTier(candidate) === tier)
+  if (rate === undefined) throw new Error(`no whole rate between -100 and 100 falls in the ${tier} band`)
+
+  return rate
+}
+
+describe('savings rate tiers', () => {
+  it('places a rate in one band on both sides of each threshold', () => {
+    expect(getSavingsRateTier(25)).toBe('positive')
+    expect(getSavingsRateTier(20)).toBe('positive')
+    expect(getSavingsRateTier(19)).toBe('accent')
+    expect(getSavingsRateTier(10)).toBe('accent')
+    expect(getSavingsRateTier(9)).toBe('negative')
+    expect(getSavingsRateTier(5)).toBe('negative')
+    expect(getSavingsRateTier(0)).toBe('negative')
+    expect(getSavingsRateTier(-100)).toBe('negative')
+  })
+
+  it('places a month with no rate and a month of pure spending in the lowest band', () => {
+    // A null rate only reaches this guard while both thresholds sit above zero, since null >= 0 is
+    // true and a threshold lowered to zero would otherwise paint a month with no activity amber
+    expect(getSavingsRateTier(null)).toBe('negative')
+    expect(getSavingsRateTier(Number.NEGATIVE_INFINITY)).toBe('negative')
+    expect(getSavingsRateTier(Number.POSITIVE_INFINITY)).toBe('positive')
+  })
+
+  it('paints each band its own colour', () => {
+    expect(getSavingsRateTierColor('positive')).toBe('var(--app-chart-positive)')
+    expect(getSavingsRateTierColor('accent')).toBe('var(--app-accent)')
+    expect(getSavingsRateTierColor('negative')).toBe('var(--app-chart-negative)')
+  })
+
+  it('lists the bands from the highest down, which is the order the legend and the stripes follow', () => {
+    expect(SAVINGS_RATE_TIERS).toEqual(['positive', 'accent', 'negative'])
+  })
+
+  it('words each legend label from the band the tier function actually applies', () => {
+    const lowestPositiveRate = getLowestRateInTier('positive')
+    const lowestAccentRate = getLowestRateInTier('accent')
+
+    expect(SAVINGS_RATE_TIER_LABELS.positive).toBe(`${lowestPositiveRate}%+`)
+    expect(SAVINGS_RATE_TIER_LABELS.accent).toBe(`${lowestAccentRate}-${lowestPositiveRate - 1}%`)
+    expect(SAVINGS_RATE_TIER_LABELS.negative).toBe(`Under ${lowestAccentRate}%`)
+  })
+})

--- a/frontend/tests/utils/savingsRateTier.test.ts
+++ b/frontend/tests/utils/savingsRateTier.test.ts
@@ -5,7 +5,6 @@
 import { describe, expect, it } from 'vitest'
 import {
   getSavingsRateTier,
-  getSavingsRateTierColor,
   SAVINGS_RATE_TIER_LABELS,
   SAVINGS_RATE_TIERS,
   type SavingsRateTier,
@@ -45,12 +44,6 @@ describe('savings rate tiers', () => {
     expect(getSavingsRateTier(null)).toBe('negative')
     expect(getSavingsRateTier(Number.NEGATIVE_INFINITY)).toBe('negative')
     expect(getSavingsRateTier(Number.POSITIVE_INFINITY)).toBe('positive')
-  })
-
-  it('paints each band its own colour', () => {
-    expect(getSavingsRateTierColor('positive')).toBe('var(--app-chart-positive)')
-    expect(getSavingsRateTierColor('accent')).toBe('var(--app-accent)')
-    expect(getSavingsRateTierColor('negative')).toBe('var(--app-chart-negative)')
   })
 
   it('lists the bands from the highest down, which is the order the legend and the stripes follow', () => {

--- a/frontend/tests/utils/valueMarkColor.test.ts
+++ b/frontend/tests/utils/valueMarkColor.test.ts
@@ -1,0 +1,19 @@
+/**
+ * Tests the colours every chart mark, meter and progress bar draws from, so a bar on one page and a
+ * bar on another cannot end up different shades of the same colour
+ */
+import { describe, expect, it } from 'vitest'
+import { getValueMarkColor } from '@/utils/valueMarkColor'
+
+describe('value mark colours', () => {
+  it('gives each tone the colour charts already use', () => {
+    expect(getValueMarkColor('positive')).toBe('var(--app-chart-positive)')
+    expect(getValueMarkColor('accent')).toBe('var(--app-accent)')
+    expect(getValueMarkColor('negative')).toBe('var(--app-chart-negative)')
+  })
+
+  it('keeps the green and the red apart from the colours text is written in', () => {
+    expect(getValueMarkColor('positive')).not.toBe('var(--app-positive)')
+    expect(getValueMarkColor('negative')).not.toBe('var(--app-negative)')
+  })
+})


### PR DESCRIPTION
Consolidated the savings rate rules so both charts use the same bands, fixing the inconsistency where a 5% rate drew different colours on each page. Every bar, line, meter and progress bar now draws from one colour source to stay consistent, while text keeps a separate pair for the contrast each was chosen for. Two Insights cards now use the text colour pair for their figures.
