### PR TITLE
feat: add bulk transaction editing

### DIFF
--- a/backend/app/permissions/accounts.py
+++ b/backend/app/permissions/accounts.py
@@ -2,7 +2,7 @@
 import uuid
 
 from fastapi import HTTPException, status
-from sqlalchemy import select
+from sqlalchemy import and_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -10,6 +10,56 @@ from app.models.account import Account, AccountPermission
 from app.models.base import PermissionLevel
 from app.models.group import GroupMember
 from app.permissions.levels import is_permission_level_at_least
+
+
+async def attach_account_write_capabilities(
+    db: AsyncSession,
+    accounts: list[Account],
+    user_id: uuid.UUID,
+) -> None:
+    """Attach the caller's effective write capability to account response rows
+
+    Args:
+        db: Active database session
+        accounts: Account rows being prepared for a response
+        user_id: User receiving the response
+    """
+    if not accounts:
+        return
+
+    account_ids = [account.id for account in accounts]
+    capability_query = (
+        select(Account.id, GroupMember.is_admin, AccountPermission.level)
+        .outerjoin(
+            GroupMember,
+            and_(
+                GroupMember.group_id == Account.group_id,
+                GroupMember.user_id == user_id,
+            ),
+        )
+        .outerjoin(
+            AccountPermission,
+            and_(
+                AccountPermission.account_id == Account.id,
+                AccountPermission.group_id == Account.group_id,
+                AccountPermission.user_id == user_id,
+            ),
+        )
+        .where(Account.id.in_(account_ids))
+    )
+
+    # Read every capability in one caller-bound query so account lists do not add one query per row
+    result = await db.execute(capability_query)
+    capability_rows = {
+        account_id: bool(is_group_admin)
+        or (
+            permission_level is not None
+            and is_permission_level_at_least(permission_level, PermissionLevel.WRITE)
+        )
+        for account_id, is_group_admin, permission_level in result.all()
+    }
+    for account in accounts:
+        account.can_write = account.owner_id == user_id or capability_rows.get(account.id, False)
 
 
 async def check_account_access(

--- a/backend/app/routes/accounts/balance_adjustment_helpers.py
+++ b/backend/app/routes/accounts/balance_adjustment_helpers.py
@@ -12,7 +12,7 @@ from app.models.category import Category
 from app.models.merchant import Merchant
 from app.models.transaction import Transaction
 from app.models.user import User
-from app.services.accounts.snapshots import get_current_balances, recompute_snapshots_from
+from app.services.accounts.snapshots import get_current_balances, recompute_account_snapshots
 from app.services.merchants.defaults import SELF_MERCHANT_NAME
 
 _BALANCE_ADJUSTMENT_CATEGORY_NAME = "Balance Adjustment"
@@ -52,7 +52,7 @@ async def add_account_starting_balance_adjustment(
         notes=_STARTING_BALANCE_NOTE,
     ))
     await db.flush()
-    await recompute_snapshots_from(db, account.id, adjustment_date)
+    await recompute_account_snapshots(db, {account.id: adjustment_date})
 
 
 async def zero_account_balance_for_archive(
@@ -88,7 +88,7 @@ async def zero_account_balance_for_archive(
         notes=_ARCHIVE_BALANCE_ADJUSTMENT_NOTE,
     ))
     await db.flush()
-    await recompute_snapshots_from(db, account.id, archive_date)
+    await recompute_account_snapshots(db, {account.id: archive_date})
 
 
 async def _get_self_merchant_id(db: AsyncSession) -> uuid.UUID:

--- a/backend/app/routes/accounts/listing_helpers.py
+++ b/backend/app/routes/accounts/listing_helpers.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import selectinload
 from app.models.account import Account, AccountPermission
 from app.models.group import GroupMember
 from app.models.user import User
+from app.permissions.accounts import attach_account_write_capabilities
 from app.routes.accounts.balance_field_helpers import attach_account_balance_fields
 
 
@@ -28,6 +29,7 @@ async def get_account_overviews_for_user(
         Accounts visible to the user with derived balance fields attached
     """
     accounts = await get_accounts_visible_to_user(db, user.id)
+    await attach_account_write_capabilities(db, accounts, user.id)
 
     # Attach balance fields after access filtering so each account has overview totals
     await attach_account_balance_fields(db, accounts, user, as_of_date)

--- a/backend/app/routes/accounts/response_loading_helpers.py
+++ b/backend/app/routes/accounts/response_loading_helpers.py
@@ -10,6 +10,7 @@ from app.models.account import Account
 from app.models.base import PermissionLevel
 from app.models.user import User
 from app.permissions import check_account_access
+from app.permissions.accounts import attach_account_write_capabilities
 from app.routes.accounts.balance_field_helpers import attach_account_balance_fields
 
 
@@ -34,6 +35,7 @@ async def get_account_response_for_user(
         HTTPException: User does not have read access
     """
     account = await check_account_access(db, account_id, user.id, PermissionLevel.READ)
+    await attach_account_write_capabilities(db, [account], user.id)
     await attach_account_balance_fields(db, [account], user, as_of_date)
     return account
 
@@ -69,5 +71,6 @@ async def get_account_for_response(
     # Fetch the account with response relationships and optional identity-map refresh
     result = await db.execute(query)
     account = result.scalar_one()
+    await attach_account_write_capabilities(db, [account], user.id)
     await attach_account_balance_fields(db, [account], user, as_of_date)
     return account

--- a/backend/app/routes/accounts/update_helpers.py
+++ b/backend/app/routes/accounts/update_helpers.py
@@ -11,7 +11,6 @@ from app.models.base import PermissionLevel
 from app.models.user import User
 from app.permissions import check_account_access
 from app.routes.accounts.balance_adjustment_helpers import zero_account_balance_for_archive
-from app.routes.accounts.balance_field_helpers import attach_account_balance_fields
 from app.routes.accounts.request_validation_helpers import validate_update_account_request
 from app.routes.accounts.response_loading_helpers import get_account_for_response
 from app.routes.accounts.tax_advantaged_category_link_helpers import validate_update_account_tax_advantaged_category_link
@@ -45,8 +44,7 @@ async def update_account_for_user(
 
     updates = data.model_dump(exclude_unset=True)
     if not updates:
-        await attach_account_balance_fields(db, [account], user, response_date)
-        return account
+        return await get_account_for_response(db, user, account_id, response_date)
 
     await validate_update_account_request(db, account, updates)
     await validate_update_account_tax_advantaged_category_link(db, account, updates, user.id)

--- a/backend/app/routes/transactions/router.py
+++ b/backend/app/routes/transactions/router.py
@@ -349,7 +349,8 @@ async def bulk_update_transactions_route(
         db: Active database session
 
     Returns:
-        The number of transactions changed and the accounts affected
+        The count of rows the request reached, whether or not a value on any of them changed, and
+        the accounts affected, including a transfer's far side account before and after the edit
     """
     return await bulk_update_transactions(db, user, data)
 

--- a/backend/app/routes/transactions/router.py
+++ b/backend/app/routes/transactions/router.py
@@ -16,6 +16,8 @@ from app.schemas.firefly_import import (
     FireflyTransactionImportResponse,
 )
 from app.schemas.transaction import (
+    BulkUpdateTransactionsRequest,
+    BulkUpdateTransactionsResponse,
     CreateTransactionRequest,
     TransactionImportResponse,
     TransactionImportRunRequest,
@@ -33,6 +35,7 @@ from app.services.importers import (
     open_import_run,
     stage_import_batch,
 )
+from app.services.transactions.bulk_update import bulk_update_transactions
 from app.services.transactions.creation import create_transaction_and_get_response
 from app.services.transactions.deletion import delete_transaction_for_user
 from app.services.transactions.detail import get_transaction_response_for_user
@@ -327,6 +330,28 @@ async def create_transaction(
         Newly created transaction response
     """
     return await create_transaction_and_get_response(db, user, data)
+
+
+@router.patch("/bulk", response_model=BulkUpdateTransactionsResponse)
+async def bulk_update_transactions_route(
+    data: BulkUpdateTransactionsRequest,
+    user: Annotated[User, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(get_db)],
+):
+    """Set a category, a merchant or extra tags across several transactions
+
+    Declared above the single-transaction route because a path parameter would otherwise read
+    "bulk" as a transaction identifier
+
+    Args:
+        data: Transactions to change and the fields to set
+        user: Authenticated user applying the change
+        db: Active database session
+
+    Returns:
+        The number of transactions changed and the accounts they belong to
+    """
+    return await bulk_update_transactions(db, user, data)
 
 
 @router.patch("/{transaction_id}", response_model=TransactionResponse)

--- a/backend/app/routes/transactions/router.py
+++ b/backend/app/routes/transactions/router.py
@@ -338,18 +338,18 @@ async def bulk_update_transactions_route(
     user: Annotated[User, Depends(get_current_user)],
     db: Annotated[AsyncSession, Depends(get_db)],
 ):
-    """Set a category, a merchant or extra tags across several transactions
+    """Set shared details across several transactions
 
     Declared above the single-transaction route because a path parameter would otherwise read
     "bulk" as a transaction identifier
 
     Args:
-        data: Transactions to change and the fields to set
+        data: Transactions to change and the details to set
         user: Authenticated user applying the change
         db: Active database session
 
     Returns:
-        The number of transactions changed and the accounts they belong to
+        The number of transactions changed and the accounts affected
     """
     return await bulk_update_transactions(db, user, data)
 

--- a/backend/app/schemas/account.py
+++ b/backend/app/schemas/account.py
@@ -29,6 +29,9 @@ class AccountsOverview(BaseModel):
     base_currency_current_balance: int | None = None
     current_balance_fx_status: FxStatus = Field(default_factory=FxStatus)
     credit_limit: int | None
+
+    # Effective transaction write permission for the caller, independent of lifecycle state
+    can_write: bool
     is_archived: bool
     closed_at: datetime | None
 
@@ -51,6 +54,9 @@ class AccountResponse(BaseModel):
     base_currency_current_balance: int | None = None
     current_balance_fx_status: FxStatus = Field(default_factory=FxStatus)
     credit_limit: int | None
+
+    # Effective transaction write permission for the caller, independent of lifecycle state
+    can_write: bool
     is_archived: bool
     closed_at: datetime | None
     created_at: datetime

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -233,8 +233,10 @@ class BulkUpdateTransactionsRequest(BaseModel):
     notes: str | None = Field(None, max_length=MAX_IMPORT_NOTES_LENGTH)
 
     # Added to whatever each transaction already carries, unlike the single-transaction update,
-    # which replaces the whole list
-    add_tag_ids: list[uuid.UUID] = []
+    # which replaces the whole list. Bounded to the cap tag_names already carries, since tags.py
+    # issues one statement per id at any count, so this cap is what bounds how many statements a
+    # request can cause while it still holds its locked rows
+    add_tag_ids: list[uuid.UUID] = Field(default=[], max_length=MAX_IMPORT_TAGS_PER_ROW)
 
     # Where a row's own account sits and what it records as the other side, once resolved against
     # its own resulting direction. Which of the two an unset field leaves alone is not fixed by name

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import date, datetime
 from typing import Annotated
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, ValidationInfo, field_validator, model_validator
 
 from app.models.base import TransferCounterpartyScope
 from app.schemas.fx import FxStatus
@@ -167,25 +167,83 @@ class UpdateTransactionRequest(BaseModel):
     counterparty_account_scope: TransferCounterpartyScope | None = None
 
 
+# Fields a bulk edit may leave out but may never send as null, because each one writes a column
+# that has no null. Sending null would otherwise reach the database as an integrity error, and a
+# null merchant would take the merchant off a row the edit rules require to have one
+_BULK_UPDATE_NON_NULLABLE_FIELDS = ("account_id", "dt", "category_id", "merchant_id")
+
+
 class BulkUpdateTransactionsRequest(BaseModel):
-    """Set a category, a merchant or extra tags on several transactions at once."""
+    """Set shared details on several transactions at once.
+
+    A field left out is left alone on every transaction. That is why the service reads which fields
+    the request carried rather than which are non-null: `notes` and the counterparty pair each take
+    null as a real answer, meaning clear it.
+    """
 
     transaction_ids: list[uuid.UUID] = Field(min_length=1, max_length=MAX_BULK_UPDATE_TRANSACTIONS)
+    account_id: uuid.UUID | None = None
+    dt: date | None = None
     category_id: uuid.UUID | None = None
     merchant_id: uuid.UUID | None = None
+
+    # Bounded here although the single-transaction update is not, which LF-387 covers
+    notes: str | None = Field(None, max_length=MAX_IMPORT_NOTES_LENGTH)
+
     # Added to whatever each transaction already carries, unlike the single-transaction update,
     # which replaces the whole list
     add_tag_ids: list[uuid.UUID] = []
+
+    counterparty_account_id: uuid.UUID | None = None
+    counterparty_account_scope: TransferCounterpartyScope | None = None
+
+    @field_validator(*_BULK_UPDATE_NON_NULLABLE_FIELDS, mode="before")
+    @classmethod
+    def reject_explicit_null(cls, value: object, info: ValidationInfo) -> object:
+        """Reject a field sent as null that has no null to write.
+
+        Runs only on a field the request carried, since a field taking its default is not validated.
+
+        Raises:
+            ValueError: The field was sent as null
+        """
+        if value is None:
+            raise ValueError(f"{info.field_name} cannot be null")
+        return value
 
     @model_validator(mode="after")
     def check_request_changes_something(self) -> BulkUpdateTransactionsRequest:
         """Reject a request that would report a count for a write it never made.
 
         Raises:
-            ValueError: No category, merchant or tag was supplied
+            ValueError: The request carried no field to set, or only an empty tag list
         """
-        if self.category_id is None and self.merchant_id is None and not self.add_tag_ids:
-            raise ValueError("A bulk edit must set a category, a merchant or at least one tag")
+        sent = self.model_fields_set - {"transaction_ids"}
+
+        # An empty tag list adds no tag, so a request carrying only that changes nothing
+        if not self.add_tag_ids:
+            sent -= {"add_tag_ids"}
+        if not sent:
+            raise ValueError("A bulk edit must set at least one detail")
+        return self
+
+    @model_validator(mode="after")
+    def check_counterparty_answer_agrees_with_itself(self) -> BulkUpdateTransactionsRequest:
+        """Reject a counterparty answer that contradicts itself.
+
+        The account and the scope are one answer, so they travel together.
+
+        Raises:
+            ValueError: A tracked scope names no account, or another scope names one
+        """
+        if not {"counterparty_account_id", "counterparty_account_scope"} & self.model_fields_set:
+            return self
+
+        tracked = self.counterparty_account_scope == TransferCounterpartyScope.TRACKED
+        if tracked and self.counterparty_account_id is None:
+            raise ValueError("counterparty_account_id is required when the counterparty is a tracked account")
+        if not tracked and self.counterparty_account_id is not None:
+            raise ValueError("counterparty_account_id is not allowed unless the counterparty is a tracked account")
         return self
 
 

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -1,5 +1,6 @@
 """Transaction schemas"""
 
+import enum
 import uuid
 from datetime import date, datetime
 from typing import Annotated
@@ -167,18 +168,57 @@ class UpdateTransactionRequest(BaseModel):
     counterparty_account_scope: TransferCounterpartyScope | None = None
 
 
-# Fields a bulk edit may leave out but may never send as null, because each one writes a column
-# that has no null. Sending null would otherwise reach the database as an integrity error, and a
-# null merchant would take the merchant off a row the edit rules require to have one
-_BULK_UPDATE_NON_NULLABLE_FIELDS = ("account_id", "dt", "category_id", "merchant_id")
+class TransferEnd(BaseModel):
+    """One side of a transfer: an account tracked in this app, or outside it.
+
+    Either end may answer outside, since this model does not know which end a row's own direction
+    will make it. The bulk service refuses an end resolved as a row's own when it answers outside,
+    since a row cannot sit outside this app itself.
+    """
+
+    scope: TransferCounterpartyScope
+    account_id: uuid.UUID | None = None
+
+    @model_validator(mode="after")
+    def check_account_agrees_with_scope(self) -> TransferEnd:
+        """Reject an end whose account contradicts its scope.
+
+        Raises:
+            ValueError: A tracked scope names no account, or another scope names one
+        """
+        tracked = self.scope == TransferCounterpartyScope.TRACKED
+        if tracked and self.account_id is None:
+            raise ValueError("account_id is required when the scope is tracked")
+        if not tracked and self.account_id is not None:
+            raise ValueError("account_id is not allowed unless the scope is tracked")
+        return self
+
+
+class BulkDirectionChange(enum.StrEnum):
+    """Which way a bulk edit turns a transaction, applied as the sign of its amount."""
+
+    DEBIT = "debit"  # Money out, a negative amount
+    CREDIT = "credit"  # Money in, a positive amount
+    REVERSE = "reverse"  # The opposite of whatever each row already points, judged per row
+
+
+# Fields a bulk edit may leave out but may never send as null. Most of them write a column that has
+# no null, where sending one would reach the database as an integrity error, and a null merchant
+# would take the merchant off a row the edit rules require to have one. Direction writes no column
+# at all, and is here because a null would still count as asked for and turn every row outward.
+# Either transfer end is the same: a null end still counts as asked for and has no account or scope
+# of its own to resolve
+_BULK_UPDATE_NON_NULLABLE_FIELDS = (
+    "account_id", "dt", "category_id", "merchant_id", "direction", "transfer_from", "transfer_to",
+)
 
 
 class BulkUpdateTransactionsRequest(BaseModel):
     """Set shared details on several transactions at once.
 
     A field left out is left alone on every transaction. That is why the service reads which fields
-    the request carried rather than which are non-null: `notes` and the counterparty pair each take
-    null as a real answer, meaning clear it.
+    the request carried rather than which are non-null: `notes` takes null as a real answer, meaning
+    clear it.
     """
 
     transaction_ids: list[uuid.UUID] = Field(min_length=1, max_length=MAX_BULK_UPDATE_TRANSACTIONS)
@@ -194,8 +234,15 @@ class BulkUpdateTransactionsRequest(BaseModel):
     # which replaces the whole list
     add_tag_ids: list[uuid.UUID] = []
 
-    counterparty_account_id: uuid.UUID | None = None
-    counterparty_account_scope: TransferCounterpartyScope | None = None
+    # Where a row's own account sits and what it records as the other side, once resolved against
+    # its own resulting direction. Which of the two an unset field leaves alone is not fixed by name
+    transfer_from: TransferEnd | None = None
+    transfer_to: TransferEnd | None = None
+
+    # Which way every transaction should end up pointing, applied as the sign of its amount. Reverse
+    # flips each row's own direction rather than naming an absolute one, and a row already pointing
+    # the way debit or credit asks for is left as it is
+    direction: BulkDirectionChange | None = None
 
     @field_validator(*_BULK_UPDATE_NON_NULLABLE_FIELDS, mode="before")
     @classmethod
@@ -228,22 +275,20 @@ class BulkUpdateTransactionsRequest(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def check_counterparty_answer_agrees_with_itself(self) -> BulkUpdateTransactionsRequest:
-        """Reject a counterparty answer that contradicts itself.
+    def check_ends_have_the_account_column_to_themselves(self) -> BulkUpdateTransactionsRequest:
+        """Reject account_id sent together with either transfer end.
 
-        The account and the scope are one answer, so they travel together.
+        An end writes account_id on every row whose resulting direction makes it that row's own end,
+        and the request cannot tell which rows those are, so account_id beside an end is two answers
+        for the same column.
 
         Raises:
-            ValueError: A tracked scope names no account, or another scope names one
+            ValueError: account_id was sent with transfer_from or transfer_to
         """
-        if not {"counterparty_account_id", "counterparty_account_scope"} & self.model_fields_set:
+        if "account_id" not in self.model_fields_set:
             return self
-
-        tracked = self.counterparty_account_scope == TransferCounterpartyScope.TRACKED
-        if tracked and self.counterparty_account_id is None:
-            raise ValueError("counterparty_account_id is required when the counterparty is a tracked account")
-        if not tracked and self.counterparty_account_id is not None:
-            raise ValueError("counterparty_account_id is not allowed unless the counterparty is a tracked account")
+        if {"transfer_from", "transfer_to"} & self.model_fields_set:
+            raise ValueError("account_id cannot be sent with transfer_from or transfer_to")
         return self
 
 

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import date, datetime
 from typing import Annotated
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from app.models.base import TransferCounterpartyScope
 from app.schemas.fx import FxStatus
@@ -40,6 +40,11 @@ MAX_IMPORT_TAG_NAME_LENGTH = 64
 
 # Characters a payee may carry, matching the column merchants are stored in
 MAX_IMPORT_MERCHANT_NAME_LENGTH = 256
+
+# Transactions one bulk edit may carry, matching the mapping cap above, since both bound an id list
+# a single request checks row by row against the database. The list loads 15 rows at a time and a
+# selection is built from rows already loaded, so reaching this takes roughly 67 pages of scrolling
+MAX_BULK_UPDATE_TRANSACTIONS = 1_000
 
 # One imported tag name, bounded so that the count and the length are stated in one place for both
 # importers
@@ -160,6 +165,35 @@ class UpdateTransactionRequest(BaseModel):
     tag_ids: list[uuid.UUID] | None = None
     counterparty_account_id: uuid.UUID | None = None
     counterparty_account_scope: TransferCounterpartyScope | None = None
+
+
+class BulkUpdateTransactionsRequest(BaseModel):
+    """Set a category, a merchant or extra tags on several transactions at once."""
+
+    transaction_ids: list[uuid.UUID] = Field(min_length=1, max_length=MAX_BULK_UPDATE_TRANSACTIONS)
+    category_id: uuid.UUID | None = None
+    merchant_id: uuid.UUID | None = None
+    # Added to whatever each transaction already carries, unlike the single-transaction update,
+    # which replaces the whole list
+    add_tag_ids: list[uuid.UUID] = []
+
+    @model_validator(mode="after")
+    def check_request_changes_something(self) -> BulkUpdateTransactionsRequest:
+        """Reject a request that would report a count for a write it never made.
+
+        Raises:
+            ValueError: No category, merchant or tag was supplied
+        """
+        if self.category_id is None and self.merchant_id is None and not self.add_tag_ids:
+            raise ValueError("A bulk edit must set a category, a merchant or at least one tag")
+        return self
+
+
+class BulkUpdateTransactionsResponse(BaseModel):
+    """Summary of a bulk transaction edit."""
+
+    transactions_updated: int
+    affected_account_ids: list[uuid.UUID]
 
 
 class TransactionImportCreateAccount(BaseModel):

--- a/backend/app/schemas/transaction.py
+++ b/backend/app/schemas/transaction.py
@@ -204,12 +204,14 @@ class BulkDirectionChange(enum.StrEnum):
 
 # Fields a bulk edit may leave out but may never send as null. Most of them write a column that has
 # no null, where sending one would reach the database as an integrity error, and a null merchant
-# would take the merchant off a row the edit rules require to have one. Direction writes no column
-# at all, and is here because a null would still count as asked for and turn every row outward.
-# Either transfer end is the same: a null end still counts as asked for and has no account or scope
-# of its own to resolve
+# would take the merchant off a row the edit rules require to have one. Direction and
+# transfer_direction are not columns of their own that a null could be written into, both writing
+# the amount column instead, and are here because a null would still count as asked for and turn
+# every row either of them reaches outward. Either transfer end is the same: a null end still
+# counts as asked for and has no account or scope of its own to resolve
 _BULK_UPDATE_NON_NULLABLE_FIELDS = (
-    "account_id", "dt", "category_id", "merchant_id", "direction", "transfer_from", "transfer_to",
+    "account_id", "dt", "category_id", "merchant_id", "direction", "transfer_direction",
+    "transfer_from", "transfer_to",
 )
 
 
@@ -243,6 +245,10 @@ class BulkUpdateTransactionsRequest(BaseModel):
     # flips each row's own direction rather than naming an absolute one, and a row already pointing
     # the way debit or credit asks for is left as it is
     direction: BulkDirectionChange | None = None
+
+    # Applied exactly as direction is, but only to the rows whose resulting category records a far
+    # side. Refused beside direction, since both set the sign of the same amount
+    transfer_direction: BulkDirectionChange | None = None
 
     @field_validator(*_BULK_UPDATE_NON_NULLABLE_FIELDS, mode="before")
     @classmethod
@@ -289,6 +295,20 @@ class BulkUpdateTransactionsRequest(BaseModel):
             return self
         if {"transfer_from", "transfer_to"} & self.model_fields_set:
             raise ValueError("account_id cannot be sent with transfer_from or transfer_to")
+        return self
+
+    @model_validator(mode="after")
+    def check_direction_has_the_amount_sign_to_itself(self) -> BulkUpdateTransactionsRequest:
+        """Reject direction sent together with transfer_direction.
+
+        Both set the sign of the same amount, one for every row and the other for the rows whose
+        resulting category records a far side, so sending both is two answers for that sign.
+
+        Raises:
+            ValueError: direction and transfer_direction were both sent
+        """
+        if {"direction", "transfer_direction"} <= self.model_fields_set:
+            raise ValueError("direction cannot be sent with transfer_direction")
         return self
 
 

--- a/backend/app/services/accounts/snapshots.py
+++ b/backend/app/services/accounts/snapshots.py
@@ -2,10 +2,12 @@
 
 Snapshots include a zero-balance anchor plus one row for each account day with
 transaction activity. Transaction and account routes call these helpers after
-mutations so the snapshot table stays aligned with account history
+mutations so the snapshot table stays aligned with account history. Rebuilds
+for the same account serialize until their caller commits or rolls back
 """
+import hashlib
 import uuid
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from datetime import date
 
 from sqlalchemy import delete, func, select
@@ -20,6 +22,9 @@ from app.utils.dates import ACCOUNT_OWNER_PROFILE, resolve_timezone
 
 PersonalOwner = aliased(User)
 GroupOwner = aliased(User)
+
+# The namespace separates this protocol's lock inputs from other advisory lock protocols
+_SNAPSHOT_LOCK_NAMESPACE = b"lumina:account-snapshots:"
 
 
 async def get_current_balances(
@@ -66,23 +71,52 @@ async def attach_current_balances(db: AsyncSession, accounts: Sequence[Account])
         account.current_balance = balances[account.id]
 
 
-async def recompute_snapshots_from(
-    db: AsyncSession, account_id: uuid.UUID, from_dt: date,
+async def recompute_account_snapshots(
+    db: AsyncSession,
+    snapshot_starts: Mapping[uuid.UUID, date],
 ) -> None:
-    """Rebuild daily balance snapshots from one date forward
+    """Rebuild daily balance snapshots for every affected account
 
-    Finds the most recent snapshot strictly before ``from_dt`` to use as an
-    anchor balance, deletes all snapshots from that day onwards, then walks
-    forward through the account transactions grouped by day
+    Flushes the caller's pending changes, then acquires transaction-scoped
+    advisory locks in stable order before reading any account's anchor. Locks
+    remain held until the caller commits or rolls back
 
     Args:
         db: Active database session
-        account_id: Account whose snapshots need recomputing
-        from_dt: First date to rebuild
+        snapshot_starts: Earliest rebuild date keyed by affected account ID
 
     Returns:
         None
     """
+    if not snapshot_starts:
+        return
+
+    await db.flush()
+    lock_keys = sorted({_snapshot_lock_key(account_id) for account_id in snapshot_starts})
+
+    # Serialize every affected account before any anchor read so a rebuild sees earlier commits
+    for lock_key in lock_keys:
+        await db.execute(select(func.pg_advisory_xact_lock(lock_key)))
+
+    for account_id, from_dt in snapshot_starts.items():
+        await _recompute_account_snapshots_from(db, account_id, from_dt)
+
+
+def _snapshot_lock_key(account_id: uuid.UUID) -> int:
+    """Return the stable signed 64-bit advisory lock key for an account."""
+    digest = hashlib.blake2b(
+        _SNAPSHOT_LOCK_NAMESPACE + account_id.bytes,
+        digest_size=8,
+    ).digest()
+    return int.from_bytes(digest, byteorder="big", signed=True)
+
+
+async def _recompute_account_snapshots_from(
+    db: AsyncSession,
+    account_id: uuid.UUID,
+    from_dt: date,
+) -> None:
+    """Rebuild one account's daily balance snapshots from one date forward."""
     # Fetch the most recent snapshot before the rebuild window to anchor the running balance
     anchor_result = await db.execute(
         select(AccountBalanceSnapshot.balance)

--- a/backend/app/services/importers/firefly/service.py
+++ b/backend/app/services/importers/firefly/service.py
@@ -18,7 +18,7 @@ from app.schemas.firefly_import import (
     FireflyTransactionImportResponse,
     FireflyTransactionRow,
 )
-from app.services.accounts.snapshots import recompute_snapshots_from
+from app.services.accounts.snapshots import recompute_account_snapshots
 from app.services.cache_state import mark_cache_changed_for_scope, mark_user_cache_changed
 from app.services.categories.transfer_rules import does_category_record_counterparty_account
 from app.services.importers.firefly.constants import FIREFLY_GENERIC_SKIP_REASON
@@ -116,9 +116,8 @@ async def import_firefly_transactions(
 
     await db.flush()
 
-    # Recompute each account from its earliest imported date to keep later balances aligned
-    for account_id, first_import_date in first_import_date_by_account_id.items():
-        await recompute_snapshots_from(db, account_id, first_import_date)
+    # Recompute every affected account together so concurrent writers use one lock order
+    await recompute_account_snapshots(db, first_import_date_by_account_id)
     await _mark_caches_changed_for_imported_accounts(
         db,
         user.id,

--- a/backend/app/services/importers/generic/service.py
+++ b/backend/app/services/importers/generic/service.py
@@ -7,7 +7,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.account import Account
 from app.models.user import User
 from app.schemas.transaction import TransactionImportRequest, TransactionImportResponse
-from app.services.accounts.snapshots import recompute_snapshots_from
+from app.services.accounts.snapshots import recompute_account_snapshots
 from app.services.cache_state import mark_cache_changed_for_scope, mark_user_cache_changed
 from app.services.importers.generic.imported_transaction_helpers import create_imported_transactions
 from app.services.importers.generic.lookup_helpers import (
@@ -47,7 +47,7 @@ async def import_transactions(
     )
 
     await db.flush()
-    await _recompute_snapshots_for_imported_accounts(db, first_import_date_by_account_id)
+    await recompute_account_snapshots(db, first_import_date_by_account_id)
     await _mark_caches_changed_for_imported_accounts(
         db,
         user.id,
@@ -62,24 +62,6 @@ async def import_transactions(
         first_import_date_by_account_id,
     )
     return transaction_import_response
-
-
-async def _recompute_snapshots_for_imported_accounts(
-    db: AsyncSession,
-    first_import_date_by_account_id: dict[uuid.UUID, date],
-) -> None:
-    """Recompute balance snapshots for accounts touched by imported transactions
-
-    Args:
-        db: Active database session
-        first_import_date_by_account_id: Earliest imported transaction date by affected account ID
-
-    Returns:
-        None
-    """
-    # Recompute each account from its earliest imported date to keep later balances aligned
-    for account_id, first_import_date in first_import_date_by_account_id.items():
-        await recompute_snapshots_from(db, account_id, first_import_date)
 
 
 async def _mark_caches_changed_for_imported_accounts(

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -14,7 +14,8 @@ from datetime import date
 from typing import NamedTuple
 
 from fastapi import HTTPException, status
-from sqlalchemy import ColumnElement, func, select, update
+from sqlalchemy import ColumnElement, func, select, text, update
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
@@ -48,6 +49,15 @@ _DIRECT_COLUMN_FIELDS = ("account_id", "dt", "category_id", "merchant_id", "note
 # The own and far ends resolved for one row, either one None where that side is left alone
 _TransferEndPair = tuple[TransferEnd | None, TransferEnd | None]
 
+# Postgres raises this for a lock the caller waited out
+_LOCK_NOT_AVAILABLE_SQLSTATE = "55P03"
+
+# The most one lock attempt waits before the statement gives up, matching the wait load_locked_run
+# in run_locking.py gives an import run. Postgres acquires a multi-row SELECT ... FOR UPDATE's locks
+# one row at a time, so a selection whose rows are held by several sessions can wait this long per
+# held row rather than once for the whole statement
+_BULK_UPDATE_LOCK_WAIT = "10s"
+
 
 class _RowResolution(NamedTuple):
     """What one transaction ends up with once the request is applied."""
@@ -75,23 +85,50 @@ async def bulk_update_transactions(
         data: Transactions to change and the details to set
 
     Returns:
-        The number of transactions changed and the accounts affected
+        The count of rows the request reached, whether or not a value on any of them changed, and
+        the accounts affected, including a transfer's far side account before and after the edit
 
     Raises:
         HTTPException: A transaction was not found, an account refuses the write, a transfer end
-            reached no row, or a row breaks a rule the single-transaction path enforces
+            reached no row, a row breaks a rule the single-transaction path enforces, or another
+            change reached one of the transactions first
     """
     sent = data.model_fields_set
     requested_ids = list(dict.fromkeys(data.transaction_ids))
 
+    # Bounded for this statement alone, following load_locked_run in run_locking.py. The setting
+    # lasts the whole transaction, so leaving it in place would put the same bound on every lock
+    # the commit takes afterwards, including the balance snapshot rebuild
+    await db.execute(text(f"SET LOCAL lock_timeout = '{_BULK_UPDATE_LOCK_WAIT}'"))
+
     # Load the requested rows inside the caller's readable scope, so an id belonging to someone else
-    # is missing from the result rather than silently changing nothing
-    result = await db.execute(
-        select(Transaction).where(
+    # is missing from the result rather than silently changing nothing. Locked in id order so two
+    # bulk edits over overlapping rows queue behind each other in the same order rather than
+    # deadlocking, and held until this transaction commits so no other writer can change a row
+    # between this read and the write below. The accessible-accounts filter stays the scalar
+    # subquery it is; a join would put the lock on the nullable side of an outer join, which
+    # Postgres refuses
+    query = (
+        select(Transaction)
+        .where(
             Transaction.id.in_(requested_ids),
             Transaction.account_id.in_(accessible_account_ids_subquery(user.id)),
-        ),
+        )
+        .order_by(Transaction.id)
+        .with_for_update()
     )
+    try:
+        result = await db.execute(query)
+    except DBAPIError as exc:
+        if getattr(exc.orig, "sqlstate", None) != _LOCK_NOT_AVAILABLE_SQLSTATE:
+            raise
+        await db.rollback()
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Another change reached one of these transactions first",
+        ) from exc
+    await db.execute(text("SET LOCAL lock_timeout = DEFAULT"))
+
     transactions = list(result.scalars().all())
     if len(transactions) != len(requested_ids):
         raise HTTPException(
@@ -131,7 +168,7 @@ async def bulk_update_transactions(
     await _validate_chosen_scope(db, user, data, sent, group_ids)
 
     resolutions = _resolve_rows(transactions, data, chosen_category, categories_by_id, target_account)
-    _refuse_ends_reaching_no_row(data, resolutions)
+    _refuse_transfer_fields_reaching_no_row(data, resolutions)
 
     accounts_by_id = {**source_accounts_by_id, **own_end_accounts}
     if target_account is not None:
@@ -139,10 +176,11 @@ async def bulk_update_transactions(
     await _refuse_rows_breaking_single_edit_rules(db, user, data, transactions, resolutions, accounts_by_id)
 
     # Collected before the update, because SQLAlchemy writes the new values back onto the loaded
-    # rows and a date read afterwards is the new one
+    # rows and a date or a counterparty read afterwards is the new one
     snapshot_starts = _collect_snapshot_starts(data, sent, transactions, resolutions)
+    far_side_account_ids = _collect_far_side_account_ids(transactions, resolutions)
 
-    await _apply_changes(db, data, sent, transactions, transaction_ids, resolutions)
+    written_ids = await _apply_changes(db, data, sent, transactions, transaction_ids, resolutions)
 
     for account_id, from_date in snapshot_starts.items():
         await recompute_snapshots_from(db, account_id, from_date)
@@ -160,9 +198,14 @@ async def bulk_update_transactions(
 
     await db.commit()
 
+    # Built apart from affected_accounts above, which only carries Account rows loaded for the
+    # write-access and archived checks. A far side is never loaded as one, so it reaches the
+    # response's id list without a query of its own
+    affected_account_ids = {account.id for account in affected_accounts} | far_side_account_ids
+
     return BulkUpdateTransactionsResponse(
-        transactions_updated=len(transaction_ids),
-        affected_account_ids=sorted({account.id for account in affected_accounts}),
+        transactions_updated=len(written_ids),
+        affected_account_ids=sorted(affected_account_ids),
     )
 
 
@@ -231,11 +274,9 @@ def _resulting_direction(transaction: Transaction, data: BulkUpdateTransactionsR
     """Return the direction a transaction ends up pointing once the request is applied
 
     A set direction overrides the row's own outright, and reverse flips it instead of naming an
-    absolute answer. Neither changes what the row's own direction was, which is what a concurrent
-    change to the stored amount would disturb. transfer_direction stands in for direction wherever
-    the request sent that instead, which every caller may do safely because each already calls this
-    only for a row whose resulting category records a far side, the same rows transfer_direction
-    reaches
+    absolute answer. transfer_direction stands in for direction wherever the request sent that
+    instead, which every caller may do safely because each already calls this only for a row whose
+    resulting category records a far side, the same rows transfer_direction reaches
 
     Args:
         transaction: Transaction the request covers
@@ -581,7 +622,7 @@ def _resolve_rows(
     return resolutions
 
 
-def _refuse_ends_reaching_no_row(
+def _refuse_transfer_fields_reaching_no_row(
     data: BulkUpdateTransactionsRequest,
     resolutions: dict[uuid.UUID, _RowResolution],
 ) -> None:
@@ -591,7 +632,9 @@ def _refuse_ends_reaching_no_row(
     and a selection holding none of those would otherwise report a count for a write it never made.
     Tested on the category rather than on `resolution.ends`, since a request sending
     transfer_direction alone resolves no end for any row and would otherwise always read as reaching
-    none
+    none. The message mentions From and To whenever either was sent, since that is the field the
+    request actually carried; a request sending transfer_direction alone mentions the direction
+    instead
 
     Args:
         data: Transactions to change and the details to set
@@ -601,16 +644,19 @@ def _refuse_ends_reaching_no_row(
         HTTPException: The request set transfer_from, transfer_to or transfer_direction but no row
             in the selection has a resulting category that records a far side
     """
-    if not {"transfer_from", "transfer_to", "transfer_direction"} & data.model_fields_set:
+    sent_ends = {"transfer_from", "transfer_to"} & data.model_fields_set
+    if not sent_ends and "transfer_direction" not in data.model_fields_set:
         return
     if any(
         does_category_record_counterparty_account(resolution.category) for resolution in resolutions.values()
     ):
         return
-    raise HTTPException(
-        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-        detail="From and To apply to transfers only, and none of the selected transactions end up as one",
+    detail = (
+        "From and To apply to transfers only, and none of the selected transactions end up as one"
+        if sent_ends
+        else "The direction applies to transfers only, and none of the selected transactions end up as one"
     )
+    raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail=detail)
 
 
 async def _refuse_rows_breaking_single_edit_rules(
@@ -796,6 +842,43 @@ def _collect_snapshot_starts(
     return starts
 
 
+def _collect_far_side_account_ids(
+    transactions: list[Transaction],
+    resolutions: dict[uuid.UUID, _RowResolution],
+) -> set[uuid.UUID]:
+    """Return every tracked account a row records as its far side, before or after the edit
+
+    A far side is read straight off the loaded rows and the already-resolved ends rather than
+    queried again, since the own and move-target accounts loaded elsewhere already cover every
+    write-access and archived check a far side does not need
+
+    Read before the change is written, since SQLAlchemy writes the new values back onto the loaded
+    rows and a counterparty read afterwards is the new one rather than the one this collection needs
+
+    Args:
+        transactions: Transactions the request covers
+        resolutions: Every transaction's resolution, keyed by identifier
+
+    Returns:
+        Identifiers of every tracked account a row recorded as its far side, before the edit or once
+        it is applied
+    """
+    far_side_ids: set[uuid.UUID] = set()
+    for transaction in transactions:
+        if (
+            transaction.counterparty_account_scope == TransferCounterpartyScope.TRACKED
+            and transaction.counterparty_account_id is not None
+        ):
+            far_side_ids.add(transaction.counterparty_account_id)
+
+        ends = resolutions[transaction.id].ends
+        far_end = ends[1] if ends is not None else None
+        if far_end is not None and far_end.scope == TransferCounterpartyScope.TRACKED:
+            far_side_ids.add(far_end.account_id)
+
+    return far_side_ids
+
+
 async def _apply_changes(
     db: AsyncSession,
     data: BulkUpdateTransactionsRequest,
@@ -803,7 +886,7 @@ async def _apply_changes(
     transactions: list[Transaction],
     transaction_ids: list[uuid.UUID],
     resolutions: dict[uuid.UUID, _RowResolution],
-) -> None:
+) -> set[uuid.UUID]:
     """Write the requested change and normalise what the change invalidates
 
     Args:
@@ -815,10 +898,9 @@ async def _apply_changes(
         resolutions: Every transaction's resolution, keyed by identifier
 
     Returns:
-        None
-
-    Raises:
-        HTTPException: A row's sign no longer matches the one its transfer ends were resolved for
+        Identifiers of the rows a write below actually reached. A row can be written twice, once
+        by the direct-column update and again by the clearing update below it, for example a
+        transfer row set to Groceries, so a plain rowcount would count it twice
     """
     column_values = {field: getattr(data, field) for field in _DIRECT_COLUMN_FIELDS if field in sent}
     if column_values:
@@ -830,24 +912,21 @@ async def _apply_changes(
         if does_category_record_counterparty_account(resolutions[transaction.id].category)
     ]
 
-    # Split into at most two buckets, keyed by each row's own sign rather than by its resulting
-    # direction, since a race is a change to that stored sign specifically. Direction or
+    # Split into at most two buckets, keyed by each row's own sign, since direction or
     # transfer_direction is one value for the whole request, whichever the request sent, so every
     # row sharing a sign also shares the resulting direction that produced its own and far ends, and
-    # the bucket can use either row's ends for the whole group. The WHERE clause re-reads the sign at
-    # write time, so a row whose sign changed between the checks and here drops out of its bucket's
-    # count and the whole request is turned down rather than written for a direction the row no
-    # longer has
+    # the bucket can use either row's ends for the whole group
+    bucket_ids: set[uuid.UUID] = set()
     for own_direction in (BulkDirectionChange.DEBIT, BulkDirectionChange.CREDIT):
-        bucket_ids = [
+        ids_for_direction = [
             transaction.id
             for transaction in transactions
             if _own_direction(transaction) == own_direction and resolutions[transaction.id].ends is not None
         ]
-        if not bucket_ids:
+        if not ids_for_direction:
             continue
 
-        own_end, far_end = resolutions[bucket_ids[0]].ends
+        own_end, far_end = resolutions[ids_for_direction[0]].ends
         values: dict[str, object] = {}
         if own_end is not None:
             values["account_id"] = own_end.account_id
@@ -855,17 +934,8 @@ async def _apply_changes(
             values["counterparty_account_scope"] = far_end.scope
             values["counterparty_account_id"] = far_end.account_id
 
-        sign_condition = (
-            Transaction.amount < 0 if own_direction == BulkDirectionChange.DEBIT else Transaction.amount >= 0
-        )
-        written = await db.execute(
-            update(Transaction).where(Transaction.id.in_(bucket_ids), sign_condition).values(**values),
-        )
-        if written.rowcount != len(bucket_ids):
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail="Another change reached one of these transactions first. Try again.",
-            )
+        await db.execute(update(Transaction).where(Transaction.id.in_(ids_for_direction)).values(**values))
+        bucket_ids.update(ids_for_direction)
 
     if "direction" in sent:
         await db.execute(
@@ -875,6 +945,7 @@ async def _apply_changes(
             .execution_options(synchronize_session=False),
         )
 
+    recording_ids: set[uuid.UUID] = set()
     if "transfer_direction" in sent:
         await db.execute(
             update(Transaction)
@@ -882,16 +953,17 @@ async def _apply_changes(
             .values(amount=_direction_amount_expression(data.transfer_direction))
             .execution_options(synchronize_session=False),
         )
+        recording_ids.update(records_counterparty)
 
     # A category that records no counterparty account drops whatever the previous one recorded, on
     # every edit rather than only on one that changes the category, matching the single-transaction
     # path. Picked row by row because the category a row ends up under is its own whenever the
     # request sets none, and clearing the whole set would take the counterparty off every transfer
-    clearable_ids = [
+    clearable_ids = {
         transaction.id
         for transaction in transactions
         if transaction.counterparty_account_scope is not None and transaction.id not in set(records_counterparty)
-    ]
+    }
     if clearable_ids:
         await db.execute(
             update(Transaction)
@@ -899,5 +971,12 @@ async def _apply_changes(
             .values(counterparty_account_id=None, counterparty_account_scope=None),
         )
 
+    # A column written straight onto every selected row, a direction of any kind, and an added tag
+    # all write across the whole selection rather than a filtered subset, so each counts as reaching
+    # every row the request carried, whether or not a given row already held that value
+    direct_ids = set(transaction_ids) if column_values or "direction" in sent or data.add_tag_ids else set()
+
     if data.add_tag_ids:
         await add_transaction_tag_assignments(db, transaction_ids, list(dict.fromkeys(data.add_tag_ids)))
+
+    return direct_ids | bucket_ids | recording_ids | clearable_ids

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -14,7 +14,7 @@ from datetime import date
 from typing import NamedTuple
 
 from fastapi import HTTPException, status
-from sqlalchemy import func, select, update
+from sqlalchemy import ColumnElement, func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
@@ -232,7 +232,10 @@ def _resulting_direction(transaction: Transaction, data: BulkUpdateTransactionsR
 
     A set direction overrides the row's own outright, and reverse flips it instead of naming an
     absolute answer. Neither changes what the row's own direction was, which is what a concurrent
-    change to the stored amount would disturb
+    change to the stored amount would disturb. transfer_direction stands in for direction wherever
+    the request sent that instead, which every caller may do safely because each already calls this
+    only for a row whose resulting category records a far side, the same rows transfer_direction
+    reaches
 
     Args:
         transaction: Transaction the request covers
@@ -242,11 +245,31 @@ def _resulting_direction(transaction: Transaction, data: BulkUpdateTransactionsR
         DEBIT for a row that ends up negative, CREDIT for one that ends up positive
     """
     own = _own_direction(transaction)
-    if data.direction == BulkDirectionChange.REVERSE:
+    chosen_direction = data.direction if data.direction is not None else data.transfer_direction
+    if chosen_direction == BulkDirectionChange.REVERSE:
         return BulkDirectionChange.CREDIT if own == BulkDirectionChange.DEBIT else BulkDirectionChange.DEBIT
-    if data.direction is not None:
-        return data.direction
+    if chosen_direction is not None:
+        return chosen_direction
     return own
+
+
+def _direction_amount_expression(direction: BulkDirectionChange) -> ColumnElement[int]:
+    """Return the amount a direction turns every row it reaches into, as a SQL expression
+
+    Reverse gives no absolute sign, so it flips the stored amount rather than replacing it. Debit and
+    credit each give an absolute sign, so they replace the amount with its magnitude, negated for
+    debit
+
+    Args:
+        direction: Absolute or reverse direction being written
+
+    Returns:
+        A SQL expression assignable to the amount column
+    """
+    if direction == BulkDirectionChange.REVERSE:
+        return -Transaction.amount
+    magnitude = func.abs(Transaction.amount)
+    return magnitude if direction == BulkDirectionChange.CREDIT else -magnitude
 
 
 def _own_end(data: BulkUpdateTransactionsRequest, resulting_direction: BulkDirectionChange) -> TransferEnd | None:
@@ -562,25 +585,31 @@ def _refuse_ends_reaching_no_row(
     data: BulkUpdateTransactionsRequest,
     resolutions: dict[uuid.UUID, _RowResolution],
 ) -> None:
-    """Reject a request whose transfer ends land on no row at all
+    """Reject a request whose transfer fields land on no row at all
 
-    An end reaches only the rows whose resulting category records a far side, and a selection
-    holding none of those would otherwise report a count for a write it never made
+    An end or transfer_direction reaches only the rows whose resulting category records a far side,
+    and a selection holding none of those would otherwise report a count for a write it never made.
+    Tested on the category rather than on `resolution.ends`, since a request sending
+    transfer_direction alone resolves no end for any row and would otherwise always read as reaching
+    none
 
     Args:
         data: Transactions to change and the details to set
         resolutions: Every transaction's resolution, keyed by identifier
 
     Raises:
-        HTTPException: The request set a transfer end but no row in the selection resolves one
+        HTTPException: The request set transfer_from, transfer_to or transfer_direction but no row
+            in the selection has a resulting category that records a far side
     """
-    if not {"transfer_from", "transfer_to"} & data.model_fields_set:
+    if not {"transfer_from", "transfer_to", "transfer_direction"} & data.model_fields_set:
         return
-    if any(resolution.ends is not None for resolution in resolutions.values()):
+    if any(
+        does_category_record_counterparty_account(resolution.category) for resolution in resolutions.values()
+    ):
         return
     raise HTTPException(
         status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-        detail="None of these transactions record the other side of a transfer",
+        detail="From and To apply to transfers only, and none of the selected transactions end up as one",
     )
 
 
@@ -658,15 +687,15 @@ async def _refuse_rows_breaking_single_edit_rules(
 
     reasons = []
     if without_merchant:
-        reasons.append(f"{len(without_merchant)} with no merchant recorded")
+        reasons.append(f"{len(without_merchant)} missing merchant information")
     if missing_fx_rate:
         reasons.append(f"{len(missing_fx_rate)} in another currency with no exchange rate recorded")
     if sits_outside:
         reasons.append(f"{len(sits_outside)} that would sit outside this app")
     if unanswered_transfers:
-        reasons.append(f"{len(unanswered_transfers)} not recording the other account of a transfer")
+        reasons.append(f"{len(unanswered_transfers)} missing the To or From account")
     if own_account_counterparty:
-        reasons.append(f"{len(own_account_counterparty)} that would record their own account")
+        reasons.append(f"{len(own_account_counterparty)} with the same account on both sides")
     if unreachable_counterparties:
         reasons.append(f"{len(unreachable_counterparties)} recording an account you can no longer open")
     if not reasons:
@@ -748,7 +777,7 @@ def _collect_snapshot_starts(
     Returns:
         The earliest date to rebuild from, keyed by account
     """
-    if not ({"account_id", "dt", "direction", "transfer_from", "transfer_to"} & sent):
+    if not ({"account_id", "dt", "direction", "transfer_direction", "transfer_from", "transfer_to"} & sent):
         return {}
 
     starts: dict[uuid.UUID, date] = {}
@@ -795,13 +824,20 @@ async def _apply_changes(
     if column_values:
         await db.execute(update(Transaction).where(Transaction.id.in_(transaction_ids)).values(**column_values))
 
+    records_counterparty = [
+        transaction.id
+        for transaction in transactions
+        if does_category_record_counterparty_account(resolutions[transaction.id].category)
+    ]
+
     # Split into at most two buckets, keyed by each row's own sign rather than by its resulting
-    # direction, since a race is a change to that stored sign specifically. Direction is one value
-    # for the whole request, so every row sharing a sign also shares the resulting direction that
-    # produced its own and far ends, and the bucket can use either row's ends for the whole group.
-    # The WHERE clause re-reads the sign at write time, so a row whose sign changed between the
-    # checks and here drops out of its bucket's count and the whole request is turned down rather
-    # than written for a direction the row no longer has
+    # direction, since a race is a change to that stored sign specifically. Direction or
+    # transfer_direction is one value for the whole request, whichever the request sent, so every
+    # row sharing a sign also shares the resulting direction that produced its own and far ends, and
+    # the bucket can use either row's ends for the whole group. The WHERE clause re-reads the sign at
+    # write time, so a row whose sign changed between the checks and here drops out of its bucket's
+    # count and the whole request is turned down rather than written for a direction the row no
+    # longer has
     for own_direction in (BulkDirectionChange.DEBIT, BulkDirectionChange.CREDIT):
         bucket_ids = [
             transaction.id
@@ -832,25 +868,20 @@ async def _apply_changes(
             )
 
     if "direction" in sent:
-        magnitude = func.abs(Transaction.amount)
-        if data.direction == BulkDirectionChange.REVERSE:
-            new_amount = -Transaction.amount
-        elif data.direction == BulkDirectionChange.CREDIT:
-            new_amount = magnitude
-        else:
-            new_amount = -magnitude
         await db.execute(
             update(Transaction)
             .where(Transaction.id.in_(transaction_ids))
-            .values(amount=new_amount)
+            .values(amount=_direction_amount_expression(data.direction))
             .execution_options(synchronize_session=False),
         )
 
-    records_counterparty = [
-        transaction.id
-        for transaction in transactions
-        if does_category_record_counterparty_account(resolutions[transaction.id].category)
-    ]
+    if "transfer_direction" in sent:
+        await db.execute(
+            update(Transaction)
+            .where(Transaction.id.in_(records_counterparty))
+            .values(amount=_direction_amount_expression(data.transfer_direction))
+            .execution_options(synchronize_session=False),
+        )
 
     # A category that records no counterparty account drops whatever the previous one recorded, on
     # every edit rather than only on one that changes the category, matching the single-transaction

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -30,7 +30,7 @@ from app.schemas.transaction import (
     BulkUpdateTransactionsResponse,
     TransferEnd,
 )
-from app.services.accounts.snapshots import recompute_snapshots_from
+from app.services.accounts.snapshots import recompute_account_snapshots
 from app.services.cache_state import mark_cache_changed_for_scope
 from app.services.categories.transfer_rules import does_category_record_counterparty_account
 from app.services.transactions.access_helpers import accessible_account_ids_subquery
@@ -182,8 +182,8 @@ async def bulk_update_transactions(
 
     written_ids = await _apply_changes(db, data, sent, transactions, transaction_ids, resolutions)
 
-    for account_id, from_date in snapshot_starts.items():
-        await recompute_snapshots_from(db, account_id, from_date)
+    if snapshot_starts:
+        await recompute_account_snapshots(db, snapshot_starts)
 
     affected_accounts = [*source_accounts]
     seen_account_ids = {account.id for account in source_accounts}

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -15,7 +15,7 @@ from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
-from app.models.base import PermissionLevel
+from app.models.base import PermissionLevel, TransferCounterpartyScope
 from app.models.category import Category
 from app.models.transaction import Transaction
 from app.models.user import User
@@ -270,7 +270,7 @@ def _resulting_counterparty(
     transaction: Transaction,
     data: BulkUpdateTransactionsRequest,
     sent: set[str],
-) -> tuple[uuid.UUID | None, object]:
+) -> tuple[uuid.UUID | None, TransferCounterpartyScope | None]:
     """Return the counterparty account and scope a transaction ends up with.
 
     Args:
@@ -341,7 +341,11 @@ async def _refuse_rows_breaking_single_edit_rules(
         resulting_account_id = target_account.id if target_account is not None else transaction.account_id
 
         if not does_category_record_counterparty_account(category):
-            if _COUNTERPARTY_FIELDS & sent and data.counterparty_account_id is not None:
+            # Either half of the answer is an answer, so a scope on its own is refused as the
+            # account is, matching update.py:127-134
+            if _COUNTERPARTY_FIELDS & sent and (
+                data.counterparty_account_id is not None or data.counterparty_account_scope is not None
+            ):
                 counterparty_not_allowed.append(transaction.id)
             continue
 

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -1,0 +1,345 @@
+"""Bulk transaction update service
+
+One request sets a category, a merchant or extra tags across several transactions. Every rule the
+single-transaction path enforces is enforced here too, and a set holding one row that refuses the
+edit is rejected whole, so a bulk edit can never write a state a single edit would have refused
+"""
+import uuid
+
+from fastapi import HTTPException, status
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.account import Account
+from app.models.base import PermissionLevel
+from app.models.category import Category
+from app.models.transaction import Transaction
+from app.models.user import User
+from app.permissions import check_account_access
+from app.schemas.transaction import BulkUpdateTransactionsRequest, BulkUpdateTransactionsResponse
+from app.services.cache_state import mark_cache_changed_for_scope
+from app.services.categories.transfer_rules import does_category_record_counterparty_account
+from app.services.transactions.access_helpers import accessible_account_ids_subquery
+from app.services.transactions.accounts import validate_transaction_account_is_not_archived
+from app.services.transactions.tags import add_transaction_tag_assignments
+from app.services.transactions.validation import (
+    get_valid_transaction_tag_ids,
+    validate_transaction_category_access,
+    validate_transaction_merchant_access,
+)
+
+
+async def bulk_update_transactions(
+    db: AsyncSession,
+    user: User,
+    data: BulkUpdateTransactionsRequest,
+) -> BulkUpdateTransactionsResponse:
+    """Apply one category, merchant or tag change across several transactions
+
+    The service loads the requested transactions inside the caller's readable scope, checks write
+    access on every account behind them, refuses the whole set when any row breaks a rule the
+    single-transaction path enforces, then applies the change and commits once
+
+    Args:
+        db: Active database session
+        user: Authenticated user applying the change
+        data: Transactions to change and the fields to set
+
+    Returns:
+        The number of transactions changed and the accounts they belong to
+
+    Raises:
+        HTTPException: A transaction was not found, an account refuses the write, or a row breaks a
+            rule the single-transaction path enforces
+    """
+    requested_ids = list(dict.fromkeys(data.transaction_ids))
+
+    # Load the requested rows inside the caller's readable scope, so an id belonging to someone else
+    # is missing from the result rather than silently changing nothing
+    result = await db.execute(
+        select(Transaction).where(
+            Transaction.id.in_(requested_ids),
+            Transaction.account_id.in_(accessible_account_ids_subquery(user.id)),
+        ),
+    )
+    transactions = list(result.scalars().all())
+    if len(transactions) != len(requested_ids):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"{len(requested_ids) - len(transactions)} of {len(requested_ids)} transactions were not found",
+        )
+
+    transaction_ids = [transaction.id for transaction in transactions]
+    accounts = await _load_writable_accounts(db, user, transactions)
+    group_ids = {account.group_id for account in accounts}
+
+    chosen_category = await _validate_chosen_records(db, user, data, group_ids)
+    categories_by_id = await _load_current_categories(db, transactions) if chosen_category is None else {}
+
+    await _refuse_rows_breaking_single_edit_rules(db, user, data, transactions, chosen_category, categories_by_id)
+
+    await _apply_changes(db, data, transactions, transaction_ids, chosen_category, categories_by_id)
+
+    # One mark per scope rather than one per transaction, since every row in a scope shares it
+    for owner_id, group_id in {(account.owner_id, account.group_id) for account in accounts}:
+        await mark_cache_changed_for_scope(db, user_id=owner_id, group_id=group_id)
+
+    await db.commit()
+
+    return BulkUpdateTransactionsResponse(
+        transactions_updated=len(transaction_ids),
+        affected_account_ids=sorted({account.id for account in accounts}),
+    )
+
+
+async def _load_writable_accounts(
+    db: AsyncSession,
+    user: User,
+    transactions: list[Transaction],
+) -> list[Account]:
+    """Return the accounts behind a set of transactions, refusing any the caller cannot write to
+
+    Row-level security secures ``transactions`` with a check that passes any account permission
+    whatever its level, so this application check is the only thing separating read from write
+
+    Args:
+        db: Active database session
+        user: Authenticated user applying the change
+        transactions: Transactions the request covers
+
+    Returns:
+        One account row per distinct account behind the transactions
+
+    Raises:
+        HTTPException: An account refuses the write or is archived
+    """
+    accounts = []
+    for account_id in sorted({transaction.account_id for transaction in transactions}):
+        account = await check_account_access(db, account_id, user.id, PermissionLevel.WRITE)
+        validate_transaction_account_is_not_archived(account)
+        accounts.append(account)
+    return accounts
+
+
+async def _validate_chosen_records(
+    db: AsyncSession,
+    user: User,
+    data: BulkUpdateTransactionsRequest,
+    group_ids: set[uuid.UUID | None],
+) -> Category | None:
+    """Confirm the chosen category, merchant and tags reach every group in the set
+
+    A selection can span a personal account and a group account, and a record reaching one of them
+    does not reach the other, so each scope is checked in its own right
+
+    Args:
+        db: Active database session
+        user: Authenticated user applying the change
+        data: Transactions to change and the fields to set
+        group_ids: Distinct groups behind the accounts in the set, with None for personal accounts
+
+    Returns:
+        The chosen category, or None when the request sets no category
+
+    Raises:
+        HTTPException: A chosen record does not reach one of the groups
+    """
+    chosen_category = None
+    for group_id in group_ids:
+        if data.category_id is not None:
+            chosen_category = await validate_transaction_category_access(db, data.category_id, user.id, group_id)
+        if data.merchant_id is not None:
+            await validate_transaction_merchant_access(db, data.merchant_id, user.id, group_id)
+        if data.add_tag_ids:
+            await get_valid_transaction_tag_ids(db, user.id, data.add_tag_ids, group_id)
+    return chosen_category
+
+
+async def _load_current_categories(
+    db: AsyncSession,
+    transactions: list[Transaction],
+) -> dict[uuid.UUID, Category]:
+    """Return the categories the transactions already use, keyed by identifier
+
+    The counterparty rules read the category a row ends up with, which is its stored one whenever
+    the request sets no category
+
+    Args:
+        db: Active database session
+        transactions: Transactions the request covers
+
+    Returns:
+        Category rows keyed by identifier
+    """
+    category_ids = {transaction.category_id for transaction in transactions}
+    result = await db.execute(select(Category).where(Category.id.in_(category_ids)))
+    return {category.id: category for category in result.scalars().all()}
+
+
+def _resulting_category(
+    transaction: Transaction,
+    chosen_category: Category | None,
+    categories_by_id: dict[uuid.UUID, Category],
+) -> Category:
+    """Return the category a transaction ends up under once the request is applied.
+
+    Args:
+        transaction: Transaction the request covers
+        chosen_category: Category the request sets, or None when it sets none
+        categories_by_id: Stored categories keyed by identifier, used when the request sets none
+
+    Returns:
+        The category the transaction ends up under
+    """
+    return chosen_category if chosen_category is not None else categories_by_id[transaction.category_id]
+
+
+async def _refuse_rows_breaking_single_edit_rules(
+    db: AsyncSession,
+    user: User,
+    data: BulkUpdateTransactionsRequest,
+    transactions: list[Transaction],
+    chosen_category: Category | None,
+    categories_by_id: dict[uuid.UUID, Category],
+) -> None:
+    """Reject the whole set when any row breaks a rule a single edit of it would break
+
+    Counts are grouped by reason rather than listing identifiers, since a raw list of identifiers
+    tells the person reading the message nothing about what to fix
+
+    Args:
+        db: Active database session
+        user: Authenticated user applying the change
+        data: Transactions to change and the fields to set
+        transactions: Transactions the request covers
+        chosen_category: Category the request sets, or None when it sets none
+        categories_by_id: Stored categories keyed by identifier, used when the request sets none
+
+    Raises:
+        HTTPException: At least one row breaks a rule
+    """
+    without_merchant = []
+    unanswered_transfers = []
+    transfers_by_counterparty: dict[uuid.UUID, list[uuid.UUID]] = {}
+
+    for transaction in transactions:
+        # Editing brings a row onto the current rule, so one recorded before a merchant was required
+        # has to gain one before any other change to it is accepted
+        if data.merchant_id is None and transaction.merchant_id is None:
+            without_merchant.append(transaction.id)
+
+        category = _resulting_category(transaction, chosen_category, categories_by_id)
+        if not does_category_record_counterparty_account(category):
+            continue
+        if transaction.counterparty_account_scope is None:
+            unanswered_transfers.append(transaction.id)
+        elif transaction.counterparty_account_id is not None:
+            transfers_by_counterparty.setdefault(transaction.counterparty_account_id, []).append(transaction.id)
+
+    unreachable_counterparties = await _find_unreachable_counterparties(db, user, transfers_by_counterparty)
+
+    reasons = []
+    if without_merchant:
+        reasons.append(f"{len(without_merchant)} with no merchant recorded")
+    if unanswered_transfers:
+        reasons.append(f"{len(unanswered_transfers)} not recording the other account of a transfer")
+    if unreachable_counterparties:
+        reasons.append(f"{len(unreachable_counterparties)} recording an account you can no longer open")
+    if not reasons:
+        return
+
+    refused_count = len({*without_merchant, *unanswered_transfers, *unreachable_counterparties})
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail=f"{refused_count} of these transactions cannot be changed: {', '.join(reasons)}",
+    )
+
+
+async def _find_unreachable_counterparties(
+    db: AsyncSession,
+    user: User,
+    transfers_by_counterparty: dict[uuid.UUID, list[uuid.UUID]],
+) -> list[uuid.UUID]:
+    """Return the transfers recording an account the caller can no longer read
+
+    The single-transaction path re-checks this on every edit, at the end of its counterparty
+    validation, so a bulk edit that skipped it would accept a row a single edit of the same row
+    refuses. One query covers the distinct accounts rather than one per transaction
+
+    Args:
+        db: Active database session
+        user: Authenticated user applying the change
+        transfers_by_counterparty: Transaction identifiers grouped by the account they record
+
+    Returns:
+        Identifiers of the transactions whose recorded account is out of reach
+    """
+    if not transfers_by_counterparty:
+        return []
+
+    result = await db.execute(
+        select(Account.id).where(
+            Account.id.in_(transfers_by_counterparty),
+            Account.id.in_(accessible_account_ids_subquery(user.id)),
+        ),
+    )
+    reachable_account_ids = set(result.scalars().all())
+    return [
+        transaction_id
+        for account_id, transaction_ids in transfers_by_counterparty.items()
+        if account_id not in reachable_account_ids
+        for transaction_id in transaction_ids
+    ]
+
+
+async def _apply_changes(
+    db: AsyncSession,
+    data: BulkUpdateTransactionsRequest,
+    transactions: list[Transaction],
+    transaction_ids: list[uuid.UUID],
+    chosen_category: Category | None,
+    categories_by_id: dict[uuid.UUID, Category],
+) -> None:
+    """Write the requested change and normalise what the change invalidates
+
+    Args:
+        db: Active database session
+        data: Transactions to change and the fields to set
+        transactions: Transactions the request covers
+        transaction_ids: Identifiers of those transactions
+        chosen_category: Category the request sets, or None when it sets none
+        categories_by_id: Stored categories keyed by identifier, used when the request sets none
+
+    Returns:
+        None
+    """
+    column_values = {}
+    if data.category_id is not None:
+        column_values["category_id"] = data.category_id
+    if data.merchant_id is not None:
+        column_values["merchant_id"] = data.merchant_id
+    if column_values:
+        await db.execute(update(Transaction).where(Transaction.id.in_(transaction_ids)).values(**column_values))
+
+    # A category that records no counterparty account drops whatever the previous one recorded, on
+    # every edit rather than only on one that changes the category, matching the single-transaction
+    # path. The rows are picked one by one because the category a row ends up under is its own
+    # whenever the request sets none, and clearing the whole set would take the counterparty off
+    # every transfer in it
+    clearable_ids = [
+        transaction.id
+        for transaction in transactions
+        if transaction.counterparty_account_scope is not None
+        and not does_category_record_counterparty_account(
+            _resulting_category(transaction, chosen_category, categories_by_id),
+        )
+    ]
+    if clearable_ids:
+        await db.execute(
+            update(Transaction)
+            .where(Transaction.id.in_(clearable_ids))
+            .values(counterparty_account_id=None, counterparty_account_scope=None),
+        )
+
+    if data.add_tag_ids:
+        await add_transaction_tag_assignments(db, transaction_ids, list(dict.fromkeys(data.add_tag_ids)))

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -273,8 +273,9 @@ def _own_direction(transaction: Transaction) -> BulkDirectionChange:
 def _resulting_direction(transaction: Transaction, data: BulkUpdateTransactionsRequest) -> BulkDirectionChange:
     """Return the direction a transaction ends up pointing once the request is applied
 
-    A set direction overrides the row's own outright, and reverse flips it instead of naming an
-    absolute answer. transfer_direction stands in for direction wherever the request sent that
+    Zero remains credit because changing its sign leaves the stored amount at zero. For nonzero
+    rows, a set direction overrides the row's own outright, and reverse flips it instead of naming
+    an absolute answer. transfer_direction stands in for direction wherever the request sent that
     instead, which every caller may do safely because each already calls this only for a row whose
     resulting category records a far side, the same rows transfer_direction reaches
 
@@ -283,8 +284,11 @@ def _resulting_direction(transaction: Transaction, data: BulkUpdateTransactionsR
         data: Transactions to change and the details to set
 
     Returns:
-        DEBIT for a row that ends up negative, CREDIT for one that ends up positive
+        DEBIT for a row that ends up negative, CREDIT for one that ends up positive or zero
     """
+    if transaction.amount == 0:
+        return BulkDirectionChange.CREDIT
+
     own = _own_direction(transaction)
     chosen_direction = data.direction if data.direction is not None else data.transfer_direction
     if chosen_direction == BulkDirectionChange.REVERSE:
@@ -912,21 +916,23 @@ async def _apply_changes(
         if does_category_record_counterparty_account(resolutions[transaction.id].category)
     ]
 
-    # Split into at most two buckets, keyed by each row's own sign, since direction or
-    # transfer_direction is one value for the whole request, whichever the request sent, so every
-    # row sharing a sign also shares the resulting direction that produced its own and far ends, and
-    # the bucket can use either row's ends for the whole group
-    bucket_ids: set[uuid.UUID] = set()
-    for own_direction in (BulkDirectionChange.DEBIT, BulkDirectionChange.CREDIT):
-        ids_for_direction = [
-            transaction.id
-            for transaction in transactions
-            if _own_direction(transaction) == own_direction and resolutions[transaction.id].ends is not None
-        ]
-        if not ids_for_direction:
+    # Split into at most two buckets by the ends each row already resolved. A stored zero stays
+    # credit even when Debit or Reverse is requested, so it can share an original sign with a
+    # positive row while resolving From and To differently
+    end_buckets: list[tuple[_TransferEndPair, list[uuid.UUID]]] = []
+    for transaction in transactions:
+        ends = resolutions[transaction.id].ends
+        if ends is None:
             continue
+        for bucket_ends, bucket_ids in end_buckets:
+            if bucket_ends == ends:
+                bucket_ids.append(transaction.id)
+                break
+        else:
+            end_buckets.append((ends, [transaction.id]))
 
-        own_end, far_end = resolutions[ids_for_direction[0]].ends
+    bucket_ids: set[uuid.UUID] = set()
+    for (own_end, far_end), ids_for_ends in end_buckets:
         values: dict[str, object] = {}
         if own_end is not None:
             values["account_id"] = own_end.account_id
@@ -934,8 +940,8 @@ async def _apply_changes(
             values["counterparty_account_scope"] = far_end.scope
             values["counterparty_account_id"] = far_end.account_id
 
-        await db.execute(update(Transaction).where(Transaction.id.in_(ids_for_direction)).values(**values))
-        bucket_ids.update(ids_for_direction)
+        await db.execute(update(Transaction).where(Transaction.id.in_(ids_for_ends)).values(**values))
+        bucket_ids.update(ids_for_ends)
 
     if "direction" in sent:
         await db.execute(

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -2,16 +2,19 @@
 
 One request sets shared details across several transactions. Every rule the single-transaction path
 enforces is enforced here too, and a set holding one row that refuses the edit is rejected whole, so
-a bulk edit can never write a state a single edit would have refused
+a bulk edit can never write a state a single edit would have refused. The one divergence is a
+transfer end sent over a row whose resulting category records no far side: the single path refuses a
+far-side answer under such a category, and this path skips the end on that row instead
 
-A field is applied when the request carried it, not when it is non-null, because the note and the
-counterparty pair each take null as a real answer meaning clear it
+A field is applied when the request carried it, not when it is non-null, because the note takes null
+as a real answer meaning clear it
 """
 import uuid
 from datetime import date
+from typing import NamedTuple
 
 from fastapi import HTTPException, status
-from sqlalchemy import select, update
+from sqlalchemy import func, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.account import Account
@@ -20,7 +23,12 @@ from app.models.category import Category
 from app.models.transaction import Transaction
 from app.models.user import User
 from app.permissions import check_account_access
-from app.schemas.transaction import BulkUpdateTransactionsRequest, BulkUpdateTransactionsResponse
+from app.schemas.transaction import (
+    BulkDirectionChange,
+    BulkUpdateTransactionsRequest,
+    BulkUpdateTransactionsResponse,
+    TransferEnd,
+)
 from app.services.accounts.snapshots import recompute_snapshots_from
 from app.services.cache_state import mark_cache_changed_for_scope
 from app.services.categories.transfer_rules import does_category_record_counterparty_account
@@ -37,7 +45,16 @@ from app.services.transactions.validation import (
 # because it is written only onto the rows whose resulting category records one
 _DIRECT_COLUMN_FIELDS = ("account_id", "dt", "category_id", "merchant_id", "notes")
 
-_COUNTERPARTY_FIELDS = frozenset({"counterparty_account_id", "counterparty_account_scope"})
+# The own and far ends resolved for one row, either one None where that side is left alone
+_TransferEndPair = tuple[TransferEnd | None, TransferEnd | None]
+
+
+class _RowResolution(NamedTuple):
+    """What one transaction ends up with once the request is applied."""
+
+    category: Category
+    account_id: uuid.UUID
+    ends: _TransferEndPair | None
 
 
 async def bulk_update_transactions(
@@ -61,8 +78,8 @@ async def bulk_update_transactions(
         The number of transactions changed and the accounts affected
 
     Raises:
-        HTTPException: A transaction was not found, an account refuses the write, or a row breaks a
-            rule the single-transaction path enforces
+        HTTPException: A transaction was not found, an account refuses the write, a transfer end
+            reached no row, or a row breaks a rule the single-transaction path enforces
     """
     sent = data.model_fields_set
     requested_ids = list(dict.fromkeys(data.transaction_ids))
@@ -84,35 +101,58 @@ async def bulk_update_transactions(
 
     transaction_ids = [transaction.id for transaction in transactions]
     source_accounts = await _load_writable_accounts(db, user, {t.account_id for t in transactions})
+    source_accounts_by_id = {account.id: account for account in source_accounts}
 
     target_account = None
     if "account_id" in sent:
         target_account = await _load_move_target(db, user, data.account_id)
 
-    # After a move every row sits in the target account's group, so that is the scope the chosen
-    # records have to reach. Without one, each source account's scope still has to be satisfied
-    group_ids = (
-        {target_account.group_id} if target_account else {account.group_id for account in source_accounts}
-    )
-    chosen_category = await _validate_chosen_records(db, user, data, sent, group_ids)
+    # Loaded by identifier alone, ahead of the scope check below, since which rows resolve a
+    # transfer end at all turns on whether their resulting category records a far side
+    chosen_category = await _load_chosen_category(db, data, sent)
     categories_by_id = await _load_current_categories(db, transactions) if chosen_category is None else {}
 
-    await _refuse_rows_breaking_single_edit_rules(
-        db, user, data, sent, transactions, chosen_category, categories_by_id, target_account,
-    )
+    if target_account is not None:
+        group_ids: set[uuid.UUID | None] = {target_account.group_id}
+        own_end_accounts: dict[uuid.UUID, Account] = {}
+    else:
+        own_end_accounts = await _load_own_end_accounts(
+            db, user, transactions, data, chosen_category, categories_by_id,
+        )
+        group_ids = set()
+        for transaction in transactions:
+            own_account = _candidate_own_account(
+                transaction, data, chosen_category, categories_by_id, own_end_accounts,
+            )
+            group_ids.add(
+                own_account.group_id if own_account is not None
+                else source_accounts_by_id[transaction.account_id].group_id,
+            )
+    await _validate_chosen_scope(db, user, data, sent, group_ids)
+
+    resolutions = _resolve_rows(transactions, data, chosen_category, categories_by_id, target_account)
+    _refuse_ends_reaching_no_row(data, resolutions)
+
+    accounts_by_id = {**source_accounts_by_id, **own_end_accounts}
+    if target_account is not None:
+        accounts_by_id[target_account.id] = target_account
+    await _refuse_rows_breaking_single_edit_rules(db, user, data, transactions, resolutions, accounts_by_id)
 
     # Collected before the update, because SQLAlchemy writes the new values back onto the loaded
     # rows and a date read afterwards is the new one
-    snapshot_starts = _collect_snapshot_starts(data, sent, transactions, target_account)
+    snapshot_starts = _collect_snapshot_starts(data, sent, transactions, resolutions)
 
-    await _apply_changes(db, data, sent, transactions, transaction_ids, chosen_category, categories_by_id)
+    await _apply_changes(db, data, sent, transactions, transaction_ids, resolutions)
 
     for account_id, from_date in snapshot_starts.items():
         await recompute_snapshots_from(db, account_id, from_date)
 
     affected_accounts = [*source_accounts]
-    if target_account is not None and target_account.id not in {a.id for a in source_accounts}:
-        affected_accounts.append(target_account)
+    seen_account_ids = {account.id for account in source_accounts}
+    for account in (*own_end_accounts.values(), *([target_account] if target_account is not None else [])):
+        if account.id not in seen_account_ids:
+            affected_accounts.append(account)
+            seen_account_ids.add(account.id)
 
     # One mark per scope rather than one per transaction, since every row in a scope shares it
     for owner_id, group_id in {(account.owner_id, account.group_id) for account in affected_accounts}:
@@ -156,12 +196,12 @@ async def _load_writable_accounts(
 
 
 async def _load_move_target(db: AsyncSession, user: User, account_id: uuid.UUID) -> Account:
-    """Return the account a move sends the transactions to
+    """Return the account a move or a tracked transfer end sends the transactions to
 
     Args:
         db: Active database session
         user: Authenticated user applying the change
-        account_id: Account the request moves the transactions to
+        account_id: Account identifier the transactions end up in
 
     Returns:
         The target account
@@ -169,19 +209,189 @@ async def _load_move_target(db: AsyncSession, user: User, account_id: uuid.UUID)
     Raises:
         HTTPException: The account refuses the write, is closed, or is archived
     """
-    # An account that is closed takes no new history, which is why the move asks for an open one
+    # An account that is closed takes no new history, which is why a move asks for an open one
     account = await check_account_access(db, account_id, user.id, PermissionLevel.WRITE, require_open=True)
     validate_transaction_account_is_not_archived(account)
     return account
 
 
-async def _validate_chosen_records(
+def _own_direction(transaction: Transaction) -> BulkDirectionChange:
+    """Return the direction a transaction points on its own, before any request override
+
+    Args:
+        transaction: Transaction the request covers
+
+    Returns:
+        DEBIT for a negative amount, CREDIT otherwise
+    """
+    return BulkDirectionChange.DEBIT if transaction.amount < 0 else BulkDirectionChange.CREDIT
+
+
+def _resulting_direction(transaction: Transaction, data: BulkUpdateTransactionsRequest) -> BulkDirectionChange:
+    """Return the direction a transaction ends up pointing once the request is applied
+
+    A set direction overrides the row's own outright, and reverse flips it instead of naming an
+    absolute answer. Neither changes what the row's own direction was, which is what a concurrent
+    change to the stored amount would disturb
+
+    Args:
+        transaction: Transaction the request covers
+        data: Transactions to change and the details to set
+
+    Returns:
+        DEBIT for a row that ends up negative, CREDIT for one that ends up positive
+    """
+    own = _own_direction(transaction)
+    if data.direction == BulkDirectionChange.REVERSE:
+        return BulkDirectionChange.CREDIT if own == BulkDirectionChange.DEBIT else BulkDirectionChange.DEBIT
+    if data.direction is not None:
+        return data.direction
+    return own
+
+
+def _own_end(data: BulkUpdateTransactionsRequest, resulting_direction: BulkDirectionChange) -> TransferEnd | None:
+    """Return the end that is a row's own, given the direction it resolves to
+
+    Money out puts the row's own account at From, and money in puts it at To
+
+    Args:
+        data: Transactions to change and the details to set
+        resulting_direction: Direction the transaction ends up pointing
+
+    Returns:
+        The end the request set for that side, or None when it left it unset
+    """
+    return data.transfer_from if resulting_direction == BulkDirectionChange.DEBIT else data.transfer_to
+
+
+def _row_records_far_side(
+    transaction: Transaction,
+    chosen_category: Category | None,
+    categories_by_id: dict[uuid.UUID, Category],
+) -> bool:
+    """Return whether a row's resulting category records a far side at all
+
+    Args:
+        transaction: Transaction the request covers
+        chosen_category: Category the request sets, or None when it sets none
+        categories_by_id: Stored categories keyed by identifier, used when the request sets none
+
+    Returns:
+        True when the row's resulting category records a far side
+    """
+    return does_category_record_counterparty_account(
+        _resulting_category(transaction, chosen_category, categories_by_id),
+    )
+
+
+async def _load_own_end_accounts(
+    db: AsyncSession,
+    user: User,
+    transactions: list[Transaction],
+    data: BulkUpdateTransactionsRequest,
+    chosen_category: Category | None,
+    categories_by_id: dict[uuid.UUID, Category],
+) -> dict[uuid.UUID, Account]:
+    """Return the accounts a tracked transfer end may move a row into, refusing any the caller cannot write to
+
+    Loaded from whichever of From and To resolves as each row's own end, and only for the rows whose
+    resulting category records a far side, since a row that resolves no end reaches for no account at
+    all. At most two accounts are ever candidates, since From and To are each a single value for the
+    whole request
+
+    Args:
+        db: Active database session
+        user: Authenticated user applying the change
+        transactions: Transactions the request covers
+        data: Transactions to change and the details to set
+        chosen_category: Category the request sets, or None when it sets none
+        categories_by_id: Stored categories keyed by identifier, used when the request sets none
+
+    Returns:
+        The target accounts keyed by identifier
+
+    Raises:
+        HTTPException: An account refuses the write, is closed, or is archived
+    """
+    candidate_ids: set[uuid.UUID] = set()
+    for transaction in transactions:
+        if not _row_records_far_side(transaction, chosen_category, categories_by_id):
+            continue
+        own_end = _own_end(data, _resulting_direction(transaction, data))
+        if own_end is not None and own_end.scope == TransferCounterpartyScope.TRACKED:
+            candidate_ids.add(own_end.account_id)
+
+    accounts: dict[uuid.UUID, Account] = {}
+    for account_id in sorted(candidate_ids):
+        accounts[account_id] = await _load_move_target(db, user, account_id)
+    return accounts
+
+
+def _candidate_own_account(
+    transaction: Transaction,
+    data: BulkUpdateTransactionsRequest,
+    chosen_category: Category | None,
+    categories_by_id: dict[uuid.UUID, Category],
+    own_end_accounts: dict[uuid.UUID, Account],
+) -> Account | None:
+    """Return the account a row's own transfer end names, when that end is a tracked account
+
+    Args:
+        transaction: Transaction the request covers
+        data: Transactions to change and the details to set
+        chosen_category: Category the request sets, or None when it sets none
+        categories_by_id: Stored categories keyed by identifier, used when the request sets none
+        own_end_accounts: Accounts a tracked own end may move a row into, keyed by identifier
+
+    Returns:
+        The account the row's own end names, or None when the row resolves no own end
+    """
+    if not _row_records_far_side(transaction, chosen_category, categories_by_id):
+        return None
+    own_end = _own_end(data, _resulting_direction(transaction, data))
+    if own_end is None or own_end.scope != TransferCounterpartyScope.TRACKED:
+        return None
+    return own_end_accounts[own_end.account_id]
+
+
+async def _load_chosen_category(
+    db: AsyncSession,
+    data: BulkUpdateTransactionsRequest,
+    sent: set[str],
+) -> Category | None:
+    """Return the category the request sets, ahead of checking it reaches any particular group
+
+    Which rows resolve a transfer end at all turns on whether their resulting category records a far
+    side, and that has to be known before `group_ids` can be computed, so this loads the category by
+    identifier alone. `_validate_chosen_scope` runs the full per-group check once the groups the rows
+    actually land in are known
+
+    Args:
+        db: Active database session
+        data: Transactions to change and the details to set
+        sent: Names of the fields the request carried
+
+    Returns:
+        The chosen category, or None when the request sets none
+
+    Raises:
+        HTTPException: The chosen category does not exist or is not visible to the caller
+    """
+    if "category_id" not in sent:
+        return None
+    category = await db.get(Category, data.category_id)
+    if category is None:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_CONTENT, detail="Category not found")
+    return category
+
+
+async def _validate_chosen_scope(
     db: AsyncSession,
     user: User,
     data: BulkUpdateTransactionsRequest,
     sent: set[str],
     group_ids: set[uuid.UUID | None],
-) -> Category | None:
+) -> None:
     """Confirm the chosen category, merchant and tags reach every group in play
 
     A selection can span a personal account and a group account, and a record reaching one of them
@@ -194,21 +404,16 @@ async def _validate_chosen_records(
         sent: Names of the fields the request carried
         group_ids: Groups the rows end up in, with None for a personal account
 
-    Returns:
-        The chosen category, or None when the request sets no category
-
     Raises:
         HTTPException: A chosen record does not reach one of the groups
     """
-    chosen_category = None
     for group_id in group_ids:
         if "category_id" in sent:
-            chosen_category = await validate_transaction_category_access(db, data.category_id, user.id, group_id)
+            await validate_transaction_category_access(db, data.category_id, user.id, group_id)
         if "merchant_id" in sent:
             await validate_transaction_merchant_access(db, data.merchant_id, user.id, group_id)
         if data.add_tag_ids:
             await get_valid_transaction_tag_ids(db, user.id, data.add_tag_ids, group_id)
-    return chosen_category
 
 
 async def _load_current_categories(
@@ -253,7 +458,7 @@ def _resulting_category(
     chosen_category: Category | None,
     categories_by_id: dict[uuid.UUID, Category],
 ) -> Category:
-    """Return the category a transaction ends up under once the request is applied.
+    """Return the category a transaction ends up under once the request is applied
 
     Args:
         transaction: Transaction the request covers
@@ -266,35 +471,126 @@ def _resulting_category(
     return chosen_category if chosen_category is not None else categories_by_id[transaction.category_id]
 
 
-def _resulting_counterparty(
+def _resolve_transfer_ends(
     transaction: Transaction,
     data: BulkUpdateTransactionsRequest,
-    sent: set[str],
-) -> tuple[uuid.UUID | None, TransferCounterpartyScope | None]:
-    """Return the counterparty account and scope a transaction ends up with.
+    resulting_direction: BulkDirectionChange,
+) -> _TransferEndPair | None:
+    """Return the own and far transfer ends a row ends up with
+
+    Money out puts the row's own account at From and its recorded account at To, and money in is the
+    other way round. An end the request left out leaves that side of the row as it is
 
     Args:
         transaction: Transaction the request covers
         data: Transactions to change and the details to set
-        sent: Names of the fields the request carried
+        resulting_direction: Direction the transaction ends up pointing
 
     Returns:
-        The resulting counterparty account identifier and scope
+        The own and far ends to write, either one None where that side is left alone, or None when
+        the request set neither end
     """
-    if _COUNTERPARTY_FIELDS & sent:
-        return data.counterparty_account_id, data.counterparty_account_scope
-    return transaction.counterparty_account_id, transaction.counterparty_account_scope
+    if not {"transfer_from", "transfer_to"} & data.model_fields_set:
+        return None
+    if resulting_direction == BulkDirectionChange.DEBIT:
+        return data.transfer_from, data.transfer_to
+    return data.transfer_to, data.transfer_from
+
+
+def _resulting_account_id(
+    transaction: Transaction,
+    target_account: Account | None,
+    ends: _TransferEndPair | None,
+) -> uuid.UUID:
+    """Return the account a row ends up sitting in once the request is applied
+
+    Args:
+        transaction: Transaction the request covers
+        target_account: Account a plain move sends the transactions to, or None
+        ends: The row's resolved transfer ends, or None when none apply
+
+    Returns:
+        The account identifier the row ends up in
+    """
+    own_end = ends[0] if ends is not None else None
+    if own_end is not None and own_end.scope == TransferCounterpartyScope.TRACKED:
+        return own_end.account_id
+    if target_account is not None:
+        return target_account.id
+    return transaction.account_id
+
+
+def _resolve_rows(
+    transactions: list[Transaction],
+    data: BulkUpdateTransactionsRequest,
+    chosen_category: Category | None,
+    categories_by_id: dict[uuid.UUID, Category],
+    target_account: Account | None,
+) -> dict[uuid.UUID, _RowResolution]:
+    """Resolve the category, resulting account and transfer ends of every row
+
+    Done once before any write, since a value read off a row after `_apply_changes` has run may
+    already be the new one rather than the one the checks judged
+
+    Args:
+        transactions: Transactions the request covers
+        data: Transactions to change and the details to set
+        chosen_category: Category the request sets, or None when it sets none
+        categories_by_id: Stored categories keyed by identifier, used when the request sets none
+        target_account: Account a plain move sends the transactions to, or None
+
+    Returns:
+        Each transaction's resolution, keyed by identifier
+    """
+    resolutions: dict[uuid.UUID, _RowResolution] = {}
+    for transaction in transactions:
+        category = _resulting_category(transaction, chosen_category, categories_by_id)
+        ends = (
+            _resolve_transfer_ends(transaction, data, _resulting_direction(transaction, data))
+            if does_category_record_counterparty_account(category)
+            else None
+        )
+        resolutions[transaction.id] = _RowResolution(
+            category=category,
+            account_id=_resulting_account_id(transaction, target_account, ends),
+            ends=ends,
+        )
+    return resolutions
+
+
+def _refuse_ends_reaching_no_row(
+    data: BulkUpdateTransactionsRequest,
+    resolutions: dict[uuid.UUID, _RowResolution],
+) -> None:
+    """Reject a request whose transfer ends land on no row at all
+
+    An end reaches only the rows whose resulting category records a far side, and a selection
+    holding none of those would otherwise report a count for a write it never made
+
+    Args:
+        data: Transactions to change and the details to set
+        resolutions: Every transaction's resolution, keyed by identifier
+
+    Raises:
+        HTTPException: The request set a transfer end but no row in the selection resolves one
+    """
+    if not {"transfer_from", "transfer_to"} & data.model_fields_set:
+        return
+    if any(resolution.ends is not None for resolution in resolutions.values()):
+        return
+    raise HTTPException(
+        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+        detail="None of these transactions record the other side of a transfer",
+    )
 
 
 async def _refuse_rows_breaking_single_edit_rules(
     db: AsyncSession,
     user: User,
     data: BulkUpdateTransactionsRequest,
-    sent: set[str],
     transactions: list[Transaction],
-    chosen_category: Category | None,
-    categories_by_id: dict[uuid.UUID, Category],
-    target_account: Account | None,
+    resolutions: dict[uuid.UUID, _RowResolution],
+    accounts_by_id: dict[uuid.UUID, Account],
 ) -> None:
     """Reject the whole set when any row breaks a rule a single edit of it would break
 
@@ -305,57 +601,58 @@ async def _refuse_rows_breaking_single_edit_rules(
         db: Active database session
         user: Authenticated user applying the change
         data: Transactions to change and the details to set
-        sent: Names of the fields the request carried
         transactions: Transactions the request covers
-        chosen_category: Category the request sets, or None when it sets none
-        categories_by_id: Stored categories keyed by identifier, used when the request sets none
-        target_account: Account the request moves the transactions to, or None
+        resolutions: Every transaction's resolution, keyed by identifier
+        accounts_by_id: Every account a row might end up in, keyed by identifier
 
     Raises:
         HTTPException: At least one row breaks a rule
     """
     without_merchant = []
-    unanswered_transfers = []
-    counterparty_not_allowed = []
-    own_account_counterparty = []
     missing_fx_rate = []
+    sits_outside = []
+    unanswered_transfers = []
+    own_account_counterparty = []
     transfers_by_counterparty: dict[uuid.UUID, list[uuid.UUID]] = {}
 
     for transaction in transactions:
         # Editing brings a row onto the current rule, so one recorded before a merchant was required
         # has to gain one before any other change to it is accepted
-        if "merchant_id" not in sent and transaction.merchant_id is None:
+        if "merchant_id" not in data.model_fields_set and transaction.merchant_id is None:
             without_merchant.append(transaction.id)
 
-        # A row keeps its stored rate across a move, and without one it cannot sit in an account of
-        # another currency at all
+        resolution = resolutions[transaction.id]
+        resulting_account = accounts_by_id[resolution.account_id]
+
+        # Checked only where the row actually moves, whether that move came from account_id or from
+        # a tracked own end, matching the single-transaction path, which re-checks the rate only when
+        # account_id changes. A row keeping its own account is not asked to justify a currency
+        # mismatch this edit did not create, however it came to have one
         if (
-            target_account is not None
-            and transaction.currency != target_account.currency
+            resolution.account_id != transaction.account_id
+            and transaction.currency != resulting_account.currency
             and transaction.fx_rate is None
         ):
             missing_fx_rate.append(transaction.id)
 
-        category = _resulting_category(transaction, chosen_category, categories_by_id)
-        counterparty_id, counterparty_scope = _resulting_counterparty(transaction, data, sent)
-        resulting_account_id = target_account.id if target_account is not None else transaction.account_id
-
-        if not does_category_record_counterparty_account(category):
-            # Either half of the answer is an answer, so a scope on its own is refused as the
-            # account is, matching update.py:127-134
-            if _COUNTERPARTY_FIELDS & sent and (
-                data.counterparty_account_id is not None or data.counterparty_account_scope is not None
-            ):
-                counterparty_not_allowed.append(transaction.id)
+        if not does_category_record_counterparty_account(resolution.category):
             continue
 
-        if counterparty_scope is None:
+        own_end, far_end = resolution.ends if resolution.ends is not None else (None, None)
+        if own_end is not None and own_end.scope == TransferCounterpartyScope.OUTSIDE:
+            sits_outside.append(transaction.id)
+            continue
+
+        far_scope = far_end.scope if far_end is not None else transaction.counterparty_account_scope
+        far_account_id = far_end.account_id if far_end is not None else transaction.counterparty_account_id
+
+        if far_scope is None:
             unanswered_transfers.append(transaction.id)
-        elif counterparty_id is not None:
-            if counterparty_id == resulting_account_id:
+        elif far_account_id is not None:
+            if far_account_id == resolution.account_id:
                 own_account_counterparty.append(transaction.id)
             else:
-                transfers_by_counterparty.setdefault(counterparty_id, []).append(transaction.id)
+                transfers_by_counterparty.setdefault(far_account_id, []).append(transaction.id)
 
     unreachable_counterparties = await _find_unreachable_counterparties(db, user, transfers_by_counterparty)
 
@@ -364,10 +661,10 @@ async def _refuse_rows_breaking_single_edit_rules(
         reasons.append(f"{len(without_merchant)} with no merchant recorded")
     if missing_fx_rate:
         reasons.append(f"{len(missing_fx_rate)} in another currency with no exchange rate recorded")
+    if sits_outside:
+        reasons.append(f"{len(sits_outside)} that would sit outside this app")
     if unanswered_transfers:
         reasons.append(f"{len(unanswered_transfers)} not recording the other account of a transfer")
-    if counterparty_not_allowed:
-        reasons.append(f"{len(counterparty_not_allowed)} under a category that records no other account")
     if own_account_counterparty:
         reasons.append(f"{len(own_account_counterparty)} that would record their own account")
     if unreachable_counterparties:
@@ -378,8 +675,8 @@ async def _refuse_rows_breaking_single_edit_rules(
     refused_count = len({
         *without_merchant,
         *missing_fx_rate,
+        *sits_outside,
         *unanswered_transfers,
-        *counterparty_not_allowed,
         *own_account_counterparty,
         *unreachable_counterparties,
     })
@@ -430,29 +727,33 @@ def _collect_snapshot_starts(
     data: BulkUpdateTransactionsRequest,
     sent: set[str],
     transactions: list[Transaction],
-    target_account: Account | None,
+    resolutions: dict[uuid.UUID, _RowResolution],
 ) -> dict[uuid.UUID, date]:
     """Return the earliest date each affected account has to be rebuilt from
 
-    Only the account and the date move a balance, so nothing is rebuilt unless one of them is set.
-    Every row counts twice, once for where it was and once for where it ends up, so an account
-    keeping a row that only changes date still rebuilds from that row's earlier date
+    A balance moves when a row changes account, changes date, or changes the sign of its amount, so
+    nothing is rebuilt unless one of those is asked for. Every row counts twice, once for where it
+    was and once for where it ends up, so an account keeping a row that only changes date still
+    rebuilds from that row's earlier date
+
+    Read before the change is written, since SQLAlchemy writes the new values back onto the loaded
+    rows and a column read afterwards is the new one rather than the one this collection needs
 
     Args:
         data: Transactions to change and the details to set
         sent: Names of the fields the request carried
         transactions: Transactions the request covers
-        target_account: Account the request moves the transactions to, or None
+        resolutions: Every transaction's resolution, keyed by identifier
 
     Returns:
         The earliest date to rebuild from, keyed by account
     """
-    if "account_id" not in sent and "dt" not in sent:
+    if not ({"account_id", "dt", "direction", "transfer_from", "transfer_to"} & sent):
         return {}
 
     starts: dict[uuid.UUID, date] = {}
     for transaction in transactions:
-        resulting_account_id = target_account.id if target_account is not None else transaction.account_id
+        resulting_account_id = resolutions[transaction.id].account_id
         resulting_date = data.dt if "dt" in sent else transaction.dt
 
         for account_id, from_date in (
@@ -472,8 +773,7 @@ async def _apply_changes(
     sent: set[str],
     transactions: list[Transaction],
     transaction_ids: list[uuid.UUID],
-    chosen_category: Category | None,
-    categories_by_id: dict[uuid.UUID, Category],
+    resolutions: dict[uuid.UUID, _RowResolution],
 ) -> None:
     """Write the requested change and normalise what the change invalidates
 
@@ -483,33 +783,74 @@ async def _apply_changes(
         sent: Names of the fields the request carried
         transactions: Transactions the request covers
         transaction_ids: Identifiers of those transactions
-        chosen_category: Category the request sets, or None when it sets none
-        categories_by_id: Stored categories keyed by identifier, used when the request sets none
+        resolutions: Every transaction's resolution, keyed by identifier
 
     Returns:
         None
+
+    Raises:
+        HTTPException: A row's sign no longer matches the one its transfer ends were resolved for
     """
     column_values = {field: getattr(data, field) for field in _DIRECT_COLUMN_FIELDS if field in sent}
     if column_values:
         await db.execute(update(Transaction).where(Transaction.id.in_(transaction_ids)).values(**column_values))
 
+    # Split into at most two buckets, keyed by each row's own sign rather than by its resulting
+    # direction, since a race is a change to that stored sign specifically. Direction is one value
+    # for the whole request, so every row sharing a sign also shares the resulting direction that
+    # produced its own and far ends, and the bucket can use either row's ends for the whole group.
+    # The WHERE clause re-reads the sign at write time, so a row whose sign changed between the
+    # checks and here drops out of its bucket's count and the whole request is turned down rather
+    # than written for a direction the row no longer has
+    for own_direction in (BulkDirectionChange.DEBIT, BulkDirectionChange.CREDIT):
+        bucket_ids = [
+            transaction.id
+            for transaction in transactions
+            if _own_direction(transaction) == own_direction and resolutions[transaction.id].ends is not None
+        ]
+        if not bucket_ids:
+            continue
+
+        own_end, far_end = resolutions[bucket_ids[0]].ends
+        values: dict[str, object] = {}
+        if own_end is not None:
+            values["account_id"] = own_end.account_id
+        if far_end is not None:
+            values["counterparty_account_scope"] = far_end.scope
+            values["counterparty_account_id"] = far_end.account_id
+
+        sign_condition = (
+            Transaction.amount < 0 if own_direction == BulkDirectionChange.DEBIT else Transaction.amount >= 0
+        )
+        written = await db.execute(
+            update(Transaction).where(Transaction.id.in_(bucket_ids), sign_condition).values(**values),
+        )
+        if written.rowcount != len(bucket_ids):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="Another change reached one of these transactions first. Try again.",
+            )
+
+    if "direction" in sent:
+        magnitude = func.abs(Transaction.amount)
+        if data.direction == BulkDirectionChange.REVERSE:
+            new_amount = -Transaction.amount
+        elif data.direction == BulkDirectionChange.CREDIT:
+            new_amount = magnitude
+        else:
+            new_amount = -magnitude
+        await db.execute(
+            update(Transaction)
+            .where(Transaction.id.in_(transaction_ids))
+            .values(amount=new_amount)
+            .execution_options(synchronize_session=False),
+        )
+
     records_counterparty = [
         transaction.id
         for transaction in transactions
-        if does_category_record_counterparty_account(
-            _resulting_category(transaction, chosen_category, categories_by_id),
-        )
+        if does_category_record_counterparty_account(resolutions[transaction.id].category)
     ]
-
-    if _COUNTERPARTY_FIELDS & sent and records_counterparty:
-        await db.execute(
-            update(Transaction)
-            .where(Transaction.id.in_(records_counterparty))
-            .values(
-                counterparty_account_id=data.counterparty_account_id,
-                counterparty_account_scope=data.counterparty_account_scope,
-            ),
-        )
 
     # A category that records no counterparty account drops whatever the previous one recorded, on
     # every edit rather than only on one that changes the category, matching the single-transaction

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -170,10 +170,26 @@ async def _load_current_categories(
 
     Returns:
         Category rows keyed by identifier
+
+    Raises:
+        HTTPException: A row uses a category the caller cannot read
     """
     category_ids = {transaction.category_id for transaction in transactions}
     result = await db.execute(select(Category).where(Category.id.in_(category_ids)))
-    return {category.id: category for category in result.scalars().all()}
+    categories_by_id = {category.id: category for category in result.scalars().all()}
+
+    # A row on a shared account can use the personal category of whoever recorded it, which nobody
+    # else can read. Refusing says so, where indexing the missing key would answer 500
+    missing = category_ids - categories_by_id.keys()
+    if missing:
+        refused = sum(1 for transaction in transactions if transaction.category_id in missing)
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"{refused} of these transactions cannot be changed: "
+            f"{refused} using a category you cannot open",
+        )
+
+    return categories_by_id
 
 
 def _resulting_category(

--- a/backend/app/services/transactions/bulk_update.py
+++ b/backend/app/services/transactions/bulk_update.py
@@ -1,10 +1,14 @@
 """Bulk transaction update service
 
-One request sets a category, a merchant or extra tags across several transactions. Every rule the
-single-transaction path enforces is enforced here too, and a set holding one row that refuses the
-edit is rejected whole, so a bulk edit can never write a state a single edit would have refused
+One request sets shared details across several transactions. Every rule the single-transaction path
+enforces is enforced here too, and a set holding one row that refuses the edit is rejected whole, so
+a bulk edit can never write a state a single edit would have refused
+
+A field is applied when the request carried it, not when it is non-null, because the note and the
+counterparty pair each take null as a real answer meaning clear it
 """
 import uuid
+from datetime import date
 
 from fastapi import HTTPException, status
 from sqlalchemy import select, update
@@ -17,6 +21,7 @@ from app.models.transaction import Transaction
 from app.models.user import User
 from app.permissions import check_account_access
 from app.schemas.transaction import BulkUpdateTransactionsRequest, BulkUpdateTransactionsResponse
+from app.services.accounts.snapshots import recompute_snapshots_from
 from app.services.cache_state import mark_cache_changed_for_scope
 from app.services.categories.transfer_rules import does_category_record_counterparty_account
 from app.services.transactions.access_helpers import accessible_account_ids_subquery
@@ -28,30 +33,38 @@ from app.services.transactions.validation import (
     validate_transaction_merchant_access,
 )
 
+# Columns the request writes straight onto every row it covers. The counterparty pair is absent
+# because it is written only onto the rows whose resulting category records one
+_DIRECT_COLUMN_FIELDS = ("account_id", "dt", "category_id", "merchant_id", "notes")
+
+_COUNTERPARTY_FIELDS = frozenset({"counterparty_account_id", "counterparty_account_scope"})
+
 
 async def bulk_update_transactions(
     db: AsyncSession,
     user: User,
     data: BulkUpdateTransactionsRequest,
 ) -> BulkUpdateTransactionsResponse:
-    """Apply one category, merchant or tag change across several transactions
+    """Apply one set of details across several transactions
 
     The service loads the requested transactions inside the caller's readable scope, checks write
-    access on every account behind them, refuses the whole set when any row breaks a rule the
-    single-transaction path enforces, then applies the change and commits once
+    access on every account behind them and on any account they move to, refuses the whole set when
+    any row breaks a rule the single-transaction path enforces, then applies the change, rebuilds
+    the balances the change moved and commits once
 
     Args:
         db: Active database session
         user: Authenticated user applying the change
-        data: Transactions to change and the fields to set
+        data: Transactions to change and the details to set
 
     Returns:
-        The number of transactions changed and the accounts they belong to
+        The number of transactions changed and the accounts affected
 
     Raises:
         HTTPException: A transaction was not found, an account refuses the write, or a row breaks a
             rule the single-transaction path enforces
     """
+    sent = data.model_fields_set
     requested_ids = list(dict.fromkeys(data.transaction_ids))
 
     # Load the requested rows inside the caller's readable scope, so an id belonging to someone else
@@ -70,34 +83,55 @@ async def bulk_update_transactions(
         )
 
     transaction_ids = [transaction.id for transaction in transactions]
-    accounts = await _load_writable_accounts(db, user, transactions)
-    group_ids = {account.group_id for account in accounts}
+    source_accounts = await _load_writable_accounts(db, user, {t.account_id for t in transactions})
 
-    chosen_category = await _validate_chosen_records(db, user, data, group_ids)
+    target_account = None
+    if "account_id" in sent:
+        target_account = await _load_move_target(db, user, data.account_id)
+
+    # After a move every row sits in the target account's group, so that is the scope the chosen
+    # records have to reach. Without one, each source account's scope still has to be satisfied
+    group_ids = (
+        {target_account.group_id} if target_account else {account.group_id for account in source_accounts}
+    )
+    chosen_category = await _validate_chosen_records(db, user, data, sent, group_ids)
     categories_by_id = await _load_current_categories(db, transactions) if chosen_category is None else {}
 
-    await _refuse_rows_breaking_single_edit_rules(db, user, data, transactions, chosen_category, categories_by_id)
+    await _refuse_rows_breaking_single_edit_rules(
+        db, user, data, sent, transactions, chosen_category, categories_by_id, target_account,
+    )
 
-    await _apply_changes(db, data, transactions, transaction_ids, chosen_category, categories_by_id)
+    # Collected before the update, because SQLAlchemy writes the new values back onto the loaded
+    # rows and a date read afterwards is the new one
+    snapshot_starts = _collect_snapshot_starts(data, sent, transactions, target_account)
+
+    await _apply_changes(db, data, sent, transactions, transaction_ids, chosen_category, categories_by_id)
+
+    for account_id, from_date in snapshot_starts.items():
+        await recompute_snapshots_from(db, account_id, from_date)
+
+    affected_accounts = [*source_accounts]
+    if target_account is not None and target_account.id not in {a.id for a in source_accounts}:
+        affected_accounts.append(target_account)
 
     # One mark per scope rather than one per transaction, since every row in a scope shares it
-    for owner_id, group_id in {(account.owner_id, account.group_id) for account in accounts}:
+    for owner_id, group_id in {(account.owner_id, account.group_id) for account in affected_accounts}:
         await mark_cache_changed_for_scope(db, user_id=owner_id, group_id=group_id)
 
     await db.commit()
 
     return BulkUpdateTransactionsResponse(
         transactions_updated=len(transaction_ids),
-        affected_account_ids=sorted({account.id for account in accounts}),
+        affected_account_ids=sorted({account.id for account in affected_accounts}),
     )
 
 
 async def _load_writable_accounts(
     db: AsyncSession,
     user: User,
-    transactions: list[Transaction],
+    account_ids: set[uuid.UUID],
 ) -> list[Account]:
-    """Return the accounts behind a set of transactions, refusing any the caller cannot write to
+    """Return the given accounts, refusing any the caller cannot write to
 
     Row-level security secures ``transactions`` with a check that passes any account permission
     whatever its level, so this application check is the only thing separating read from write
@@ -105,29 +139,50 @@ async def _load_writable_accounts(
     Args:
         db: Active database session
         user: Authenticated user applying the change
-        transactions: Transactions the request covers
+        account_ids: Accounts to check
 
     Returns:
-        One account row per distinct account behind the transactions
+        One account row per identifier
 
     Raises:
         HTTPException: An account refuses the write or is archived
     """
     accounts = []
-    for account_id in sorted({transaction.account_id for transaction in transactions}):
+    for account_id in sorted(account_ids):
         account = await check_account_access(db, account_id, user.id, PermissionLevel.WRITE)
         validate_transaction_account_is_not_archived(account)
         accounts.append(account)
     return accounts
 
 
+async def _load_move_target(db: AsyncSession, user: User, account_id: uuid.UUID) -> Account:
+    """Return the account a move sends the transactions to
+
+    Args:
+        db: Active database session
+        user: Authenticated user applying the change
+        account_id: Account the request moves the transactions to
+
+    Returns:
+        The target account
+
+    Raises:
+        HTTPException: The account refuses the write, is closed, or is archived
+    """
+    # An account that is closed takes no new history, which is why the move asks for an open one
+    account = await check_account_access(db, account_id, user.id, PermissionLevel.WRITE, require_open=True)
+    validate_transaction_account_is_not_archived(account)
+    return account
+
+
 async def _validate_chosen_records(
     db: AsyncSession,
     user: User,
     data: BulkUpdateTransactionsRequest,
+    sent: set[str],
     group_ids: set[uuid.UUID | None],
 ) -> Category | None:
-    """Confirm the chosen category, merchant and tags reach every group in the set
+    """Confirm the chosen category, merchant and tags reach every group in play
 
     A selection can span a personal account and a group account, and a record reaching one of them
     does not reach the other, so each scope is checked in its own right
@@ -135,8 +190,9 @@ async def _validate_chosen_records(
     Args:
         db: Active database session
         user: Authenticated user applying the change
-        data: Transactions to change and the fields to set
-        group_ids: Distinct groups behind the accounts in the set, with None for personal accounts
+        data: Transactions to change and the details to set
+        sent: Names of the fields the request carried
+        group_ids: Groups the rows end up in, with None for a personal account
 
     Returns:
         The chosen category, or None when the request sets no category
@@ -146,9 +202,9 @@ async def _validate_chosen_records(
     """
     chosen_category = None
     for group_id in group_ids:
-        if data.category_id is not None:
+        if "category_id" in sent:
             chosen_category = await validate_transaction_category_access(db, data.category_id, user.id, group_id)
-        if data.merchant_id is not None:
+        if "merchant_id" in sent:
             await validate_transaction_merchant_access(db, data.merchant_id, user.id, group_id)
         if data.add_tag_ids:
             await get_valid_transaction_tag_ids(db, user.id, data.add_tag_ids, group_id)
@@ -210,13 +266,35 @@ def _resulting_category(
     return chosen_category if chosen_category is not None else categories_by_id[transaction.category_id]
 
 
+def _resulting_counterparty(
+    transaction: Transaction,
+    data: BulkUpdateTransactionsRequest,
+    sent: set[str],
+) -> tuple[uuid.UUID | None, object]:
+    """Return the counterparty account and scope a transaction ends up with.
+
+    Args:
+        transaction: Transaction the request covers
+        data: Transactions to change and the details to set
+        sent: Names of the fields the request carried
+
+    Returns:
+        The resulting counterparty account identifier and scope
+    """
+    if _COUNTERPARTY_FIELDS & sent:
+        return data.counterparty_account_id, data.counterparty_account_scope
+    return transaction.counterparty_account_id, transaction.counterparty_account_scope
+
+
 async def _refuse_rows_breaking_single_edit_rules(
     db: AsyncSession,
     user: User,
     data: BulkUpdateTransactionsRequest,
+    sent: set[str],
     transactions: list[Transaction],
     chosen_category: Category | None,
     categories_by_id: dict[uuid.UUID, Category],
+    target_account: Account | None,
 ) -> None:
     """Reject the whole set when any row breaks a rule a single edit of it would break
 
@@ -226,45 +304,81 @@ async def _refuse_rows_breaking_single_edit_rules(
     Args:
         db: Active database session
         user: Authenticated user applying the change
-        data: Transactions to change and the fields to set
+        data: Transactions to change and the details to set
+        sent: Names of the fields the request carried
         transactions: Transactions the request covers
         chosen_category: Category the request sets, or None when it sets none
         categories_by_id: Stored categories keyed by identifier, used when the request sets none
+        target_account: Account the request moves the transactions to, or None
 
     Raises:
         HTTPException: At least one row breaks a rule
     """
     without_merchant = []
     unanswered_transfers = []
+    counterparty_not_allowed = []
+    own_account_counterparty = []
+    missing_fx_rate = []
     transfers_by_counterparty: dict[uuid.UUID, list[uuid.UUID]] = {}
 
     for transaction in transactions:
         # Editing brings a row onto the current rule, so one recorded before a merchant was required
         # has to gain one before any other change to it is accepted
-        if data.merchant_id is None and transaction.merchant_id is None:
+        if "merchant_id" not in sent and transaction.merchant_id is None:
             without_merchant.append(transaction.id)
 
+        # A row keeps its stored rate across a move, and without one it cannot sit in an account of
+        # another currency at all
+        if (
+            target_account is not None
+            and transaction.currency != target_account.currency
+            and transaction.fx_rate is None
+        ):
+            missing_fx_rate.append(transaction.id)
+
         category = _resulting_category(transaction, chosen_category, categories_by_id)
+        counterparty_id, counterparty_scope = _resulting_counterparty(transaction, data, sent)
+        resulting_account_id = target_account.id if target_account is not None else transaction.account_id
+
         if not does_category_record_counterparty_account(category):
+            if _COUNTERPARTY_FIELDS & sent and data.counterparty_account_id is not None:
+                counterparty_not_allowed.append(transaction.id)
             continue
-        if transaction.counterparty_account_scope is None:
+
+        if counterparty_scope is None:
             unanswered_transfers.append(transaction.id)
-        elif transaction.counterparty_account_id is not None:
-            transfers_by_counterparty.setdefault(transaction.counterparty_account_id, []).append(transaction.id)
+        elif counterparty_id is not None:
+            if counterparty_id == resulting_account_id:
+                own_account_counterparty.append(transaction.id)
+            else:
+                transfers_by_counterparty.setdefault(counterparty_id, []).append(transaction.id)
 
     unreachable_counterparties = await _find_unreachable_counterparties(db, user, transfers_by_counterparty)
 
     reasons = []
     if without_merchant:
         reasons.append(f"{len(without_merchant)} with no merchant recorded")
+    if missing_fx_rate:
+        reasons.append(f"{len(missing_fx_rate)} in another currency with no exchange rate recorded")
     if unanswered_transfers:
         reasons.append(f"{len(unanswered_transfers)} not recording the other account of a transfer")
+    if counterparty_not_allowed:
+        reasons.append(f"{len(counterparty_not_allowed)} under a category that records no other account")
+    if own_account_counterparty:
+        reasons.append(f"{len(own_account_counterparty)} that would record their own account")
     if unreachable_counterparties:
         reasons.append(f"{len(unreachable_counterparties)} recording an account you can no longer open")
     if not reasons:
         return
 
-    refused_count = len({*without_merchant, *unanswered_transfers, *unreachable_counterparties})
+    refused_count = len({
+        *without_merchant,
+        *missing_fx_rate,
+        *unanswered_transfers,
+        *counterparty_not_allowed,
+        *own_account_counterparty,
+        *unreachable_counterparties,
+    })
     raise HTTPException(
         status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
         detail=f"{refused_count} of these transactions cannot be changed: {', '.join(reasons)}",
@@ -276,7 +390,7 @@ async def _find_unreachable_counterparties(
     user: User,
     transfers_by_counterparty: dict[uuid.UUID, list[uuid.UUID]],
 ) -> list[uuid.UUID]:
-    """Return the transfers recording an account the caller can no longer read
+    """Return the transfers recording an account the caller cannot read
 
     The single-transaction path re-checks this on every edit, at the end of its counterparty
     validation, so a bulk edit that skipped it would accept a row a single edit of the same row
@@ -308,9 +422,50 @@ async def _find_unreachable_counterparties(
     ]
 
 
+def _collect_snapshot_starts(
+    data: BulkUpdateTransactionsRequest,
+    sent: set[str],
+    transactions: list[Transaction],
+    target_account: Account | None,
+) -> dict[uuid.UUID, date]:
+    """Return the earliest date each affected account has to be rebuilt from
+
+    Only the account and the date move a balance, so nothing is rebuilt unless one of them is set.
+    Every row counts twice, once for where it was and once for where it ends up, so an account
+    keeping a row that only changes date still rebuilds from that row's earlier date
+
+    Args:
+        data: Transactions to change and the details to set
+        sent: Names of the fields the request carried
+        transactions: Transactions the request covers
+        target_account: Account the request moves the transactions to, or None
+
+    Returns:
+        The earliest date to rebuild from, keyed by account
+    """
+    if "account_id" not in sent and "dt" not in sent:
+        return {}
+
+    starts: dict[uuid.UUID, date] = {}
+    for transaction in transactions:
+        resulting_account_id = target_account.id if target_account is not None else transaction.account_id
+        resulting_date = data.dt if "dt" in sent else transaction.dt
+
+        for account_id, from_date in (
+            (transaction.account_id, transaction.dt),
+            (resulting_account_id, resulting_date),
+        ):
+            existing = starts.get(account_id)
+            if existing is None or from_date < existing:
+                starts[account_id] = from_date
+
+    return starts
+
+
 async def _apply_changes(
     db: AsyncSession,
     data: BulkUpdateTransactionsRequest,
+    sent: set[str],
     transactions: list[Transaction],
     transaction_ids: list[uuid.UUID],
     chosen_category: Category | None,
@@ -320,7 +475,8 @@ async def _apply_changes(
 
     Args:
         db: Active database session
-        data: Transactions to change and the fields to set
+        data: Transactions to change and the details to set
+        sent: Names of the fields the request carried
         transactions: Transactions the request covers
         transaction_ids: Identifiers of those transactions
         chosen_category: Category the request sets, or None when it sets none
@@ -329,26 +485,36 @@ async def _apply_changes(
     Returns:
         None
     """
-    column_values = {}
-    if data.category_id is not None:
-        column_values["category_id"] = data.category_id
-    if data.merchant_id is not None:
-        column_values["merchant_id"] = data.merchant_id
+    column_values = {field: getattr(data, field) for field in _DIRECT_COLUMN_FIELDS if field in sent}
     if column_values:
         await db.execute(update(Transaction).where(Transaction.id.in_(transaction_ids)).values(**column_values))
 
+    records_counterparty = [
+        transaction.id
+        for transaction in transactions
+        if does_category_record_counterparty_account(
+            _resulting_category(transaction, chosen_category, categories_by_id),
+        )
+    ]
+
+    if _COUNTERPARTY_FIELDS & sent and records_counterparty:
+        await db.execute(
+            update(Transaction)
+            .where(Transaction.id.in_(records_counterparty))
+            .values(
+                counterparty_account_id=data.counterparty_account_id,
+                counterparty_account_scope=data.counterparty_account_scope,
+            ),
+        )
+
     # A category that records no counterparty account drops whatever the previous one recorded, on
     # every edit rather than only on one that changes the category, matching the single-transaction
-    # path. The rows are picked one by one because the category a row ends up under is its own
-    # whenever the request sets none, and clearing the whole set would take the counterparty off
-    # every transfer in it
+    # path. Picked row by row because the category a row ends up under is its own whenever the
+    # request sets none, and clearing the whole set would take the counterparty off every transfer
     clearable_ids = [
         transaction.id
         for transaction in transactions
-        if transaction.counterparty_account_scope is not None
-        and not does_category_record_counterparty_account(
-            _resulting_category(transaction, chosen_category, categories_by_id),
-        )
+        if transaction.counterparty_account_scope is not None and transaction.id not in set(records_counterparty)
     ]
     if clearable_ids:
         await db.execute(

--- a/backend/app/services/transactions/creation.py
+++ b/backend/app/services/transactions/creation.py
@@ -6,7 +6,7 @@ from app.models.transaction import Transaction
 from app.models.user import User
 from app.permissions import check_account_access
 from app.schemas.transaction import CreateTransactionRequest, TransactionResponse
-from app.services.accounts.snapshots import recompute_snapshots_from
+from app.services.accounts.snapshots import recompute_account_snapshots
 from app.services.cache_state import mark_cache_changed_for_scope
 from app.services.transactions.accounts import validate_transaction_account_is_not_archived
 from app.services.transactions.response_helpers import get_transaction_response
@@ -94,7 +94,7 @@ async def create_transaction_and_get_response(
         await replace_transaction_tag_assignments(db, txn.id, validated_tag_ids)
 
     # Rebuild balance snapshots from this transaction's day forward
-    await recompute_snapshots_from(db, data.account_id, data.dt)
+    await recompute_account_snapshots(db, {data.account_id: data.dt})
 
     # Mark the affected user or group cache after all transaction writes are flushed
     await mark_cache_changed_for_scope(db, user_id=account.owner_id, group_id=account.group_id)

--- a/backend/app/services/transactions/deletion.py
+++ b/backend/app/services/transactions/deletion.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.base import PermissionLevel
 from app.models.user import User
 from app.permissions import check_transaction_access
-from app.services.accounts.snapshots import recompute_snapshots_from
+from app.services.accounts.snapshots import recompute_account_snapshots
 from app.services.cache_state import mark_cache_changed_for_scope
 from app.services.transactions.accounts import (
     get_parent_account_for_transaction,
@@ -52,7 +52,7 @@ async def delete_transaction_for_user(
     await db.flush()
 
     # Rebuild balance snapshots from the deleted transaction's day forward
-    await recompute_snapshots_from(db, account_id, deleted_dt)
+    await recompute_account_snapshots(db, {account_id: deleted_dt})
 
     # Mark the affected user or group cache after all delete writes are flushed
     await mark_cache_changed_for_scope(db, user_id=account.owner_id, group_id=account.group_id)

--- a/backend/app/services/transactions/snapshots.py
+++ b/backend/app/services/transactions/snapshots.py
@@ -6,7 +6,7 @@ from datetime import date
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.transaction import Transaction
-from app.services.accounts.snapshots import recompute_snapshots_from
+from app.services.accounts.snapshots import recompute_account_snapshots
 
 _SNAPSHOT_AFFECTING_UPDATE_FIELDS = frozenset({"account_id", "dt", "amount"})
 
@@ -38,13 +38,17 @@ async def recompute_snapshots_after_transaction_update(
     if not _transaction_update_affects_snapshots(changed_fields):
         return
 
-    await db.flush()
     if txn.account_id != previous_account_id:
-        await recompute_snapshots_from(db, previous_account_id, previous_date)
-        await recompute_snapshots_from(db, txn.account_id, txn.dt)
+        await recompute_account_snapshots(db, {
+            previous_account_id: previous_date,
+            txn.account_id: txn.dt,
+        })
         return
 
-    await recompute_snapshots_from(db, txn.account_id, min(previous_date, txn.dt))
+    await recompute_account_snapshots(
+        db,
+        {txn.account_id: min(previous_date, txn.dt)},
+    )
 
 
 def _transaction_update_affects_snapshots(changed_fields: Mapping[str, object]) -> bool:

--- a/backend/app/services/transactions/tags.py
+++ b/backend/app/services/transactions/tags.py
@@ -2,6 +2,7 @@
 import uuid
 
 from sqlalchemy import delete
+from sqlalchemy.dialects.postgresql import insert as postgres_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.tag import TransactionTag
@@ -32,6 +33,34 @@ async def replace_transaction_tag_assignments(
     )
     for tag_id in tag_ids:
         db.add(TransactionTag(transaction_id=transaction_id, tag_id=tag_id))
+
+
+async def add_transaction_tag_assignments(
+    db: AsyncSession,
+    transaction_ids: list[uuid.UUID],
+    tag_ids: list[uuid.UUID],
+) -> None:
+    """Attach tags to several transactions without disturbing the tags they already carry
+
+    One statement per tag keeps the bind parameter count proportional to the transaction count
+    rather than to the product of the two, which a single combined insert would reach
+
+    Args:
+        db: Active database session
+        transaction_ids: Transactions to attach the tags to
+        tag_ids: Validated tag identifiers to attach
+
+    Returns:
+        None
+    """
+    for tag_id in tag_ids:
+        # A transaction already carrying the tag is left as it is, which the composite primary key
+        # is what makes detectable
+        await db.execute(
+            postgres_insert(TransactionTag)
+            .values([{"transaction_id": transaction_id, "tag_id": tag_id} for transaction_id in transaction_ids])
+            .on_conflict_do_nothing(),
+        )
 
 
 async def delete_transaction_tag_assignments(db: AsyncSession, transaction_id: uuid.UUID) -> None:

--- a/backend/tests/routes/accounts/test_account_creation.py
+++ b/backend/tests/routes/accounts/test_account_creation.py
@@ -22,6 +22,7 @@ async def test_create_account_returns_201(client):
     assert data["account_type"] == ACCOUNT_PAYLOAD["account_type"]
     assert data["currency"] == ACCOUNT_PAYLOAD["currency"]
     assert data["is_archived"] is False
+    assert data["can_write"] is True
     assert data["id"] is not None
     assert data["created_at"] is not None
 

--- a/backend/tests/routes/accounts/test_account_listing.py
+++ b/backend/tests/routes/accounts/test_account_listing.py
@@ -54,6 +54,67 @@ async def test_list_accounts_returns_user_accounts(client):
     assert len(data) == 2
     names = {a["name"] for a in data}
     assert names == {"Account A", "Account B"}
+    assert all(account["can_write"] is True for account in data)
+
+
+async def test_list_accounts_keeps_write_capabilities_bound_to_the_caller_and_group(client):
+    """Admin access in one group does not raise a read grant from another group to write."""
+    await _seed_currency()
+    alice = await _signup_user(
+        client, email="capability-alice@example.com", first_name="Alice", tz="America/Toronto",
+    )
+    assert alice.status_code == 201, alice.json()
+    alice_headers = _get_auth_header(alice)
+    alice_id = alice.json()["user"]["id"]
+    household_a = (await client.post(
+        "/groups", json={"name": "Household A"}, headers=alice_headers,
+    )).json()["id"]
+    account_a = (await _create_account(
+        client, alice_headers, name="Household A Chequing", group_id=household_a,
+    )).json()["id"]
+
+    bob = await _signup_user(
+        client, email="capability-bob@example.com", first_name="Bob", tz="America/Toronto",
+    )
+    assert bob.status_code == 201, bob.json()
+    bob_headers = _get_auth_header(bob)
+    household_b = (await client.post(
+        "/groups", json={"name": "Household B"}, headers=bob_headers,
+    )).json()["id"]
+    await client.post(
+        f"/groups/{household_b}/members", json={"user_id": alice_id}, headers=bob_headers,
+    )
+    account_b = (await _create_account(
+        client, bob_headers, name="Household B Chequing", group_id=household_b,
+    )).json()["id"]
+    await client.post(
+        f"/accounts/{account_b}/permissions",
+        json={"user_id": alice_id, "level": "read"},
+        headers=bob_headers,
+    )
+    charlie = await _signup_user(
+        client, email="capability-charlie@example.com", first_name="Charlie", tz="America/Toronto",
+    )
+    assert charlie.status_code == 201, charlie.json()
+    charlie_id = charlie.json()["user"]["id"]
+    await client.post(
+        f"/groups/{household_b}/members", json={"user_id": charlie_id}, headers=bob_headers,
+    )
+    await client.post(
+        f"/accounts/{account_b}/permissions",
+        json={"user_id": charlie_id, "level": "write"},
+        headers=bob_headers,
+    )
+
+    resp = await client.get("/accounts", headers=alice_headers)
+
+    assert resp.status_code == 200
+    rows = {row["id"]: row for row in resp.json()}
+    listed_ids = [row["id"] for row in resp.json()]
+    assert listed_ids.count(account_a) == 1
+    assert listed_ids.count(account_b) == 1
+    assert rows[account_a]["can_write"] is True
+    assert rows[account_b]["can_write"] is False
 
 
 async def test_list_accounts_returns_overview_shape(client):
@@ -86,7 +147,7 @@ async def test_list_accounts_returns_overview_shape(client):
         "id", "owner_id", "group_id", "account_kind", "account_type", "name",
         "tax_advantaged_category_id", "currency", "institution", "current_balance",
         "base_currency_current_balance", "current_balance_fx_status", "credit_limit",
-        "is_archived", "closed_at",
+        "can_write", "is_archived", "closed_at",
     ):
         assert field in row, f"missing overview field: {field}"
 

--- a/backend/tests/routes/accounts/test_account_retrieval.py
+++ b/backend/tests/routes/accounts/test_account_retrieval.py
@@ -31,6 +31,7 @@ async def test_get_account_returns_account(client):
     assert data["currency"] == ACCOUNT_PAYLOAD["currency"]
     assert data["current_balance"] == 0
     assert data["credit_limit"] is None
+    assert data["can_write"] is True
     for field in (
         "tax_treatment",
         "lifetime_contribution_limit",

--- a/backend/tests/routes/accounts/test_account_updates.py
+++ b/backend/tests/routes/accounts/test_account_updates.py
@@ -25,6 +25,7 @@ async def test_patch_account_updates_name(client):
 
     assert resp.status_code == 200
     assert resp.json()["name"] == "Renamed"
+    assert resp.json()["can_write"] is True
 
 
 async def test_patch_account_updates_is_archived(client):
@@ -38,6 +39,7 @@ async def test_patch_account_updates_is_archived(client):
 
     assert resp.status_code == 200
     assert resp.json()["is_archived"] is True
+    assert resp.json()["can_write"] is True
 
 
 async def test_patch_account_archiving_non_zero_balance_creates_balance_adjustment(client, monkeypatch):
@@ -149,6 +151,7 @@ async def test_patch_account_sets_closed_at(client):
 
     assert resp.status_code == 200
     assert resp.json()["closed_at"] is not None
+    assert resp.json()["can_write"] is True
 
 
 async def test_patch_account_empty_body_returns_unchanged(client):

--- a/backend/tests/routes/accounts/test_permissions.py
+++ b/backend/tests/routes/accounts/test_permissions.py
@@ -1,3 +1,5 @@
+import pytest
+
 from tests.routes.support import _create_user, _get_auth_header
 
 # --- Helpers ---
@@ -538,9 +540,80 @@ async def test_read_permission_allows_get_account(client):
     await _grant_account_permission(client, admin_headers, account_id, member_user_id, "read")
 
     resp = await client.get(f"/accounts/{account_id}", headers=member_headers)
+    listing = await client.get("/accounts", headers=member_headers)
 
     assert resp.status_code == 200
     assert resp.json()["id"] == account_id
+    assert resp.json()["can_write"] is False
+    assert listing.status_code == 200
+    assert listing.json()[0]["id"] == account_id
+    assert listing.json()[0]["can_write"] is False
+
+
+@pytest.mark.parametrize("level", ["write", "admin"])
+async def test_write_or_admin_permission_reports_write_capability(client, level):
+    """WRITE and ADMIN grants both let a regular member write transactions."""
+    admin_headers, member_headers, member_user_id, _, account_id = await _setup_group_with_member_and_account(client)
+    await _grant_account_permission(client, admin_headers, account_id, member_user_id, level)
+
+    detail = await client.get(f"/accounts/{account_id}", headers=member_headers)
+    listing = await client.get("/accounts", headers=member_headers)
+
+    assert detail.status_code == 200
+    assert detail.json()["can_write"] is True
+    assert listing.status_code == 200
+    assert listing.json()[0]["can_write"] is True
+
+
+async def test_group_admin_reports_write_capability_despite_an_explicit_read_grant(client):
+    """Group administrator access overrides the lower explicit account grant."""
+    admin_headers, member_headers, member_user_id, group_id, account_id = (
+        await _setup_group_with_member_and_account(client)
+    )
+    await _grant_account_permission(client, admin_headers, account_id, member_user_id, "read")
+    promote = await client.patch(
+        f"/groups/{group_id}/members/{member_user_id}",
+        json={"is_admin": True},
+        headers=admin_headers,
+    )
+    assert promote.status_code == 200
+
+    detail = await client.get(f"/accounts/{account_id}", headers=member_headers)
+    listing = await client.get("/accounts", headers=member_headers)
+
+    assert detail.status_code == 200
+    assert detail.json()["can_write"] is True
+    assert listing.status_code == 200
+    assert listing.json()[0]["can_write"] is True
+
+
+@pytest.mark.parametrize(
+    ("account_patch", "level", "expected"),
+    [
+        ({"is_archived": True}, "read", False),
+        ({"is_archived": True}, "write", True),
+        ({"closed_at": "2026-03-01T00:00:00Z"}, "read", False),
+        ({"closed_at": "2026-03-01T00:00:00Z"}, "write", True),
+    ],
+)
+async def test_archive_and_closed_state_do_not_change_write_capability(
+    client,
+    account_patch,
+    level,
+    expected,
+):
+    """Lifecycle state stays separate from the caller's permission level."""
+    admin_headers, member_headers, member_user_id, _, account_id = await _setup_group_with_member_and_account(client)
+    await _grant_account_permission(client, admin_headers, account_id, member_user_id, level)
+    update_resp = await client.patch(
+        f"/accounts/{account_id}", json=account_patch, headers=admin_headers,
+    )
+    assert update_resp.status_code == 200
+
+    detail = await client.get(f"/accounts/{account_id}", headers=member_headers)
+
+    assert detail.status_code == 200
+    assert detail.json()["can_write"] is expected
 
 
 async def test_read_permission_blocks_patch_account(client):

--- a/backend/tests/routes/accounts/test_tax_advantaged_category_links.py
+++ b/backend/tests/routes/accounts/test_tax_advantaged_category_links.py
@@ -102,6 +102,7 @@ async def test_list_accounts_includes_tax_advantaged_category_id(client):
             "base_currency_current_balance": 0,
             "current_balance_fx_status": {"state": "none", "missing_pairs": []},
             "credit_limit": None,
+            "can_write": True,
             "is_archived": False,
             "closed_at": None,
         },

--- a/backend/tests/routes/groups/test_transactions.py
+++ b/backend/tests/routes/groups/test_transactions.py
@@ -654,6 +654,30 @@ async def test_bulk_update_with_group_category_on_personal_transaction_returns_4
     assert resp.json()["detail"] == "Category not found"
 
 
+async def test_bulk_update_refuses_a_row_using_a_category_the_caller_cannot_read(client):
+    """A shared row can carry the personal category of whoever recorded it, which nobody else reads."""
+    admin_headers, member_headers, member_user_id, _, account_id, _, _ = (
+        await _setup_group_with_shared_account(client)
+    )
+    await _grant_account_permission(client, admin_headers, account_id, member_user_id, "write")
+    admin_personal_category = (
+        await _create_category(client, admin_headers, name="Admin Only", kind="expense")
+    ).json()["id"]
+    txn_id = (
+        await _create_transaction(client, admin_headers, account_id, admin_personal_category)
+    ).json()["id"]
+    merchant_id = (await _create_merchant(client, member_headers, name="Member Costco")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn_id], "merchant_id": merchant_id},
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 422
+    assert "cannot open" in resp.json()["detail"]
+
+
 async def test_bulk_update_refuses_a_transfer_recording_an_account_now_out_of_reach(client):
     """Losing access to the account a transfer records refuses the edit, as a single edit does."""
     admin_headers, member_headers, member_user_id, group_id, group_account_id, _, _ = (

--- a/backend/tests/routes/groups/test_transactions.py
+++ b/backend/tests/routes/groups/test_transactions.py
@@ -612,23 +612,103 @@ async def test_move_transaction_to_closed_group_account_returns_422(client):
 
 
 async def test_bulk_update_on_group_account_requires_write(client):
-    """Member with read-only permission cannot bulk edit a group transaction."""
+    """One read-only group row refuses the whole request before a writable row changes."""
     admin_headers, member_headers, member_user_id, _, account_id, category_id, _ = (
         await _setup_group_with_shared_account(client)
     )
     await _grant_account_permission(client, admin_headers, account_id, member_user_id, "read")
 
-    create_resp = await _create_transaction(client, admin_headers, account_id, category_id)
-    txn_id = create_resp.json()["id"]
+    read_only_id = (
+        await _create_transaction(client, admin_headers, account_id, category_id, amount=-1200)
+    ).json()["id"]
+    personal_account_id = (
+        await _create_account(client, member_headers, name="Member Chequing")
+    ).json()["id"]
+    personal_category_id = (
+        await _create_category(client, member_headers, name="Member Groceries", kind="expense")
+    ).json()["id"]
+    writable_id = (
+        await _create_transaction(
+            client, member_headers, personal_account_id, personal_category_id, amount=-1200,
+        )
+    ).json()["id"]
 
     resp = await client.patch(
         "/transactions/bulk",
-        json={"transaction_ids": [txn_id], "category_id": category_id},
+        json={"transaction_ids": [writable_id, read_only_id], "notes": "Should not be saved"},
         headers=member_headers,
     )
 
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Insufficient permissions"
+    assert (await client.get(f"/transactions/{writable_id}", headers=member_headers)).json()["notes"] is None
+    assert (await client.get(f"/transactions/{read_only_id}", headers=member_headers)).json()["notes"] is None
+
+
+async def test_bulk_update_refuses_a_move_into_a_read_only_group_account(client):
+    """A readable account cannot receive a transaction without write permission."""
+    admin_headers, member_headers, member_user_id, _, group_account_id, _, _ = (
+        await _setup_group_with_shared_account(client)
+    )
+    await _grant_account_permission(client, admin_headers, group_account_id, member_user_id, "read")
+    personal_account_id = (
+        await _create_account(client, member_headers, name="Member Chequing")
+    ).json()["id"]
+    personal_category_id = (
+        await _create_category(client, member_headers, name="Member Groceries", kind="expense")
+    ).json()["id"]
+    transaction_id = (
+        await _create_transaction(
+            client, member_headers, personal_account_id, personal_category_id, amount=-1200,
+        )
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transaction_id], "account_id": group_account_id},
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Insufficient permissions"
+    detail = await client.get(f"/transactions/{transaction_id}", headers=member_headers)
+    assert detail.json()["account_id"] == personal_account_id
+
+
+async def test_bulk_update_allows_a_read_only_group_account_as_the_far_side(client):
+    """A readable account may be recorded as From when the writable row remains where it is."""
+    admin_headers, member_headers, member_user_id, _, group_account_id, _, _ = (
+        await _setup_group_with_shared_account(client)
+    )
+    await _grant_account_permission(client, admin_headers, group_account_id, member_user_id, "read")
+    personal_account_id = (
+        await _create_account(client, member_headers, name="Member Chequing")
+    ).json()["id"]
+    transfer_category_id = await _get_system_category_id(client, member_headers, "Transfer")
+    transaction_id = (
+        await _create_transaction(
+            client,
+            member_headers,
+            personal_account_id,
+            transfer_category_id,
+            amount=4000,
+            counterparty_account_scope="outside",
+        )
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transaction_id],
+            "transfer_from": {"scope": "tracked", "account_id": group_account_id},
+        },
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 200
+    detail = await client.get(f"/transactions/{transaction_id}", headers=member_headers)
+    assert detail.json()["account_id"] == personal_account_id
+    assert detail.json()["counterparty_account_id"] == group_account_id
 
 
 async def test_bulk_update_with_group_category_on_personal_transaction_returns_422(client):

--- a/backend/tests/routes/groups/test_transactions.py
+++ b/backend/tests/routes/groups/test_transactions.py
@@ -678,6 +678,33 @@ async def test_bulk_update_refuses_a_row_using_a_category_the_caller_cannot_read
     assert "cannot open" in resp.json()["detail"]
 
 
+async def test_bulk_update_validates_the_chosen_category_against_the_account_moved_into(client):
+    """After a move the rows sit in the target's scope, so that is what the category has to reach."""
+    admin_headers, _, _, _, group_account_id, group_category_id, _ = (
+        await _setup_group_with_shared_account(client)
+    )
+    personal_account_id = (
+        await _create_account(client, admin_headers, name="Personal Chequing")
+    ).json()["id"]
+    txn_id = (
+        await _create_transaction(client, admin_headers, group_account_id, group_category_id)
+    ).json()["id"]
+
+    # The group's own category does not reach a personal account, which is where the move lands it
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [txn_id],
+            "account_id": personal_account_id,
+            "category_id": group_category_id,
+        },
+        headers=admin_headers,
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Category not found"
+
+
 async def test_bulk_update_refuses_a_transfer_recording_an_account_now_out_of_reach(client):
     """Losing access to the account a transfer records refuses the edit, as a single edit does."""
     admin_headers, member_headers, member_user_id, group_id, group_account_id, _, _ = (

--- a/backend/tests/routes/groups/test_transactions.py
+++ b/backend/tests/routes/groups/test_transactions.py
@@ -606,3 +606,87 @@ async def test_move_transaction_to_closed_group_account_returns_422(client):
 
     assert resp.status_code == 422
     assert resp.json()["detail"] == "Account is closed"
+
+
+# --- PATCH /transactions/bulk across group boundaries ---
+
+
+async def test_bulk_update_on_group_account_requires_write(client):
+    """Member with read-only permission cannot bulk edit a group transaction."""
+    admin_headers, member_headers, member_user_id, _, account_id, category_id, _ = (
+        await _setup_group_with_shared_account(client)
+    )
+    await _grant_account_permission(client, admin_headers, account_id, member_user_id, "read")
+
+    create_resp = await _create_transaction(client, admin_headers, account_id, category_id)
+    txn_id = create_resp.json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn_id], "category_id": category_id},
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "Insufficient permissions"
+
+
+async def test_bulk_update_with_group_category_on_personal_transaction_returns_422(client):
+    """A group category does not reach a transaction recorded in a personal account."""
+    admin_headers, _, _, _, _, group_category_id, _ = await _setup_group_with_shared_account(client)
+    personal_account_id = (
+        await _create_account(client, admin_headers, name="Personal Chequing")
+    ).json()["id"]
+    personal_category_id = (
+        await _create_category(client, admin_headers, name="Personal Groceries", kind="expense")
+    ).json()["id"]
+    txn_id = (
+        await _create_transaction(client, admin_headers, personal_account_id, personal_category_id)
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn_id], "category_id": group_category_id},
+        headers=admin_headers,
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "Category not found"
+
+
+async def test_bulk_update_refuses_a_transfer_recording_an_account_now_out_of_reach(client):
+    """Losing access to the account a transfer records refuses the edit, as a single edit does."""
+    admin_headers, member_headers, member_user_id, group_id, group_account_id, _, _ = (
+        await _setup_group_with_shared_account(client)
+    )
+    await _grant_account_permission(client, admin_headers, group_account_id, member_user_id, "read")
+    member_account_id = (
+        await _create_account(client, member_headers, name="Member Chequing")
+    ).json()["id"]
+    categories = await client.get("/categories", headers=member_headers)
+    transfer_id = next(row["id"] for row in categories.json() if row["name"] == "Transfer")
+    txn_id = (
+        await _create_transaction(
+            client,
+            member_headers,
+            member_account_id,
+            transfer_id,
+            counterparty_account_scope="tracked",
+            counterparty_account_id=group_account_id,
+        )
+    ).json()["id"]
+    merchant_id = (await _create_merchant(client, member_headers, name="Member Costco")).json()["id"]
+
+    remove_resp = await client.delete(
+        f"/groups/{group_id}/members/{member_user_id}", headers=admin_headers,
+    )
+    assert remove_resp.status_code in (200, 204)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn_id], "merchant_id": merchant_id},
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 422
+    assert "no longer open" in resp.json()["detail"]

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import date
 
 from sqlalchemy import select
 
@@ -14,6 +15,7 @@ from tests.routes.transactions._helpers import (
     _create_tag,
     _create_transaction,
     _get_system_category_id,
+    _seed_usd_currency,
     _setup_user_with_deps,
 )
 
@@ -372,7 +374,7 @@ async def test_bulk_update_refuses_a_request_carrying_only_an_empty_tag_list(cli
 
 
 async def test_bulk_update_leaves_the_account_balances_where_they_were(client):
-    """Category, merchant and tags move no money, so every stored balance stays as it was."""
+    """Category, merchant, tags and notes move no money, so every stored balance stays as it was."""
     headers, account_id, category_id = await _setup_user_with_deps(client)
     txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
     dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
@@ -381,9 +383,391 @@ async def test_bulk_update_leaves_the_account_balances_where_they_were(client):
 
     resp = await client.patch(
         "/transactions/bulk",
-        json={"transaction_ids": [txn], "category_id": dining_id},
+        json={"transaction_ids": [txn], "category_id": dining_id, "notes": "Corrected"},
         headers=headers,
     )
 
     assert resp.status_code == 200
     assert await _read_snapshots(account_id) == before
+
+
+# --- A field sent as null ---
+
+
+async def test_bulk_update_refuses_a_null_date(client):
+    """The date column takes no null, so sending one is refused rather than reaching the database."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "dt": None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_update_refuses_a_null_merchant(client):
+    """Clearing the merchant would leave a row the edit rules require to have one."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "merchant_id": None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert (await _read_transaction(txn)).merchant_id is not None
+
+
+# --- The note ---
+
+
+async def test_bulk_update_sets_a_note_on_every_selected_transaction(client):
+    """A note replaces whatever each transaction carried."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    first = (await _create_transaction(client, headers, account_id, category_id, notes="Weekly shop")).json()["id"]
+    second = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [first, second], "notes": "Corrected"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(first)).notes == "Corrected"
+    assert (await _read_transaction(second)).notes == "Corrected"
+
+
+async def test_bulk_update_clears_a_note_sent_as_null(client):
+    """Null is a real answer for a note, meaning take it off."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id, notes="Weekly shop")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "notes": None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(txn)).notes is None
+
+
+async def test_bulk_update_leaves_a_note_alone_when_the_request_omits_it(client):
+    """A field the request did not carry is left as it was."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id, notes="Weekly shop")).json()["id"]
+    dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "category_id": dining_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(txn)).notes == "Weekly shop"
+
+
+# --- Moving to another account ---
+
+
+async def test_bulk_update_moves_transactions_and_rebuilds_both_accounts(client):
+    """A move rebuilds the account the rows left and the one they arrived in."""
+    headers, source_id, category_id = await _setup_user_with_deps(client)
+    target_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+
+    # Stays behind, so the source account still has history after the move
+    await _create_transaction(client, headers, source_id, category_id, dt="2026-07-15", amount=-400)
+    first = (
+        await _create_transaction(client, headers, source_id, category_id, dt="2026-08-01", amount=-1000)
+    ).json()["id"]
+    second = (
+        await _create_transaction(client, headers, source_id, category_id, dt="2026-08-20", amount=-2500)
+    ).json()["id"]
+
+    # Already in the target, bracketing the arrival date, so its later balances have to be rebuilt
+    await _create_transaction(client, headers, target_id, category_id, dt="2026-08-10", amount=-800)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [first, second], "account_id": target_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["affected_account_ids"] == sorted([source_id, target_id])
+
+    source_balances = dict(await _read_snapshots(source_id))
+    assert source_balances[date(2026, 7, 15)] == -400
+    assert max(source_balances) == date(2026, 7, 15)
+
+    target_balances = dict(await _read_snapshots(target_id))
+    assert target_balances[date(2026, 8, 1)] == -1000
+    assert target_balances[date(2026, 8, 10)] == -1800
+    assert target_balances[date(2026, 8, 20)] == -4300
+
+
+async def test_bulk_update_rebuilds_every_account_a_date_change_touches(client):
+    """A selection spans accounts, so a date change rebuilds each one it reaches."""
+    headers, first_account, category_id = await _setup_user_with_deps(client)
+    second_account = (await _create_account(client, headers, name="Savings")).json()["id"]
+    first = (
+        await _create_transaction(client, headers, first_account, category_id, dt="2026-08-20", amount=-1000)
+    ).json()["id"]
+    second = (
+        await _create_transaction(client, headers, second_account, category_id, dt="2026-08-20", amount=-2000)
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [first, second], "dt": "2026-08-14"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert dict(await _read_snapshots(first_account))[date(2026, 8, 14)] == -1000
+    assert date(2026, 8, 20) not in dict(await _read_snapshots(first_account))
+    assert dict(await _read_snapshots(second_account))[date(2026, 8, 14)] == -2000
+    assert date(2026, 8, 20) not in dict(await _read_snapshots(second_account))
+
+
+async def test_bulk_update_rebuilds_the_target_from_a_row_that_was_already_there(client):
+    """A row already in the target account contributes its own earlier date to the rebuild."""
+    headers, source_id, category_id = await _setup_user_with_deps(client)
+    target_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+    moving = (
+        await _create_transaction(client, headers, source_id, category_id, dt="2026-08-20", amount=-1000)
+    ).json()["id"]
+    already_there = (
+        await _create_transaction(client, headers, target_id, category_id, dt="2026-08-01", amount=-500)
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [moving, already_there], "account_id": target_id, "dt": "2026-08-25"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    target_balances = dict(await _read_snapshots(target_id))
+
+    # Rebuilt from 2026-08-01, so the row that used to sit there is gone from that date
+    assert date(2026, 8, 1) not in target_balances
+    assert target_balances[date(2026, 8, 25)] == -1500
+
+
+async def test_bulk_update_refuses_a_move_that_leaves_a_row_without_an_exchange_rate(client):
+    """A row keeps its stored rate across a move, and without one it cannot change currency."""
+    await _seed_usd_currency()
+    headers, source_id, category_id = await _setup_user_with_deps(client)
+    target_id = (await _create_account(client, headers, name="US Savings", currency="USD")).json()["id"]
+    txn = (
+        await _create_transaction(client, headers, source_id, category_id, currency="CAD")
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "account_id": target_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "exchange rate" in resp.json()["detail"]
+    assert str((await _read_transaction(txn)).account_id) == source_id
+
+
+async def test_bulk_update_moves_a_row_that_carries_an_exchange_rate(client):
+    """The same move is accepted once the row records a rate."""
+    await _seed_usd_currency()
+    headers, source_id, category_id = await _setup_user_with_deps(client)
+    target_id = (await _create_account(client, headers, name="US Savings", currency="USD")).json()["id"]
+    txn = (
+        await _create_transaction(client, headers, source_id, category_id, currency="CAD", fx_rate=1.35)
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "account_id": target_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert str((await _read_transaction(txn)).account_id) == target_id
+
+
+async def test_bulk_update_refuses_a_move_to_an_archived_account(client):
+    """An archived account takes no history."""
+    headers, source_id, category_id = await _setup_user_with_deps(client)
+    target_id = (await _create_account(client, headers, name="Old Savings")).json()["id"]
+    txn = (await _create_transaction(client, headers, source_id, category_id)).json()["id"]
+    await client.patch(f"/accounts/{target_id}", json={"is_archived": True}, headers=headers)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "account_id": target_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert str((await _read_transaction(txn)).account_id) == source_id
+
+
+async def test_bulk_update_refuses_a_move_to_a_closed_account(client):
+    """A closed account is a second state that takes no new transactions."""
+    headers, source_id, category_id = await _setup_user_with_deps(client)
+    target_id = (await _create_account(client, headers, name="Closed Savings")).json()["id"]
+    txn = (await _create_transaction(client, headers, source_id, category_id)).json()["id"]
+    await client.patch(f"/accounts/{target_id}", json={"closed_at": "2026-03-01"}, headers=headers)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "account_id": target_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert str((await _read_transaction(txn)).account_id) == source_id
+
+
+# --- The other account a transfer records ---
+
+
+async def test_bulk_update_sets_a_transfer_category_and_its_other_account_together(client):
+    """One request can move rows onto a transfer category and answer what that category asks."""
+    headers, account_id, _, other_account_id, transfer_id = await _setup_transfer_user(client)
+    category_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+    first = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [first, second],
+            "category_id": transfer_id,
+            "counterparty_account_scope": "tracked",
+            "counterparty_account_id": other_account_id,
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    for txn in (first, second):
+        row = await _read_transaction(txn)
+        assert str(row.category_id) == transfer_id
+        assert str(row.counterparty_account_id) == other_account_id
+
+
+async def test_bulk_update_records_money_that_left_the_tracked_accounts(client):
+    """An outside answer records the scope and no account."""
+    headers, account_id, category_id, _, transfer_id = await _setup_transfer_user(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [txn],
+            "category_id": transfer_id,
+            "counterparty_account_scope": "outside",
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(txn)
+    assert row.counterparty_account_scope == TransferCounterpartyScope.OUTSIDE
+    assert row.counterparty_account_id is None
+
+
+async def test_bulk_update_refuses_an_other_account_under_a_category_that_records_none(client):
+    """An expense records no other account, so naming one is refused."""
+    headers, account_id, category_id, other_account_id, _ = await _setup_transfer_user(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [txn],
+            "counterparty_account_scope": "tracked",
+            "counterparty_account_id": other_account_id,
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "records no other account" in resp.json()["detail"]
+
+
+async def test_bulk_update_refuses_a_transfer_recording_its_own_account(client):
+    """A transfer cannot record the account it already sits in."""
+    headers, account_id, _, _, transfer_id = await _setup_transfer_user(client)
+    category_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [txn],
+            "category_id": transfer_id,
+            "counterparty_account_scope": "tracked",
+            "counterparty_account_id": account_id,
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "their own account" in resp.json()["detail"]
+
+
+async def test_bulk_update_refuses_a_move_into_the_account_a_transfer_already_records(client):
+    """The move makes the recorded account the row's own, which a check on the sent value would miss."""
+    headers, account_id, _, other_account_id, transfer_id = await _setup_transfer_user(client)
+    txn = (
+        await _create_transaction(
+            client,
+            headers,
+            account_id,
+            transfer_id,
+            counterparty_account_scope="tracked",
+            counterparty_account_id=other_account_id,
+        )
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "account_id": other_account_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "their own account" in resp.json()["detail"]
+    assert str((await _read_transaction(txn)).account_id) == account_id
+
+
+async def test_bulk_update_refuses_a_counterparty_answer_that_contradicts_itself(client):
+    """A tracked answer needs an account and any other answer forbids one."""
+    headers, account_id, category_id, other_account_id, _ = await _setup_transfer_user(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    tracked_without_account = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "counterparty_account_scope": "tracked"},
+        headers=headers,
+    )
+    outside_with_account = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [txn],
+            "counterparty_account_scope": "outside",
+            "counterparty_account_id": other_account_id,
+        },
+        headers=headers,
+    )
+
+    assert tracked_without_account.status_code == 422
+    assert outside_with_account.status_code == 422

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -1,9 +1,8 @@
 import asyncio
-import threading
 import uuid
 from datetime import date
 
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from app.models.account import AccountBalanceSnapshot
 from app.models.base import TransferCounterpartyScope
@@ -40,14 +39,6 @@ async def _clear_counterparty(transaction_id):
         txn = await session.get(Transaction, uuid.UUID(transaction_id))
         txn.counterparty_account_id = None
         txn.counterparty_account_scope = None
-        await session.commit()
-
-
-async def _flip_sign(transaction_id):
-    """Flip a transaction's amount directly, standing in for a concurrent session's edit."""
-    async with TestSession() as session:
-        txn = await session.get(Transaction, uuid.UUID(transaction_id))
-        txn.amount = -txn.amount
         await session.commit()
 
 
@@ -309,11 +300,28 @@ async def test_bulk_update_adding_a_tag_the_transaction_already_has_changes_noth
     )
 
     assert resp.status_code == 200
+    # The request still reached this row, so it counts even though nothing about it changed
+    assert resp.json()["transactions_updated"] == 1
     async with TestSession() as session:
         rows = await session.execute(
             select(TransactionTag).where(TransactionTag.transaction_id == uuid.UUID(txn)),
         )
         assert len(list(rows.scalars().all())) == 1
+
+
+async def test_bulk_update_refuses_more_tags_than_one_request_may_add(client):
+    """add_tag_ids is bounded, since past a few dozen tags.py would issue one statement per id."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    tag_ids = [(await _create_tag(client, headers, name=f"tag{i}")).json()["id"] for i in range(33)]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "add_tag_ids": tag_ids},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
 
 
 async def test_bulk_update_accepts_the_same_transaction_named_twice(client):
@@ -708,11 +716,60 @@ async def test_bulk_transfer_to_answers_a_transfer_category_change(client):
     )
 
     assert resp.status_code == 200
+    # Written twice each, once for the category and once for the end, but a row counts once
+    assert resp.json()["transactions_updated"] == 2
     for txn in (first, second):
         row = await _read_transaction(txn)
         assert str(row.category_id) == transfer_id
         assert str(row.account_id) == chequing_id
         assert str(row.counterparty_account_id) == savings_id
+
+
+async def test_bulk_transfer_to_outside_over_a_mixed_selection_counts_only_the_transfer(client):
+    """A count built from a plain rowcount would report every selected row, not just the one written."""
+    headers, chequing_id, category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=-1000,
+    )).json()["id"]
+    first_expense = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
+    second_expense = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer, first_expense, second_expense],
+            "transfer_to": {"scope": "outside"},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["transactions_updated"] == 1
+    assert (await _read_transaction(transfer)).counterparty_account_scope == TransferCounterpartyScope.OUTSIDE
+
+
+async def test_bulk_transfer_to_reports_the_previous_and_new_far_side_accounts(client):
+    """Moving a transfer's far side affects both the account it left and the one it now records."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    rrsp_id = (await _create_account(client, headers, name="RRSP")).json()["id"]
+    first = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=-2000,
+    )).json()["id"]
+    second = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=-3000,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [first, second],
+            "transfer_to": {"scope": "tracked", "account_id": rrsp_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["affected_account_ids"] == sorted([chequing_id, savings_id, rrsp_id])
 
 
 async def test_bulk_transfer_from_refuses_a_selection_with_no_transfer(client):
@@ -1365,41 +1422,77 @@ async def test_bulk_transfer_from_leaves_an_expense_out_of_the_group_write_check
     assert str(expense_row.category_id) == category_id
 
 
-async def test_bulk_update_refuses_a_row_whose_sign_changed_between_the_checks_and_the_write(client, monkeypatch):
-    """A sign flipped by another session between the checks and the write is caught, not written over."""
+async def test_bulk_transfer_from_refuses_a_row_another_session_holds(client, monkeypatch):
+    """A row another session already holds answers 409 rather than waiting behind it."""
+    monkeypatch.setattr(bulk_update_module, "_BULK_UPDATE_LOCK_WAIT", "100ms")
     headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
     cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
     transfer = (await _make_transfer(
         client, headers, chequing_id, transfer_id, savings_id, amount=-4000,
     )).json()["id"]
 
-    original = bulk_update_module._collect_snapshot_starts
+    # Held open for the length of the request below, which is what the request has to wait on. The
+    # request is bounded so that a wait that never gives up fails this test rather than hanging it
+    async with TestSession() as holder:
+        await holder.execute(
+            text("SELECT id FROM transactions WHERE id = :id FOR UPDATE"), {"id": uuid.UUID(transfer)},
+        )
+        async with asyncio.timeout(5):
+            resp = await client.patch(
+                "/transactions/bulk",
+                json={
+                    "transaction_ids": [transfer],
+                    "transfer_from": {"scope": "tracked", "account_id": cash_id},
+                },
+                headers=headers,
+            )
+        await holder.rollback()
 
-    def _flip_sign_between_checks_and_write(*args, **kwargs):
-        """Run the real snapshot collection, then flip the row's sign on a separate connection.
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Another change reached one of these transactions first"
+    assert str((await _read_transaction(transfer)).account_id) == chequing_id
 
-        Stands in for another session racing in after the checks pass but before the write, so the
-        sign the write's guard reads no longer matches the one the checks judged.
-        """
-        starts = original(*args, **kwargs)
-        thread = threading.Thread(target=lambda: asyncio.run(_flip_sign(transfer)))
-        thread.start()
-        thread.join()
-        return starts
 
-    monkeypatch.setattr(bulk_update_module, "_collect_snapshot_starts", _flip_sign_between_checks_and_write)
+async def test_bulk_direction_reverse_refuses_a_row_another_session_holds(client, monkeypatch):
+    """Reverse, which names no absolute answer, still cannot write onto a row another session holds."""
+    monkeypatch.setattr(bulk_update_module, "_BULK_UPDATE_LOCK_WAIT", "100ms")
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=-4000,
+    )).json()["id"]
+
+    async with TestSession() as holder:
+        await holder.execute(
+            text("SELECT id FROM transactions WHERE id = :id FOR UPDATE"), {"id": uuid.UUID(transfer)},
+        )
+        async with asyncio.timeout(5):
+            resp = await client.patch(
+                "/transactions/bulk",
+                json={"transaction_ids": [transfer], "direction": "reverse"},
+                headers=headers,
+            )
+        await holder.rollback()
+
+    assert resp.status_code == 409
+    assert resp.json()["detail"] == "Another change reached one of these transactions first"
+    assert (await _read_transaction(transfer)).amount == -4000
+
+
+async def test_bulk_direction_reverse_with_no_other_session_flips_the_stored_amount(client):
+    """With nothing else holding the row, reverse still flips its stored amount as it always did."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=-20000,
+    )).json()["id"]
 
     resp = await client.patch(
         "/transactions/bulk",
-        json={
-            "transaction_ids": [transfer],
-            "transfer_from": {"scope": "tracked", "account_id": cash_id},
-        },
+        json={"transaction_ids": [transfer], "direction": "reverse"},
         headers=headers,
     )
 
-    assert resp.status_code == 409
-    assert str((await _read_transaction(transfer)).account_id) == chequing_id
+    assert resp.status_code == 200
+    assert (await _read_transaction(transfer)).amount == 20000
 
 
 async def _setup_transfer_into_a_group_account(client):
@@ -1717,6 +1810,29 @@ async def test_bulk_transfer_direction_refuses_a_selection_with_no_transfer(clie
     resp = await client.patch(
         "/transactions/bulk",
         json={"transaction_ids": [first, second], "transfer_direction": "credit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == (
+        "The direction applies to transfers only, and none of the selected transactions end up as one"
+    )
+
+
+async def test_bulk_transfer_direction_with_an_end_refuses_a_selection_with_no_transfer(client):
+    """An end sent alongside the direction keeps the From and To wording, since an end was sent."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    first = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [first, second],
+            "transfer_direction": "credit",
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
         headers=headers,
     )
 

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -1,0 +1,379 @@
+import uuid
+
+from sqlalchemy import select
+
+from app.models.base import TransferCounterpartyScope
+from app.models.tag import TransactionTag
+from app.models.transaction import Transaction
+from tests.conftest import TestSession
+from tests.routes.transactions._helpers import (
+    _create_account,
+    _create_category,
+    _create_merchant,
+    _create_tag,
+    _create_transaction,
+    _get_system_category_id,
+    _setup_user_with_deps,
+)
+
+# --- PATCH /transactions/bulk ---
+
+
+async def _clear_merchant(transaction_id):
+    """Take the merchant off a transaction, as rows recorded before the rule have it."""
+    async with TestSession() as session:
+        txn = await session.get(Transaction, uuid.UUID(transaction_id))
+        txn.merchant_id = None
+        await session.commit()
+
+
+async def _clear_counterparty(transaction_id):
+    """Take the recorded counterparty off a transfer, as rows predating the field have it."""
+    async with TestSession() as session:
+        txn = await session.get(Transaction, uuid.UUID(transaction_id))
+        txn.counterparty_account_id = None
+        txn.counterparty_account_scope = None
+        await session.commit()
+
+
+async def _read_transaction(transaction_id):
+    """Return a transaction row straight from the database."""
+    async with TestSession() as session:
+        return await session.get(Transaction, uuid.UUID(transaction_id))
+
+
+async def _setup_transfer_user(client):
+    """Sign up a user with an account, an expense category, a second account and the Transfer category."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    other_account_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+    transfer_id = await _get_system_category_id(client, headers, "Transfer")
+    return headers, account_id, category_id, other_account_id, transfer_id
+
+
+async def test_bulk_update_sets_a_category_on_every_selected_transaction(client):
+    """One request applies the chosen category to each transaction it names."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    first = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [first, second], "category_id": dining_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["transactions_updated"] == 2
+    assert resp.json()["affected_account_ids"] == [account_id]
+    assert str((await _read_transaction(first)).category_id) == dining_id
+    assert str((await _read_transaction(second)).category_id) == dining_id
+
+
+async def test_bulk_update_refuses_a_set_holding_a_transaction_with_no_merchant(client):
+    """A row recorded before a merchant was required refuses any other change until it has one."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    first = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    await _clear_merchant(first)
+    dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [first, second], "category_id": dining_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "no merchant recorded" in resp.json()["detail"]
+    assert str((await _read_transaction(second)).category_id) == category_id
+
+
+async def test_bulk_update_setting_a_merchant_leaves_a_transfer_counterparty_alone(client):
+    """A set holding one transfer and one expense keeps the transfer's recorded account."""
+    headers, account_id, category_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    expense = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    transfer = (
+        await _create_transaction(
+            client,
+            headers,
+            account_id,
+            transfer_id,
+            counterparty_account_scope="tracked",
+            counterparty_account_id=other_account_id,
+        )
+    ).json()["id"]
+    merchant_id = (await _create_merchant(client, headers, name="Costco")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [expense, transfer], "merchant_id": merchant_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    transfer_row = await _read_transaction(transfer)
+    assert str(transfer_row.counterparty_account_id) == other_account_id
+    assert transfer_row.counterparty_account_scope == TransferCounterpartyScope.TRACKED
+    assert str(transfer_row.merchant_id) == merchant_id
+    assert str((await _read_transaction(expense)).merchant_id) == merchant_id
+
+
+async def test_bulk_update_refuses_a_transfer_that_records_no_other_account(client):
+    """Setting only a merchant still answers the transfer question, as a single edit does."""
+    headers, account_id, _, _, transfer_id = await _setup_transfer_user(client)
+    transfer = (
+        await _create_transaction(client, headers, account_id, transfer_id, counterparty_account_scope="outside")
+    ).json()["id"]
+    await _clear_counterparty(transfer)
+    merchant_id = (await _create_merchant(client, headers, name="Costco")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transfer], "merchant_id": merchant_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "other account of a transfer" in resp.json()["detail"]
+    assert (await _read_transaction(transfer)).merchant_id is not None
+
+
+async def test_bulk_update_refuses_a_transfer_category_over_a_row_recording_nothing(client):
+    """Moving an expense onto a transfer category needs the other account, which the bar cannot set."""
+    headers, account_id, category_id, _, transfer_id = await _setup_transfer_user(client)
+    expense = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [expense], "category_id": transfer_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert str((await _read_transaction(expense)).category_id) == category_id
+
+
+async def test_bulk_update_clears_the_counterparty_when_the_new_category_records_none(client):
+    """A transfer moved onto an expense category drops the account it recorded."""
+    headers, account_id, category_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (
+        await _create_transaction(
+            client,
+            headers,
+            account_id,
+            transfer_id,
+            counterparty_account_scope="tracked",
+            counterparty_account_id=other_account_id,
+        )
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transfer], "category_id": category_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert row.counterparty_account_id is None
+    assert row.counterparty_account_scope is None
+
+
+async def test_bulk_update_adding_a_tag_clears_a_counterparty_the_category_does_not_record(client):
+    """A tags-only edit normalises the row the same way a single edit does."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    async with TestSession() as session:
+        row = await session.get(Transaction, uuid.UUID(txn))
+        row.counterparty_account_scope = TransferCounterpartyScope.OUTSIDE
+        await session.commit()
+    tag_id = (await _create_tag(client, headers, name="vacation")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "add_tag_ids": [tag_id]},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(txn)).counterparty_account_scope is None
+
+
+async def test_bulk_update_rejects_a_transaction_belonging_to_another_user(client):
+    """An unreachable identifier answers 404 rather than reporting a change it never made."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    mine = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    other_headers, other_account_id, other_category_id = await _setup_user_with_deps(
+        client, email="stranger@example.com", name_prefix="Stranger",
+    )
+    theirs = (
+        await _create_transaction(client, other_headers, other_account_id, other_category_id)
+    ).json()["id"]
+    dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [mine, theirs], "category_id": dining_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 404
+    assert str((await _read_transaction(mine)).category_id) == category_id
+    assert str((await _read_transaction(theirs)).category_id) == other_category_id
+
+
+async def test_bulk_update_refuses_a_set_holding_an_archived_account(client):
+    """An archived account takes no edits, so the whole set is refused."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    archived_account_id = (await _create_account(client, headers, name="Old Chequing")).json()["id"]
+    kept = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    archived = (await _create_transaction(client, headers, archived_account_id, category_id)).json()["id"]
+    archive_resp = await client.patch(
+        f"/accounts/{archived_account_id}", json={"is_archived": True}, headers=headers,
+    )
+    assert archive_resp.status_code == 200
+    dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [kept, archived], "category_id": dining_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert str((await _read_transaction(kept)).category_id) == category_id
+
+
+async def test_bulk_update_adds_a_tag_without_disturbing_the_tags_already_there(client):
+    """Adding a tag leaves every tag the transaction already carries in place."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    travel_id = (await _create_tag(client, headers, name="travel")).json()["id"]
+    reimbursable_id = (await _create_tag(client, headers, name="reimbursable")).json()["id"]
+    txn = (
+        await _create_transaction(client, headers, account_id, category_id, tag_ids=[travel_id])
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "add_tag_ids": [reimbursable_id]},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    detail = await client.get(f"/transactions/{txn}", headers=headers)
+    assert set(detail.json()["tag_ids"]) == {travel_id, reimbursable_id}
+
+
+async def test_bulk_update_adding_a_tag_the_transaction_already_has_changes_nothing(client):
+    """A tag already attached is left as it is rather than failing the request."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    travel_id = (await _create_tag(client, headers, name="travel")).json()["id"]
+    txn = (
+        await _create_transaction(client, headers, account_id, category_id, tag_ids=[travel_id])
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "add_tag_ids": [travel_id]},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    async with TestSession() as session:
+        rows = await session.execute(
+            select(TransactionTag).where(TransactionTag.transaction_id == uuid.UUID(txn)),
+        )
+        assert len(list(rows.scalars().all())) == 1
+
+
+async def test_bulk_update_accepts_the_same_transaction_named_twice(client):
+    """A repeated identifier is one transaction, not one found and one missing."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    first = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [first, second, first], "category_id": dining_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["transactions_updated"] == 2
+    assert str((await _read_transaction(first)).category_id) == dining_id
+    assert str((await _read_transaction(second)).category_id) == dining_id
+
+
+async def test_bulk_update_refuses_more_transactions_than_one_request_may_carry(client):
+    """The request is bounded, so a selection past the cap is refused before any work."""
+    headers, _account_id, category_id = await _setup_user_with_deps(client)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [str(uuid.uuid4()) for _ in range(1001)], "category_id": category_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_update_refuses_an_empty_selection(client):
+    """A request naming no transaction has nothing to apply to."""
+    headers, _account_id, category_id = await _setup_user_with_deps(client)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [], "category_id": category_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_update_refuses_a_request_that_sets_nothing(client):
+    """Naming transactions without a field to set would report a count for no write."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch("/transactions/bulk", json={"transaction_ids": [txn]}, headers=headers)
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_update_refuses_a_request_carrying_only_an_empty_tag_list(client):
+    """An empty tag list sets no field, so it is not a change either."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "add_tag_ids": []},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_update_does_not_rebuild_balance_snapshots(client, monkeypatch):
+    """Category, merchant and tags move no balance, so no snapshot is rebuilt."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+
+    calls = []
+
+    async def _record_call(*args, **kwargs):
+        calls.append(args)
+
+    monkeypatch.setattr("app.services.accounts.snapshots.recompute_snapshots_from", _record_call)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "category_id": dining_id},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert calls == []

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -3,13 +3,19 @@ import uuid
 from datetime import date
 
 import pytest
-from sqlalchemy import select, text
+from sqlalchemy import func, select, text
 
 from app.models.account import AccountBalanceSnapshot
 from app.models.base import TransferCounterpartyScope
 from app.models.tag import TransactionTag
 from app.models.transaction import Transaction
+from app.services.accounts import snapshots as account_snapshots_module
+from app.services.importers.firefly import service as firefly_import_module
+from app.services.importers.generic import service as generic_import_module
 from app.services.transactions import bulk_update as bulk_update_module
+from app.services.transactions import creation as creation_module
+from app.services.transactions import deletion as deletion_module
+from app.services.transactions import snapshots as transaction_snapshots_module
 from tests.conftest import TestSession
 from tests.routes.support import _create_user, _get_auth_header
 from tests.routes.transactions._helpers import (
@@ -19,6 +25,7 @@ from tests.routes.transactions._helpers import (
     _create_tag,
     _create_transaction,
     _get_system_category_id,
+    _import_transactions,
     _seed_usd_currency,
     _setup_user_with_deps,
 )
@@ -58,6 +65,83 @@ async def _read_snapshots(account_id):
             .order_by(AccountBalanceSnapshot.dt),
         )
         return list(rows.all())
+
+
+async def _read_transaction_total(account_id):
+    """Return the persisted transaction total for an account."""
+    async with TestSession() as session:
+        return await session.scalar(
+            select(func.coalesce(func.sum(Transaction.amount), 0)).where(
+                Transaction.account_id == uuid.UUID(account_id),
+            ),
+        )
+
+
+async def _wait_until_blocked(blocker_pid, blocked_pid):
+    """Wait until PostgreSQL reports one backend blocked by another."""
+    async with asyncio.timeout(5):
+        async with TestSession() as observer:
+            while blocker_pid not in await observer.scalar(
+                text("SELECT pg_blocking_pids(:pid)"),
+                {"pid": blocked_pid},
+            ):
+                await asyncio.sleep(0.01)
+
+
+async def _run_bulk_with_blocked_writer(
+    client,
+    headers,
+    transaction_id,
+    monkeypatch,
+    writer_module,
+    writer_request,
+):
+    """Hold a real bulk rebuild while another writer waits on its advisory lock."""
+    original_recompute = bulk_update_module.recompute_account_snapshots
+    first_rebuilt = asyncio.Event()
+    release_first = asyncio.Event()
+    writer_started = asyncio.Event()
+    backend_pids = []
+
+    async def hold_bulk_rebuild(db, snapshot_starts):
+        """Hold the bulk request after its real rebuild and before its commit."""
+        backend_pids.append(await db.scalar(text("SELECT pg_backend_pid()")))
+        await original_recompute(db, snapshot_starts)
+        first_rebuilt.set()
+        await release_first.wait()
+
+    async def observe_writer_rebuild(db, snapshot_starts):
+        """Record the other writer's backend before entering the real rebuild."""
+        backend_pids.append(await db.scalar(text("SELECT pg_backend_pid()")))
+        writer_started.set()
+        await original_recompute(db, snapshot_starts)
+
+    monkeypatch.setattr(bulk_update_module, "recompute_account_snapshots", hold_bulk_rebuild)
+    monkeypatch.setattr(writer_module, "recompute_account_snapshots", observe_writer_rebuild)
+    requests = []
+    try:
+        async with asyncio.timeout(10):
+            requests.append(asyncio.create_task(client.patch(
+                "/transactions/bulk",
+                json={"transaction_ids": [transaction_id], "direction": "credit"},
+                headers=headers,
+            )))
+            await first_rebuilt.wait()
+            requests.append(asyncio.create_task(writer_request()))
+            await writer_started.wait()
+            await _wait_until_blocked(backend_pids[0], backend_pids[1])
+            release_first.set()
+            results = await asyncio.gather(*requests, return_exceptions=True)
+    finally:
+        release_first.set()
+        for request in requests:
+            if not request.done():
+                request.cancel()
+        await asyncio.gather(*requests, return_exceptions=True)
+
+    for result in results:
+        assert not isinstance(result, BaseException), repr(result)
+    return results
 
 
 async def _setup_transfer_user(client):
@@ -1604,24 +1688,24 @@ async def test_bulk_edits_to_different_rows_in_one_account_preserve_both_balance
         transaction_ids.append(response.json()["id"])
     assert await _read_snapshots(account_id) == [(date(2026, 8, 1), -3000)]
 
-    original_recompute = bulk_update_module.recompute_snapshots_from
+    original_recompute = bulk_update_module.recompute_account_snapshots
     first_rebuilt = asyncio.Event()
     release_first = asyncio.Event()
     second_started = asyncio.Event()
     backend_pids = []
 
-    async def hold_first_rebuild(db, rebuild_account_id, from_dt):
+    async def hold_first_rebuild(db, snapshot_starts):
         """Keep the first rebuild uncommitted until the other request waits on its database lock."""
         backend_pids.append(await db.scalar(text("SELECT pg_backend_pid()")))
         if len(backend_pids) == 1:
-            await original_recompute(db, rebuild_account_id, from_dt)
+            await original_recompute(db, snapshot_starts)
             first_rebuilt.set()
             await release_first.wait()
         else:
             second_started.set()
-            await original_recompute(db, rebuild_account_id, from_dt)
+            await original_recompute(db, snapshot_starts)
 
-    monkeypatch.setattr(bulk_update_module, "recompute_snapshots_from", hold_first_rebuild)
+    monkeypatch.setattr(bulk_update_module, "recompute_account_snapshots", hold_first_rebuild)
     requests = []
     try:
         async with asyncio.timeout(10):
@@ -1638,12 +1722,7 @@ async def test_bulk_edits_to_different_rows_in_one_account_preserve_both_balance
             )))
             await second_started.wait()
 
-            # Observe a real database wait rather than relying on scheduler timing or a fixed delay.
-            async with TestSession() as observer:
-                while backend_pids[0] not in await observer.scalar(
-                    text("SELECT pg_blocking_pids(:pid)"), {"pid": backend_pids[1]},
-                ):
-                    await asyncio.sleep(0.01)
+            await _wait_until_blocked(backend_pids[0], backend_pids[1])
             release_first.set()
             results = await asyncio.gather(*requests, return_exceptions=True)
     finally:
@@ -1665,6 +1744,356 @@ async def test_bulk_edits_to_different_rows_in_one_account_preserve_both_balance
     response = await client.get(f"/accounts/{account_id}", headers=headers)
     assert response.status_code == 200
     assert response.json()["current_balance"] == 3000
+
+
+async def test_waiting_bulk_rebuild_reads_anchor_after_the_earlier_request_commits(client, monkeypatch):
+    """A waiting rebuild reads the committed earlier day's balance before rebuilding later days."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    first = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-1000, dt="2026-08-01",
+    )).json()["id"]
+    second = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-2000, dt="2026-08-02",
+    )).json()["id"]
+
+    original_recompute = bulk_update_module.recompute_account_snapshots
+    first_rebuilt = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+    backend_pids = []
+
+    async def hold_first_rebuild(db, snapshot_starts):
+        """Hold the first real rebuild while the second waits for its account lock."""
+        backend_pids.append(await db.scalar(text("SELECT pg_backend_pid()")))
+        if len(backend_pids) == 1:
+            await original_recompute(db, snapshot_starts)
+            first_rebuilt.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+            await original_recompute(db, snapshot_starts)
+
+    monkeypatch.setattr(bulk_update_module, "recompute_account_snapshots", hold_first_rebuild)
+    requests = []
+    try:
+        async with asyncio.timeout(10):
+            requests.append(asyncio.create_task(client.patch(
+                "/transactions/bulk",
+                json={"transaction_ids": [first], "direction": "credit"},
+                headers=headers,
+            )))
+            await first_rebuilt.wait()
+            requests.append(asyncio.create_task(client.patch(
+                "/transactions/bulk",
+                json={"transaction_ids": [second], "direction": "credit"},
+                headers=headers,
+            )))
+            await second_started.wait()
+            await _wait_until_blocked(backend_pids[0], backend_pids[1])
+            release_first.set()
+            results = await asyncio.gather(*requests, return_exceptions=True)
+    finally:
+        release_first.set()
+        for request in requests:
+            if not request.done():
+                request.cancel()
+        await asyncio.gather(*requests, return_exceptions=True)
+
+    for result in results:
+        assert not isinstance(result, BaseException), repr(result)
+        assert result.status_code == 200, result.text
+    assert await _read_snapshots(account_id) == [
+        (date(2026, 8, 1), 1000),
+        (date(2026, 8, 2), 3000),
+    ]
+
+
+async def test_reverse_account_maps_wait_on_the_same_first_lock(client, monkeypatch):
+    """Bulk and single moves lock the same first account despite reversed source maps."""
+    headers, first_account_id, category_id = await _setup_user_with_deps(client)
+    second_account_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+    first_transaction = (await _create_transaction(
+        client, headers, first_account_id, category_id, amount=-1000, dt="2026-08-01",
+    )).json()["id"]
+    second_transaction = (await _create_transaction(
+        client, headers, second_account_id, category_id, amount=-2000, dt="2026-08-01",
+    )).json()["id"]
+
+    controlled_keys = {
+        uuid.UUID(first_account_id): 1,
+        uuid.UUID(second_account_id): 2,
+    }
+
+    def controlled_lock_key(account_id):
+        """Give the two accounts predictable increasing advisory keys."""
+        return controlled_keys[account_id]
+
+    monkeypatch.setattr(account_snapshots_module, "_snapshot_lock_key", controlled_lock_key)
+    original_recompute = bulk_update_module.recompute_account_snapshots
+    first_locked = asyncio.Event()
+    release_first = asyncio.Event()
+    backend_pids = []
+
+    async def pause_first_request_after_first_lock(db, snapshot_starts):
+        """Pause the first request after acquiring its real first advisory lock."""
+        backend_pids.append(await db.scalar(text("SELECT pg_backend_pid()")))
+        if len(backend_pids) == 1:
+            first_key = min(controlled_keys[account_id] for account_id in snapshot_starts)
+            await db.execute(text("SELECT pg_advisory_xact_lock(:key)"), {"key": first_key})
+            first_locked.set()
+            await release_first.wait()
+        await original_recompute(db, snapshot_starts)
+
+    monkeypatch.setattr(
+        bulk_update_module,
+        "recompute_account_snapshots",
+        pause_first_request_after_first_lock,
+    )
+    monkeypatch.setattr(
+        transaction_snapshots_module,
+        "recompute_account_snapshots",
+        pause_first_request_after_first_lock,
+    )
+
+    requests = []
+    try:
+        async with asyncio.timeout(10):
+            requests.append(asyncio.create_task(client.patch(
+                "/transactions/bulk",
+                json={"transaction_ids": [first_transaction], "account_id": second_account_id},
+                headers=headers,
+            )))
+            await first_locked.wait()
+            requests.append(asyncio.create_task(client.patch(
+                f"/transactions/{second_transaction}",
+                json={"account_id": first_account_id},
+                headers=headers,
+            )))
+            async with asyncio.timeout(5):
+                while len(backend_pids) < 2:
+                    await asyncio.sleep(0)
+            await _wait_until_blocked(backend_pids[0], backend_pids[1])
+            release_first.set()
+            results = await asyncio.gather(*requests, return_exceptions=True)
+    finally:
+        release_first.set()
+        for request in requests:
+            if not request.done():
+                request.cancel()
+        await asyncio.gather(*requests, return_exceptions=True)
+
+    for result in results:
+        assert not isinstance(result, BaseException), repr(result)
+        assert result.status_code == 200, result.text
+    assert await _read_snapshots(first_account_id) == [(date(2026, 8, 1), -2000)]
+    assert await _read_snapshots(second_account_id) == [(date(2026, 8, 1), -1000)]
+
+
+async def test_bulk_move_of_last_transaction_restores_source_zero_anchor(client):
+    """Moving the source's last row restores its creation-day zero snapshot."""
+    headers, source_id, category_id = await _setup_user_with_deps(client)
+    target_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+    transaction_id = (await _create_transaction(
+        client, headers, source_id, category_id, amount=-1000, dt="2026-08-01",
+    )).json()["id"]
+
+    response = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transaction_id], "account_id": target_id},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    source_snapshots = await _read_snapshots(source_id)
+    assert len(source_snapshots) == 1
+    assert source_snapshots[0][1] == 0
+    assert await _read_snapshots(target_id) == [(date(2026, 8, 1), -1000)]
+
+
+async def test_bulk_date_move_rebuilds_from_earlier_date_without_stale_snapshot(client):
+    """Moving a row to an earlier date removes its old later-day snapshot."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    transaction_id = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-1000, dt="2026-08-02",
+    )).json()["id"]
+
+    response = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transaction_id], "dt": "2026-08-01"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert await _read_snapshots(account_id) == [(date(2026, 8, 1), -1000)]
+
+
+async def test_bulk_note_only_edit_skips_snapshot_rebuild(client, monkeypatch):
+    """Changing only a note does not enter the snapshot rebuild path."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    transaction_id = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-1000, dt="2026-08-01",
+    )).json()["id"]
+
+    async def refuse_rebuild(_db, _snapshot_starts):
+        """Fail if a note-only request reaches snapshot recomputation."""
+        raise AssertionError("note-only edit rebuilt account snapshots")
+
+    monkeypatch.setattr(bulk_update_module, "recompute_account_snapshots", refuse_rebuild)
+
+    response = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transaction_id], "notes": "Corrected"},
+        headers=headers,
+    )
+
+    assert response.status_code == 200
+    assert (await _read_transaction(transaction_id)).notes == "Corrected"
+
+
+async def test_concurrent_create_waits_for_bulk_rebuild_and_preserves_total(client, monkeypatch):
+    """A create waiting on a bulk rebuild contributes to the final account balance."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    transaction_id = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-1000, dt="2026-08-01",
+    )).json()["id"]
+
+    async def create_other_transaction():
+        """Create the second transaction through the real route."""
+        return await _create_transaction(
+            client,
+            headers,
+            account_id,
+            category_id,
+            amount=-2000,
+            dt="2026-08-01",
+        )
+
+    bulk_response, create_response = await _run_bulk_with_blocked_writer(
+        client,
+        headers,
+        transaction_id,
+        monkeypatch,
+        creation_module,
+        create_other_transaction,
+    )
+
+    assert bulk_response.status_code == 200, bulk_response.text
+    assert create_response.status_code == 201, create_response.text
+    assert await _read_snapshots(account_id) == [(date(2026, 8, 1), -1000)]
+    assert await _read_transaction_total(account_id) == -1000
+
+
+async def test_concurrent_delete_waits_for_bulk_rebuild_and_preserves_total(client, monkeypatch):
+    """A delete waiting on a bulk rebuild is reflected in the final account balance."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    transaction_id = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-1000, dt="2026-08-01",
+    )).json()["id"]
+    deleted_id = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-2000, dt="2026-08-01",
+    )).json()["id"]
+
+    async def delete_other_transaction():
+        """Delete the second transaction through the real route."""
+        return await client.delete(f"/transactions/{deleted_id}", headers=headers)
+
+    bulk_response, delete_response = await _run_bulk_with_blocked_writer(
+        client,
+        headers,
+        transaction_id,
+        monkeypatch,
+        deletion_module,
+        delete_other_transaction,
+    )
+
+    assert bulk_response.status_code == 200, bulk_response.text
+    assert delete_response.status_code == 204, delete_response.text
+    assert await _read_snapshots(account_id) == [(date(2026, 8, 1), 1000)]
+    assert await _read_transaction_total(account_id) == 1000
+
+
+async def test_concurrent_generic_import_waits_for_bulk_rebuild_and_preserves_total(
+    client, monkeypatch,
+):
+    """A generic import waiting on a bulk rebuild contributes to the final balance."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    transaction_id = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-1000, dt="2026-08-01",
+    )).json()["id"]
+
+    async def import_other_transaction():
+        """Import the second transaction through the real staged-import route."""
+        return await _import_transactions(client, headers, {
+            "accounts": [{"source": "Main Chequing", "account_id": account_id}],
+            "categories": [{"source": "Groceries", "category_id": category_id}],
+            "rows": [{
+                "account_source": "Main Chequing",
+                "category_source": "Groceries",
+                "dt": "2026-08-01",
+                "amount": "-20.00",
+                "merchant_name": "Neighbourhood Market",
+                "tag_names": [],
+            }],
+        })
+
+    bulk_response, import_response = await _run_bulk_with_blocked_writer(
+        client,
+        headers,
+        transaction_id,
+        monkeypatch,
+        generic_import_module,
+        import_other_transaction,
+    )
+
+    assert bulk_response.status_code == 200, bulk_response.text
+    assert import_response.status_code == 201, import_response.text
+    assert await _read_snapshots(account_id) == [(date(2026, 8, 1), -1000)]
+    assert await _read_transaction_total(account_id) == -1000
+
+
+async def test_concurrent_firefly_import_waits_for_bulk_rebuild_and_preserves_total(
+    client, monkeypatch,
+):
+    """A Firefly import waiting on a bulk rebuild contributes to the final balance."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    transaction_id = (await _create_transaction(
+        client, headers, account_id, category_id, amount=-1000, dt="2026-08-01",
+    )).json()["id"]
+
+    async def import_other_transaction():
+        """Import the second transaction through the real Firefly route."""
+        return await client.post("/transactions/import/firefly", json={
+            "accounts": [{"source": "Main Chequing", "account_id": account_id}],
+            "categories": [{"source": "Groceries", "category_id": category_id}],
+            "rows": [{
+                "journal_id": "bulk-concurrency",
+                "type": "Withdrawal",
+                "dt": "2026-08-01",
+                "amount": "-20.00",
+                "currency_code": "CAD",
+                "description": "Weekly groceries",
+                "source_name": "Main Chequing",
+                "source_type": "Asset account",
+                "destination_name": "Neighbourhood Market",
+                "destination_type": "Expense account",
+                "category": "Groceries",
+                "tag_names": [],
+            }],
+        }, headers=headers)
+
+    bulk_response, import_response = await _run_bulk_with_blocked_writer(
+        client,
+        headers,
+        transaction_id,
+        monkeypatch,
+        firefly_import_module,
+        import_other_transaction,
+    )
+
+    assert bulk_response.status_code == 200, bulk_response.text
+    assert import_response.status_code == 201, import_response.text
+    assert await _read_snapshots(account_id) == [(date(2026, 8, 1), -1000)]
+    assert await _read_transaction_total(account_id) == -1000
 
 
 async def test_bulk_direction_reverse_with_no_other_session_flips_the_stored_amount(client):

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -1592,6 +1592,81 @@ async def test_bulk_direction_reverse_refuses_a_row_another_session_holds(client
     assert (await _read_transaction(transfer)).amount == -4000
 
 
+async def test_bulk_edits_to_different_rows_in_one_account_preserve_both_balances(client, monkeypatch):
+    """Overlapping edits to different rows must both save and rebuild the shared balance correctly."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    transaction_ids = []
+    for amount in (-1000, -2000):
+        response = await _create_transaction(
+            client, headers, account_id, category_id, amount=amount, dt="2026-08-01",
+        )
+        assert response.status_code == 201
+        transaction_ids.append(response.json()["id"])
+    assert await _read_snapshots(account_id) == [(date(2026, 8, 1), -3000)]
+
+    original_recompute = bulk_update_module.recompute_snapshots_from
+    first_rebuilt = asyncio.Event()
+    release_first = asyncio.Event()
+    second_started = asyncio.Event()
+    backend_pids = []
+
+    async def hold_first_rebuild(db, rebuild_account_id, from_dt):
+        """Keep the first rebuild uncommitted until the other request waits on its database lock."""
+        backend_pids.append(await db.scalar(text("SELECT pg_backend_pid()")))
+        if len(backend_pids) == 1:
+            await original_recompute(db, rebuild_account_id, from_dt)
+            first_rebuilt.set()
+            await release_first.wait()
+        else:
+            second_started.set()
+            await original_recompute(db, rebuild_account_id, from_dt)
+
+    monkeypatch.setattr(bulk_update_module, "recompute_snapshots_from", hold_first_rebuild)
+    requests = []
+    try:
+        async with asyncio.timeout(10):
+            requests.append(asyncio.create_task(client.patch(
+                "/transactions/bulk",
+                json={"transaction_ids": [transaction_ids[0]], "direction": "credit"},
+                headers=headers,
+            )))
+            await first_rebuilt.wait()
+            requests.append(asyncio.create_task(client.patch(
+                "/transactions/bulk",
+                json={"transaction_ids": [transaction_ids[1]], "direction": "credit"},
+                headers=headers,
+            )))
+            await second_started.wait()
+
+            # Observe a real database wait rather than relying on scheduler timing or a fixed delay.
+            async with TestSession() as observer:
+                while backend_pids[0] not in await observer.scalar(
+                    text("SELECT pg_blocking_pids(:pid)"), {"pid": backend_pids[1]},
+                ):
+                    await asyncio.sleep(0.01)
+            release_first.set()
+            results = await asyncio.gather(*requests, return_exceptions=True)
+    finally:
+        release_first.set()
+        for request in requests:
+            if not request.done():
+                request.cancel()
+        await asyncio.gather(*requests, return_exceptions=True)
+
+    assert len(set(backend_pids)) == 2
+    for result in results:
+        assert not isinstance(result, BaseException), repr(result)
+        assert result.status_code == 200, result.text
+        assert result.json()["transactions_updated"] == 1
+        assert result.json()["affected_account_ids"] == [account_id]
+    assert (await _read_transaction(transaction_ids[0])).amount == 1000
+    assert (await _read_transaction(transaction_ids[1])).amount == 2000
+    assert await _read_snapshots(account_id) == [(date(2026, 8, 1), 3000)]
+    response = await client.get(f"/accounts/{account_id}", headers=headers)
+    assert response.status_code == 200
+    assert response.json()["current_balance"] == 3000
+
+
 async def test_bulk_direction_reverse_with_no_other_session_flips_the_stored_amount(client):
     """With nothing else holding the row, reverse still flips its stored amount as it always did."""
     headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -2,6 +2,7 @@ import uuid
 
 from sqlalchemy import select
 
+from app.models.account import AccountBalanceSnapshot
 from app.models.base import TransferCounterpartyScope
 from app.models.tag import TransactionTag
 from app.models.transaction import Transaction
@@ -40,6 +41,17 @@ async def _read_transaction(transaction_id):
     """Return a transaction row straight from the database."""
     async with TestSession() as session:
         return await session.get(Transaction, uuid.UUID(transaction_id))
+
+
+async def _read_snapshots(account_id):
+    """Return an account's stored running balances, oldest first."""
+    async with TestSession() as session:
+        rows = await session.execute(
+            select(AccountBalanceSnapshot.dt, AccountBalanceSnapshot.balance)
+            .where(AccountBalanceSnapshot.account_id == uuid.UUID(account_id))
+            .order_by(AccountBalanceSnapshot.dt),
+        )
+        return list(rows.all())
 
 
 async def _setup_transfer_user(client):
@@ -126,6 +138,7 @@ async def test_bulk_update_refuses_a_transfer_that_records_no_other_account(clie
         await _create_transaction(client, headers, account_id, transfer_id, counterparty_account_scope="outside")
     ).json()["id"]
     await _clear_counterparty(transfer)
+    merchant_before = (await _read_transaction(transfer)).merchant_id
     merchant_id = (await _create_merchant(client, headers, name="Costco")).json()["id"]
 
     resp = await client.patch(
@@ -136,7 +149,9 @@ async def test_bulk_update_refuses_a_transfer_that_records_no_other_account(clie
 
     assert resp.status_code == 422
     assert "other account of a transfer" in resp.json()["detail"]
-    assert (await _read_transaction(transfer)).merchant_id is not None
+
+    # The row keeps the merchant it had, which is what proves the refusal ran before any write
+    assert (await _read_transaction(transfer)).merchant_id == merchant_before
 
 
 async def test_bulk_update_refuses_a_transfer_category_over_a_row_recording_nothing(client):
@@ -356,18 +371,13 @@ async def test_bulk_update_refuses_a_request_carrying_only_an_empty_tag_list(cli
     assert resp.status_code == 422
 
 
-async def test_bulk_update_does_not_rebuild_balance_snapshots(client, monkeypatch):
-    """Category, merchant and tags move no balance, so no snapshot is rebuilt."""
+async def test_bulk_update_leaves_the_account_balances_where_they_were(client):
+    """Category, merchant and tags move no money, so every stored balance stays as it was."""
     headers, account_id, category_id = await _setup_user_with_deps(client)
     txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
     dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
-
-    calls = []
-
-    async def _record_call(*args, **kwargs):
-        calls.append(args)
-
-    monkeypatch.setattr("app.services.accounts.snapshots.recompute_snapshots_from", _record_call)
+    before = await _read_snapshots(account_id)
+    assert before, "the account should carry balances before the edit, or this proves nothing"
 
     resp = await client.patch(
         "/transactions/bulk",
@@ -376,4 +386,4 @@ async def test_bulk_update_does_not_rebuild_balance_snapshots(client, monkeypatc
     )
 
     assert resp.status_code == 200
-    assert calls == []
+    assert await _read_snapshots(account_id) == before

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -111,7 +111,7 @@ async def test_bulk_update_refuses_a_set_holding_a_transaction_with_no_merchant(
     )
 
     assert resp.status_code == 422
-    assert "no merchant recorded" in resp.json()["detail"]
+    assert "missing merchant information" in resp.json()["detail"]
     assert str((await _read_transaction(second)).category_id) == category_id
 
 
@@ -162,7 +162,7 @@ async def test_bulk_update_refuses_a_transfer_that_records_no_other_account(clie
     )
 
     assert resp.status_code == 422
-    assert "other account of a transfer" in resp.json()["detail"]
+    assert "missing the To or From account" in resp.json()["detail"]
 
     # The row keeps the merchant it had, which is what proves the refusal ran before any write
     assert (await _read_transaction(transfer)).merchant_id == merchant_before
@@ -732,7 +732,9 @@ async def test_bulk_transfer_from_refuses_a_selection_with_no_transfer(client):
     )
 
     assert resp.status_code == 422
-    assert resp.json()["detail"] == "None of these transactions record the other side of a transfer"
+    assert resp.json()["detail"] == (
+        "From and To apply to transfers only, and none of the selected transactions end up as one"
+    )
 
 
 async def test_bulk_transfer_to_refuses_a_selection_with_no_transfer(client):
@@ -752,7 +754,9 @@ async def test_bulk_transfer_to_refuses_a_selection_with_no_transfer(client):
     )
 
     assert resp.status_code == 422
-    assert resp.json()["detail"] == "None of these transactions record the other side of a transfer"
+    assert resp.json()["detail"] == (
+        "From and To apply to transfers only, and none of the selected transactions end up as one"
+    )
 
 
 async def test_bulk_transfer_from_reads_each_rows_resulting_category_not_its_stored_one(client):
@@ -773,7 +777,9 @@ async def test_bulk_transfer_from_reads_each_rows_resulting_category_not_its_sto
     )
 
     assert resp.status_code == 422
-    assert resp.json()["detail"] == "None of these transactions record the other side of a transfer"
+    assert resp.json()["detail"] == (
+        "From and To apply to transfers only, and none of the selected transactions end up as one"
+    )
 
 
 async def test_bulk_update_refuses_a_move_into_the_account_a_transfer_already_records(client):
@@ -797,7 +803,7 @@ async def test_bulk_update_refuses_a_move_into_the_account_a_transfer_already_re
     )
 
     assert resp.status_code == 422
-    assert "their own account" in resp.json()["detail"]
+    assert "with the same account on both sides" in resp.json()["detail"]
     assert str((await _read_transaction(txn)).account_id) == account_id
 
 
@@ -1214,7 +1220,7 @@ async def test_bulk_transfer_from_refuses_a_row_that_would_record_its_own_accoun
 
     assert resp.status_code == 422
     assert "2 of these transactions cannot be changed" in resp.json()["detail"]
-    assert "their own account" in resp.json()["detail"]
+    assert "with the same account on both sides" in resp.json()["detail"]
     assert str((await _read_transaction(out_id)).account_id) == chequing_id
     assert str((await _read_transaction(in_id)).account_id) == savings_id
 
@@ -1616,3 +1622,105 @@ async def test_bulk_direction_leaves_the_accounts_alone(client):
     assert str(row.account_id) == account_id
     assert str(row.counterparty_account_id) == other_account_id
     assert row.counterparty_account_scope is TransferCounterpartyScope.TRACKED
+
+
+# --- transfer_direction, applied only to the rows recording a far side ---
+
+
+async def test_bulk_transfer_direction_turns_only_the_transfer_and_leaves_the_expense(client):
+    """transfer_direction reaches the transfer and skips a plain expense in the same selection."""
+    headers, chequing_id, category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, dt="2026-08-23", amount=-20000,
+    )).json()["id"]
+    expense = (
+        await _create_transaction(client, headers, savings_id, category_id, dt="2026-08-22", amount=-1200)
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transfer, expense], "transfer_direction": "credit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(transfer)).amount == 20000
+    assert (await _read_transaction(expense)).amount == -1200
+    assert dict(await _read_snapshots(chequing_id))[date(2026, 8, 23)] == 20000
+
+
+async def test_bulk_transfer_direction_combines_with_an_end_on_the_row_it_reaches(client):
+    """transfer_from sets the far side transfer_direction resolves to, and stays off the expense."""
+    headers, chequing_id, category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, dt="2026-08-23", amount=-20000,
+    )).json()["id"]
+    expense = (
+        await _create_transaction(client, headers, savings_id, category_id, dt="2026-08-22", amount=-1200)
+    ).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer, expense],
+            "transfer_direction": "credit",
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    transfer_row = await _read_transaction(transfer)
+    assert transfer_row.amount == 20000
+    assert str(transfer_row.account_id) == chequing_id
+    assert str(transfer_row.counterparty_account_id) == cash_id
+    expense_row = await _read_transaction(expense)
+    assert expense_row.amount == -1200
+    assert str(expense_row.account_id) == savings_id
+
+
+async def test_bulk_update_refuses_direction_and_transfer_direction_together(client):
+    """Both set the sign of the same amount, so sending both is two answers for one column."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "direction": "credit", "transfer_direction": "credit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_update_refuses_a_null_transfer_direction(client):
+    """transfer_direction writes a sign like direction does, so it has no null to write."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "transfer_direction": None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_transfer_direction_refuses_a_selection_with_no_transfer(client):
+    """transfer_direction reaches only rows recording a far side, so two expenses reach none."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    first = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [first, second], "transfer_direction": "credit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == (
+        "From and To apply to transfers only, and none of the selected transactions end up as one"
+    )

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -1,3 +1,5 @@
+import asyncio
+import threading
 import uuid
 from datetime import date
 
@@ -7,7 +9,9 @@ from app.models.account import AccountBalanceSnapshot
 from app.models.base import TransferCounterpartyScope
 from app.models.tag import TransactionTag
 from app.models.transaction import Transaction
+from app.services.transactions import bulk_update as bulk_update_module
 from tests.conftest import TestSession
+from tests.routes.support import _create_user, _get_auth_header
 from tests.routes.transactions._helpers import (
     _create_account,
     _create_category,
@@ -36,6 +40,14 @@ async def _clear_counterparty(transaction_id):
         txn = await session.get(Transaction, uuid.UUID(transaction_id))
         txn.counterparty_account_id = None
         txn.counterparty_account_scope = None
+        await session.commit()
+
+
+async def _flip_sign(transaction_id):
+    """Flip a transaction's amount directly, standing in for a concurrent session's edit."""
+    async with TestSession() as session:
+        txn = await session.get(Transaction, uuid.UUID(transaction_id))
+        txn.amount = -txn.amount
         await session.commit()
 
 
@@ -493,6 +505,27 @@ async def test_bulk_update_leaves_a_note_alone_when_the_request_omits_it(client)
     assert (await _read_transaction(txn)).notes == "Weekly shop"
 
 
+async def test_bulk_update_accepts_a_note_only_edit_on_a_row_with_no_stored_rate(client):
+    """A row that keeps its own account is not asked to justify a currency mismatch it did not cause."""
+    await _seed_usd_currency()
+    headers, _account_id, category_id = await _setup_user_with_deps(client)
+    usd_account_id = (await _create_account(client, headers, name="US Savings", currency="USD")).json()["id"]
+    txn = (
+        await _create_transaction(client, headers, usd_account_id, category_id, currency="CAD", fx_rate=1.35)
+    ).json()["id"]
+    cleared = await client.patch(f"/transactions/{txn}", json={"fx_rate": None}, headers=headers)
+    assert cleared.status_code == 200
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "notes": "Corrected"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(txn)).notes == "Corrected"
+
+
 # --- Moving to another account ---
 
 
@@ -657,20 +690,19 @@ async def test_bulk_update_refuses_a_move_to_a_closed_account(client):
 # --- The other account a transfer records ---
 
 
-async def test_bulk_update_sets_a_transfer_category_and_its_other_account_together(client):
+async def test_bulk_transfer_to_answers_a_transfer_category_change(client):
     """One request can move rows onto a transfer category and answer what that category asks."""
-    headers, account_id, _, other_account_id, transfer_id = await _setup_transfer_user(client)
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
     category_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
-    first = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
-    second = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    first = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
 
     resp = await client.patch(
         "/transactions/bulk",
         json={
             "transaction_ids": [first, second],
             "category_id": transfer_id,
-            "counterparty_account_scope": "tracked",
-            "counterparty_account_id": other_account_id,
+            "transfer_to": {"scope": "tracked", "account_id": savings_id},
         },
         headers=headers,
     )
@@ -679,83 +711,69 @@ async def test_bulk_update_sets_a_transfer_category_and_its_other_account_togeth
     for txn in (first, second):
         row = await _read_transaction(txn)
         assert str(row.category_id) == transfer_id
-        assert str(row.counterparty_account_id) == other_account_id
+        assert str(row.account_id) == chequing_id
+        assert str(row.counterparty_account_id) == savings_id
 
 
-async def test_bulk_update_records_money_that_left_the_tracked_accounts(client):
-    """An outside answer records the scope and no account."""
-    headers, account_id, category_id, _, transfer_id = await _setup_transfer_user(client)
-    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
-
-    resp = await client.patch(
-        "/transactions/bulk",
-        json={
-            "transaction_ids": [txn],
-            "category_id": transfer_id,
-            "counterparty_account_scope": "outside",
-        },
-        headers=headers,
-    )
-
-    assert resp.status_code == 200
-    row = await _read_transaction(txn)
-    assert row.counterparty_account_scope == TransferCounterpartyScope.OUTSIDE
-    assert row.counterparty_account_id is None
-
-
-async def test_bulk_update_refuses_an_other_account_under_a_category_that_records_none(client):
-    """An expense records no other account, so naming one is refused."""
-    headers, account_id, category_id, other_account_id, _ = await _setup_transfer_user(client)
-    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+async def test_bulk_transfer_from_refuses_a_selection_with_no_transfer(client):
+    """An end that reaches no row would report a count for a write it never made, so it is refused."""
+    headers, chequing_id, category_id = await _setup_user_with_deps(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    first = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
 
     resp = await client.patch(
         "/transactions/bulk",
         json={
-            "transaction_ids": [txn],
-            "counterparty_account_scope": "tracked",
-            "counterparty_account_id": other_account_id,
+            "transaction_ids": [first, second],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
         },
         headers=headers,
     )
 
     assert resp.status_code == 422
-    assert "records no other account" in resp.json()["detail"]
+    assert resp.json()["detail"] == "None of these transactions record the other side of a transfer"
 
 
-async def test_bulk_update_refuses_a_scope_alone_under_a_category_that_records_none(client):
-    """Either half of the answer is an answer, so a scope on its own is refused as an account is."""
-    headers, account_id, category_id = await _setup_user_with_deps(client)
-    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
-
-    resp = await client.patch(
-        "/transactions/bulk",
-        json={"transaction_ids": [txn], "counterparty_account_scope": "outside"},
-        headers=headers,
-    )
-
-    assert resp.status_code == 422
-    assert "records no other account" in resp.json()["detail"]
-
-
-async def test_bulk_update_refuses_a_transfer_recording_its_own_account(client):
-    """A transfer cannot record the account it already sits in."""
-    headers, account_id, _, _, transfer_id = await _setup_transfer_user(client)
-    category_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
-    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+async def test_bulk_transfer_to_refuses_a_selection_with_no_transfer(client):
+    """The same refusal applies whichever end the request answers."""
+    headers, chequing_id, category_id = await _setup_user_with_deps(client)
+    savings_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+    first = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
+    second = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
 
     resp = await client.patch(
         "/transactions/bulk",
         json={
-            "transaction_ids": [txn],
-            "category_id": transfer_id,
-            "counterparty_account_scope": "tracked",
-            "counterparty_account_id": account_id,
+            "transaction_ids": [first, second],
+            "transfer_to": {"scope": "tracked", "account_id": savings_id},
         },
         headers=headers,
     )
 
     assert resp.status_code == 422
-    assert "their own account" in resp.json()["detail"]
+    assert resp.json()["detail"] == "None of these transactions record the other side of a transfer"
+
+
+async def test_bulk_transfer_from_reads_each_rows_resulting_category_not_its_stored_one(client):
+    """An end resolves against what a row ends up under, so recategorizing it away drops the end too."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    expense_category_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
+    transfer = (await _make_transfer(client, headers, chequing_id, transfer_id, savings_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "category_id": expense_category_id,
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert resp.json()["detail"] == "None of these transactions record the other side of a transfer"
 
 
 async def test_bulk_update_refuses_a_move_into_the_account_a_transfer_already_records(client):
@@ -783,25 +801,818 @@ async def test_bulk_update_refuses_a_move_into_the_account_a_transfer_already_re
     assert str((await _read_transaction(txn)).account_id) == account_id
 
 
-async def test_bulk_update_refuses_a_counterparty_answer_that_contradicts_itself(client):
-    """A tracked answer needs an account and any other answer forbids one."""
-    headers, account_id, category_id, other_account_id, _ = await _setup_transfer_user(client)
-    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+async def test_bulk_update_refuses_a_transfer_end_that_contradicts_its_own_scope(client):
+    """A tracked end needs an account and any other scope forbids one."""
+    headers, chequing_id, category_id = await _setup_user_with_deps(client)
+    savings_id = (await _create_account(client, headers, name="Savings")).json()["id"]
+    txn = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
 
     tracked_without_account = await client.patch(
         "/transactions/bulk",
-        json={"transaction_ids": [txn], "counterparty_account_scope": "tracked"},
+        json={"transaction_ids": [txn], "transfer_from": {"scope": "tracked"}},
         headers=headers,
     )
     outside_with_account = await client.patch(
         "/transactions/bulk",
         json={
             "transaction_ids": [txn],
-            "counterparty_account_scope": "outside",
-            "counterparty_account_id": other_account_id,
+            "transfer_from": {"scope": "outside", "account_id": savings_id},
         },
         headers=headers,
     )
 
     assert tracked_without_account.status_code == 422
     assert outside_with_account.status_code == 422
+
+
+async def test_bulk_update_refuses_a_null_transfer_end(client):
+    """An end has no null to write, so sending one is refused rather than read as clear."""
+    headers, chequing_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "transfer_from": None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_update_refuses_an_account_move_sent_with_a_transfer_end(client):
+    """A move and an end both decide the account a row sits in, so they cannot travel together."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (await _make_transfer(client, headers, chequing_id, transfer_id, savings_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "account_id": savings_id,
+            "transfer_from": {"scope": "tracked", "account_id": savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def _make_transfer(client, headers, account_id, transfer_id, other_account_id, **overrides):
+    """Create a transfer recording another tracked account as its other side."""
+    return await _create_transaction(
+        client,
+        headers,
+        account_id,
+        transfer_id,
+        counterparty_account_id=other_account_id,
+        counterparty_account_scope="tracked",
+        **overrides,
+    )
+
+
+async def _make_transfer_pair(client, headers, chequing_id, savings_id, transfer_id):
+    """Create both rows of one transfer: money out of Chequing, money in to Savings, on 2026-08-23."""
+    out_id = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, dt="2026-08-23", amount=-20000,
+    )).json()["id"]
+    in_id = (await _make_transfer(
+        client, headers, savings_id, transfer_id, chequing_id, dt="2026-08-23", amount=20000,
+    )).json()["id"]
+    return out_id, in_id
+
+
+async def test_bulk_transfer_ends_move_and_record_by_each_rows_own_direction(client):
+    """Both ends apply per row: the money-out half moves into From and the money-in half records it."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    out_id, in_id = await _make_transfer_pair(client, headers, chequing_id, savings_id, transfer_id)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [out_id, in_id],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+            "transfer_to": {"scope": "tracked", "account_id": savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    out_row = await _read_transaction(out_id)
+    assert str(out_row.account_id) == cash_id
+    assert str(out_row.counterparty_account_id) == savings_id
+    in_row = await _read_transaction(in_id)
+    assert str(in_row.account_id) == savings_id
+    assert str(in_row.counterparty_account_id) == cash_id
+
+
+async def test_bulk_transfer_from_alone_moves_the_money_out_half_and_records_on_the_other(client):
+    """Only From answered: it moves the row whose direction makes it the own end and records on the rest."""
+    headers, chequing_id, category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    await _create_transaction(client, headers, chequing_id, category_id, dt="2026-08-01", amount=-400)
+    await _create_transaction(client, headers, cash_id, category_id, dt="2026-08-10", amount=-800)
+    out_id, in_id = await _make_transfer_pair(client, headers, chequing_id, savings_id, transfer_id)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [out_id, in_id],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    out_row = await _read_transaction(out_id)
+    assert str(out_row.account_id) == cash_id
+    assert str(out_row.counterparty_account_id) == savings_id
+    in_row = await _read_transaction(in_id)
+    assert str(in_row.account_id) == savings_id
+    assert str(in_row.counterparty_account_id) == cash_id
+
+    chequing_balances = dict(await _read_snapshots(chequing_id))
+    assert date(2026, 8, 23) not in chequing_balances
+    assert max(chequing_balances) == date(2026, 8, 1)
+
+    cash_balances = dict(await _read_snapshots(cash_id))
+    assert cash_balances[date(2026, 8, 10)] == -800
+    assert cash_balances[date(2026, 8, 23)] == -20800
+
+
+async def test_bulk_transfer_to_alone_answers_two_money_out_rows_recording_outside(client):
+    """Only To answered: it records on rows that recorded outside, without moving either."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    first = (await _create_transaction(
+        client, headers, chequing_id, transfer_id, counterparty_account_scope="outside",
+    )).json()["id"]
+    second = (await _create_transaction(
+        client, headers, chequing_id, transfer_id, counterparty_account_scope="outside",
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [first, second],
+            "transfer_to": {"scope": "tracked", "account_id": savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    for txn_id in (first, second):
+        row = await _read_transaction(txn_id)
+        assert str(row.account_id) == chequing_id
+        assert str(row.counterparty_account_id) == savings_id
+
+
+async def test_bulk_direction_reverse_flips_the_pair_and_rebuilds_both_accounts(client):
+    """Reverse flips each row's own sign, leaving the accounts and far sides untouched."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    out_id, in_id = await _make_transfer_pair(client, headers, chequing_id, savings_id, transfer_id)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [out_id, in_id], "direction": "reverse"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    out_row = await _read_transaction(out_id)
+    assert out_row.amount == 20000
+    assert str(out_row.account_id) == chequing_id
+    assert str(out_row.counterparty_account_id) == savings_id
+    in_row = await _read_transaction(in_id)
+    assert in_row.amount == -20000
+    assert str(in_row.account_id) == savings_id
+    assert str(in_row.counterparty_account_id) == chequing_id
+
+    assert dict(await _read_snapshots(chequing_id))[date(2026, 8, 23)] == 20000
+    assert dict(await _read_snapshots(savings_id))[date(2026, 8, 23)] == -20000
+
+
+async def test_bulk_transfer_ends_with_reverse_use_each_rows_resulting_direction(client):
+    """Reverse changes which end is a row's own before the ends are applied, not after."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    out_id, in_id = await _make_transfer_pair(client, headers, chequing_id, savings_id, transfer_id)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [out_id, in_id],
+            "direction": "reverse",
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+            "transfer_to": {"scope": "tracked", "account_id": savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    out_row = await _read_transaction(out_id)
+    assert out_row.amount == 20000
+    assert str(out_row.account_id) == savings_id
+    assert str(out_row.counterparty_account_id) == cash_id
+    in_row = await _read_transaction(in_id)
+    assert in_row.amount == -20000
+    assert str(in_row.account_id) == cash_id
+    assert str(in_row.counterparty_account_id) == savings_id
+
+
+async def test_bulk_transfer_ends_with_an_absolute_direction_apply_the_same_end_to_every_row(client):
+    """An absolute direction makes every row's own end the same one, whatever its own sign was."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    out_id, in_id = await _make_transfer_pair(client, headers, chequing_id, savings_id, transfer_id)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [out_id, in_id],
+            "direction": "debit",
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+            "transfer_to": {"scope": "tracked", "account_id": savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    for txn_id in (out_id, in_id):
+        row = await _read_transaction(txn_id)
+        assert str(row.account_id) == cash_id
+        assert str(row.counterparty_account_id) == savings_id
+        assert row.amount < 0
+
+
+async def test_bulk_transfer_from_outside_refuses_a_money_out_row(client):
+    """A row cannot sit outside this app, so From cannot resolve to outside for its own end."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (await _make_transfer(client, headers, chequing_id, transfer_id, savings_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transfer], "transfer_from": {"scope": "outside"}},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "1 that would sit outside this app" in resp.json()["detail"]
+    assert str((await _read_transaction(transfer)).account_id) == chequing_id
+
+
+async def test_bulk_transfer_from_outside_on_a_money_in_row_records_outside(client):
+    """Outside is valid as a far end, so it is only refused when a row's direction makes it own."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (await _make_transfer(
+        client, headers, savings_id, transfer_id, chequing_id, amount=4000,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transfer], "transfer_from": {"scope": "outside"}},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert str(row.account_id) == savings_id
+    assert row.counterparty_account_scope == TransferCounterpartyScope.OUTSIDE
+    assert row.counterparty_account_id is None
+
+
+async def test_bulk_transfer_from_alone_leaves_a_selected_expense_untouched(client):
+    """An end reaches only rows whose resulting category records a far side, so others sit still."""
+    headers, chequing_id, category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    expense = (await _create_transaction(client, headers, chequing_id, category_id)).json()["id"]
+    before = await _read_transaction(expense)
+    transfer = (await _make_transfer(client, headers, chequing_id, transfer_id, savings_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [expense, transfer],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    after = await _read_transaction(expense)
+    assert str(after.account_id) == chequing_id
+    assert after.category_id == before.category_id
+    assert after.amount == before.amount
+    assert after.counterparty_account_id == before.counterparty_account_id
+    assert after.counterparty_account_scope == before.counterparty_account_scope
+    assert str((await _read_transaction(transfer)).account_id) == cash_id
+
+
+async def test_bulk_transfer_to_alone_leaves_a_selected_balance_adjustment_untouched(client):
+    """Balance Adjustment records no far side, so an end passes over it the way any far-side field does."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    adjustment_id = await _get_system_category_id(client, headers, "Balance Adjustment")
+    adjustment = (await _create_transaction(client, headers, chequing_id, adjustment_id)).json()["id"]
+    transfer = (await _create_transaction(
+        client, headers, chequing_id, transfer_id, counterparty_account_scope="outside",
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [adjustment, transfer],
+            "transfer_to": {"scope": "tracked", "account_id": savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    transfer_row = await _read_transaction(transfer)
+    assert str(transfer_row.counterparty_account_id) == savings_id
+    adjustment_row = await _read_transaction(adjustment)
+    assert adjustment_row.counterparty_account_id is None
+    assert adjustment_row.counterparty_account_scope is None
+
+
+async def test_bulk_transfer_from_refuses_a_move_with_no_exchange_rate(client):
+    """A tracked own end is a move, so it needs a rate across currencies exactly as a plain move does."""
+    await _seed_usd_currency()
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    us_savings_id = (await _create_account(client, headers, name="US Savings", currency="USD")).json()["id"]
+    transfer = (await _make_transfer(client, headers, chequing_id, transfer_id, savings_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_from": {"scope": "tracked", "account_id": us_savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "exchange rate" in resp.json()["detail"]
+    assert str((await _read_transaction(transfer)).account_id) == chequing_id
+
+
+async def test_bulk_transfer_from_moves_a_row_that_carries_an_exchange_rate(client):
+    """The same move is accepted once the row records a rate, exactly as a plain move is."""
+    await _seed_usd_currency()
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    us_savings_id = (await _create_account(client, headers, name="US Savings", currency="USD")).json()["id"]
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, fx_rate=1.35,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_from": {"scope": "tracked", "account_id": us_savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert str((await _read_transaction(transfer)).account_id) == us_savings_id
+
+
+async def test_bulk_transfer_to_records_an_account_in_another_currency(client):
+    """A far end only records, so it needs no rate even where a move to it would."""
+    await _seed_usd_currency()
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    us_savings_id = (await _create_account(client, headers, name="US Savings", currency="USD")).json()["id"]
+    transfer = (await _make_transfer(client, headers, chequing_id, transfer_id, savings_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_to": {"scope": "tracked", "account_id": us_savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert str(row.account_id) == chequing_id
+    assert str(row.counterparty_account_id) == us_savings_id
+
+
+async def test_bulk_transfer_from_refuses_a_row_that_would_record_its_own_account(client):
+    """An end that lands a row's far side on the account it already sits in is refused, like a move is."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    out_id, in_id = await _make_transfer_pair(client, headers, chequing_id, savings_id, transfer_id)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [out_id, in_id],
+            "transfer_from": {"scope": "tracked", "account_id": savings_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "2 of these transactions cannot be changed" in resp.json()["detail"]
+    assert "their own account" in resp.json()["detail"]
+    assert str((await _read_transaction(out_id)).account_id) == chequing_id
+    assert str((await _read_transaction(in_id)).account_id) == savings_id
+
+
+async def test_bulk_transfer_from_refuses_a_move_to_an_archived_account(client):
+    """An archived account takes no history, whether a move reaches it through account_id or an end."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    transfer = (await _make_transfer(client, headers, chequing_id, transfer_id, savings_id)).json()["id"]
+    await client.patch(f"/accounts/{cash_id}", json={"is_archived": True}, headers=headers)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert str((await _read_transaction(transfer)).account_id) == chequing_id
+
+
+async def test_bulk_transfer_from_on_a_zero_amount_row_records_it_as_the_far_side(client):
+    """Zero is money in, so a zero-amount transfer records From rather than moving into it."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=0,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert str(row.account_id) == chequing_id
+    assert str(row.counterparty_account_id) == cash_id
+
+
+async def test_bulk_transfer_from_records_a_read_only_account_without_moving_into_it(client):
+    """A far end only has to be readable, since recording an account writes nothing to it."""
+    admin_signup = await _create_user(client)
+    admin_headers = _get_auth_header(admin_signup)
+    group_id = (await client.post("/groups", json={"name": "Household"}, headers=admin_headers)).json()["id"]
+    cash_id = (await _create_account(client, admin_headers, name="Cash", group_id=group_id)).json()["id"]
+
+    member_signup = await client.post("/auth/signup", json={
+        "email": "member@example.com",
+        "password": "SecurePassword123!",
+        "first_name": "Member",
+        "tz": "America/Toronto",
+        "base_currency": "CAD",
+    })
+    member_headers = _get_auth_header(member_signup)
+    member_id = member_signup.json()["user"]["id"]
+    await client.post(f"/groups/{group_id}/members", json={"user_id": member_id}, headers=admin_headers)
+    await client.post(
+        f"/accounts/{cash_id}/permissions",
+        json={"user_id": member_id, "level": "read"},
+        headers=admin_headers,
+    )
+
+    chequing_id = (await _create_account(client, member_headers, name="Member Chequing")).json()["id"]
+    savings_id = (await _create_account(client, member_headers, name="Member Savings")).json()["id"]
+    transfer_id = await _get_system_category_id(client, member_headers, "Transfer")
+    transfer = (await _make_transfer(
+        client, member_headers, savings_id, transfer_id, chequing_id, amount=4000,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert str(row.account_id) == savings_id
+    assert str(row.counterparty_account_id) == cash_id
+
+
+async def test_bulk_transfer_from_leaves_an_expense_out_of_the_group_write_check(client):
+    """An expense resolves no end at all, so it never needs write access to the account From names."""
+    admin_signup = await _create_user(client)
+    admin_headers = _get_auth_header(admin_signup)
+    group_id = (await client.post("/groups", json={"name": "Household"}, headers=admin_headers)).json()["id"]
+    cash_id = (await _create_account(client, admin_headers, name="Cash", group_id=group_id)).json()["id"]
+
+    member_signup = await client.post("/auth/signup", json={
+        "email": "member2@example.com",
+        "password": "SecurePassword123!",
+        "first_name": "Member",
+        "tz": "America/Toronto",
+        "base_currency": "CAD",
+    })
+    member_headers = _get_auth_header(member_signup)
+    member_id = member_signup.json()["user"]["id"]
+    await client.post(f"/groups/{group_id}/members", json={"user_id": member_id}, headers=admin_headers)
+    await client.post(
+        f"/accounts/{cash_id}/permissions",
+        json={"user_id": member_id, "level": "read"},
+        headers=admin_headers,
+    )
+
+    chequing_id = (await _create_account(client, member_headers, name="Member Chequing")).json()["id"]
+    savings_id = (await _create_account(client, member_headers, name="Member Savings")).json()["id"]
+    category_id = (await _create_category(client, member_headers, name="Member Groceries")).json()["id"]
+    transfer_id = await _get_system_category_id(client, member_headers, "Transfer")
+    expense = (await _create_transaction(
+        client, member_headers, chequing_id, category_id, amount=-1200,
+    )).json()["id"]
+    transfer = (await _make_transfer(
+        client, member_headers, savings_id, transfer_id, chequing_id, amount=20000,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [expense, transfer],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 200
+    transfer_row = await _read_transaction(transfer)
+    assert str(transfer_row.account_id) == savings_id
+    assert str(transfer_row.counterparty_account_id) == cash_id
+    expense_row = await _read_transaction(expense)
+    assert str(expense_row.account_id) == chequing_id
+    assert str(expense_row.category_id) == category_id
+
+
+async def test_bulk_update_refuses_a_row_whose_sign_changed_between_the_checks_and_the_write(client, monkeypatch):
+    """A sign flipped by another session between the checks and the write is caught, not written over."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=-4000,
+    )).json()["id"]
+
+    original = bulk_update_module._collect_snapshot_starts
+
+    def _flip_sign_between_checks_and_write(*args, **kwargs):
+        """Run the real snapshot collection, then flip the row's sign on a separate connection.
+
+        Stands in for another session racing in after the checks pass but before the write, so the
+        sign the write's guard reads no longer matches the one the checks judged.
+        """
+        starts = original(*args, **kwargs)
+        thread = threading.Thread(target=lambda: asyncio.run(_flip_sign(transfer)))
+        thread.start()
+        thread.join()
+        return starts
+
+    monkeypatch.setattr(bulk_update_module, "_collect_snapshot_starts", _flip_sign_between_checks_and_write)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 409
+    assert str((await _read_transaction(transfer)).account_id) == chequing_id
+
+
+async def _setup_transfer_into_a_group_account(client):
+    """Put a member's transfer in their own account, recording a group account they can reach.
+
+    The member is granted write access first so the transfer can be recorded, which is what a real
+    one looks like before access is narrowed.
+    """
+    admin_signup = await _create_user(client)
+    admin_headers = _get_auth_header(admin_signup)
+    group_id = (await client.post("/groups", json={"name": "Smith Family"}, headers=admin_headers)).json()["id"]
+    shared_id = (await _create_account(
+        client, admin_headers, name="Shared Savings", group_id=group_id,
+    )).json()["id"]
+
+    member_signup = await client.post("/auth/signup", json={
+        "email": "member@example.com",
+        "password": "SecurePassword123!",
+        "first_name": "Member",
+        "tz": "America/Toronto",
+        "base_currency": "CAD",
+    })
+    member_headers = _get_auth_header(member_signup)
+    member_id = member_signup.json()["user"]["id"]
+    await client.post(f"/groups/{group_id}/members", json={"user_id": member_id}, headers=admin_headers)
+    await client.post(
+        f"/accounts/{shared_id}/permissions",
+        json={"user_id": member_id, "level": "write"},
+        headers=admin_headers,
+    )
+
+    own_account_id = (await _create_account(client, member_headers, name="Member Chequing")).json()["id"]
+    own_category_id = (await _create_category(client, member_headers, name="Member Groceries")).json()["id"]
+    transfer_id = await _get_system_category_id(client, member_headers, "Transfer")
+    transfer = (await _create_transaction(
+        client,
+        member_headers,
+        own_account_id,
+        transfer_id,
+        counterparty_account_id=shared_id,
+        counterparty_account_scope="tracked",
+    )).json()["id"]
+
+    return (
+        admin_headers, member_headers, member_id, group_id, shared_id,
+        own_account_id, own_category_id, transfer,
+    )
+
+
+async def test_bulk_transfer_from_refuses_a_group_account_the_caller_cannot_write(client):
+    """An own end writes into the account it names, so reading it is not enough."""
+    admin_headers, member_headers, member_id, _group_id, shared_id, own_account_id, _cat, transfer = (
+        await _setup_transfer_into_a_group_account(client)
+    )
+    await client.post(
+        f"/accounts/{shared_id}/permissions",
+        json={"user_id": member_id, "level": "read"},
+        headers=admin_headers,
+    )
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_from": {"scope": "tracked", "account_id": shared_id},
+        },
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 403
+    assert str((await _read_transaction(transfer)).account_id) == own_account_id
+
+
+async def test_bulk_transfer_from_checks_a_chosen_category_against_the_group_it_lands_in(client):
+    """An end leaves its source account behind, so only the group it lands in has to reach the category."""
+    admin_headers, member_headers, _member_id, group_id, shared_id, own_account_id, _own_cat, transfer = (
+        await _setup_transfer_into_a_group_account(client)
+    )
+
+    # Owned by the group, so it reaches the account the row lands in and nothing else. Checking it
+    # against the personal account the row is leaving as well would turn a valid request down
+    family_transfer = (await _create_category(
+        client, admin_headers, name="Family Transfer", kind="transfer", group_id=group_id,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_from": {"scope": "tracked", "account_id": shared_id},
+            "transfer_to": {"scope": "tracked", "account_id": own_account_id},
+            "category_id": family_transfer,
+        },
+        headers=member_headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert str(row.category_id) == family_transfer
+    assert str(row.account_id) == shared_id
+    assert str(row.counterparty_account_id) == own_account_id
+
+
+async def test_bulk_direction_turns_a_row_the_way_it_is_asked(client):
+    """Setting money in makes every amount positive and rebuilds the balance behind it."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    first = (await _create_transaction(
+        client, headers, account_id, category_id, dt="2026-08-01", amount=-4000,
+    )).json()["id"]
+    await _create_transaction(client, headers, account_id, category_id, dt="2026-08-10", amount=-800)
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [first], "direction": "credit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(first)).amount == 4000
+    assert [(dt, balance) for dt, balance in await _read_snapshots(account_id)] == [
+        (date(2026, 8, 1), 4000),
+        (date(2026, 8, 10), 3200),
+    ]
+
+
+async def test_bulk_direction_leaves_a_row_already_pointing_that_way(client):
+    """Money out on a row that already goes out changes nothing."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    row = (await _create_transaction(client, headers, account_id, category_id, amount=-4000)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [row], "direction": "debit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(row)).amount == -4000
+
+
+async def test_bulk_direction_applies_to_every_kind(client):
+    """Direction is the sign of the amount, which a transfer and an expense both carry."""
+    headers, account_id, category_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    expense = (await _create_transaction(client, headers, account_id, category_id, amount=5000)).json()["id"]
+    transfer = (await _make_transfer(
+        client, headers, account_id, transfer_id, other_account_id, amount=4000,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [expense, transfer], "direction": "debit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(expense)).amount == -5000
+    assert (await _read_transaction(transfer)).amount == -4000
+
+
+async def test_bulk_update_refuses_a_null_direction(client):
+    """Direction writes a sign, so it has no null to write."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    row = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [row], "direction": None},
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+
+
+async def test_bulk_direction_reverse_turns_an_expense_around(client):
+    """Reverse is not limited to transfers, and an expense flips exactly as a set direction allows."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    row = (await _create_transaction(client, headers, account_id, category_id, amount=-4000)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [row], "direction": "reverse"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(row)).amount == 4000
+
+
+async def test_bulk_direction_leaves_a_zero_amount_alone(client):
+    """A zero amount has no sign to set, so a direction leaves it as it is."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    row = (await _create_transaction(client, headers, account_id, category_id, amount=0)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [row], "direction": "debit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert (await _read_transaction(row)).amount == 0
+
+
+async def test_bulk_direction_leaves_the_accounts_alone(client):
+    """Direction writes a sign and nothing else, so a transfer stays where it is and keeps its far side."""
+    headers, account_id, _category_id, other_account_id, transfer_id = await _setup_transfer_user(client)
+    transfer = (await _make_transfer(
+        client, headers, account_id, transfer_id, other_account_id, amount=4000,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [transfer], "direction": "debit"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert row.amount == -4000
+    assert str(row.account_id) == account_id
+    assert str(row.counterparty_account_id) == other_account_id
+    assert row.counterparty_account_scope is TransferCounterpartyScope.TRACKED

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -374,7 +374,7 @@ async def test_bulk_update_refuses_a_request_carrying_only_an_empty_tag_list(cli
 
 
 async def test_bulk_update_leaves_the_account_balances_where_they_were(client):
-    """Category, merchant, tags and notes move no money, so every stored balance stays as it was."""
+    """A category or a note moves no money, so every stored balance stays as it was."""
     headers, account_id, category_id = await _setup_user_with_deps(client)
     txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
     dining_id = (await _create_category(client, headers, name="Bulk Dining", kind="expense")).json()["id"]
@@ -384,6 +384,25 @@ async def test_bulk_update_leaves_the_account_balances_where_they_were(client):
     resp = await client.patch(
         "/transactions/bulk",
         json={"transaction_ids": [txn], "category_id": dining_id, "notes": "Corrected"},
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert await _read_snapshots(account_id) == before
+
+
+async def test_bulk_update_leaves_the_balances_alone_for_a_merchant_and_tag_edit(client):
+    """A merchant and a tag move no money either, and they are the most common bulk edit there is."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+    merchant_id = (await _create_merchant(client, headers, name="Costco")).json()["id"]
+    tag_id = (await _create_tag(client, headers, name="vacation")).json()["id"]
+    before = await _read_snapshots(account_id)
+    assert before, "the account should carry balances before the edit, or this proves nothing"
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "merchant_id": merchant_id, "add_tag_ids": [tag_id]},
         headers=headers,
     )
 
@@ -696,6 +715,21 @@ async def test_bulk_update_refuses_an_other_account_under_a_category_that_record
             "counterparty_account_scope": "tracked",
             "counterparty_account_id": other_account_id,
         },
+        headers=headers,
+    )
+
+    assert resp.status_code == 422
+    assert "records no other account" in resp.json()["detail"]
+
+
+async def test_bulk_update_refuses_a_scope_alone_under_a_category_that_records_none(client):
+    """Either half of the answer is an answer, so a scope on its own is refused as an account is."""
+    headers, account_id, category_id = await _setup_user_with_deps(client)
+    txn = (await _create_transaction(client, headers, account_id, category_id)).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={"transaction_ids": [txn], "counterparty_account_scope": "outside"},
         headers=headers,
     )
 

--- a/backend/tests/routes/transactions/test_bulk_update.py
+++ b/backend/tests/routes/transactions/test_bulk_update.py
@@ -2,6 +2,7 @@ import asyncio
 import uuid
 from datetime import date
 
+import pytest
 from sqlalchemy import select, text
 
 from app.models.account import AccountBalanceSnapshot
@@ -1323,6 +1324,119 @@ async def test_bulk_transfer_from_on_a_zero_amount_row_records_it_as_the_far_sid
     row = await _read_transaction(transfer)
     assert str(row.account_id) == chequing_id
     assert str(row.counterparty_account_id) == cash_id
+
+
+@pytest.mark.parametrize("direction_field", ["direction", "transfer_direction"])
+@pytest.mark.parametrize("direction", ["debit", "reverse"])
+async def test_bulk_zero_amount_keeps_credit_end_resolution_with_a_direction(
+    client,
+    direction_field,
+    direction,
+):
+    """Debit and reverse leave zero credit for resolving From, whichever direction field carries it."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=0,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            direction_field: direction,
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert row.amount == 0
+    assert str(row.account_id) == chequing_id
+    assert str(row.counterparty_account_id) == cash_id
+
+
+@pytest.mark.parametrize("zero_sorts_first", [True, False])
+@pytest.mark.parametrize("direction_field", ["direction", "transfer_direction"])
+@pytest.mark.parametrize("direction", ["debit", "reverse"])
+async def test_bulk_zero_and_positive_transfers_apply_their_own_resulting_ends(
+    client,
+    zero_sorts_first,
+    direction_field,
+    direction,
+):
+    """A batched end write keeps each row's result when zero and positive started as credit."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    zero_id = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=0,
+    )).json()["id"]
+    positive_id = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=4000,
+    )).json()["id"]
+    case_offset = (
+        (0 if direction_field == "direction" else 4)
+        + (0 if direction == "debit" else 2)
+        + (0 if zero_sorts_first else 1)
+    )
+    low_id = uuid.UUID(int=10_000 + case_offset)
+    high_id = uuid.UUID(int=20_000 + case_offset)
+    fixed_zero_id, fixed_positive_id = (
+        (low_id, high_id) if zero_sorts_first else (high_id, low_id)
+    )
+    async with TestSession() as session:
+        zero_row = await session.get(Transaction, uuid.UUID(zero_id))
+        positive_row = await session.get(Transaction, uuid.UUID(positive_id))
+        zero_row.id = fixed_zero_id
+        positive_row.id = fixed_positive_id
+        await session.commit()
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [str(fixed_zero_id), str(fixed_positive_id)],
+            direction_field: direction,
+            "transfer_from": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.json()["transactions_updated"] == 2
+    assert resp.json()["affected_account_ids"] == sorted([chequing_id, savings_id, cash_id])
+    zero_row = await _read_transaction(str(fixed_zero_id))
+    assert zero_row.amount == 0
+    assert str(zero_row.account_id) == chequing_id
+    assert str(zero_row.counterparty_account_id) == cash_id
+    positive_row = await _read_transaction(str(fixed_positive_id))
+    assert positive_row.amount == -4000
+    assert str(positive_row.account_id) == cash_id
+    assert str(positive_row.counterparty_account_id) == savings_id
+
+
+async def test_bulk_transfer_to_on_a_zero_amount_row_moves_it_and_keeps_its_far_side(client):
+    """Zero is money in, so To changes its own account and leaves the recorded From account alone."""
+    headers, chequing_id, _category_id, savings_id, transfer_id = await _setup_transfer_user(client)
+    cash_id = (await _create_account(client, headers, name="Cash")).json()["id"]
+    transfer = (await _make_transfer(
+        client, headers, chequing_id, transfer_id, savings_id, amount=0,
+    )).json()["id"]
+
+    resp = await client.patch(
+        "/transactions/bulk",
+        json={
+            "transaction_ids": [transfer],
+            "transfer_to": {"scope": "tracked", "account_id": cash_id},
+        },
+        headers=headers,
+    )
+
+    assert resp.status_code == 200
+    row = await _read_transaction(transfer)
+    assert row.amount == 0
+    assert str(row.account_id) == cash_id
+    assert str(row.counterparty_account_id) == savings_id
 
 
 async def test_bulk_transfer_from_records_a_read_only_account_without_moving_into_it(client):

--- a/backend/tests/services/accounts/test_snapshots.py
+++ b/backend/tests/services/accounts/test_snapshots.py
@@ -1,9 +1,10 @@
 """Tests for the account balance snapshot recomputation service."""
+import asyncio
 from datetime import UTC, date, datetime
 from zoneinfo import ZoneInfo
 
 import pytest
-from sqlalchemy import select
+from sqlalchemy import select, text
 
 from app.models.account import Account, AccountBalanceSnapshot
 from app.models.base import AccountKind, AccountType, CategoryKind
@@ -11,7 +12,9 @@ from app.models.category import Category
 from app.models.currency import Currency
 from app.models.transaction import Transaction
 from app.models.user import User
-from app.services.accounts.snapshots import recompute_snapshots_from
+from app.services.accounts import snapshots as snapshots_module
+from app.services.accounts.snapshots import recompute_account_snapshots
+from tests.conftest import TestSession
 
 # --- Fixtures ---
 
@@ -86,12 +89,23 @@ async def _get_snapshots(db, account_id):
     return list(result.scalars().all())
 
 
+async def _wait_until_blocked(blocker_pid, blocked_pid):
+    """Wait until PostgreSQL reports one backend blocked by another."""
+    async with asyncio.timeout(5):
+        async with TestSession() as observer:
+            while blocker_pid not in await observer.scalar(
+                text("SELECT pg_blocking_pids(:pid)"),
+                {"pid": blocked_pid},
+            ):
+                await asyncio.sleep(0.01)
+
+
 # --- Tests ---
 
 
 async def test_recompute_with_no_transactions_restores_zero_anchor(db, user, account):
     """Empty transaction history leaves the account with its zero anchor."""
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [
@@ -112,7 +126,7 @@ async def test_recompute_restores_zero_anchor_from_owner_local_created_at(db, us
     db.add(account)
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 1, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 1, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [(date(2025, 12, 31), 0)]
@@ -126,7 +140,7 @@ async def test_recompute_single_day_writes_one_snapshot(db, user, account, categ
     ])
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert len(snapshots) == 1
@@ -143,7 +157,7 @@ async def test_recompute_multiple_days_accumulates_running_balance(db, user, acc
     ])
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [
@@ -159,7 +173,7 @@ async def test_recompute_anchor_carries_forward_from_earlier_snapshot(db, user, 
     db.add(_make_transaction(user, account, category, -1000, date(2026, 3, 1)))
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [
@@ -186,7 +200,7 @@ async def test_recompute_replaces_stale_snapshots_in_range(db, user, account, ca
     ])
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [
@@ -204,7 +218,7 @@ async def test_recompute_skips_days_without_transactions(db, user, account, cate
     ])
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [s.dt for s in snapshots] == [date(2026, 3, 1), date(2026, 3, 3)]
@@ -225,7 +239,7 @@ async def test_recompute_ignores_transactions_on_other_accounts(
     ))
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     target_snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in target_snapshots] == [(date(2026, 3, 1), 1000)]
@@ -241,7 +255,7 @@ async def test_recompute_with_no_activity_on_or_after_from_dt_preserves_earlier_
     db.add(AccountBalanceSnapshot(account_id=account.id, dt=date(2026, 2, 28), balance=5000))
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [(date(2026, 2, 28), 5000)]
@@ -257,7 +271,7 @@ async def test_recompute_excludes_transactions_before_from_dt(db, user, account,
     await db.flush()
 
     # Recompute from 3/2 — the 3/1 transaction must be ignored
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 2))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 2)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [
@@ -274,7 +288,7 @@ async def test_recompute_writes_snapshot_for_zero_delta_day(db, user, account, c
     ])
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [(date(2026, 3, 1), 0)]
@@ -288,7 +302,7 @@ async def test_recompute_anchor_balance_of_zero_is_treated_as_anchor(
     db.add(_make_transaction(user, account, category, 500, date(2026, 3, 1)))
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2026, 3, 1))
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [
@@ -302,7 +316,202 @@ async def test_recompute_from_dt_before_any_transaction(db, user, account, categ
     db.add(_make_transaction(user, account, category, 2000, date(2026, 3, 1)))
     await db.flush()
 
-    await recompute_snapshots_from(db, account.id, date(2020, 1, 1))
+    await recompute_account_snapshots(db, {account.id: date(2020, 1, 1)})
 
     snapshots = await _get_snapshots(db, account.id)
     assert [(s.dt, s.balance) for s in snapshots] == [(date(2026, 3, 1), 2000)]
+
+
+async def test_recompute_empty_map_does_not_flush_pending_changes(db, user, account, category):
+    """An empty affected-account map performs no database work."""
+    pending = _make_transaction(user, account, category, -1000, date(2026, 3, 1))
+    db.add(pending)
+
+    await recompute_account_snapshots(db, {})
+
+    assert pending in db.new
+
+
+async def test_recompute_acquires_deduplicated_lock_keys_in_numeric_order(
+    db, user, account, second_account, category, monkeypatch,
+):
+    """Multi-account rebuilds acquire each advisory key once in numeric order."""
+    third_account = Account(
+        owner_id=user.id,
+        account_kind=AccountKind.ASSET,
+        account_type=AccountType.CASH,
+        name="Cash",
+        currency="CAD",
+    )
+    db.add(third_account)
+    await db.flush()
+
+    lock_keys_by_account = {
+        account.id: 9,
+        second_account.id: -4,
+        third_account.id: -4,
+    }
+
+    def controlled_lock_key(account_id):
+        """Return test keys that include reverse order and a collision."""
+        return lock_keys_by_account[account_id]
+
+    observed_lock_keys = []
+    original_execute = db.execute
+
+    async def record_real_execute(statement, *args, **kwargs):
+        """Record advisory keys while executing each real database statement."""
+        if "pg_advisory_xact_lock" in str(statement):
+            observed_lock_keys.append(next(iter(statement.compile().params.values())))
+        return await original_execute(statement, *args, **kwargs)
+
+    monkeypatch.setattr(snapshots_module, "_snapshot_lock_key", controlled_lock_key)
+    monkeypatch.setattr(db, "execute", record_real_execute)
+
+    await recompute_account_snapshots(db, {
+        account.id: date(2026, 3, 1),
+        second_account.id: date(2026, 3, 1),
+        third_account.id: date(2026, 3, 1),
+    })
+
+    assert observed_lock_keys == [-4, 9]
+
+
+async def test_recompute_rollback_releases_lock_and_restores_prior_snapshots(
+    db, user, account, category,
+):
+    """Rolling back a held rebuild releases its lock and discards its snapshot rows."""
+    transaction = _make_transaction(user, account, category, -1000, date(2026, 3, 1))
+    db.add(transaction)
+    await recompute_account_snapshots(db, {account.id: date(2026, 3, 1)})
+    await db.commit()
+
+    async with TestSession() as holder, TestSession() as waiter:
+        held_transaction = await holder.get(Transaction, transaction.id)
+        held_transaction.amount = -2000
+        holder_pid = await holder.scalar(text("SELECT pg_backend_pid()"))
+        waiter_pid = await waiter.scalar(text("SELECT pg_backend_pid()"))
+        await recompute_account_snapshots(holder, {account.id: date(2026, 3, 1)})
+
+        waiting_rebuild = asyncio.create_task(
+            recompute_account_snapshots(waiter, {account.id: date(2026, 3, 1)}),
+        )
+        try:
+            await _wait_until_blocked(holder_pid, waiter_pid)
+            waiting_rebuild.cancel()
+            async with asyncio.timeout(5):
+                await asyncio.gather(waiting_rebuild, return_exceptions=True)
+            await waiter.rollback()
+            await holder.rollback()
+        finally:
+            if not waiting_rebuild.done():
+                waiting_rebuild.cancel()
+            async with asyncio.timeout(5):
+                await asyncio.gather(waiting_rebuild, return_exceptions=True)
+            await holder.rollback()
+            await waiter.rollback()
+
+    async with TestSession() as observer:
+        snapshots = await _get_snapshots(observer, account.id)
+    assert [(snapshot.dt, snapshot.balance) for snapshot in snapshots] == [
+        (date(2026, 3, 1), -1000),
+    ]
+
+    async with TestSession() as after_rollback:
+        async with asyncio.timeout(5):
+            await recompute_account_snapshots(
+                after_rollback,
+                {account.id: date(2026, 3, 1)},
+            )
+            await after_rollback.commit()
+
+
+async def test_recompute_for_other_account_completes_while_lock_is_held(
+    db, user, account, second_account, category,
+):
+    """A held account rebuild does not block an unrelated account rebuild."""
+    first_transaction = _make_transaction(user, account, category, -1000, date(2026, 3, 1))
+    second_transaction = _make_transaction(user, second_account, category, -2000, date(2026, 3, 1))
+    db.add_all([first_transaction, second_transaction])
+    await recompute_account_snapshots(db, {
+        account.id: date(2026, 3, 1),
+        second_account.id: date(2026, 3, 1),
+    })
+    await db.commit()
+
+    async with TestSession() as holder, TestSession() as independent:
+        held_transaction = await holder.get(Transaction, first_transaction.id)
+        held_transaction.amount = -3000
+        await recompute_account_snapshots(holder, {account.id: date(2026, 3, 1)})
+
+        independent_transaction = await independent.get(Transaction, second_transaction.id)
+        independent_transaction.amount = -4000
+        async with asyncio.timeout(2):
+            await recompute_account_snapshots(
+                independent,
+                {second_account.id: date(2026, 3, 1)},
+            )
+            await independent.commit()
+        await holder.rollback()
+
+    async with TestSession() as observer:
+        first_snapshots = await _get_snapshots(observer, account.id)
+        second_snapshots = await _get_snapshots(observer, second_account.id)
+    assert [(snapshot.dt, snapshot.balance) for snapshot in first_snapshots] == [
+        (date(2026, 3, 1), -1000),
+    ]
+    assert [(snapshot.dt, snapshot.balance) for snapshot in second_snapshots] == [
+        (date(2026, 3, 1), -4000),
+    ]
+
+
+async def test_recompute_lock_key_collision_serializes_correct_independent_balances(
+    db, user, account, second_account, category, monkeypatch,
+):
+    """A shared test lock key serializes accounts without mixing their balances."""
+    db.add_all([
+        _make_transaction(user, account, category, 1000, date(2026, 3, 1)),
+        _make_transaction(user, second_account, category, 2000, date(2026, 3, 1)),
+    ])
+    await recompute_account_snapshots(db, {
+        account.id: date(2026, 3, 1),
+        second_account.id: date(2026, 3, 1),
+    })
+    await db.commit()
+
+    def colliding_lock_key(_account_id):
+        """Force every account through one advisory key for this test."""
+        return 73
+
+    monkeypatch.setattr(snapshots_module, "_snapshot_lock_key", colliding_lock_key)
+
+    async with TestSession() as holder, TestSession() as waiter:
+        holder_pid = await holder.scalar(text("SELECT pg_backend_pid()"))
+        waiter_pid = await waiter.scalar(text("SELECT pg_backend_pid()"))
+        await recompute_account_snapshots(holder, {account.id: date(2026, 3, 1)})
+        waiting_rebuild = asyncio.create_task(
+            recompute_account_snapshots(waiter, {second_account.id: date(2026, 3, 1)}),
+        )
+        try:
+            await _wait_until_blocked(holder_pid, waiter_pid)
+            await holder.commit()
+            async with asyncio.timeout(5):
+                await waiting_rebuild
+                await waiter.commit()
+        finally:
+            if not waiting_rebuild.done():
+                waiting_rebuild.cancel()
+            async with asyncio.timeout(5):
+                await asyncio.gather(waiting_rebuild, return_exceptions=True)
+            await holder.rollback()
+            await waiter.rollback()
+
+    async with TestSession() as observer:
+        first_snapshots = await _get_snapshots(observer, account.id)
+        second_snapshots = await _get_snapshots(observer, second_account.id)
+    assert [(snapshot.dt, snapshot.balance) for snapshot in first_snapshots] == [
+        (date(2026, 3, 1), 1000),
+    ]
+    assert [(snapshot.dt, snapshot.balance) for snapshot in second_snapshots] == [
+        (date(2026, 3, 1), 2000),
+    ]

--- a/frontend/src/api/accounts/types.ts
+++ b/frontend/src/api/accounts/types.ts
@@ -43,6 +43,7 @@ export interface AccountsOverview {
    * Credit limit in currency minor units when the account is revolving credit
    */
   credit_limit: number | null;
+  can_write: boolean;
   is_archived: boolean;
   closed_at: string | null;
 }

--- a/frontend/src/api/cache/updates/transactions.ts
+++ b/frontend/src/api/cache/updates/transactions.ts
@@ -326,8 +326,9 @@ export function invalidatePatchedTransactionData(
  *
  * The field sets above are written against a single-transaction patch, so the bulk request has to
  * be read in those terms first. Its tag field is named differently and would otherwise match
- * nothing, and a move or a date change would match neither the balances nor the account activity,
- * leaving the figures on the Accounts page wrong until something else refetched them
+ * nothing, and a move, a direction change or a set end would match neither the balances nor the
+ * account activity, leaving the figures on the Accounts page wrong until something else refetched
+ * them
  */
 export function invalidateBulkUpdatedTransactionData(
   queryClient: QueryClient,
@@ -341,6 +342,13 @@ export function invalidateBulkUpdatedTransactionData(
   if (payload.dt !== undefined) patch.dt = payload.dt;
   if (payload.notes !== undefined) patch.notes = payload.notes;
   if (payload.add_tag_ids?.length) patch.tag_ids = payload.add_tag_ids;
+
+  // A direction change writes the sign of the amount column, and a set end writes account_id on
+  // whichever rows resolve to be their own. The request cannot say which rows those are, so a sent
+  // direction or end marks the column it could touch rather than the column it always does. The
+  // placeholder values below are read only for their key, never for what they hold
+  if (payload.direction !== undefined) patch.amount ??= 0;
+  if (payload.transfer_from !== undefined || payload.transfer_to !== undefined) patch.account_id ??= '';
 
   // Every bulk edit drops a counterparty account left recorded under a category that does not
   // record one, so the totals reading that field are refreshed whatever the request set

--- a/frontend/src/api/cache/updates/transactions.ts
+++ b/frontend/src/api/cache/updates/transactions.ts
@@ -20,7 +20,11 @@ import {
 import { accountKeys, transactionKeys } from '@/api/cache/queryKeys';
 import { uniqueIds } from '@/api/cache/invalidation/types';
 import type { Account, AccountKind, AccountsOverview } from '@/api/accounts/types';
-import type { Transaction, UpdateTransactionPayload } from '@/api/transactions/types';
+import type {
+  BulkUpdateTransactionsPayload,
+  Transaction,
+  UpdateTransactionPayload,
+} from '@/api/transactions/types';
 
 const TRANSACTION_LIST_FIELDS = new Set<keyof UpdateTransactionPayload>([
   'account_id',
@@ -315,4 +319,28 @@ export function invalidatePatchedTransactionData(
   if (patchTouches(patch, TAX_ADVANTAGED_FIELDS)) invalidateTaxAdvantagedActivity(queryClient, accountIds);
   if (patchTouches(patch, CREDIT_ACTIVITY_FIELDS)) invalidateCreditActivity(queryClient, accountIds);
   if (patchTouches(patch, MERCHANT_ACTIVITY_FIELDS)) invalidateInsightsMerchants(queryClient);
+}
+
+/**
+ * Invalidates the cached views a bulk transaction edit changed
+ *
+ * The field sets above are written against a single-transaction patch, so the bulk request has to
+ * be read in those terms first. Its tag field is named differently and would otherwise match
+ * nothing, leaving the rows on screen showing their old tags
+ */
+export function invalidateBulkUpdatedTransactionData(
+  queryClient: QueryClient,
+  payload: BulkUpdateTransactionsPayload,
+  accountIds: string[],
+) {
+  const patch: UpdateTransactionPayload = {};
+  if (payload.category_id !== undefined) patch.category_id = payload.category_id;
+  if (payload.merchant_id !== undefined) patch.merchant_id = payload.merchant_id;
+  if (payload.add_tag_ids?.length) patch.tag_ids = payload.add_tag_ids;
+
+  // Every bulk edit drops a counterparty account left recorded under a category that does not
+  // record one, so the totals reading that field are refreshed whatever the request set
+  patch.counterparty_account_id = null;
+
+  invalidatePatchedTransactionData(queryClient, patch, accountIds);
 }

--- a/frontend/src/api/cache/updates/transactions.ts
+++ b/frontend/src/api/cache/updates/transactions.ts
@@ -343,11 +343,12 @@ export function invalidateBulkUpdatedTransactionData(
   if (payload.notes !== undefined) patch.notes = payload.notes;
   if (payload.add_tag_ids?.length) patch.tag_ids = payload.add_tag_ids;
 
-  // A direction change writes the sign of the amount column, and a set end writes account_id on
-  // whichever rows resolve to be their own. The request cannot say which rows those are, so a sent
-  // direction or end marks the column it could touch rather than the column it always does. The
-  // placeholder values below are read only for their key, never for what they hold
-  if (payload.direction !== undefined) patch.amount ??= 0;
+  // A direction change, whether it reaches every row or only the transfer rows, writes the sign of
+  // the amount column, and a set end writes account_id on whichever rows resolve to be their own.
+  // The request cannot say which rows those are, so a sent direction or end marks the column it
+  // could touch rather than the column it always does. The placeholder values below are read only
+  // for their key, never for what they hold
+  if (payload.direction !== undefined || payload.transfer_direction !== undefined) patch.amount ??= 0;
   if (payload.transfer_from !== undefined || payload.transfer_to !== undefined) patch.account_id ??= '';
 
   // Every bulk edit drops a counterparty account left recorded under a category that does not

--- a/frontend/src/api/cache/updates/transactions.ts
+++ b/frontend/src/api/cache/updates/transactions.ts
@@ -326,7 +326,8 @@ export function invalidatePatchedTransactionData(
  *
  * The field sets above are written against a single-transaction patch, so the bulk request has to
  * be read in those terms first. Its tag field is named differently and would otherwise match
- * nothing, leaving the rows on screen showing their old tags
+ * nothing, and a move or a date change would match neither the balances nor the account activity,
+ * leaving the figures on the Accounts page wrong until something else refetched them
  */
 export function invalidateBulkUpdatedTransactionData(
   queryClient: QueryClient,
@@ -336,6 +337,9 @@ export function invalidateBulkUpdatedTransactionData(
   const patch: UpdateTransactionPayload = {};
   if (payload.category_id !== undefined) patch.category_id = payload.category_id;
   if (payload.merchant_id !== undefined) patch.merchant_id = payload.merchant_id;
+  if (payload.account_id !== undefined) patch.account_id = payload.account_id;
+  if (payload.dt !== undefined) patch.dt = payload.dt;
+  if (payload.notes !== undefined) patch.notes = payload.notes;
   if (payload.add_tag_ids?.length) patch.tag_ids = payload.add_tag_ids;
 
   // Every bulk edit drops a counterparty account left recorded under a category that does not

--- a/frontend/src/api/transactions/hooks.ts
+++ b/frontend/src/api/transactions/hooks.ts
@@ -16,12 +16,14 @@ import { runWithMinimumPendingTime } from '@/api/utils/mutationFeedback';
 import { transactionKeys, transactionOverviewKeys } from '@/api/cache/queryKeys';
 import {
   findCachedTransaction,
+  invalidateBulkUpdatedTransactionData,
   invalidateFinancialTransactionData,
   invalidatePatchedTransactionData,
   invalidateTransactionAccountData,
   removeTransactionFromLists,
 } from '@/api/cache/updates/transactions';
 import {
+  bulkUpdateTransactions,
   createTransaction,
   deleteTransaction,
   fetchTransaction,
@@ -169,6 +171,20 @@ export function useUpdateTransaction() {
         updated.account_id,
       ]);
       invalidatePatchedTransactionData(queryClient, patch, accountIds);
+    },
+  });
+}
+
+/**
+ * Applies one category, merchant or tag change across several transactions and refreshes the views
+ * those fields feed
+ */
+export function useBulkUpdateTransactions() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: bulkUpdateTransactions,
+    onSuccess: (result, payload) => {
+      invalidateBulkUpdatedTransactionData(queryClient, payload, result.affected_account_ids);
     },
   });
 }

--- a/frontend/src/api/transactions/hooks.ts
+++ b/frontend/src/api/transactions/hooks.ts
@@ -176,8 +176,7 @@ export function useUpdateTransaction() {
 }
 
 /**
- * Applies one category, merchant or tag change across several transactions and refreshes the views
- * those fields feed
+ * Applies one set of details across several transactions and refreshes the views those fields feed
  */
 export function useBulkUpdateTransactions() {
   const queryClient = useQueryClient();

--- a/frontend/src/api/transactions/index.ts
+++ b/frontend/src/api/transactions/index.ts
@@ -1,4 +1,6 @@
 export type {
+  BulkUpdateTransactionsPayload,
+  BulkUpdateTransactionsResult,
   CreateTransactionPayload,
   DailyCashFlow,
   OutlierTransaction,
@@ -13,6 +15,7 @@ export type {
 } from '@/api/transactions/types';
 
 export {
+  bulkUpdateTransactions,
   createTransaction,
   deleteTransaction,
   fetchTransaction,
@@ -24,6 +27,7 @@ export {
 
 export {
   applyTransactionDeletion,
+  useBulkUpdateTransactions,
   useCreateTransaction,
   useDeleteTransaction,
   useInfiniteTransactions,

--- a/frontend/src/api/transactions/index.ts
+++ b/frontend/src/api/transactions/index.ts
@@ -1,4 +1,6 @@
 export type {
+  BulkDirectionChange,
+  BulkTransferEnd,
   BulkUpdateTransactionsPayload,
   BulkUpdateTransactionsResult,
   CreateTransactionPayload,
@@ -10,6 +12,7 @@ export type {
   TransactionFilters,
   TransactionTag,
   TransactionsOverview,
+  TransactionDirection,
   TransferCounterpartyScope,
   UpdateTransactionPayload,
 } from '@/api/transactions/types';

--- a/frontend/src/api/transactions/requests.ts
+++ b/frontend/src/api/transactions/requests.ts
@@ -1,6 +1,8 @@
 import { authenticatedFetch } from '@/api/client';
 import { buildQueryString, type QueryStringValue } from '@/api/utils/queryString';
 import type {
+  BulkUpdateTransactionsPayload,
+  BulkUpdateTransactionsResult,
   CreateTransactionPayload,
   OverviewFilters,
   Transaction,
@@ -66,6 +68,16 @@ export function updateTransaction({ id, patch }: { id: string; patch: UpdateTran
   return authenticatedFetch<Transaction>(`/transactions/${id}`, {
     method: 'PATCH',
     body: JSON.stringify(patch),
+  });
+}
+
+/**
+ * Sets a category, a merchant or extra tags across several transactions in one request
+ */
+export function bulkUpdateTransactions(payload: BulkUpdateTransactionsPayload) {
+  return authenticatedFetch<BulkUpdateTransactionsResult>('/transactions/bulk', {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
   });
 }
 

--- a/frontend/src/api/transactions/types.ts
+++ b/frontend/src/api/transactions/types.ts
@@ -142,3 +142,22 @@ export interface UpdateTransactionPayload {
   counterparty_account_id?: string | null;
   counterparty_account_scope?: TransferCounterpartyScope | null;
 }
+
+export interface BulkUpdateTransactionsPayload {
+  transaction_ids: string[];
+  category_id?: string;
+  merchant_id?: string;
+
+  /**
+   * Attached on top of the tags each transaction already carries, unlike `tag_ids` on a single
+   * update, which replaces the whole list
+   */
+  add_tag_ids?: string[];
+}
+
+export interface BulkUpdateTransactionsResult {
+  transactions_updated: number;
+
+  /** Accounts behind the changed transactions, used to refresh only the views they feed */
+  affected_account_ids: string[];
+}

--- a/frontend/src/api/transactions/types.ts
+++ b/frontend/src/api/transactions/types.ts
@@ -143,16 +143,28 @@ export interface UpdateTransactionPayload {
   counterparty_account_scope?: TransferCounterpartyScope | null;
 }
 
+/**
+ * Details to set across several transactions.
+ *
+ * A field left out is left alone on every transaction, which is why `notes` and the counterparty
+ * pair distinguish absent from null: null clears, absent does not touch.
+ */
 export interface BulkUpdateTransactionsPayload {
   transaction_ids: string[];
+  account_id?: string;
+  dt?: string;
   category_id?: string;
   merchant_id?: string;
+  notes?: string | null;
 
   /**
    * Attached on top of the tags each transaction already carries, unlike `tag_ids` on a single
    * update, which replaces the whole list
    */
   add_tag_ids?: string[];
+
+  counterparty_account_id?: string | null;
+  counterparty_account_scope?: TransferCounterpartyScope | null;
 }
 
 export interface BulkUpdateTransactionsResult {

--- a/frontend/src/api/transactions/types.ts
+++ b/frontend/src/api/transactions/types.ts
@@ -6,6 +6,12 @@ import type { FxStatus } from '@/api/shared/fx';
  */
 export type TransferCounterpartyScope = 'tracked' | 'outside';
 
+/**
+ * Which way a transaction moves money, held as the sign of its amount rather than as a field of its
+ * own. Money out is a negative amount and money in a positive one
+ */
+export type TransactionDirection = 'debit' | 'credit';
+
 export interface Transaction {
   id: string;
   created_by_user_id: string;
@@ -144,10 +150,24 @@ export interface UpdateTransactionPayload {
 }
 
 /**
+ * Where a bulk edit's transfer end sits: a tracked account elsewhere in the app, or money that left
+ * the tracked accounts entirely. Distinct from `TransferCounterpartyScope`, which shapes the
+ * single-transaction counterparty pair this replaces on the bulk request
+ */
+export type BulkTransferEnd =
+  | { scope: 'tracked'; account_id: string }
+  | { scope: 'outside' };
+
+/** Which way a bulk direction change points: a fixed direction, or `reverse` to flip each row's own */
+export type BulkDirectionChange = TransactionDirection | 'reverse';
+
+/**
  * Details to set across several transactions.
  *
- * A field left out is left alone on every transaction, which is why `notes` and the counterparty
- * pair distinguish absent from null: null clears, absent does not touch.
+ * A field left out is left alone on every transaction. `notes` distinguishes absent from null: null
+ * clears, absent does not touch. `transfer_from` and `transfer_to` take absent the same way, but
+ * refuse an explicit null rather than reading it as a clear, since which row an end lands on as its
+ * own account is resolved per row rather than naming one column to blank.
  */
 export interface BulkUpdateTransactionsPayload {
   transaction_ids: string[];
@@ -163,8 +183,21 @@ export interface BulkUpdateTransactionsPayload {
    */
   add_tag_ids?: string[];
 
-  counterparty_account_id?: string | null;
-  counterparty_account_scope?: TransferCounterpartyScope | null;
+  /**
+   * The transfer's From account. Resolved per row: on a money-out row this is the account the row
+   * itself moves into, on a money-in row it is the account recorded as the far side. Valid as a far
+   * side only, since a row cannot sit outside the tracked accounts
+   */
+  transfer_from?: BulkTransferEnd;
+
+  /**
+   * The transfer's To account, resolved the opposite way from `transfer_from`: the row's own
+   * account on a money-in row, the far side on a money-out row
+   */
+  transfer_to?: BulkTransferEnd;
+
+  /** Which way every covered transaction should end up pointing, applied as the sign of its amount */
+  direction?: BulkDirectionChange;
 }
 
 export interface BulkUpdateTransactionsResult {

--- a/frontend/src/api/transactions/types.ts
+++ b/frontend/src/api/transactions/types.ts
@@ -198,6 +198,12 @@ export interface BulkUpdateTransactionsPayload {
 
   /** Which way every covered transaction should end up pointing, applied as the sign of its amount */
   direction?: BulkDirectionChange;
+
+  /**
+   * Which way the covered transactions that resolve to a transfer recording a far side should end
+   * up pointing, leaving every other covered row untouched. Never sent alongside direction
+   */
+  transfer_direction?: BulkDirectionChange;
 }
 
 export interface BulkUpdateTransactionsResult {

--- a/frontend/src/components/InfoCallout.tsx
+++ b/frontend/src/components/InfoCallout.tsx
@@ -1,0 +1,22 @@
+import { Info } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+interface InfoCalloutProps {
+  children: ReactNode;
+}
+
+/**
+ * Neutral banner with an info icon, used to give guidance that is not a warning or an error
+ */
+export function InfoCallout({ children }: InfoCalloutProps) {
+  return (
+    <div
+      className="flex items-start gap-2 rounded-lg p-3 text-sm"
+      style={{ backgroundColor: 'var(--app-accent-soft)', color: 'var(--app-text)' }}
+      role="note"
+    >
+      <Info size={16} strokeWidth={2} className="mt-0.5 shrink-0" style={{ color: 'var(--app-accent)' }} aria-hidden />
+      <span>{children}</span>
+    </div>
+  );
+}

--- a/frontend/src/components/WarningCallout.tsx
+++ b/frontend/src/components/WarningCallout.tsx
@@ -6,8 +6,9 @@ interface WarningCalloutProps {
 }
 
 /**
- * Red caution banner with an alert icon, used to flag irreversible or lockout-risk two-factor actions
- * The text is sized to match the modal body copy while staying in the warning colour
+ * Red caution banner with an alert icon, used to flag an action a modal cannot undo or that could
+ * lock the user out. The text is sized to match the modal body's own text while staying in the
+ * warning colour
  */
 export function WarningCallout({ children }: WarningCalloutProps) {
   return (

--- a/frontend/src/components/dropdown/Dropdown.tsx
+++ b/frontend/src/components/dropdown/Dropdown.tsx
@@ -40,7 +40,18 @@ interface DropdownProps {
   options: DropdownOption[];
   selectedOption?: DropdownOption;
   value: string;
+
+  /** Ticks every listed option whose value is in this list, instead of the single selected value */
+  selectedValues?: string[];
+
   onChange: (value: string) => void;
+
+  /**
+   * Closes the list once a pick is made, the default. False leaves it open, keeps focus where it
+   * is, clears the highlighted option so a second Enter cannot repeat the pick, and keeps the
+   * search text, for a field that takes several picks from one search in a row
+   */
+  closeOnSelect?: boolean;
 
   /**
    * Classes for how the control sits among the things around it, and for anything drawn over it,
@@ -80,6 +91,15 @@ interface DropdownProps {
   onSearchCommit?: (value: string) => void;
   disabled?: boolean;
   blankWhenEmpty?: boolean;
+
+  /**
+   * Draws the trigger in the placeholder colour while the value is blank and resolves to a listed
+   * option, for a field whose blank entry (such as "Leave as is") should not read as a real choice
+   * sitting there already. A label built by the caller's own selectedOption still draws as a value,
+   * since that is a summary of a real choice rather than a placeholder-shaped entry
+   */
+  blankOptionIsPlaceholder?: boolean;
+
   /** Called when the user clicks the dropdown create action with the current search text */
   onCreateNew?: (query: string) => void;
   createNewLabel?: DropdownCreateLabel;
@@ -105,7 +125,9 @@ const Dropdown = ({
   options,
   selectedOption,
   value,
+  selectedValues,
   onChange,
+  closeOnSelect = true,
   className,
   size = 'field',
   hasError = false,
@@ -127,6 +149,7 @@ const Dropdown = ({
   onSearchCommit,
   disabled = false,
   blankWhenEmpty = false,
+  blankOptionIsPlaceholder = false,
   onCreateNew,
   createNewLabel,
   onEditOption,
@@ -161,6 +184,12 @@ const Dropdown = ({
     [options, selectedOption, value],
   );
   const emptySelectionIsBlank = blankWhenEmpty && value === '';
+
+  // getSelectedDropdownOption prefers a listed option over selectedOption, so a match here means
+  // the resolved label came from the list rather than from a caller-built summary
+  const blankOptionSelected = blankOptionIsPlaceholder
+    && value === ''
+    && options.some((option) => option.value === value);
   const searchText = searchValue ?? search;
   const heldLoading = useMinimumVisibleFlag(isLoading, loadingMinMs);
   const showLoading = loadingMinMs <= 0 ? isLoading : heldLoading;
@@ -292,6 +321,15 @@ const Dropdown = ({
 
   const handleSelect = (optionValue: string) => {
     onChange(optionValue);
+
+    if (!closeOnSelect) {
+      // Leaves the list open and the search text as it was, for a caller that lets several matches
+      // of one search be picked in turn. The highlight still clears, so a second Enter lands on
+      // nothing rather than repeating the pick it just made
+      setHighlightedIndex(-1);
+      return;
+    }
+
     close();
 
     // Closing unmounts the focused option or search input, so return focus to the trigger
@@ -436,6 +474,7 @@ const Dropdown = ({
           placeholder={placeholder}
           selected={selected}
           size={size}
+          blankOptionSelected={blankOptionSelected}
           onClick={handleTriggerClick}
           onKeyDown={handleKeyDown}
         />
@@ -484,6 +523,7 @@ const Dropdown = ({
                   loadingText={loadingText}
                   options={visibleFiltered}
                   selectedValue={value}
+                  selectedValues={selectedValues}
                   showLoading={showLoading}
                   editOptionLabel={editOptionLabel}
                   onEditOption={onEditOption && handleEditOption}

--- a/frontend/src/components/dropdown/OptionList.tsx
+++ b/frontend/src/components/dropdown/OptionList.tsx
@@ -2,7 +2,7 @@ import { Fragment, type MouseEvent, type RefObject, type UIEvent } from 'react'
 import { Check, Pencil } from 'lucide-react'
 import { joinClassNames } from '@/utils/classNames'
 import { DropdownBadge, DropdownCount } from './Badge'
-import { canEditDropdownOption } from './options'
+import { canEditDropdownOption, isDropdownOptionSelected } from './options'
 import type { DropdownOption, DropdownOptionGroup } from './types'
 
 interface DropdownOptionListProps {
@@ -14,6 +14,9 @@ interface DropdownOptionListProps {
   loadingText: string
   options: DropdownOption[]
   selectedValue: string
+
+  /** Ticks every listed option whose value is in this list, instead of the single selected value */
+  selectedValues: string[] | undefined
   showLoading: boolean
   editOptionLabel: string | undefined
   onHighlight: (index: number) => void
@@ -124,6 +127,7 @@ export function DropdownOptionList({
   loadingText,
   options,
   selectedValue,
+  selectedValues,
   showLoading,
   editOptionLabel,
   onHighlight,
@@ -154,7 +158,7 @@ export function DropdownOptionList({
                 flatIndex={flatIndex}
                 highlighted={flatIndex === effectiveHighlightedIndex}
                 option={option}
-                selected={option.value === selectedValue}
+                selected={isDropdownOptionSelected(option, selectedValue, selectedValues)}
                 editOptionLabel={editOptionLabel}
                 onHighlight={onHighlight}
                 onSelect={onSelect}
@@ -170,7 +174,7 @@ export function DropdownOptionList({
             flatIndex={index}
             highlighted={index === effectiveHighlightedIndex}
             option={option}
-            selected={option.value === selectedValue}
+            selected={isDropdownOptionSelected(option, selectedValue, selectedValues)}
             editOptionLabel={editOptionLabel}
             onHighlight={onHighlight}
             onSelect={onSelect}

--- a/frontend/src/components/dropdown/OptionList.tsx
+++ b/frontend/src/components/dropdown/OptionList.tsx
@@ -149,9 +149,13 @@ export function DropdownOptionList({
       ) : groupedOptions ? (
         groupedOptions.map((group, groupIndex) => (
           <Fragment key={`${group.label}-${groupIndex}`}>
-            <li role="presentation" className="app-dropdown-group">
-              {group.label}
-            </li>
+            {/* An option with no group of its own, such as a leading blank entry, sits ahead of
+                the real groups without a header bar of its own */}
+            {group.label && (
+              <li role="presentation" className="app-dropdown-group">
+                {group.label}
+              </li>
+            )}
             {group.items.map(({ option, flatIndex }) => (
               <DropdownOptionRow
                 key={option.value}

--- a/frontend/src/components/dropdown/Trigger.tsx
+++ b/frontend/src/components/dropdown/Trigger.tsx
@@ -25,6 +25,13 @@ interface DropdownHeadProps {
   placeholder: string
   selected: DropdownOption | undefined
   size: DropdownSize
+
+  /**
+   * True once the value is blank and resolves to an option the caller listed, under a dropdown
+   * that opted in to drawing that as a placeholder rather than as a real selection
+   */
+  blankOptionSelected: boolean
+
   onClick: () => void
   onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => void
 }
@@ -51,11 +58,12 @@ export function DropdownHead({
   placeholder,
   selected,
   size,
+  blankOptionSelected,
   onClick,
   onKeyDown,
 }: DropdownHeadProps) {
   const shouldReduceMotion = useReducedMotion()
-  const hasVisibleSelection = Boolean(selected && !emptySelectionIsBlank)
+  const hasVisibleSelection = Boolean(selected && !emptySelectionIsBlank && !blankOptionSelected)
 
   return (
     <button

--- a/frontend/src/components/dropdown/options.ts
+++ b/frontend/src/components/dropdown/options.ts
@@ -23,6 +23,25 @@ export function getSelectedDropdownOption(
 }
 
 /**
+ * Returns whether one option's tick should show.
+ *
+ * Reads selectedValues when the caller has set it, for a field that ticks every option among
+ * several picks, and falls back to the single selected value otherwise.
+ *
+ * @param option The option the row is rendering
+ * @param selectedValue The dropdown's single selected value
+ * @param selectedValues Every value to tick at once, or undefined for a single-value dropdown
+ */
+export function isDropdownOptionSelected(
+  option: DropdownOption,
+  selectedValue: string,
+  selectedValues: string[] | undefined,
+): boolean {
+  if (selectedValues !== undefined) return selectedValues.includes(option.value)
+  return option.value === selectedValue
+}
+
+/**
  * Reports whether an option offers the edit action, which needs a caller that handles it and an
  * option that stands for something editable
  *

--- a/frontend/src/components/feedback/Toast.tsx
+++ b/frontend/src/components/feedback/Toast.tsx
@@ -59,7 +59,7 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
               type="button"
               onClick={onDismiss}
               aria-label="Dismiss message"
-              className="app-icon-button -mr-1 -mt-1 h-6 w-6 shrink-0"
+              className="app-icon-button -mr-1 h-6 w-6 shrink-0 self-center"
             >
               <X size={14} aria-hidden />
             </button>

--- a/frontend/src/components/filters/hooks/useDesktopToolbarLayout.ts
+++ b/frontend/src/components/filters/hooks/useDesktopToolbarLayout.ts
@@ -17,8 +17,12 @@ export type DesktopToolbarLayoutState = DesktopToolbarRefs & {
 
 /**
  * Measures the desktop toolbar so the search field, filter group, and create button wrap before they collide
+ *
+ * @param actionsKey Changes whenever the toolbar swaps its own controls, which re-measures. The observers
+ *     watch boxes rather than contents, and a wrapped filter group is already stretched to the row, so a
+ *     button appearing inside it changes nothing any of them would see
  */
-export function useDesktopToolbarLayout(): DesktopToolbarLayoutState {
+export function useDesktopToolbarLayout(actionsKey = ''): DesktopToolbarLayoutState {
   const toolbarRef = useRef<HTMLDivElement>(null)
   const controlsRef = useRef<HTMLDivElement>(null)
   const filterGroupRef = useRef<HTMLDivElement>(null)
@@ -77,7 +81,7 @@ export function useDesktopToolbarLayout(): DesktopToolbarLayoutState {
       resizeObserver.disconnect()
       window.removeEventListener('resize', updateCreateLayout)
     }
-  }, [])
+  }, [actionsKey])
 
   return {
     toolbarRef,

--- a/frontend/src/components/filters/hooks/useDesktopToolbarLayout.ts
+++ b/frontend/src/components/filters/hooks/useDesktopToolbarLayout.ts
@@ -21,8 +21,11 @@ export type DesktopToolbarLayoutState = DesktopToolbarRefs & {
  * @param actionsKey Changes whenever the toolbar swaps its own controls, which re-measures. The observers
  *     watch boxes rather than contents, and a wrapped filter group is already stretched to the row, so a
  *     button appearing inside it changes nothing any of them would see
+ * @param pauseMeasuring While true, skips re-measuring so a width animation running elsewhere in the
+ *     actions row cannot flip the inline and stacked layouts mid-transition and flip them back once the
+ *     animation is closer to done. Measures once, immediately, when it turns back to false
  */
-export function useDesktopToolbarLayout(actionsKey = ''): DesktopToolbarLayoutState {
+export function useDesktopToolbarLayout(actionsKey = '', pauseMeasuring = false): DesktopToolbarLayoutState {
   const toolbarRef = useRef<HTMLDivElement>(null)
   const controlsRef = useRef<HTMLDivElement>(null)
   const filterGroupRef = useRef<HTMLDivElement>(null)
@@ -45,6 +48,7 @@ export function useDesktopToolbarLayout(actionsKey = ''): DesktopToolbarLayoutSt
      * Recomputes the inline and stacked layout against the rendered toolbar widths
      */
     function updateCreateLayout() {
+      if (pauseMeasuring) return
       if (!window.matchMedia('(min-width: 750px)').matches) {
         setDesktopInlineLayout(false)
         setDesktopCreateStacked(false)
@@ -81,7 +85,7 @@ export function useDesktopToolbarLayout(actionsKey = ''): DesktopToolbarLayoutSt
       resizeObserver.disconnect()
       window.removeEventListener('resize', updateCreateLayout)
     }
-  }, [actionsKey])
+  }, [actionsKey, pauseMeasuring])
 
   return {
     toolbarRef,

--- a/frontend/src/components/forms/Checkbox.tsx
+++ b/frontend/src/components/forms/Checkbox.tsx
@@ -13,12 +13,17 @@ export function Checkbox({
   disabled,
   indeterminate = false,
   label,
+  uncheckedBackground = 'var(--app-input-bg)',
   onChange,
 }: {
   checked: boolean
   disabled?: boolean
   indeterminate?: boolean
   label: string
+
+  // What an empty box is filled with. The default reads against the page, and a caller putting a box
+  // on a surface of that same colour passes something else so the box does not disappear into it
+  uncheckedBackground?: string
 
   // Takes the click so a caller can read a held modifier key from it, which a range selection needs
   onChange: (event: React.MouseEvent) => void
@@ -31,7 +36,7 @@ export function Checkbox({
       aria-label={label}
       className="flex h-5 w-5 items-center justify-center rounded-lg transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
       style={{
-        background: checked || indeterminate ? 'var(--app-accent)' : 'var(--app-input-bg)',
+        background: checked || indeterminate ? 'var(--app-accent)' : uncheckedBackground,
         border: `1px solid ${checked || indeterminate ? 'var(--app-accent)' : 'var(--app-border-strong)'}`,
         color: 'var(--app-button-primary-text)',
         opacity: disabled ? 0.38 : 1,

--- a/frontend/src/components/forms/Checkbox.tsx
+++ b/frontend/src/components/forms/Checkbox.tsx
@@ -34,7 +34,7 @@ export function Checkbox({
       role="checkbox"
       aria-checked={indeterminate ? 'mixed' : checked}
       aria-label={label}
-      className="flex h-5 w-5 items-center justify-center rounded-lg transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+      className="flex h-5 w-5 items-center justify-center rounded-lg transition-[background-color,border-color,opacity] duration-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
       style={{
         background: checked || indeterminate ? 'var(--app-accent)' : uncheckedBackground,
         border: `1px solid ${checked || indeterminate ? 'var(--app-accent)' : 'var(--app-border-strong)'}`,

--- a/frontend/src/components/forms/Checkbox.tsx
+++ b/frontend/src/components/forms/Checkbox.tsx
@@ -1,0 +1,49 @@
+import type React from 'react'
+import { Check } from 'lucide-react'
+
+/**
+ * Checkbox button, supporting a mixed state for a selection that is only partly checked
+ *
+ * A button rather than an input, so it can carry the app's own styling. That is also why it cannot
+ * sit inside another button, which is what a row offering both a checkbox and a click of its own
+ * has to be built around
+ */
+export function Checkbox({
+  checked,
+  disabled,
+  indeterminate = false,
+  label,
+  onChange,
+}: {
+  checked: boolean
+  disabled?: boolean
+  indeterminate?: boolean
+  label: string
+
+  // Takes the click so a caller can read a held modifier key from it, which a range selection needs
+  onChange: (event: React.MouseEvent) => void
+}) {
+  return (
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={indeterminate ? 'mixed' : checked}
+      aria-label={label}
+      className="flex h-5 w-5 items-center justify-center rounded-lg transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
+      style={{
+        background: checked || indeterminate ? 'var(--app-accent)' : 'var(--app-input-bg)',
+        border: `1px solid ${checked || indeterminate ? 'var(--app-accent)' : 'var(--app-border-strong)'}`,
+        color: 'var(--app-button-primary-text)',
+        opacity: disabled ? 0.38 : 1,
+        cursor: disabled ? 'not-allowed' : 'pointer',
+      }}
+      onClick={onChange}
+      disabled={disabled}
+    >
+      {checked && <Check size={13} strokeWidth={3} aria-hidden />}
+      {!checked && indeterminate && (
+        <span className="h-0.5 w-2.5 rounded-full" style={{ background: 'currentColor' }} aria-hidden />
+      )}
+    </button>
+  )
+}

--- a/frontend/src/components/list-controls/useToolbarShellState.ts
+++ b/frontend/src/components/list-controls/useToolbarShellState.ts
@@ -23,9 +23,11 @@ export type ToolbarShellState = DesktopToolbarLayoutState & MobileSearchStuckSta
  * toolbars
  *
  * @param actionsKey Changes whenever the toolbar swaps its own controls, so the wrap layout re-measures
+ * @param pauseMeasuring Forwarded to the desktop wrap layout hook so a caller can hold its measuring
+ *     still while something it does not control, such as a button's own width animation, is in motion
  */
-export function useToolbarShellState(actionsKey?: string): ToolbarShellState {
-  const desktopLayout = useDesktopToolbarLayout(actionsKey)
+export function useToolbarShellState(actionsKey?: string, pauseMeasuring?: boolean): ToolbarShellState {
+  const desktopLayout = useDesktopToolbarLayout(actionsKey, pauseMeasuring)
   const mobileSearchStuck = useMobileSearchStuck()
   const toolbarStuck = useToolbarStuck()
   const [isMobileSheetOpen, setIsMobileSheetOpen] = useState(false)

--- a/frontend/src/components/list-controls/useToolbarShellState.ts
+++ b/frontend/src/components/list-controls/useToolbarShellState.ts
@@ -21,9 +21,11 @@ export type ToolbarShellState = DesktopToolbarLayoutState & MobileSearchStuckSta
  * Combines the desktop wrap layout, the mobile sticky search state, the toolbar dock state, and the
  * mobile filter sheet's open and mounted lifecycle shared by the account and transaction list
  * toolbars
+ *
+ * @param actionsKey Changes whenever the toolbar swaps its own controls, so the wrap layout re-measures
  */
-export function useToolbarShellState(): ToolbarShellState {
-  const desktopLayout = useDesktopToolbarLayout()
+export function useToolbarShellState(actionsKey?: string): ToolbarShellState {
+  const desktopLayout = useDesktopToolbarLayout(actionsKey)
   const mobileSearchStuck = useMobileSearchStuck()
   const toolbarStuck = useToolbarStuck()
   const [isMobileSheetOpen, setIsMobileSheetOpen] = useState(false)

--- a/frontend/src/components/modal/FormFooter.tsx
+++ b/frontend/src/components/modal/FormFooter.tsx
@@ -1,9 +1,11 @@
 import type { ModalLevel } from '@/components/modal/Shell'
 
-// The stacked level is the narrower panel, so its actions sit tighter to the edge to match its body padding
-const FOOTER_CLASS_NAME = {
-  page: 'grid shrink-0 grid-cols-2 gap-3 px-6 py-4 sm:flex sm:justify-end sm:px-8 min-[1050px]:py-5',
-  stacked: 'grid shrink-0 grid-cols-2 gap-3 px-6 py-4 sm:flex sm:justify-end sm:px-7 min-[1050px]:py-5',
+// The stacked level is the narrower panel, so its actions sit tighter to the edge to match its body
+// padding. The justify side is applied separately below, since a footer drawn with the primary on
+// the left swaps it for sm:justify-between rather than adding to it
+const FOOTER_BASE_CLASS_NAME = {
+  page: 'grid shrink-0 grid-cols-2 gap-3 px-6 py-4 sm:flex sm:px-8 min-[1050px]:py-5',
+  stacked: 'grid shrink-0 grid-cols-2 gap-3 px-6 py-4 sm:flex sm:px-7 min-[1050px]:py-5',
 } as const
 
 interface ModalFormFooterProps {
@@ -16,6 +18,15 @@ interface ModalFormFooterProps {
   error?: string | null
   level?: ModalLevel
   onCancel: () => void
+
+  /** Runs the primary action directly and renders it as a plain button, for a panel with nothing to submit */
+  onPrimary?: () => void
+
+  /**
+   * Draws the primary button at the left and Cancel at the right by CSS order, with Cancel staying
+   * first in the DOM so it is still the first stop after the close button on a Tab
+   */
+  primaryOnLeft?: boolean
 }
 
 /**
@@ -28,29 +39,36 @@ export function ModalFormFooter({
   error,
   level = 'page',
   onCancel,
+  onPrimary,
+  primaryOnLeft = false,
 }: ModalFormFooterProps) {
   return (
     <div
-      className={`${FOOTER_CLASS_NAME[level]} ${error ? 'items-center' : ''}`}
+      className={`${FOOTER_BASE_CLASS_NAME[level]} ${primaryOnLeft ? 'sm:justify-between' : 'sm:justify-end'} ${error ? 'items-center' : ''}`}
       style={{ borderTop: '1px solid var(--app-border)' }}
     >
       {error && (
-        <p className="col-span-2 text-sm font-medium sm:col-span-1 sm:mr-auto" style={{ color: 'var(--app-negative)' }}>
+        <p
+          className={`col-span-2 text-sm font-medium sm:col-span-1 ${primaryOnLeft ? 'order-2' : 'sm:mr-auto'}`}
+          role="alert"
+          style={{ color: 'var(--app-negative)' }}
+        >
           {error}
         </p>
       )}
       <button
         type="button"
-        className="app-secondary-button w-full sm:w-auto"
+        className={`app-secondary-button w-full sm:w-auto ${primaryOnLeft ? 'order-3' : ''}`}
         onClick={onCancel}
         disabled={submitDisabled}
       >
         Cancel
       </button>
       <button
-        type="submit"
+        type={onPrimary ? 'button' : 'submit'}
+        onClick={onPrimary}
         disabled={submitDisabled}
-        className={`app-primary-button overflow-hidden whitespace-nowrap duration-300 ${submitDisabled ? 'app-primary-button-loading justify-self-center sm:justify-self-auto' : submitWidthClassName}`}
+        className={`app-primary-button overflow-hidden whitespace-nowrap duration-300 ${primaryOnLeft ? 'order-1' : ''} ${submitDisabled ? 'app-primary-button-loading justify-self-center sm:justify-self-auto' : submitWidthClassName}`}
       >
         {/* The spinner replaces the label, so it carries the label as its own name and a screen reader still
             says which action is in flight */}

--- a/frontend/src/components/modal/TitledPanel.tsx
+++ b/frontend/src/components/modal/TitledPanel.tsx
@@ -115,7 +115,7 @@ export function ModalTitledPanel({
         </div>
       </div>
 
-      <div className={chrome.bodyClassName}>{children}</div>
+      <div className={chrome.bodyClassName} data-tooltip-bounds>{children}</div>
 
       {footer}
     </>

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { motion } from 'motion/react'
+import { AnimatePresence, motion } from 'motion/react'
 import { StickyNote, Tag as TagIcon } from 'lucide-react'
 import type { Institution } from '@/api/institutions'
 import type { Category } from '@/api/categories'
@@ -227,23 +227,37 @@ export default function TransactionRow({
       transition={{ duration: prefersReducedMotion ? 0 : 0.24, ease: ROW_EXIT_EASE }}
       onAnimationStart={() => setIsAnimatingHeight(true)}
       onAnimationComplete={() => setIsAnimatingHeight(false)}
-      className={`${selection ? 'flex items-center' : 'block'} w-full transition-colors duration-100 hover:bg-[var(--app-surface-soft)] min-[1300px]:col-span-full min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3`}
+      // Always a flex row, whether or not a checkbox is in it, so turning selection mode on and off
+      // does not switch layout mode underneath the checkbox while it animates
+      className="flex w-full items-center transition-colors duration-100 hover:bg-[var(--app-surface-soft)] min-[1300px]:col-span-full min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
       style={{
         borderBottom: '1px solid var(--app-border)',
         overflow: isAnimatingHeight ? 'hidden' : 'visible',
         background: selectionBackground,
       }}
     >
-      {selection && (
-        <span className="flex shrink-0 items-center justify-center pl-3 min-[1300px]:pl-0">
-          <Checkbox
-            checked={selection.mark === 'selected'}
-            disabled={!selection.isSelectable}
-            label={`Select ${title} on ${transaction.dt}`}
-            onChange={(event) => selection.onToggle(event.shiftKey)}
-          />
-        </span>
-      )}
+      {/* initial={false} so a row scrolling into view while selection mode is already on shows its
+          checkbox rather than growing one. AnimatePresence keeps the last rendered checkbox mounted
+          through its exit, which is why it can still read the selection that has just gone */}
+      <AnimatePresence initial={false}>
+        {selection && (
+          <motion.span
+            key="row-checkbox"
+            className="flex shrink-0 items-center justify-center overflow-hidden"
+            initial={prefersReducedMotion ? { opacity: 0 } : { width: 0, opacity: 0, paddingLeft: 0 }}
+            animate={{ width: 'auto', opacity: 1, paddingLeft: '0.75rem' }}
+            exit={prefersReducedMotion ? { opacity: 0 } : { width: 0, opacity: 0, paddingLeft: 0 }}
+            transition={{ duration: prefersReducedMotion ? 0 : 0.22, ease: ROW_EXIT_EASE }}
+          >
+            <Checkbox
+              checked={selection.mark === 'selected'}
+              disabled={!selection.isSelectable}
+              label={`Select ${title} on ${transaction.dt}`}
+              onChange={(event) => selection.onToggle(event.shiftKey)}
+            />
+          </motion.span>
+        )}
+      </AnimatePresence>
 
       {/* The row's own click target. It is a button nested inside the row rather than the row
           itself, because a checkbox is a button too and one cannot contain the other. On a wide

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -209,7 +209,7 @@ export default function TransactionRow({
   // cannot be edited
   const selectionBackground = selection?.mark === 'selected'
     ? 'var(--app-accent-soft)'
-    : selection?.mark === 'pending' ? 'var(--app-surface-soft)' : undefined
+    : selection?.mark === 'pending' ? 'var(--app-hover-soft)' : undefined
 
   return (
     <motion.div
@@ -233,7 +233,7 @@ export default function TransactionRow({
       transition={{ duration: prefersReducedMotion ? 0 : 0.24, ease: ROW_EXIT_EASE }}
       onAnimationStart={() => setIsAnimatingHeight(true)}
       onAnimationComplete={() => setIsAnimatingHeight(false)}
-      className="relative flex items-center transition-colors duration-100 hover:bg-[var(--app-surface-soft)] min-[1300px]:col-span-full min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
+      className="relative flex items-center transition-colors duration-100 hover:bg-[var(--app-hover-soft)] min-[1300px]:col-span-full min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
       style={{
         borderBottom: '1px solid var(--app-border)',
         overflow: isAnimatingHeight ? 'hidden' : 'visible',
@@ -295,7 +295,7 @@ export default function TransactionRow({
           // pointer the highlight has already answered
           if (selection.isSelectable || event.shiftKey) selection.onToggle(event.shiftKey)
         }}
-        className="block w-full min-w-0 flex-1 cursor-pointer px-3 text-left focus-visible:bg-[var(--app-surface-soft)] focus-visible:outline-none min-[1300px]:col-span-6 min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
+        className="block w-full min-w-0 flex-1 cursor-pointer px-3 text-left focus-visible:bg-[var(--app-hover-soft)] focus-visible:outline-none min-[1300px]:col-span-6 min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
       >
       {/* Desktop row: each cell is a direct child of this button's subgrid, which spans the list's
           content tracks, so every row shares the same column tracks and stays aligned. The category

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -244,17 +244,22 @@ export default function TransactionRow({
           <motion.span
             key="row-checkbox"
             className="flex shrink-0 items-center justify-center overflow-hidden"
-            initial={prefersReducedMotion ? { opacity: 0 } : { width: 0, opacity: 0, paddingLeft: 0 }}
-            animate={{ width: 'auto', opacity: 1, paddingLeft: '0.75rem' }}
-            exit={prefersReducedMotion ? { opacity: 0 } : { width: 0, opacity: 0, paddingLeft: 0 }}
+            initial={prefersReducedMotion ? { opacity: 0 } : { width: 0, opacity: 0 }}
+            animate={{ width: 'auto', opacity: 1 }}
+            exit={prefersReducedMotion ? { opacity: 0 } : { width: 0, opacity: 0 }}
             transition={{ duration: prefersReducedMotion ? 0 : 0.22, ease: ROW_EXIT_EASE }}
           >
-            <Checkbox
-              checked={selection.mark === 'selected'}
-              disabled={!selection.isSelectable}
-              label={`Select ${title} on ${transaction.dt}`}
-              onChange={(event) => selection.onToggle(event.shiftKey)}
-            />
+            {/* The padding sits inside the collapsing wrapper so it goes with the width, and it is
+                dropped on a wide screen, where the column track is the only room the checkbox has
+                and padding on top of it would push the box out of the track and clip it square */}
+            <span className="flex items-center pl-3 min-[1300px]:pl-0">
+              <Checkbox
+                checked={selection.mark === 'selected'}
+                disabled={!selection.isSelectable}
+                label={`Select ${title} on ${transaction.dt}`}
+                onChange={(event) => selection.onToggle(event.shiftKey)}
+              />
+            </span>
           </motion.span>
         )}
       </AnimatePresence>

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -5,6 +5,7 @@ import type { Institution } from '@/api/institutions'
 import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
 import { Checkbox } from '@/components/forms/Checkbox'
+import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import type { RowSelectionMark } from '@/pages/transactions/components/bulk-edit/selection'
 import {
   REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL,
@@ -205,6 +206,12 @@ export default function TransactionRow({
   const formattedAmount = `${transaction.amount >= 0 ? '+' : '-'}${formatCurrency(Math.abs(transaction.amount), currency)}`
   const transactionAmountColor = amountColor(category, transaction.amount)
 
+  // Only the limit gets a title here, since a read-only row already explains itself through the
+  // pill beside its account name
+  const tickTitle = selection && !selection.isSelectable && !readOnly
+    ? `Up to ${MAX_BULK_EDIT_TRANSACTIONS} transactions can be ticked at once`
+    : undefined
+
   // A ticked row is marked with a background rather than with opacity, which already says the row
   // cannot be edited
   const selectionBackground = selection?.mark === 'selected'
@@ -257,6 +264,7 @@ export default function TransactionRow({
             // opens and closes underneath the rest of the row
             className="absolute inset-y-0 left-0 flex items-center justify-center"
             style={{ width: TRANSACTION_CHECKBOX_RAIL_WIDTH }}
+            title={tickTitle}
             initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 0.72 }}
             animate={{ opacity: 1, scale: 1 }}
             exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 0.72 }}

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -209,7 +209,8 @@ export default function TransactionRow({
     <motion.div
       onMouseEnter={selection?.onPointerEnter}
       initial={skipEnterAnimation ? false : prefersReducedMotion ? { opacity: 0 } : { opacity: 0, height: 0, paddingTop: 0, paddingBottom: 0 }}
-      // The padding targets mirror the py-2.5 class so the row grows from a fully collapsed height
+      // The row's whole vertical padding, set here rather than in a class, so it can animate from
+      // zero and the row grows from a fully collapsed height
       animate={{ opacity: readOnly ? 0.68 : 1, height: 'auto', paddingTop: '0.625rem', paddingBottom: '0.625rem' }}
       exit={
         prefersReducedMotion
@@ -258,7 +259,11 @@ export default function TransactionRow({
             onOpen(transaction)
             return
           }
-          if (selection.isSelectable) selection.onToggle(event.shiftKey)
+
+          // A shift-click lands on a row the app will not edit as readily as on any other, and the
+          // range it takes steps over that row, so it runs anyway rather than doing nothing under a
+          // pointer the highlight has already answered
+          if (selection.isSelectable || event.shiftKey) selection.onToggle(event.shiftKey)
         }}
         className="block w-full min-w-0 flex-1 cursor-pointer px-3 text-left focus-visible:bg-[var(--app-surface-soft)] focus-visible:outline-none min-[1300px]:col-span-6 min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
       >

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -13,6 +13,10 @@ const MAX_VISIBLE_TAGS = 1
 const DEFAULT_CATEGORY_ICON = '🏷️'
 const ROW_EXIT_EASE = [0.25, 0.1, 0.25, 1] as const
 
+// Comfortably past the checkbox and its padding, so the cap never decides how wide the cell sits,
+// only how it opens and closes
+const CHECKBOX_CELL_MAX_WIDTH = 64
+
 /**
  * Describes the counterparty of a transfer for the line that shows a merchant on other kinds
  *
@@ -244,9 +248,14 @@ export default function TransactionRow({
           <motion.span
             key="row-checkbox"
             className="flex shrink-0 items-center justify-center overflow-hidden"
-            initial={prefersReducedMotion ? { opacity: 0 } : { width: 0, opacity: 0 }}
-            animate={{ width: 'auto', opacity: 1 }}
-            exit={prefersReducedMotion ? { opacity: 0 } : { width: 0, opacity: 0 }}
+            // The cap rather than the width, because a width can only be animated between two
+            // concrete values. Animating to auto leaves the box at auto, and the exit back to zero
+            // then has nothing to start from, so the space holds for the whole duration and snaps
+            // shut at the end. The cap starts and ends at a real number and never stretches the box
+            // past what the checkbox needs
+            initial={prefersReducedMotion ? { opacity: 0 } : { maxWidth: 0, opacity: 0 }}
+            animate={{ maxWidth: CHECKBOX_CELL_MAX_WIDTH, opacity: 1 }}
+            exit={prefersReducedMotion ? { opacity: 0 } : { maxWidth: 0, opacity: 0 }}
             transition={{ duration: prefersReducedMotion ? 0 : 0.22, ease: ROW_EXIT_EASE }}
           >
             {/* The padding sits inside the collapsing wrapper so it goes with the width, and it is

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -4,6 +4,8 @@ import { StickyNote, Tag as TagIcon } from 'lucide-react'
 import type { Institution } from '@/api/institutions'
 import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
+import { Checkbox } from '@/components/forms/Checkbox'
+import type { RowSelectionMark } from '@/pages/transactions/components/bulk-edit/selection'
 import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { resolveInstitutionLogoUrl } from '@/utils/institutionLogo'
 
@@ -31,6 +33,23 @@ function describeTransferCounterparty(
   return transaction.amount < 0 ? `To ${counterparty}` : `From ${counterparty}`
 }
 
+/**
+ * What the row needs while the list is in selection mode
+ *
+ * Absent everywhere else, including the import preview, which renders the same row and offers no
+ * selection at all
+ */
+export interface TransactionRowSelection {
+  /** How the row is marked once any pending shift-click is taken into account */
+  mark: RowSelectionMark
+
+  /** False for a row the app does not allow editing, such as one on an archived account */
+  isSelectable: boolean
+
+  onToggle: (withShift: boolean) => void
+  onPointerEnter: () => void
+}
+
 interface TransactionRowProps {
   accountName?: string
 
@@ -46,6 +65,7 @@ interface TransactionRowProps {
   prefersReducedMotion?: boolean | null
   // Makes the row appear without the grow in, used for a lazy loaded batch that would otherwise all grow at once
   skipEnterAnimation?: boolean
+  selection?: TransactionRowSelection
   onOpen: (transaction: Transaction) => void
 }
 
@@ -150,6 +170,7 @@ export default function TransactionRow({
   transaction,
   prefersReducedMotion,
   skipEnterAnimation = false,
+  selection,
   onOpen,
 }: TransactionRowProps) {
   // The row clips its content only while the height animates, so the grow and collapse read cleanly
@@ -178,10 +199,15 @@ export default function TransactionRow({
   const formattedAmount = `${transaction.amount >= 0 ? '+' : '-'}${formatCurrency(Math.abs(transaction.amount), currency)}`
   const transactionAmountColor = amountColor(category, transaction.amount)
 
+  // A ticked row is marked with a background rather than with opacity, which already says the row
+  // cannot be edited
+  const selectionBackground = selection?.mark === 'selected'
+    ? 'var(--app-accent-soft)'
+    : selection?.mark === 'pending' ? 'var(--app-surface-soft)' : undefined
+
   return (
-    <motion.button
-      type="button"
-      onClick={() => onOpen(transaction)}
+    <motion.div
+      onMouseEnter={selection?.onPointerEnter}
       initial={skipEnterAnimation ? false : prefersReducedMotion ? { opacity: 0 } : { opacity: 0, height: 0, paddingTop: 0, paddingBottom: 0 }}
       // The padding targets mirror the py-2.5 class so the row grows from a fully collapsed height
       animate={{ opacity: readOnly ? 0.68 : 1, height: 'auto', paddingTop: '0.625rem', paddingBottom: '0.625rem' }}
@@ -200,13 +226,47 @@ export default function TransactionRow({
       transition={{ duration: prefersReducedMotion ? 0 : 0.24, ease: ROW_EXIT_EASE }}
       onAnimationStart={() => setIsAnimatingHeight(true)}
       onAnimationComplete={() => setIsAnimatingHeight(false)}
-      className="block w-full cursor-pointer px-3 py-2.5 text-left transition-colors duration-100 hover:bg-[var(--app-surface-soft)] focus-visible:bg-[var(--app-surface-soft)] focus-visible:outline-none min-[1300px]:col-span-full min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
-      style={{ borderBottom: '1px solid var(--app-border)', overflow: isAnimatingHeight ? 'hidden' : 'visible' }}
+      className={`${selection ? 'flex items-center' : 'block'} w-full transition-colors duration-100 hover:bg-[var(--app-surface-soft)] min-[1300px]:col-span-full min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3`}
+      style={{
+        borderBottom: '1px solid var(--app-border)',
+        overflow: isAnimatingHeight ? 'hidden' : 'visible',
+        background: selectionBackground,
+      }}
     >
-      {/* Desktop row: each cell is a direct child of the row's subgrid, so every row shares the same
-          column tracks and stays aligned. The category and account tracks grow to their widest content
-          across all rows, showing long names while there is room and truncating only when there is not,
-          with notes as the flexible filler that compresses first */}
+      {selection && (
+        <span className="flex shrink-0 items-center justify-center pl-3 min-[1300px]:pl-0">
+          <Checkbox
+            checked={selection.mark === 'selected'}
+            disabled={!selection.isSelectable}
+            label={`Select ${title} on ${transaction.dt}`}
+            onChange={(event) => selection.onToggle(event.shiftKey)}
+          />
+        </span>
+      )}
+
+      {/* The row's own click target. It is a button nested inside the row rather than the row
+          itself, because a checkbox is a button too and one cannot contain the other. On a wide
+          screen it declares a subgrid of its own so the cells inside it still line up against the
+          tracks the list declares */}
+      <button
+        type="button"
+        // In selection mode the checkbox is the row's single stop, so the same row does not offer
+        // two controls doing the same thing
+        tabIndex={selection ? -1 : undefined}
+        onClick={(event) => {
+          if (!selection) {
+            onOpen(transaction)
+            return
+          }
+          if (selection.isSelectable) selection.onToggle(event.shiftKey)
+        }}
+        className="block w-full min-w-0 flex-1 cursor-pointer px-3 text-left focus-visible:bg-[var(--app-surface-soft)] focus-visible:outline-none min-[1300px]:col-span-6 min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
+      >
+      {/* Desktop row: each cell is a direct child of this button's subgrid, which spans the list's
+          content tracks, so every row shares the same column tracks and stays aligned. The category
+          and account tracks grow to their widest content across all rows, showing long names while
+          there is room and truncating only when there is not, with notes as the flexible filler
+          that compresses first */}
       <span className="hidden text-2xl leading-none min-[1300px]:block" aria-hidden>
         {categoryIcon}
       </span>
@@ -412,6 +472,7 @@ export default function TransactionRow({
           </span>
         )}
       </span>
-    </motion.button>
+      </button>
+    </motion.div>
   )
 }

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -6,16 +6,18 @@ import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
 import { Checkbox } from '@/components/forms/Checkbox'
 import type { RowSelectionMark } from '@/pages/transactions/components/bulk-edit/selection'
+import {
+  REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL,
+  TRANSACTION_CHECKBOX_RAIL,
+  TRANSACTION_CHECKBOX_RAIL_DURATION_S,
+  TRANSACTION_CHECKBOX_RAIL_WIDTH,
+} from '@/pages/transactions/constants/transactionList'
 import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import { resolveInstitutionLogoUrl } from '@/utils/institutionLogo'
 
 const MAX_VISIBLE_TAGS = 1
 const DEFAULT_CATEGORY_ICON = '🏷️'
 const ROW_EXIT_EASE = [0.25, 0.1, 0.25, 1] as const
-
-// Comfortably past the checkbox and its padding, so the cap never decides how wide the cell sits,
-// only how it opens and closes
-const CHECKBOX_CELL_MAX_WIDTH = 64
 
 /**
  * Describes the counterparty of a transfer for the line that shows a merchant on other kinds
@@ -231,13 +233,15 @@ export default function TransactionRow({
       transition={{ duration: prefersReducedMotion ? 0 : 0.24, ease: ROW_EXIT_EASE }}
       onAnimationStart={() => setIsAnimatingHeight(true)}
       onAnimationComplete={() => setIsAnimatingHeight(false)}
-      // Always a flex row, whether or not a checkbox is in it, so turning selection mode on and off
-      // does not switch layout mode underneath the checkbox while it animates
-      className="flex w-full items-center transition-colors duration-100 hover:bg-[var(--app-surface-soft)] min-[1300px]:col-span-full min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
+      className="relative flex items-center transition-colors duration-100 hover:bg-[var(--app-surface-soft)] min-[1300px]:col-span-full min-[1300px]:grid min-[1300px]:grid-cols-subgrid min-[1300px]:items-center min-[1300px]:gap-x-3"
       style={{
         borderBottom: '1px solid var(--app-border)',
         overflow: isAnimatingHeight ? 'hidden' : 'visible',
         background: selectionBackground,
+        // The row starts at the left edge of the rail rather than after it, so its background and its
+        // separator cover the checkbox as well, while the padding puts its cells back on the tracks
+        ...REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL,
+        paddingLeft: TRANSACTION_CHECKBOX_RAIL,
       }}
     >
       {/* initial={false} so a row scrolling into view while selection mode is already on shows its
@@ -247,28 +251,26 @@ export default function TransactionRow({
         {selection && (
           <motion.span
             key="row-checkbox"
-            className="flex shrink-0 items-center justify-center overflow-hidden"
-            // The cap rather than the width, because a width can only be animated between two
-            // concrete values. Animating to auto leaves the box at auto, and the exit back to zero
-            // then has nothing to start from, so the space holds for the whole duration and snaps
-            // shut at the end. The cap starts and ends at a real number and never stretches the box
-            // past what the checkbox needs
-            initial={prefersReducedMotion ? { opacity: 0 } : { maxWidth: 0, opacity: 0 }}
-            animate={{ maxWidth: CHECKBOX_CELL_MAX_WIDTH, opacity: 1 }}
-            exit={prefersReducedMotion ? { opacity: 0 } : { maxWidth: 0, opacity: 0 }}
-            transition={{ duration: prefersReducedMotion ? 0 : 0.22, ease: ROW_EXIT_EASE }}
+            // Laid over the rail rather than placed in the row, because a cell of the row would take
+            // one of the list's columns, and the button beside it asks for all six of them. The rail
+            // is the row's own left padding, so the box sits still at the list's edge while the rail
+            // opens and closes underneath the rest of the row
+            className="absolute inset-y-0 left-0 flex items-center justify-center"
+            style={{ width: TRANSACTION_CHECKBOX_RAIL_WIDTH }}
+            initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 0.72 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 0.72 }}
+            transition={{
+              duration: prefersReducedMotion ? 0 : TRANSACTION_CHECKBOX_RAIL_DURATION_S,
+              ease: ROW_EXIT_EASE,
+            }}
           >
-            {/* The padding sits inside the collapsing wrapper so it goes with the width, and it is
-                dropped on a wide screen, where the column track is the only room the checkbox has
-                and padding on top of it would push the box out of the track and clip it square */}
-            <span className="flex items-center pl-3 min-[1300px]:pl-0">
-              <Checkbox
-                checked={selection.mark === 'selected'}
-                disabled={!selection.isSelectable}
-                label={`Select ${title} on ${transaction.dt}`}
-                onChange={(event) => selection.onToggle(event.shiftKey)}
-              />
-            </span>
+            <Checkbox
+              checked={selection.mark === 'selected'}
+              disabled={!selection.isSelectable}
+              label={`Select ${title} on ${transaction.dt}`}
+              onChange={(event) => selection.onToggle(event.shiftKey)}
+            />
           </motion.span>
         )}
       </AnimatePresence>

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -46,7 +46,7 @@ function describeTransferCounterparty(
  * selection at all
  */
 export interface TransactionRowSelection {
-  /** How the row is marked once any pending shift-click is taken into account */
+  /** How the row is marked once any pending shift-click or day tick is taken into account */
   mark: RowSelectionMark
 
   /** False for a row the app does not allow editing, such as one on an archived account */

--- a/frontend/src/components/two-factor/ForcedReenrollScreen.tsx
+++ b/frontend/src/components/two-factor/ForcedReenrollScreen.tsx
@@ -4,7 +4,7 @@ import { AnimatePresence, motion } from 'motion/react';
 import { usePasskeyConfig } from '@/api/passkeys';
 import { PasskeyReenrollment } from '@/components/two-factor/PasskeyReenrollment';
 import { TotpEnrollment } from '@/components/two-factor/TotpEnrollment';
-import { WarningCallout } from '@/components/two-factor/WarningCallout';
+import { WarningCallout } from '@/components/WarningCallout';
 import { useAuth } from '@/hooks/useAuth';
 import { assessPasskeySupport } from '@/utils/passkeySupport';
 

--- a/frontend/src/components/two-factor/MfaChallenge.tsx
+++ b/frontend/src/components/two-factor/MfaChallenge.tsx
@@ -1,7 +1,7 @@
 import type { FormEvent } from 'react';
 import { KeyRound } from 'lucide-react';
 import { OtpInput, OTP_LENGTH } from '@/components/OtpInput';
-import { WarningCallout } from '@/components/two-factor/WarningCallout';
+import { WarningCallout } from '@/components/WarningCallout';
 
 /**
  * What this screen may offer for a second-factor challenge

--- a/frontend/src/components/two-factor/PasskeyReenrollment.tsx
+++ b/frontend/src/components/two-factor/PasskeyReenrollment.tsx
@@ -2,7 +2,7 @@ import { KeyRound } from 'lucide-react';
 import { useState } from 'react';
 import { usePasskeyConfig, useConfirmPasskeyRegistration, useRegisterPasskey } from '@/api/passkeys';
 import { RecoveryCodesModal } from '@/components/two-factor/RecoveryCodesModal';
-import { WarningCallout } from '@/components/two-factor/WarningCallout';
+import { WarningCallout } from '@/components/WarningCallout';
 import { getPasskeyRegistrationMessage } from '@/utils/passkeyErrors';
 import { assessPasskeySupport } from '@/utils/passkeySupport';
 

--- a/frontend/src/components/two-factor/RecoveryCodesPanel.tsx
+++ b/frontend/src/components/two-factor/RecoveryCodesPanel.tsx
@@ -1,4 +1,4 @@
-import { WarningCallout } from '@/components/two-factor/WarningCallout';
+import { WarningCallout } from '@/components/WarningCallout';
 import { copyText } from '@/utils/clipboard';
 
 const RECOVERY_CODES_FILENAME = 'lumina-recovery-codes.txt';

--- a/frontend/src/components/two-factor/StepUpModal.tsx
+++ b/frontend/src/components/two-factor/StepUpModal.tsx
@@ -7,7 +7,7 @@ import { OtpInput, OTP_LENGTH } from '@/components/OtpInput';
 import { StepTransition } from '@/components/two-factor/StepTransition';
 import { ModalContentPanel } from '@/components/modal/ContentPanel';
 import type { ModalLevel } from '@/components/modal/Shell';
-import { WarningCallout } from '@/components/two-factor/WarningCallout';
+import { WarningCallout } from '@/components/WarningCallout';
 import { useAuth } from '@/hooks/useAuth';
 import { buildLockoutWarning, describeStepUpFailure, getAttemptsRemaining } from '@/utils/lockoutWarning';
 import { isPasskeyCeremonyCancelled } from '@/utils/passkeyErrors';

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -23,8 +23,9 @@ const SIX_MONTHS_MS = 180 * 24 * 60 * 60 * 1000;
 // outlives a deploy by up to six months and a fresh one is not refetched while it is still
 // within its stale window, so without this the first render after such a change draws a card from
 // fields that are no longer there. Bump it on any shape change. Version 1 is the account spending
-// breakdown carrying a total per card in place of one shared figure
-const PERSISTED_CACHE_SHAPE = '1';
+// breakdown carrying a total per card in place of one shared figure. Version 2 adds the caller's
+// write capability to every account response
+const PERSISTED_CACHE_SHAPE = '2';
 
 const queryClient = new QueryClient({
   defaultOptions: {

--- a/frontend/src/pages/imports/components/Primitives.tsx
+++ b/frontend/src/pages/imports/components/Primitives.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode } from 'react'
-import { Check, ChevronDown, CircleHelp, Info, TriangleAlert } from 'lucide-react'
+import { ChevronDown, CircleHelp, Info, TriangleAlert } from 'lucide-react'
 import { IMPORT_INSET_STYLE } from '@/pages/imports/constants'
 
 /**
@@ -278,45 +278,4 @@ export function ImportInfoCard({ title, children }: { title: string; children: R
   )
 }
 
-/**
- * Checkbox button used across import tables, supporting a mixed state for a row selection that is
- * only partially checked
- */
-export function ImportCheckbox({
-  checked,
-  disabled,
-  indeterminate = false,
-  label,
-  onChange,
-}: {
-  checked: boolean
-  disabled?: boolean
-  indeterminate?: boolean
-  label: string
-  onChange: () => void
-}) {
-  return (
-    <button
-      type="button"
-      role="checkbox"
-      aria-checked={indeterminate ? 'mixed' : checked}
-      aria-label={label}
-      className="mx-auto flex h-5 w-5 items-center justify-center rounded-lg transition-opacity duration-150 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2"
-      style={{
-        background: checked || indeterminate ? 'var(--app-accent)' : 'var(--app-input-bg)',
-        border: `1px solid ${checked || indeterminate ? 'var(--app-accent)' : 'var(--app-border-strong)'}`,
-        color: 'var(--app-button-primary-text)',
-        opacity: disabled ? 0.38 : 1,
-        cursor: disabled ? 'not-allowed' : 'pointer',
-      }}
-      onClick={onChange}
-      disabled={disabled}
-    >
-      {checked && <Check size={13} strokeWidth={3} aria-hidden />}
-      {!checked && indeterminate && (
-        <span className="h-0.5 w-2.5 rounded-full" style={{ background: 'currentColor' }} aria-hidden />
-      )}
-    </button>
-  )
-}
 

--- a/frontend/src/pages/imports/components/tables/AccountMappingTable.tsx
+++ b/frontend/src/pages/imports/components/tables/AccountMappingTable.tsx
@@ -2,7 +2,7 @@ import Dropdown, { type DropdownOption } from '@/components/dropdown/Dropdown'
 import { CREATE_ACCOUNT_VALUE, IMPORT_INSET_STYLE, UNSET_BATCH_INSTITUTION } from '@/pages/imports/constants'
 import { OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
 import { canApplyBatchEditToRow, countImportAccountRowStates } from '@/pages/imports/utils'
-import { ImportCheckbox } from '@/pages/imports/components/Primitives'
+import { Checkbox } from '@/components/forms/Checkbox'
 
 /**
  * Table mapping every source account found in an import to an existing account or a new one, with a
@@ -147,11 +147,13 @@ export function ImportAccountMappingTable({
     return (
       <tr key={row.id} className={row.autoFilled ? 'import-auto-fill-row' : undefined}>
         <td className="px-4 py-3 align-middle">
-          <ImportCheckbox
-            checked={selectedRowIds.has(row.id)}
-            onChange={() => toggleRow(row)}
-            label={`Select ${row.source}`}
-          />
+          <span className="flex justify-center">
+            <Checkbox
+              checked={selectedRowIds.has(row.id)}
+              onChange={() => toggleRow(row)}
+              label={`Select ${row.source}`}
+            />
+          </span>
         </td>
         <td className="px-4 py-3 align-middle">
           <div className="flex min-w-0 items-center gap-2">
@@ -304,13 +306,15 @@ export function ImportAccountMappingTable({
           <thead style={{ color: 'var(--app-text-subtle)', background: 'var(--app-input-bg)' }}>
             <tr>
               <th className="w-12 px-4 py-3 font-medium">
-                <ImportCheckbox
-                  checked={allRowsSelected}
-                  indeterminate={someRowsSelected}
-                  onChange={toggleAllRows}
-                  disabled={rows.length === 0}
-                  label={allRowsSelected ? 'Deselect all accounts' : 'Select all accounts'}
-                />
+                <span className="flex justify-center">
+                  <Checkbox
+                    checked={allRowsSelected}
+                    indeterminate={someRowsSelected}
+                    onChange={toggleAllRows}
+                    disabled={rows.length === 0}
+                    label={allRowsSelected ? 'Deselect all accounts' : 'Select all accounts'}
+                  />
+                </span>
               </th>
               <th className="px-4 py-3 font-medium">Source Account</th>
               <th className="px-4 py-3 font-medium">Existing Account</th>

--- a/frontend/src/pages/imports/firefly/sections/FireflyBudgetImportStep.tsx
+++ b/frontend/src/pages/imports/firefly/sections/FireflyBudgetImportStep.tsx
@@ -1,5 +1,6 @@
 import { EyeOff } from 'lucide-react'
-import { EmptyState, ImportCheckbox, ImportInfoCard, ImportStep } from '@/pages/imports/components'
+import { Checkbox } from '@/components/forms/Checkbox'
+import { EmptyState, ImportInfoCard, ImportStep } from '@/pages/imports/components'
 import { FireflySkippedBudgetsTable } from '@/pages/imports/firefly/components'
 import type { FireflyImportWorkflow } from '@/pages/imports/firefly/hooks'
 
@@ -113,12 +114,14 @@ export function FireflyBudgetImportStep({
                 return (
                   <tr key={draft.name}>
                     <td className="px-4 py-2.5 align-middle">
-                      <ImportCheckbox
-                        checked={status !== 'imported' && selectedBudgetNames.has(draft.name)}
-                        disabled={!selectable}
-                        label={`Import ${draft.name}`}
-                        onChange={() => toggleBudgetSelection(draft.name)}
-                      />
+                      <span className="flex justify-center">
+                        <Checkbox
+                          checked={status !== 'imported' && selectedBudgetNames.has(draft.name)}
+                          disabled={!selectable}
+                          label={`Import ${draft.name}`}
+                          onChange={() => toggleBudgetSelection(draft.name)}
+                        />
+                      </span>
                     </td>
                     <td className="truncate px-4 py-2.5 align-middle font-medium">
                       <span className="inline-flex max-w-full min-w-0 items-center gap-2">

--- a/frontend/src/pages/settings/components/security-section/MultiFactorModal.tsx
+++ b/frontend/src/pages/settings/components/security-section/MultiFactorModal.tsx
@@ -7,7 +7,7 @@ import { ModalTitledPanel } from '@/components/modal/TitledPanel';
 import { RecoveryCodesModal } from '@/components/two-factor/RecoveryCodesModal';
 import { StepUpModal, type StepUpCredentials } from '@/components/two-factor/StepUpModal';
 import { TotpEnrollmentModal } from '@/components/two-factor/TotpEnrollmentModal';
-import { WarningCallout } from '@/components/two-factor/WarningCallout';
+import { WarningCallout } from '@/components/WarningCallout';
 import { usePasskeyManagement } from '@/pages/settings/hooks/usePasskeyManagement';
 import { useTwoFactorManagement } from '@/pages/settings/hooks/useTwoFactorManagement';
 import { ApiError } from '@/api/auth';

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -3,23 +3,24 @@ import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
 import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
 import TransactionRow, { type TransactionRowSelection } from '@/components/transactions/Row'
-import { TRANSACTION_LIST_EASE } from '@/pages/transactions/constants/transactionList'
+import {
+  REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL,
+  TRANSACTION_CHECKBOX_RAIL,
+  TRANSACTION_CHECKBOX_RAIL_DURATION_S,
+  TRANSACTION_CHECKBOX_RAIL_VARIABLE,
+  TRANSACTION_CHECKBOX_RAIL_WIDTH,
+  TRANSACTION_LIST_EASE,
+} from '@/pages/transactions/constants/transactionList'
 import type { TransactionDateGroup, TransactionListAccount } from '@/pages/transactions/types/transactionList'
 import { getTransactionDateGroupTotal } from '@/pages/transactions/utils/transactionDateGroups'
 import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEditability'
 
-// The six content tracks every row lines its cells up against
+// The six content tracks every row lines its cells up against, declared once and never added to.
+// Selection mode opens a rail beside them instead, because a checkbox column would have to appear
+// and disappear with the checkbox, and a row still animating one out against a list that has
+// already dropped the column has nowhere to put its content but a second line
 const LIST_COLUMNS =
   'min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
-
-// The same six, behind a track holding the checkbox, so selection mode adds a column rather than
-// squeezing the ones already there.
-//
-// A collapsed seventh track would let the browser ease the column open, but the row's column gap
-// applies after it whether or not it has any width, so every row outside selection mode would lose
-// that much space and start truncating text it fits today
-const SELECTING_COLUMNS =
-  'min-[1300px]:grid-cols-[1.75rem_2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
 
 /**
  * Renders grouped transaction rows with sticky date totals
@@ -48,7 +49,7 @@ export default function TransactionDateGroupList({
   prefersReducedMotion: boolean | null
   // Makes a newly added row or group appear without the grow in, used for a lazy loaded page of rows
   skipEnterAnimation?: boolean
-  // Adds the checkbox column, which the import preview never asks for
+  // Opens the rail the checkbox sits in, which the import preview never asks for
   isSelecting?: boolean
   buildRowSelection?: (transactionId: string, isReadOnly: boolean) => TransactionRowSelection
   onEditTransaction: (transaction: Transaction) => void
@@ -56,7 +57,18 @@ export default function TransactionDateGroupList({
   const { formatCurrency } = useMoneyFormatters()
 
   return (
-    <div className={`min-[1300px]:grid min-[1300px]:gap-x-3 ${isSelecting ? SELECTING_COLUMNS : LIST_COLUMNS}`}>
+    <motion.div
+      className={`min-[1300px]:grid min-[1300px]:gap-x-3 ${LIST_COLUMNS}`}
+      style={{ paddingLeft: TRANSACTION_CHECKBOX_RAIL }}
+      initial={false}
+      animate={{
+        [TRANSACTION_CHECKBOX_RAIL_VARIABLE]: isSelecting ? TRANSACTION_CHECKBOX_RAIL_WIDTH : '0rem',
+      }}
+      transition={{
+        duration: prefersReducedMotion ? 0 : TRANSACTION_CHECKBOX_RAIL_DURATION_S,
+        ease: TRANSACTION_LIST_EASE,
+      }}
+    >
       {/* initial={false} suppresses the first render and the whole-list swap on filter changes, so a
           group only animates here when it is genuinely added (a new day's first transaction) or removed
           (its last transaction deleted) while the list stays mounted */}
@@ -83,11 +95,13 @@ export default function TransactionDateGroupList({
               transition={{ duration: prefersReducedMotion ? 0 : 0.28, ease: TRANSACTION_LIST_EASE }}
             >
             <div
-              className="sticky z-20 flex items-center justify-between rounded-lg px-3 py-2 min-[1300px]:col-span-full"
+              className="sticky z-20 flex items-center justify-between rounded-lg py-2 pr-3 min-[1300px]:col-span-full"
               style={{
                 top: stickyTop,
                 background: 'var(--app-input-bg)',
                 borderBottom: '1px solid var(--app-border)',
+                ...REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL,
+                paddingLeft: `calc(0.75rem + ${TRANSACTION_CHECKBOX_RAIL})`,
               }}
             >
               <p
@@ -137,6 +151,6 @@ export default function TransactionDateGroupList({
           )
         })}
       </AnimatePresence>
-    </div>
+    </motion.div>
   )
 }

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -115,19 +115,19 @@ export default function TransactionDateGroupList({
               transition={{ duration: prefersReducedMotion ? 0 : 0.28, ease: TRANSACTION_LIST_EASE }}
             >
             <div
-              className="sticky z-20 min-[1300px]:col-span-full"
+              className="sticky z-20 flex items-center justify-between rounded-lg py-2 pr-3 min-[1300px]:col-span-full"
               style={{
                 top: stickyTop,
-                // The page colour, which shows only in the rail beside the pill. It has to be
-                // opaque, since rows scroll underneath a heading once it has stuck
-                background: 'var(--app-bg)',
+                background: 'var(--app-input-bg)',
+                borderBottom: '1px solid var(--app-border)',
                 ...REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL,
-                paddingLeft: TRANSACTION_CHECKBOX_RAIL,
+                // The rail on top of the same padding the other side carries as pr-3, so the label
+                // starts level with the category icon under it
+                paddingLeft: `calc(0.75rem + ${TRANSACTION_CHECKBOX_RAIL})`,
               }}
             >
-              {/* Laid over the rail the way a row's tick is, so it takes none of the list's columns.
-                  It sits on the page colour rather than on the pill, whose own colour is the one an
-                  unticked box fills with and against which it would not read */}
+              {/* Laid over the rail the way a row's tick is, so it takes none of the list's columns
+                  and lines up with the ticks below it, while staying inside the heading's own bar */}
               <AnimatePresence initial={false}>
                 {headingSelection && (
                   <motion.span
@@ -150,6 +150,9 @@ export default function TransactionDateGroupList({
                       checked={headingSelection.mark === 'all'}
                       indeterminate={headingSelection.mark === 'some'}
                       disabled={headingSelection.mark === 'unselectable'}
+                      // The heading's bar is the colour an empty box fills with by default, so the
+                      // box takes the page colour instead and reads as a well cut into the bar
+                      uncheckedBackground="var(--app-bg)"
                       // Says the rows it covers rather than the day, since the list loads a page at
                       // a time and the last heading usually stands over only part of its day
                       label={`Select the transactions shown on ${dateLabel}`}
@@ -159,26 +162,18 @@ export default function TransactionDateGroupList({
                 )}
               </AnimatePresence>
 
-              <div
-                className="flex items-center justify-between rounded-lg px-3 py-2"
-                style={{
-                  background: 'var(--app-input-bg)',
-                  borderBottom: '1px solid var(--app-border)',
-                }}
+              <p
+                className="text-sm font-semibold uppercase tracking-wide"
+                style={{ color: 'var(--app-text-subtle)' }}
               >
-                <p
-                  className="text-sm font-semibold uppercase tracking-wide"
-                  style={{ color: 'var(--app-text-subtle)' }}
-                >
-                  {dateLabel}
-                </p>
-                <p
-                  className="font-financial text-sm font-medium"
-                  style={{ color: dailyColor }}
-                >
-                  {formatCurrency(dailyTotal, currency)}
-                </p>
-              </div>
+                {dateLabel}
+              </p>
+              <p
+                className="font-financial text-sm font-medium"
+                style={{ color: dailyColor }}
+              >
+                {formatCurrency(dailyTotal, currency)}
+              </p>
             </div>
 
             <AnimatePresence initial={false}>

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -8,13 +8,16 @@ import type { TransactionDateGroup, TransactionListAccount } from '@/pages/trans
 import { getTransactionDateGroupTotal } from '@/pages/transactions/utils/transactionDateGroups'
 import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEditability'
 
-// The six content tracks every row lines its cells up against, behind a seventh holding the
-// checkbox. The checkbox track is always declared and collapses to nothing outside selection mode,
-// because a browser interpolates grid-template-columns only while the track count holds still, and
-// swapping between a six-track and a seven-track template would snap instead of easing
+// The six content tracks every row lines its cells up against
 const LIST_COLUMNS =
-  'min-[1300px]:grid-cols-[0rem_2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
+  'min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
 
+// The same six, behind a track holding the checkbox, so selection mode adds a column rather than
+// squeezing the ones already there.
+//
+// A collapsed seventh track would let the browser ease the column open, but the row's column gap
+// applies after it whether or not it has any width, so every row outside selection mode would lose
+// that much space and start truncating text it fits today
 const SELECTING_COLUMNS =
   'min-[1300px]:grid-cols-[1.75rem_2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
 
@@ -53,9 +56,7 @@ export default function TransactionDateGroupList({
   const { formatCurrency } = useMoneyFormatters()
 
   return (
-    <div
-      className={`min-[1300px]:grid min-[1300px]:gap-x-3 motion-reduce:transition-none min-[1300px]:transition-[grid-template-columns] min-[1300px]:duration-[220ms] min-[1300px]:ease-[cubic-bezier(0.25,0.1,0.25,1)] ${isSelecting ? SELECTING_COLUMNS : LIST_COLUMNS}`}
-    >
+    <div className={`min-[1300px]:grid min-[1300px]:gap-x-3 ${isSelecting ? SELECTING_COLUMNS : LIST_COLUMNS}`}>
       {/* initial={false} suppresses the first render and the whole-list swap on filter changes, so a
           group only animates here when it is genuinely added (a new day's first transaction) or removed
           (its last transaction deleted) while the list stays mounted */}

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -31,7 +31,11 @@ const LIST_COLUMNS =
  * Absent outside it, which is also how the heading knows whether to offer a tick at all
  */
 export interface TransactionDateHeadingSelection {
-  /** How the tick is marked, read against the rows the heading shows that the app allows editing */
+  /**
+   * How the tick is marked, read against the rows the heading shows that the app allows editing.
+   * Greyed as unselectable both when none of them can be edited at all and, with none of them
+   * ticked, when the limit leaves no room to add any
+   */
   mark: GroupSelectionMark
 
   // Takes whether the click that toggled the tick should clear the hover afterward, which the

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -2,10 +2,20 @@ import { AnimatePresence, motion } from 'motion/react'
 import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
 import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
-import TransactionRow from '@/components/transactions/Row'
+import TransactionRow, { type TransactionRowSelection } from '@/components/transactions/Row'
 import { TRANSACTION_LIST_EASE } from '@/pages/transactions/constants/transactionList'
 import type { TransactionDateGroup, TransactionListAccount } from '@/pages/transactions/types/transactionList'
 import { getTransactionDateGroupTotal } from '@/pages/transactions/utils/transactionDateGroups'
+import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEditability'
+
+// The six content tracks every row lines its cells up against
+const LIST_COLUMNS =
+  'min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
+
+// The same six, behind a track holding the checkbox, so selection mode adds a column rather than
+// squeezing the ones already there
+const SELECTING_COLUMNS =
+  'min-[1300px]:grid-cols-[1.75rem_2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
 
 /**
  * Renders grouped transaction rows with sticky date totals
@@ -20,6 +30,8 @@ export default function TransactionDateGroupList({
   stickyTop,
   prefersReducedMotion,
   skipEnterAnimation = false,
+  isSelecting = false,
+  buildRowSelection,
   onEditTransaction,
 }: {
   dateGroups: TransactionDateGroup[]
@@ -32,12 +44,15 @@ export default function TransactionDateGroupList({
   prefersReducedMotion: boolean | null
   // Makes a newly added row or group appear without the grow in, used for a lazy loaded page of rows
   skipEnterAnimation?: boolean
+  // Adds the checkbox column, which the import preview never asks for
+  isSelecting?: boolean
+  buildRowSelection?: (transactionId: string, isReadOnly: boolean) => TransactionRowSelection
   onEditTransaction: (transaction: Transaction) => void
 }) {
   const { formatCurrency } = useMoneyFormatters()
 
   return (
-    <div className="min-[1300px]:grid min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content] min-[1300px]:gap-x-3">
+    <div className={`min-[1300px]:grid min-[1300px]:gap-x-3 ${isSelecting ? SELECTING_COLUMNS : LIST_COLUMNS}`}>
       {/* initial={false} suppresses the first render and the whole-list swap on filter changes, so a
           group only animates here when it is genuinely added (a new day's first transaction) or removed
           (its last transaction deleted) while the list stays mounted */}
@@ -95,10 +110,11 @@ export default function TransactionDateGroupList({
                 const counterpartyAccount = transaction.counterparty_account_id
                   ? accountMap.get(transaction.counterparty_account_id)
                   : undefined
-                const readOnlyReason = rowAccount?.is_archived ? 'Archived · Read-only' : undefined
+                const readOnlyReason = getTransactionReadOnlyReason(transaction, accountMap, fixedAccount)
                 return (
                   <TransactionRow
                     key={transaction.id}
+                    selection={buildRowSelection?.(transaction.id, Boolean(readOnlyReason))}
                     accountInstitution={rowAccount?.institution}
                     accountName={rowAccount?.name}
                     counterpartyAccountName={counterpartyAccount?.name}

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -2,7 +2,9 @@ import { AnimatePresence, motion } from 'motion/react'
 import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
 import { useMoneyFormatters } from '@/hooks/useMoneyFormatters'
+import { Checkbox } from '@/components/forms/Checkbox'
 import TransactionRow, { type TransactionRowSelection } from '@/components/transactions/Row'
+import type { GroupSelectionMark } from '@/pages/transactions/components/bulk-edit/selection'
 import {
   REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL,
   TRANSACTION_CHECKBOX_RAIL,
@@ -23,6 +25,20 @@ const LIST_COLUMNS =
   'min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
 
 /**
+ * What a day heading needs while the list is in selection mode
+ *
+ * Absent outside it, which is also how the heading knows whether to offer a tick at all
+ */
+export interface TransactionDateHeadingSelection {
+  /** How the tick is marked, read against the rows the heading shows that the app allows editing */
+  mark: GroupSelectionMark
+
+  onToggle: () => void
+  onPointerMove: () => void
+  onPointerLeave: () => void
+}
+
+/**
  * Renders grouped transaction rows with sticky date totals
  */
 export default function TransactionDateGroupList({
@@ -37,6 +53,7 @@ export default function TransactionDateGroupList({
   skipEnterAnimation = false,
   isSelecting = false,
   buildRowSelection,
+  buildHeadingSelection,
   onEditTransaction,
 }: {
   dateGroups: TransactionDateGroup[]
@@ -52,6 +69,8 @@ export default function TransactionDateGroupList({
   // Opens the rail the checkbox sits in, which the import preview never asks for
   isSelecting?: boolean
   buildRowSelection?: (transactionId: string, isReadOnly: boolean) => TransactionRowSelection
+  // Takes the transactions one heading shows, which is what its tick covers
+  buildHeadingSelection?: (shownTransactionIds: string[]) => TransactionDateHeadingSelection
   onEditTransaction: (transaction: Transaction) => void
 }) {
   const { formatCurrency } = useMoneyFormatters()
@@ -76,6 +95,7 @@ export default function TransactionDateGroupList({
         {dateGroups.map(({ dateLabel, transactions }) => {
           const dailyTotal = getTransactionDateGroupTotal(transactions, fixedAccount)
           const dailyColor = dailyTotal >= 0 ? 'var(--app-positive)' : 'var(--app-negative)'
+          const headingSelection = buildHeadingSelection?.(transactions.map((transaction) => transaction.id))
           return (
             <motion.div
               key={`${dateLabel}-${listRevealKey}`}
@@ -95,27 +115,70 @@ export default function TransactionDateGroupList({
               transition={{ duration: prefersReducedMotion ? 0 : 0.28, ease: TRANSACTION_LIST_EASE }}
             >
             <div
-              className="sticky z-20 flex items-center justify-between rounded-lg py-2 pr-3 min-[1300px]:col-span-full"
+              className="sticky z-20 min-[1300px]:col-span-full"
               style={{
                 top: stickyTop,
-                background: 'var(--app-input-bg)',
-                borderBottom: '1px solid var(--app-border)',
+                // The page colour, which shows only in the rail beside the pill. It has to be
+                // opaque, since rows scroll underneath a heading once it has stuck
+                background: 'var(--app-bg)',
                 ...REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL,
-                paddingLeft: `calc(0.75rem + ${TRANSACTION_CHECKBOX_RAIL})`,
+                paddingLeft: TRANSACTION_CHECKBOX_RAIL,
               }}
             >
-              <p
-                className="text-sm font-semibold uppercase tracking-wide"
-                style={{ color: 'var(--app-text-subtle)' }}
+              {/* Laid over the rail the way a row's tick is, so it takes none of the list's columns.
+                  It sits on the page colour rather than on the pill, whose own colour is the one an
+                  unticked box fills with and against which it would not read */}
+              <AnimatePresence initial={false}>
+                {headingSelection && (
+                  <motion.span
+                    key="heading-checkbox"
+                    className="absolute inset-y-0 left-0 flex items-center justify-center"
+                    style={{ width: TRANSACTION_CHECKBOX_RAIL_WIDTH }}
+                    initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 0.72 }}
+                    animate={{ opacity: 1, scale: 1 }}
+                    exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, scale: 0.72 }}
+                    transition={{
+                      duration: prefersReducedMotion ? 0 : TRANSACTION_CHECKBOX_RAIL_DURATION_S,
+                      ease: TRANSACTION_LIST_EASE,
+                    }}
+                    // On a move rather than on entry, since a stuck heading travels under a still
+                    // pointer as the list scrolls and would otherwise light each day it passed
+                    onMouseMove={headingSelection.onPointerMove}
+                    onMouseLeave={headingSelection.onPointerLeave}
+                  >
+                    <Checkbox
+                      checked={headingSelection.mark === 'all'}
+                      indeterminate={headingSelection.mark === 'some'}
+                      disabled={headingSelection.mark === 'unselectable'}
+                      // Says the rows it covers rather than the day, since the list loads a page at
+                      // a time and the last heading usually stands over only part of its day
+                      label={`Select the transactions shown on ${dateLabel}`}
+                      onChange={headingSelection.onToggle}
+                    />
+                  </motion.span>
+                )}
+              </AnimatePresence>
+
+              <div
+                className="flex items-center justify-between rounded-lg px-3 py-2"
+                style={{
+                  background: 'var(--app-input-bg)',
+                  borderBottom: '1px solid var(--app-border)',
+                }}
               >
-                {dateLabel}
-              </p>
-              <p
-                className="font-financial text-sm font-medium"
-                style={{ color: dailyColor }}
-              >
-                {formatCurrency(dailyTotal, currency)}
-              </p>
+                <p
+                  className="text-sm font-semibold uppercase tracking-wide"
+                  style={{ color: 'var(--app-text-subtle)' }}
+                >
+                  {dateLabel}
+                </p>
+                <p
+                  className="font-financial text-sm font-medium"
+                  style={{ color: dailyColor }}
+                >
+                  {formatCurrency(dailyTotal, currency)}
+                </p>
+              </div>
             </div>
 
             <AnimatePresence initial={false}>

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -1,3 +1,4 @@
+import type React from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
@@ -33,9 +34,20 @@ export interface TransactionDateHeadingSelection {
   /** How the tick is marked, read against the rows the heading shows that the app allows editing */
   mark: GroupSelectionMark
 
-  onToggle: () => void
+  // Takes whether the click that toggled the tick should clear the hover afterward, which the
+  // heading decides off the raw event since only it has that
+  onToggle: (clearsHover: boolean) => void
   onPointerMove: () => void
   onPointerLeave: () => void
+}
+
+/**
+ * Returns whether a click came from an actual mouse, which is the only input that leaves a pointer
+ * resting on the heading afterward for a later move to clear the hover preview. A touch tap and a
+ * keyboard activation both lack that, so the heading clears the hover itself for either one
+ */
+function isMouseClick(event: React.MouseEvent): boolean {
+  return event.nativeEvent instanceof PointerEvent && event.nativeEvent.pointerType === 'mouse'
 }
 
 /**
@@ -156,7 +168,7 @@ export default function TransactionDateGroupList({
                       // Says the rows it covers rather than the day, since the list loads a page at
                       // a time and the last heading usually stands over only part of its day
                       label={`Select the transactions shown on ${dateLabel}`}
-                      onChange={headingSelection.onToggle}
+                      onChange={(event) => headingSelection.onToggle(!isMouseClick(event))}
                     />
                   </motion.span>
                 )}

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -8,12 +8,13 @@ import type { TransactionDateGroup, TransactionListAccount } from '@/pages/trans
 import { getTransactionDateGroupTotal } from '@/pages/transactions/utils/transactionDateGroups'
 import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEditability'
 
-// The six content tracks every row lines its cells up against
+// The six content tracks every row lines its cells up against, behind a seventh holding the
+// checkbox. The checkbox track is always declared and collapses to nothing outside selection mode,
+// because a browser interpolates grid-template-columns only while the track count holds still, and
+// swapping between a six-track and a seven-track template would snap instead of easing
 const LIST_COLUMNS =
-  'min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
+  'min-[1300px]:grid-cols-[0rem_2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
 
-// The same six, behind a track holding the checkbox, so selection mode adds a column rather than
-// squeezing the ones already there
 const SELECTING_COLUMNS =
   'min-[1300px]:grid-cols-[1.75rem_2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
 
@@ -52,7 +53,9 @@ export default function TransactionDateGroupList({
   const { formatCurrency } = useMoneyFormatters()
 
   return (
-    <div className={`min-[1300px]:grid min-[1300px]:gap-x-3 ${isSelecting ? SELECTING_COLUMNS : LIST_COLUMNS}`}>
+    <div
+      className={`min-[1300px]:grid min-[1300px]:gap-x-3 motion-reduce:transition-none min-[1300px]:transition-[grid-template-columns] min-[1300px]:duration-[220ms] min-[1300px]:ease-[cubic-bezier(0.25,0.1,0.25,1)] ${isSelecting ? SELECTING_COLUMNS : LIST_COLUMNS}`}
+    >
       {/* initial={false} suppresses the first render and the whole-list swap on filter changes, so a
           group only animates here when it is genuinely added (a new day's first transaction) or removed
           (its last transaction deleted) while the list stays mounted */}

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -202,7 +202,7 @@ export default function TransactionDateGroupList({
                 const counterpartyAccount = transaction.counterparty_account_id
                   ? accountMap.get(transaction.counterparty_account_id)
                   : undefined
-                const readOnlyReason = getTransactionReadOnlyReason(transaction, accountMap, fixedAccount)
+                const readOnlyReason = getTransactionReadOnlyReason(transaction, accountMap, categoryMap, fixedAccount)
                 return (
                   <TransactionRow
                     key={transaction.id}

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -152,6 +152,11 @@ export default function TransactionListSection({
 
   const [isSelecting, setIsSelecting] = useState(false)
   const [pendingChange, setPendingChange] = useState<BulkEditFields | null>(null)
+
+  // The ids the change was validated against at Apply, frozen alongside pendingChange rather than
+  // read fresh off the live selection at Confirm, since the two have to agree on the same rows the
+  // panel's blockers were computed for
+  const [pendingChangeIds, setPendingChangeIds] = useState<string[]>([])
   const [applyError, setApplyError] = useState<string | null>(null)
   const { showToast } = useToast()
   const bulkUpdate = useBulkUpdateTransactions()
@@ -161,9 +166,9 @@ export default function TransactionListSection({
   const selectableRows = useMemo(
     () => displayedTransactions.map((transaction) => ({
       id: transaction.id,
-      isReadOnly: Boolean(getTransactionReadOnlyReason(transaction, accountMap, fixedAccount)),
+      isReadOnly: Boolean(getTransactionReadOnlyReason(transaction, accountMap, categoryMap, fixedAccount)),
     })),
-    [displayedTransactions, accountMap, fixedAccount],
+    [displayedTransactions, accountMap, categoryMap, fixedAccount],
   )
 
   const transactionCurrencyById = useMemo(
@@ -272,6 +277,26 @@ export default function TransactionListSection({
     // A write already sent keeps its confirmation, which is where its refusal has to land
     if (!bulkUpdate.isPending) {
       setPendingChange(null)
+      setPendingChangeIds([])
+      setApplyError(null)
+    }
+  }
+
+  // A refetch that changes which rows are selected, such as one dropping the only transfer among
+  // them, can land while the confirmation is open and holding ids the panel's blockers were
+  // validated against. Read by identity rather than by content, the same way the selection's own
+  // array is a new one on every dispatch that changes it, so this only fires on an actual change.
+  // The edit modal stays open underneath and picks up the new rows in its own preview, since only
+  // the confirmation, not the edit itself, was tied to the ids that just moved
+  const [lastCheckedSelectedIds, setLastCheckedSelectedIds] = useState(selection.selectedIds)
+  if (selection.selectedIds !== lastCheckedSelectedIds) {
+    setLastCheckedSelectedIds(selection.selectedIds)
+
+    // A write already sent keeps its confirmation, which is where its result has to land, whatever
+    // shrank the list while it was in flight
+    if (pendingChange !== null && !bulkUpdate.isPending) {
+      setPendingChange(null)
+      setPendingChangeIds([])
       setApplyError(null)
     }
   }
@@ -282,9 +307,19 @@ export default function TransactionListSection({
   const stopSelecting = useCallback(() => {
     setIsSelecting(false)
     setPendingChange(null)
+    setPendingChangeIds([])
     setApplyError(null)
     clearSelection()
   }, [clearSelection])
+
+  /**
+   * Freezes the modal's change together with the ids it was validated against, so a selection that
+   * moves before Confirm cannot pair a stale change with a different set of rows
+   */
+  function applyBulkEdit(fields: BulkEditFields) {
+    setPendingChangeIds(selection.selectedIds)
+    setPendingChange(fields)
+  }
 
   /**
    * Writes the change the modal holds, keeping the confirmation open when the server refuses it
@@ -293,7 +328,7 @@ export default function TransactionListSection({
     if (!pendingChange) return
     setApplyError(null)
     bulkUpdate.mutate(
-      { transaction_ids: selection.selectedIds, ...pendingChange },
+      { transaction_ids: pendingChangeIds, ...pendingChange },
       {
         onSuccess: (result) => {
           setPendingChange(null)
@@ -449,25 +484,31 @@ export default function TransactionListSection({
         <BulkEditModal
           key={editOpenings}
           open={isEditOpen}
-          onClose={() => setIsEditOpen(false)}
+          onClose={() => {
+            setIsEditOpen(false)
+            setPendingChange(null)
+            setPendingChangeIds([])
+            setApplyError(null)
+          }}
           onExitComplete={() => {
             if (!isEditOpen) setIsEditMounted(false)
           }}
           rows={selectedFacts}
           selectedCurrencies={selectedCurrencies}
           accounts={accountsForBulkEdit}
-          onApply={setPendingChange}
+          onApply={applyBulkEdit}
         />
       )}
 
       <BulkEditConfirm
         open={pendingChange !== null}
-        count={selection.selectedIds.length}
+        count={pendingChangeIds.length}
         error={applyError}
         isApplying={bulkUpdate.isPending}
         onConfirm={applyPendingChange}
         onCancel={() => {
           setPendingChange(null)
+          setPendingChangeIds([])
           setApplyError(null)
         }}
       />

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -164,6 +164,11 @@ export default function TransactionListSection({
     [displayedTransactions, accountMap, fixedAccount],
   )
 
+  const transactionCurrencyById = useMemo(
+    () => new Map(displayedTransactions.map((transaction) => [transaction.id, transaction.currency])),
+    [displayedTransactions],
+  )
+
   // The search text is not part of the filters, so both go into the key that empties a selection
   const requestKey = useMemo(
     () => `${JSON.stringify(filters)}|${activeSearch}`,
@@ -344,6 +349,14 @@ export default function TransactionListSection({
       {isSelecting && selection.selectedIds.length > 0 && (
         <BulkEditBar
           selectedIds={selection.selectedIds}
+          selectedCurrencies={[
+            ...new Set(
+              selection.selectedIds
+                .map((id) => transactionCurrencyById.get(id))
+                .filter((currency): currency is string => Boolean(currency)),
+            ),
+          ]}
+          accounts={fixedAccount ? [fixedAccount, ...accounts] : accounts}
           onApply={setPendingChange}
           onCancel={stopSelecting}
         />

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -194,7 +194,11 @@ export default function TransactionListSection({
   const buildHeadingSelection = useCallback(
     (shownTransactionIds: string[]) => ({
       mark: selection.groupMarkFor(shownTransactionIds),
-      onToggle: () => selection.toggleGroup(shownTransactionIds),
+
+      // A touch tap or a keyboard activation leaves no pointer resting on the heading afterward to
+      // clear the preview the way a mouse leaving the tick does, so the heading passes that along
+      // from the click itself
+      onToggle: (clearsHover: boolean) => selection.toggleGroup(shownTransactionIds, { clearsHover }),
       onPointerMove: () => selection.handleGroupPointerMove(shownTransactionIds),
       onPointerLeave: () => selection.handleGroupPointerLeave(),
     }),

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -356,7 +356,11 @@ export default function TransactionListSection({
                 .filter((currency): currency is string => Boolean(currency)),
             ),
           ]}
-          accounts={fixedAccount ? [fixedAccount, ...accounts] : accounts}
+          accounts={
+            fixedAccount && !accounts.some((account) => account.id === fixedAccount.id)
+              ? [fixedAccount, ...accounts]
+              : accounts
+          }
           onApply={setPendingChange}
           onCancel={stopSelecting}
         />

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -1,10 +1,18 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { useCategories } from '@/api/categories'
+import { ApiError } from '@/api/auth'
 import {
+  useBulkUpdateTransactions,
   useInfiniteTransactions,
+  type BulkUpdateTransactionsPayload,
   type Transaction,
 } from '@/api/transactions'
+import { useToast } from '@/hooks/useToast'
+import { BulkEditBar } from '@/pages/transactions/components/bulk-edit/BulkEditBar'
+import { BulkEditConfirm } from '@/pages/transactions/components/bulk-edit/BulkEditConfirm'
+import { useBulkSelection } from '@/pages/transactions/components/bulk-edit/useBulkSelection'
+import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEditability'
 import { getImportBlockReason, isImportableAccount } from '@/pages/imports/utils'
 import { TRANSACTION_FILTER_KEYS, TRANSACTION_LIST_EASE } from '@/pages/transactions/constants/transactionList'
 import TransactionDateGroupList from '@/pages/transactions/components/DateGroupList'
@@ -18,6 +26,9 @@ import { groupTransactionsByDate } from '@/pages/transactions/utils/transactionD
 import { normalizeTransactionFilters } from '@/pages/transactions/utils/normalizeTransactionFilters'
 
 const DEFAULT_DATE_HEADER_STICKY_TOP = 72
+
+/** What the bar sets, which is everything in a bulk request except the transactions it covers */
+type BulkEditFields = Omit<BulkUpdateTransactionsPayload, 'transaction_ids'>
 
 /**
  * Compares two filter values, treating arrays as equal when they hold the same members so
@@ -137,6 +148,75 @@ export default function TransactionListSection({
   const createDisabled = Boolean(fixedAccount?.is_archived)
   const createDisabledReason = createDisabled ? 'Archived accounts are read-only' : undefined
 
+  const [isSelecting, setIsSelecting] = useState(false)
+  const [pendingChange, setPendingChange] = useState<BulkEditFields | null>(null)
+  const [applyError, setApplyError] = useState<string | null>(null)
+  const { showToast } = useToast()
+  const bulkUpdate = useBulkUpdateTransactions()
+
+  // The rows a range runs along, in the order they appear, carrying the same editable rule the row
+  // itself shows
+  const selectableRows = useMemo(
+    () => displayedTransactions.map((transaction) => ({
+      id: transaction.id,
+      isReadOnly: Boolean(getTransactionReadOnlyReason(transaction, accountMap, fixedAccount)),
+    })),
+    [displayedTransactions, accountMap, fixedAccount],
+  )
+
+  // The search text is not part of the filters, so both go into the key that empties a selection
+  const requestKey = useMemo(
+    () => `${JSON.stringify(filters)}|${activeSearch}`,
+    [filters, activeSearch],
+  )
+
+  const selection = useBulkSelection(selectableRows, requestKey, !filterListLoading)
+  const { clear: clearSelection } = selection
+
+  const buildRowSelection = useCallback(
+    (transactionId: string, isReadOnly: boolean) => ({
+      mark: selection.markFor(transactionId),
+      isSelectable: !isReadOnly,
+      onToggle: (withShift: boolean) => selection.toggle(transactionId, withShift),
+      onPointerEnter: () => selection.handlePointerEnter(transactionId),
+    }),
+    [selection],
+  )
+
+  /**
+   * Leaves selection mode, dropping the ticks and the anchor with it
+   */
+  const stopSelecting = useCallback(() => {
+    setIsSelecting(false)
+    setPendingChange(null)
+    setApplyError(null)
+    clearSelection()
+  }, [clearSelection])
+
+  /**
+   * Writes the change the bar holds, keeping the confirmation open when the server refuses it
+   */
+  function applyPendingChange() {
+    if (!pendingChange) return
+    setApplyError(null)
+    bulkUpdate.mutate(
+      { transaction_ids: selection.selectedIds, ...pendingChange },
+      {
+        onSuccess: (result) => {
+          setPendingChange(null)
+          clearSelection()
+          showToast({
+            status: 'success',
+            text: `${result.transactions_updated} ${result.transactions_updated === 1 ? 'transaction' : 'transactions'} updated.`,
+          })
+        },
+        onError: (error) => {
+          setApplyError(error instanceof ApiError ? error.message : 'Something went wrong. Please try again.')
+        },
+      },
+    )
+  }
+
   // Only a list fixed to one account can be blocked, since only that one writes rows to an account
   // of its own. On the list of every account the button is the way to the import page and is always
   // offered. Where it is blocked it stays on the row, greyed out with the reason, rather than
@@ -187,9 +267,15 @@ export default function TransactionListSection({
         importDisabled={importDisabled}
         importDisabledReason={importDisabledReason}
         onStickyOffsetChange={setDateHeaderStickyTop}
+        isSelecting={isSelecting}
+        onToggleSelecting={() => (isSelecting ? stopSelecting() : setIsSelecting(true))}
       />
 
-      <div className="relative" aria-busy={filterListLoading}>
+      <div
+        className="relative"
+        aria-busy={filterListLoading}
+        onMouseLeave={selection.handlePointerLeaveList}
+      >
         <AnimatePresence>
           {filterListLoading && <TransactionFilterLoadingOverlay reducedMotion={prefersReducedMotion} />}
         </AnimatePresence>
@@ -235,6 +321,8 @@ export default function TransactionListSection({
                 stickyTop={dateHeaderStickyTop}
                 prefersReducedMotion={prefersReducedMotion}
                 skipEnterAnimation={skipAppendedEnter}
+                isSelecting={isSelecting}
+                buildRowSelection={isSelecting ? buildRowSelection : undefined}
                 onEditTransaction={onEditTransaction}
               />
 
@@ -252,6 +340,26 @@ export default function TransactionListSection({
           ) : null}
         </AnimatePresence>
       </div>
+
+      {isSelecting && selection.selectedIds.length > 0 && (
+        <BulkEditBar
+          selectedIds={selection.selectedIds}
+          onApply={setPendingChange}
+          onCancel={stopSelecting}
+        />
+      )}
+
+      <BulkEditConfirm
+        open={pendingChange !== null}
+        count={selection.selectedIds.length}
+        error={applyError}
+        isApplying={bulkUpdate.isPending}
+        onConfirm={applyPendingChange}
+        onCancel={() => {
+          setPendingChange(null)
+          setApplyError(null)
+        }}
+      />
     </section>
   )
 }

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -227,6 +227,8 @@ export default function TransactionListSection({
         recordsFarSide: doesChosenCategoryRecordTransferTarget(categoryMap.get(transaction.category_id)),
         hasFarSideRecorded: transaction.counterparty_account_scope !== null,
         farSideAccountId: transaction.counterparty_account_id,
+        currency: transaction.currency,
+        direction: transaction.amount < 0 ? 'debit' : 'credit',
       }))
   }, [displayedTransactions, selection.selectedIds, categoryMap])
 

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -5,12 +5,16 @@ import { ApiError } from '@/api/auth'
 import {
   useBulkUpdateTransactions,
   useInfiniteTransactions,
-  type BulkUpdateTransactionsPayload,
   type Transaction,
 } from '@/api/transactions'
 import { useToast } from '@/hooks/useToast'
-import { BulkEditBar } from '@/pages/transactions/components/bulk-edit/BulkEditBar'
+import { BulkEditModal } from '@/pages/transactions/components/bulk-edit/BulkEditModal'
 import { BulkEditConfirm } from '@/pages/transactions/components/bulk-edit/BulkEditConfirm'
+import {
+  doesChosenCategoryRecordTransferTarget,
+  type BulkEditFields,
+  type SelectedTransactionFacts,
+} from '@/pages/transactions/components/bulk-edit/selection'
 import { useBulkSelection } from '@/pages/transactions/components/bulk-edit/useBulkSelection'
 import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEditability'
 import { getImportBlockReason, isImportableAccount } from '@/pages/imports/utils'
@@ -26,9 +30,6 @@ import { groupTransactionsByDate } from '@/pages/transactions/utils/transactionD
 import { normalizeTransactionFilters } from '@/pages/transactions/utils/normalizeTransactionFilters'
 
 const DEFAULT_DATE_HEADER_STICKY_TOP = 72
-
-/** What the bar sets, which is everything in a bulk request except the transactions it covers */
-type BulkEditFields = Omit<BulkUpdateTransactionsPayload, 'transaction_ids'>
 
 /**
  * Compares two filter values, treating arrays as equal when they hold the same members so
@@ -200,6 +201,70 @@ export default function TransactionListSection({
     [selection],
   )
 
+  const [isEditOpen, setIsEditOpen] = useState(false)
+
+  // Kept mounted only while the edit is up or closing, so each opening starts on a fresh set of
+  // controls. Left mounted throughout, it would come back holding what the last edit set, and applying
+  // that to a different set of transactions is a change nobody asked for. It would also keep loading
+  // merchants and tags on a page where nobody has asked to edit anything
+  const [isEditMounted, setIsEditMounted] = useState(false)
+
+  // Keys the modal, so a reopen inside the quarter second the last one takes to fade out still mounts a
+  // fresh instance rather than reusing the one still on its way off screen
+  const [editOpenings, setEditOpenings] = useState(0)
+
+  // What the bulk edit rules read about each ticked row. Whether a transfer has an answer for its
+  // other side is read off the scope rather than the account, the way the server reads it, so one
+  // recorded as going outside the tracked accounts counts as answered
+  const selectedFacts = useMemo<SelectedTransactionFacts[]>(() => {
+    const selected = new Set(selection.selectedIds)
+    return displayedTransactions
+      .filter((transaction) => selected.has(transaction.id))
+      .map((transaction) => ({
+        id: transaction.id,
+        accountId: transaction.account_id,
+        hasMerchant: Boolean(transaction.merchant_id),
+        recordsFarSide: doesChosenCategoryRecordTransferTarget(categoryMap.get(transaction.category_id)),
+        hasFarSideRecorded: transaction.counterparty_account_scope !== null,
+        farSideAccountId: transaction.counterparty_account_id,
+      }))
+  }, [displayedTransactions, selection.selectedIds, categoryMap])
+
+  const selectedCurrencies = useMemo(
+    () => [
+      ...new Set(
+        selection.selectedIds
+          .map((id) => transactionCurrencyById.get(id))
+          .filter((currency): currency is string => Boolean(currency)),
+      ),
+    ],
+    [selection.selectedIds, transactionCurrencyById],
+  )
+
+  // A list fixed to one account is often showing an account the account list does not carry, and both
+  // the move targets and the far account options have to be able to name it
+  const accountsForBulkEdit = useMemo(
+    () => (fixedAccount && !accounts.some((account) => account.id === fixedAccount.id)
+      ? [fixedAccount, ...accounts]
+      : accounts),
+    [fixedAccount, accounts],
+  )
+
+  // Losing the last ticked row ends the edit, which a refetch that no longer carries those rows can do
+  // while it is open. It goes rather than animating out, since what it would animate out is a panel
+  // relabelling itself to nothing on the way. Closed here rather than derived from the count, since a
+  // count the user then puts back would reopen a dialog they never asked for a second time
+  if (isEditMounted && selection.selectedIds.length === 0) {
+    setIsEditOpen(false)
+    setIsEditMounted(false)
+
+    // A write already sent keeps its confirmation, which is where its refusal has to land
+    if (!bulkUpdate.isPending) {
+      setPendingChange(null)
+      setApplyError(null)
+    }
+  }
+
   /**
    * Leaves selection mode, dropping the ticks, the anchor and any preview with them
    */
@@ -211,7 +276,7 @@ export default function TransactionListSection({
   }, [clearSelection])
 
   /**
-   * Writes the change the bar holds, keeping the confirmation open when the server refuses it
+   * Writes the change the modal holds, keeping the confirmation open when the server refuses it
    */
   function applyPendingChange() {
     if (!pendingChange) return
@@ -221,7 +286,10 @@ export default function TransactionListSection({
       {
         onSuccess: (result) => {
           setPendingChange(null)
-          clearSelection()
+
+          // Ends selection mode rather than only dropping the ticks, which would leave every checkbox
+          // on screen with nothing in them and read as though nothing had happened
+          stopSelecting()
           showToast({
             status: 'success',
             text: `${result.transactions_updated} ${result.transactions_updated === 1 ? 'transaction' : 'transactions'} updated.`,
@@ -285,6 +353,13 @@ export default function TransactionListSection({
         importDisabledReason={importDisabledReason}
         onStickyOffsetChange={setDateHeaderStickyTop}
         isSelecting={isSelecting}
+        selectedCount={selection.selectedIds.length}
+        editDisabledReason={categories ? undefined : 'Categories have not loaded yet'}
+        onEditSelection={() => {
+          setEditOpenings((count) => count + 1)
+          setIsEditMounted(true)
+          setIsEditOpen(true)
+        }}
         onToggleSelecting={() => (isSelecting ? stopSelecting() : setIsSelecting(true))}
       />
 
@@ -359,23 +434,18 @@ export default function TransactionListSection({
         </AnimatePresence>
       </div>
 
-      {isSelecting && selection.selectedIds.length > 0 && (
-        <BulkEditBar
-          selectedIds={selection.selectedIds}
-          selectedCurrencies={[
-            ...new Set(
-              selection.selectedIds
-                .map((id) => transactionCurrencyById.get(id))
-                .filter((currency): currency is string => Boolean(currency)),
-            ),
-          ]}
-          accounts={
-            fixedAccount && !accounts.some((account) => account.id === fixedAccount.id)
-              ? [fixedAccount, ...accounts]
-              : accounts
-          }
+      {isEditMounted && (
+        <BulkEditModal
+          key={editOpenings}
+          open={isEditOpen}
+          onClose={() => setIsEditOpen(false)}
+          onExitComplete={() => {
+            if (!isEditOpen) setIsEditMounted(false)
+          }}
+          rows={selectedFacts}
+          selectedCurrencies={selectedCurrencies}
+          accounts={accountsForBulkEdit}
           onApply={setPendingChange}
-          onCancel={stopSelecting}
         />
       )}
 

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -10,6 +10,7 @@ import {
 import { useToast } from '@/hooks/useToast'
 import { BulkEditModal } from '@/pages/transactions/components/bulk-edit/BulkEditModal'
 import { BulkEditConfirm } from '@/pages/transactions/components/bulk-edit/BulkEditConfirm'
+import { selectedTransactionsSignature } from '@/pages/transactions/components/bulk-edit/confirmation'
 import {
   doesChosenCategoryRecordTransferTarget,
   isRowSelectable,
@@ -153,10 +154,10 @@ export default function TransactionListSection({
   const [isSelecting, setIsSelecting] = useState(false)
   const [pendingChange, setPendingChange] = useState<BulkEditFields | null>(null)
 
-  // The ids the change was validated against at Apply, frozen alongside pendingChange rather than
-  // read fresh off the live selection at Confirm, since the two have to agree on the same rows the
-  // panel's blockers were computed for
+  // The ids and stored values the change was validated against at Apply, frozen alongside
+  // pendingChange so Confirm cannot apply an old preview to refreshed transaction data
   const [pendingChangeIds, setPendingChangeIds] = useState<string[]>([])
+  const [pendingChangeSignature, setPendingChangeSignature] = useState<string | null>(null)
   const [applyError, setApplyError] = useState<string | null>(null)
   const { showToast } = useToast()
   const bulkUpdate = useBulkUpdateTransactions()
@@ -188,6 +189,10 @@ export default function TransactionListSection({
   // A Set rather than the array useBulkSelection returns, since isRowSelectable does a membership
   // check per row and a fresh array scan for each one would be quadratic in the list's length
   const selectedIdsSet = useMemo(() => new Set(selection.selectedIds), [selection.selectedIds])
+  const selectedChangeSignature = useMemo(
+    () => selectedTransactionsSignature(displayedTransactions, selection.selectedIds),
+    [displayedTransactions, selection.selectedIds],
+  )
 
   const buildRowSelection = useCallback(
     (transactionId: string, isReadOnly: boolean) => ({
@@ -279,27 +284,23 @@ export default function TransactionListSection({
     if (!bulkUpdate.isPending) {
       setPendingChange(null)
       setPendingChangeIds([])
+      setPendingChangeSignature(null)
       setApplyError(null)
     }
   }
 
-  // A refetch that changes which rows are selected, such as one dropping the only transfer among
-  // them, can land while the confirmation is open and holding ids the panel's blockers were
-  // validated against. Read by identity rather than by content, the same way the selection's own
-  // array is a new one on every dispatch that changes it, so this only fires on an actual change.
-  // The edit modal stays open underneath and picks up the new rows in its own preview, since only
-  // the confirmation, not the edit itself, was tied to the ids that just moved
-  const [lastCheckedSelectedIds, setLastCheckedSelectedIds] = useState(selection.selectedIds)
-  if (selection.selectedIds !== lastCheckedSelectedIds) {
-    setLastCheckedSelectedIds(selection.selectedIds)
-
-    // A write already sent keeps its confirmation, which is where its result has to land, whatever
-    // shrank the list while it was in flight
-    if (pendingChange !== null && !bulkUpdate.isPending) {
-      setPendingChange(null)
-      setPendingChangeIds([])
-      setApplyError(null)
-    }
+  // Keep a sent request visible until it settles. If its confirmation then remains open after a
+  // refusal, the refreshed values still invalidate it on that render
+  if (
+    pendingChange !== null
+    && pendingChangeSignature !== null
+    && pendingChangeSignature !== selectedChangeSignature
+    && !bulkUpdate.isPending
+  ) {
+    setPendingChange(null)
+    setPendingChangeIds([])
+    setPendingChangeSignature(null)
+    setApplyError(null)
   }
 
   /**
@@ -309,24 +310,32 @@ export default function TransactionListSection({
     setIsSelecting(false)
     setPendingChange(null)
     setPendingChangeIds([])
+    setPendingChangeSignature(null)
     setApplyError(null)
     clearSelection()
   }, [clearSelection])
 
   /**
-   * Freezes the modal's change together with the ids it was validated against, so a selection that
-   * moves before Confirm cannot pair a stale change with a different set of rows
+   * Freezes the modal's change with the selected ids and their stored values at Apply
    */
   function applyBulkEdit(fields: BulkEditFields) {
-    setPendingChangeIds(selection.selectedIds)
+    setPendingChangeIds([...selection.selectedIds])
+    setPendingChangeSignature(selectedChangeSignature)
     setPendingChange(fields)
   }
 
   /**
-   * Writes the change the modal holds, keeping the confirmation open when the server refuses it
+   * Writes the change the modal holds, keeping a refusal open while the selected values still match
    */
   function applyPendingChange() {
     if (!pendingChange) return
+    if (pendingChangeSignature !== selectedChangeSignature) {
+      setPendingChange(null)
+      setPendingChangeIds([])
+      setPendingChangeSignature(null)
+      setApplyError(null)
+      return
+    }
     setApplyError(null)
     bulkUpdate.mutate(
       { transaction_ids: pendingChangeIds, ...pendingChange },
@@ -489,6 +498,7 @@ export default function TransactionListSection({
             setIsEditOpen(false)
             setPendingChange(null)
             setPendingChangeIds([])
+            setPendingChangeSignature(null)
             setApplyError(null)
           }}
           onExitComplete={() => {
@@ -510,6 +520,7 @@ export default function TransactionListSection({
         onCancel={() => {
           setPendingChange(null)
           setPendingChangeIds([])
+          setPendingChangeSignature(null)
           setApplyError(null)
         }}
       />

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -242,6 +242,7 @@ export default function TransactionListSection({
         hasFarSideRecorded: transaction.counterparty_account_scope !== null,
         farSideAccountId: transaction.counterparty_account_id,
         currency: transaction.currency,
+        isZeroAmount: transaction.amount === 0,
         direction: transaction.amount < 0 ? 'debit' : 'credit',
       }))
   }, [displayedTransactions, selection.selectedIds, categoryMap])
@@ -260,8 +261,8 @@ export default function TransactionListSection({
   // A list fixed to one account is often showing an account the account list does not carry, and both
   // the move targets and the far account options have to be able to name it
   const accountsForBulkEdit = useMemo(
-    () => (fixedAccount && !accounts.some((account) => account.id === fixedAccount.id)
-      ? [fixedAccount, ...accounts]
+    () => (fixedAccount
+      ? [fixedAccount, ...accounts.filter((account) => account.id !== fixedAccount.id)]
       : accounts),
     [fixedAccount, accounts],
   )

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -188,8 +188,20 @@ export default function TransactionListSection({
     [selection],
   )
 
+  // Takes the transactions one day heading shows, which is what its tick covers. Whether any of them
+  // can be edited is decided inside the selection, so nothing is filtered here
+  const buildHeadingSelection = useCallback(
+    (shownTransactionIds: string[]) => ({
+      mark: selection.groupMarkFor(shownTransactionIds),
+      onToggle: () => selection.toggleGroup(shownTransactionIds),
+      onPointerMove: () => selection.handleGroupPointerMove(shownTransactionIds),
+      onPointerLeave: () => selection.handleGroupPointerLeave(),
+    }),
+    [selection],
+  )
+
   /**
-   * Leaves selection mode, dropping the ticks and the anchor with it
+   * Leaves selection mode, dropping the ticks, the anchor and any preview with them
    */
   const stopSelecting = useCallback(() => {
     setIsSelecting(false)
@@ -328,6 +340,7 @@ export default function TransactionListSection({
                 skipEnterAnimation={skipAppendedEnter}
                 isSelecting={isSelecting}
                 buildRowSelection={isSelecting ? buildRowSelection : undefined}
+                buildHeadingSelection={isSelecting ? buildHeadingSelection : undefined}
                 onEditTransaction={onEditTransaction}
               />
 

--- a/frontend/src/pages/transactions/components/ListSection.tsx
+++ b/frontend/src/pages/transactions/components/ListSection.tsx
@@ -12,6 +12,7 @@ import { BulkEditModal } from '@/pages/transactions/components/bulk-edit/BulkEdi
 import { BulkEditConfirm } from '@/pages/transactions/components/bulk-edit/BulkEditConfirm'
 import {
   doesChosenCategoryRecordTransferTarget,
+  isRowSelectable,
   type BulkEditFields,
   type SelectedTransactionFacts,
 } from '@/pages/transactions/components/bulk-edit/selection'
@@ -179,14 +180,18 @@ export default function TransactionListSection({
   const selection = useBulkSelection(selectableRows, requestKey, !filterListLoading)
   const { clear: clearSelection } = selection
 
+  // A Set rather than the array useBulkSelection returns, since isRowSelectable does a membership
+  // check per row and a fresh array scan for each one would be quadratic in the list's length
+  const selectedIdsSet = useMemo(() => new Set(selection.selectedIds), [selection.selectedIds])
+
   const buildRowSelection = useCallback(
     (transactionId: string, isReadOnly: boolean) => ({
       mark: selection.markFor(transactionId),
-      isSelectable: !isReadOnly,
+      isSelectable: isRowSelectable(transactionId, selectedIdsSet, isReadOnly),
       onToggle: (withShift: boolean) => selection.toggle(transactionId, withShift),
       onPointerEnter: () => selection.handlePointerEnter(transactionId),
     }),
-    [selection],
+    [selection, selectedIdsSet],
   )
 
   // Takes the transactions one day heading shows, which is what its tick covers. Whether any of them

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
@@ -6,6 +6,10 @@ import { useInfiniteTags } from '@/api/tags'
 import type { BulkUpdateTransactionsPayload } from '@/api/transactions'
 import Dropdown from '@/components/dropdown/Dropdown'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
+import {
+  buildBulkEditFields,
+  hasBulkEditChoice,
+} from '@/pages/transactions/components/bulk-edit/selection'
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
 
@@ -30,7 +34,14 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
   const [tagIds, setTagIds] = useState<string[]>([])
 
   const { data: categories } = useCategories()
-  const categoryOptions = useMemo(() => buildCategoryOptions(categories ?? []), [categories])
+
+  // Transfer categories are left out. A transfer has to record the account on its other side, this
+  // request carries no field for one, and a row that does not already record one is refused, so
+  // offering the choice would mostly produce a refused batch
+  const categoryOptions = useMemo(
+    () => buildCategoryOptions((categories ?? []).filter((category) => category.kind !== 'transfer')),
+    [categories],
+  )
 
   const merchantSearch = useDebouncedReferenceSearch(REFERENCE_SEARCH_DEBOUNCE_MS)
   const merchantQuery = useInfiniteMerchants(
@@ -48,12 +59,15 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
     .map((tag) => ({ value: tag.id, label: tag.name }))
   const tagNamesById = new Map(tags.map((tag) => [tag.id, tag.name]))
 
+  const choice = { categoryId, merchantId, tagIds }
   const overCap = selectedIds.length > MAX_BULK_EDIT_TRANSACTIONS
-  const setsSomething = Boolean(categoryId) || Boolean(merchantId) || tagIds.length > 0
+  const setsSomething = hasBulkEditChoice(choice)
 
   return (
     <div
-      className="fixed inset-x-0 bottom-0 z-40 border-t px-3 py-3"
+      // Sticky rather than fixed, so it takes the width of the page content instead of the whole
+      // viewport, keeps clear of the sidebar, and lands after the last row rather than covering it
+      className="sticky bottom-0 z-30 border-t px-3 py-3"
       style={{ background: 'var(--app-surface-soft)', borderColor: 'var(--app-border)' }}
       role="region"
       aria-label="Edit the selected transactions"
@@ -106,13 +120,7 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
           type="button"
           className="app-primary-button h-9 px-4 text-sm"
           disabled={!setsSomething || overCap}
-          onClick={() =>
-            onApply({
-              ...(categoryId ? { category_id: categoryId } : {}),
-              ...(merchantId ? { merchant_id: merchantId } : {}),
-              ...(tagIds.length ? { add_tag_ids: tagIds } : {}),
-            })
-          }
+          onClick={() => onApply(buildBulkEditFields(choice))}
         >
           Apply
         </button>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
@@ -12,6 +12,10 @@ import {
 } from '@/pages/transactions/components/bulk-edit/selection'
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
+import {
+  BALANCE_ADJUSTMENT_CATEGORY_NAME,
+  doesTransferRecordCounterpartyAccount,
+} from '@/utils/transfers'
 
 const REFERENCE_SEARCH_DEBOUNCE_MS = 250
 const REFERENCE_PAGE_SIZE = 20
@@ -23,23 +27,37 @@ interface BulkEditBarProps {
 }
 
 /**
- * The controls for a bulk edit, docked to the bottom of the viewport
+ * The controls for a bulk edit, held at the bottom of the list
  *
- * Docked there rather than in the toolbar, because the toolbar publishes its height to every sticky
- * date heading and a bar added to it would move all of them.
+ * At the bottom rather than in the toolbar, because the toolbar publishes its height to every
+ * sticky date heading and a bar added to it would move all of them.
  */
 export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps) {
   const [categoryId, setCategoryId] = useState('')
-  const [merchantId, setMerchantId] = useState('')
-  const [tagIds, setTagIds] = useState<string[]>([])
+
+  // The chosen merchant and tags are held with the label they were picked under. Closing a dropdown
+  // resets its search, which refetches the first page of records, and a record the search had found
+  // is not in it, so a label read back off the loaded page would turn into an identifier
+  const [merchant, setMerchant] = useState<{ value: string; label: string } | null>(null)
+  const [chosenTags, setChosenTags] = useState<{ value: string; label: string }[]>([])
+  const merchantId = merchant?.value ?? ''
+  const tagIds = chosenTags.map((tag) => tag.value)
 
   const { data: categories } = useCategories()
 
-  // Transfer categories are left out. A transfer has to record the account on its other side, this
-  // request carries no field for one, and a row that does not already record one is refused, so
-  // offering the choice would mostly produce a refused batch
+  // A category recording a counterparty account is left out. This request carries no field for one,
+  // and a row that does not already record one is refused, so offering the choice would mostly
+  // produce a refused batch. Balance Adjustment stays, being the one transfer category that records
+  // no counterparty and so applies to any row
   const categoryOptions = useMemo(
-    () => buildCategoryOptions((categories ?? []).filter((category) => category.kind !== 'transfer')),
+    () => buildCategoryOptions(
+      (categories ?? []).filter(
+        (category) => !doesTransferRecordCounterpartyAccount(
+          category.kind,
+          category.name === BALANCE_ADJUSTMENT_CATEGORY_NAME,
+        ),
+      ),
+    ),
     [categories],
   )
 
@@ -49,7 +67,7 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
     REFERENCE_PAGE_SIZE,
   )
   const merchants = merchantQuery.data?.pages.flat() ?? []
-  const merchantOptions = merchants.map((merchant) => ({ value: merchant.id, label: merchant.name }))
+  const merchantOptions = merchants.map((record) => ({ value: record.id, label: record.name }))
 
   const tagSearch = useDebouncedReferenceSearch(REFERENCE_SEARCH_DEBOUNCE_MS)
   const tagQuery = useInfiniteTags({ q: tagSearch.activeSearchText || undefined }, REFERENCE_PAGE_SIZE)
@@ -57,7 +75,6 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
   const tagOptions = tags
     .filter((tag) => !tagIds.includes(tag.id))
     .map((tag) => ({ value: tag.id, label: tag.name }))
-  const tagNamesById = new Map(tags.map((tag) => [tag.id, tag.name]))
 
   const choice = { categoryId, merchantId, tagIds }
   const overCap = selectedIds.length > MAX_BULK_EDIT_TRANSACTIONS
@@ -89,7 +106,10 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
         <Dropdown
           options={merchantOptions}
           value={merchantId}
-          onChange={setMerchantId}
+          selectedOption={merchant ?? undefined}
+          onChange={(value) => setMerchant(
+            merchantOptions.find((option) => option.value === value) ?? null,
+          )}
           placeholder="Merchant"
           searchable
           filterOptions={false}
@@ -104,7 +124,10 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
         <Dropdown
           options={tagOptions}
           value=""
-          onChange={(value) => setTagIds((current) => [...current, value])}
+          onChange={(value) => {
+            const picked = tagOptions.find((option) => option.value === value)
+            if (picked) setChosenTags((current) => [...current, picked])
+          }}
           placeholder="Add a tag"
           searchable
           filterOptions={false}
@@ -130,19 +153,19 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
         </button>
       </div>
 
-      {tagIds.length > 0 && (
+      {chosenTags.length > 0 && (
         <div className="mx-auto mt-2 flex max-w-6xl flex-wrap gap-1">
-          {tagIds.map((tagId) => (
+          {chosenTags.map((tag) => (
             <span
-              key={tagId}
+              key={tag.value}
               className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
               style={{ background: 'var(--app-accent-soft)' }}
             >
-              {tagNamesById.get(tagId) ?? tagId}
+              {tag.label}
               <button
                 type="button"
-                aria-label={`Remove ${tagNamesById.get(tagId) ?? tagId}`}
-                onClick={() => setTagIds((current) => current.filter((id) => id !== tagId))}
+                aria-label={`Remove ${tag.label}`}
+                onClick={() => setChosenTags((current) => current.filter((item) => item.value !== tag.value))}
               >
                 <X size={12} aria-hidden />
               </button>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
@@ -7,6 +7,8 @@ import Dropdown from '@/components/dropdown/Dropdown'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   buildBulkEditFields,
+  doesChosenCategoryRecordTransferTarget,
+  getBulkMoveTargets,
   hasBulkEditChoice,
   type BulkEditFields,
   type TransferTargetChoice,
@@ -14,12 +16,7 @@ import {
 import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
-import {
-  BALANCE_ADJUSTMENT_CATEGORY_NAME,
-  doesTransferRecordCounterpartyAccount,
-  OUTSIDE_ACCOUNT_LABEL,
-  OUTSIDE_ACCOUNT_VALUE,
-} from '@/utils/transfers'
+import { OUTSIDE_ACCOUNT_LABEL, OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
 
 const REFERENCE_SEARCH_DEBOUNCE_MS = 250
 const REFERENCE_PAGE_SIZE = 20
@@ -67,24 +64,10 @@ export function BulkEditBar({
   const categoryOptions = useMemo(() => buildCategoryOptions(categories ?? []), [categories])
 
   const chosenCategory = categories?.find((category) => category.id === categoryId)
-  const categoryRecordsTransferTarget = Boolean(
-    chosenCategory
-    && doesTransferRecordCounterpartyAccount(
-      chosenCategory.kind,
-      chosenCategory.name === BALANCE_ADJUSTMENT_CATEGORY_NAME,
-    ),
-  )
+  const categoryRecordsTransferTarget = doesChosenCategoryRecordTransferTarget(chosenCategory)
 
-  // A move keeps each row's stored exchange rate, and almost no imported row has one, so an account
-  // in another currency would refuse the whole batch. Offering only the ones that fit turns that
-  // refusal into a choice the user can see is unavailable
   const moveTargets = useMemo(
-    () => accounts.filter(
-      (account) => !account.is_archived
-        && !account.closed_at
-        && selectedCurrencies.length === 1
-        && account.currency === selectedCurrencies[0],
-    ),
+    () => getBulkMoveTargets(accounts, selectedCurrencies),
     [accounts, selectedCurrencies],
   )
   const accountOptions = moveTargets.map((account) => ({ value: account.id, label: account.name ?? 'Account' }))

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
@@ -1,0 +1,153 @@
+import { useMemo, useState } from 'react'
+import { X } from 'lucide-react'
+import { useCategories } from '@/api/categories'
+import { useInfiniteMerchants } from '@/api/merchants'
+import { useInfiniteTags } from '@/api/tags'
+import type { BulkUpdateTransactionsPayload } from '@/api/transactions'
+import Dropdown from '@/components/dropdown/Dropdown'
+import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
+import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
+import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
+
+const REFERENCE_SEARCH_DEBOUNCE_MS = 250
+const REFERENCE_PAGE_SIZE = 20
+
+interface BulkEditBarProps {
+  selectedIds: string[]
+  onApply: (payload: Omit<BulkUpdateTransactionsPayload, 'transaction_ids'>) => void
+  onCancel: () => void
+}
+
+/**
+ * The controls for a bulk edit, docked to the bottom of the viewport
+ *
+ * Docked there rather than in the toolbar, because the toolbar publishes its height to every sticky
+ * date heading and a bar added to it would move all of them.
+ */
+export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps) {
+  const [categoryId, setCategoryId] = useState('')
+  const [merchantId, setMerchantId] = useState('')
+  const [tagIds, setTagIds] = useState<string[]>([])
+
+  const { data: categories } = useCategories()
+  const categoryOptions = useMemo(() => buildCategoryOptions(categories ?? []), [categories])
+
+  const merchantSearch = useDebouncedReferenceSearch(REFERENCE_SEARCH_DEBOUNCE_MS)
+  const merchantQuery = useInfiniteMerchants(
+    { q: merchantSearch.activeSearchText || undefined },
+    REFERENCE_PAGE_SIZE,
+  )
+  const merchants = merchantQuery.data?.pages.flat() ?? []
+  const merchantOptions = merchants.map((merchant) => ({ value: merchant.id, label: merchant.name }))
+
+  const tagSearch = useDebouncedReferenceSearch(REFERENCE_SEARCH_DEBOUNCE_MS)
+  const tagQuery = useInfiniteTags({ q: tagSearch.activeSearchText || undefined }, REFERENCE_PAGE_SIZE)
+  const tags = tagQuery.data?.pages.flat() ?? []
+  const tagOptions = tags
+    .filter((tag) => !tagIds.includes(tag.id))
+    .map((tag) => ({ value: tag.id, label: tag.name }))
+  const tagNamesById = new Map(tags.map((tag) => [tag.id, tag.name]))
+
+  const overCap = selectedIds.length > MAX_BULK_EDIT_TRANSACTIONS
+  const setsSomething = Boolean(categoryId) || Boolean(merchantId) || tagIds.length > 0
+
+  return (
+    <div
+      className="fixed inset-x-0 bottom-0 z-40 border-t px-3 py-3"
+      style={{ background: 'var(--app-surface-soft)', borderColor: 'var(--app-border)' }}
+      role="region"
+      aria-label="Edit the selected transactions"
+    >
+      <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-2">
+        <p className="text-sm font-medium">
+          {selectedIds.length} selected
+        </p>
+
+        <Dropdown
+          options={categoryOptions}
+          value={categoryId}
+          onChange={setCategoryId}
+          placeholder="Category"
+          searchable
+          className="min-w-40 flex-1"
+        />
+
+        <Dropdown
+          options={merchantOptions}
+          value={merchantId}
+          onChange={setMerchantId}
+          placeholder="Merchant"
+          searchable
+          filterOptions={false}
+          searchValue={merchantSearch.search}
+          onSearchChange={merchantSearch.setSearch}
+          isLoading={merchantQuery.isFetching}
+          hasMore={merchantQuery.hasNextPage}
+          onLoadMore={merchantQuery.fetchNextPage}
+          className="min-w-40 flex-1"
+        />
+
+        <Dropdown
+          options={tagOptions}
+          value=""
+          onChange={(value) => setTagIds((current) => [...current, value])}
+          placeholder="Add a tag"
+          searchable
+          filterOptions={false}
+          searchValue={tagSearch.search}
+          onSearchChange={tagSearch.setSearch}
+          isLoading={tagQuery.isFetching}
+          hasMore={tagQuery.hasNextPage}
+          onLoadMore={tagQuery.fetchNextPage}
+          className="min-w-40 flex-1"
+        />
+
+        <button
+          type="button"
+          className="app-primary-button h-9 px-4 text-sm"
+          disabled={!setsSomething || overCap}
+          onClick={() =>
+            onApply({
+              ...(categoryId ? { category_id: categoryId } : {}),
+              ...(merchantId ? { merchant_id: merchantId } : {}),
+              ...(tagIds.length ? { add_tag_ids: tagIds } : {}),
+            })
+          }
+        >
+          Apply
+        </button>
+
+        <button type="button" className="app-secondary-button h-9 px-3 text-sm" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+
+      {tagIds.length > 0 && (
+        <div className="mx-auto mt-2 flex max-w-6xl flex-wrap gap-1">
+          {tagIds.map((tagId) => (
+            <span
+              key={tagId}
+              className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
+              style={{ background: 'var(--app-accent-soft)' }}
+            >
+              {tagNamesById.get(tagId) ?? tagId}
+              <button
+                type="button"
+                aria-label={`Remove ${tagNamesById.get(tagId) ?? tagId}`}
+                onClick={() => setTagIds((current) => current.filter((id) => id !== tagId))}
+              >
+                <X size={12} aria-hidden />
+              </button>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {overCap && (
+        <p className="mx-auto mt-2 max-w-6xl text-xs" style={{ color: 'var(--app-negative)' }}>
+          One edit covers at most {MAX_BULK_EDIT_TRANSACTIONS} transactions. Deselect some to continue.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditBar.tsx
@@ -3,18 +3,22 @@ import { X } from 'lucide-react'
 import { useCategories } from '@/api/categories'
 import { useInfiniteMerchants } from '@/api/merchants'
 import { useInfiniteTags } from '@/api/tags'
-import type { BulkUpdateTransactionsPayload } from '@/api/transactions'
 import Dropdown from '@/components/dropdown/Dropdown'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   buildBulkEditFields,
   hasBulkEditChoice,
+  type BulkEditFields,
+  type TransferTargetChoice,
 } from '@/pages/transactions/components/bulk-edit/selection'
+import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
 import {
   BALANCE_ADJUSTMENT_CATEGORY_NAME,
   doesTransferRecordCounterpartyAccount,
+  OUTSIDE_ACCOUNT_LABEL,
+  OUTSIDE_ACCOUNT_VALUE,
 } from '@/utils/transfers'
 
 const REFERENCE_SEARCH_DEBOUNCE_MS = 250
@@ -22,7 +26,12 @@ const REFERENCE_PAGE_SIZE = 20
 
 interface BulkEditBarProps {
   selectedIds: string[]
-  onApply: (payload: Omit<BulkUpdateTransactionsPayload, 'transaction_ids'>) => void
+
+  /** Currencies of the selected transactions, which is what limits where they can move to */
+  selectedCurrencies: string[]
+
+  accounts: TransactionListAccount[]
+  onApply: (payload: BulkEditFields) => void
   onCancel: () => void
 }
 
@@ -30,10 +39,21 @@ interface BulkEditBarProps {
  * The controls for a bulk edit, held at the bottom of the list
  *
  * At the bottom rather than in the toolbar, because the toolbar publishes its height to every
- * sticky date heading and a bar added to it would move all of them.
+ * sticky date heading and a panel added to it would move all of them.
  */
-export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps) {
+export function BulkEditBar({
+  selectedIds,
+  selectedCurrencies,
+  accounts,
+  onApply,
+  onCancel,
+}: BulkEditBarProps) {
   const [categoryId, setCategoryId] = useState('')
+  const [accountId, setAccountId] = useState('')
+  const [date, setDate] = useState('')
+  const [note, setNote] = useState('')
+  const [clearsNote, setClearsNote] = useState(false)
+  const [transferTarget, setTransferTarget] = useState<TransferTargetChoice | null>(null)
 
   // The chosen merchant and tags are held with the label they were picked under. Closing a dropdown
   // resets its search, which refetches the first page of records, and a record the search had found
@@ -44,22 +64,38 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
   const tagIds = chosenTags.map((tag) => tag.value)
 
   const { data: categories } = useCategories()
+  const categoryOptions = useMemo(() => buildCategoryOptions(categories ?? []), [categories])
 
-  // A category recording a counterparty account is left out. This request carries no field for one,
-  // and a row that does not already record one is refused, so offering the choice would mostly
-  // produce a refused batch. Balance Adjustment stays, being the one transfer category that records
-  // no counterparty and so applies to any row
-  const categoryOptions = useMemo(
-    () => buildCategoryOptions(
-      (categories ?? []).filter(
-        (category) => !doesTransferRecordCounterpartyAccount(
-          category.kind,
-          category.name === BALANCE_ADJUSTMENT_CATEGORY_NAME,
-        ),
-      ),
+  const chosenCategory = categories?.find((category) => category.id === categoryId)
+  const categoryRecordsTransferTarget = Boolean(
+    chosenCategory
+    && doesTransferRecordCounterpartyAccount(
+      chosenCategory.kind,
+      chosenCategory.name === BALANCE_ADJUSTMENT_CATEGORY_NAME,
     ),
-    [categories],
   )
+
+  // A move keeps each row's stored exchange rate, and almost no imported row has one, so an account
+  // in another currency would refuse the whole batch. Offering only the ones that fit turns that
+  // refusal into a choice the user can see is unavailable
+  const moveTargets = useMemo(
+    () => accounts.filter(
+      (account) => !account.is_archived
+        && !account.closed_at
+        && selectedCurrencies.length === 1
+        && account.currency === selectedCurrencies[0],
+    ),
+    [accounts, selectedCurrencies],
+  )
+  const accountOptions = moveTargets.map((account) => ({ value: account.id, label: account.name ?? 'Account' }))
+
+  const transferTargetOptions = [
+    { value: OUTSIDE_ACCOUNT_VALUE, label: OUTSIDE_ACCOUNT_LABEL },
+    ...accounts.map((account) => ({ value: account.id, label: account.name ?? 'Account' })),
+  ]
+  const transferTargetValue = transferTarget === null
+    ? ''
+    : transferTarget.scope === 'outside' ? OUTSIDE_ACCOUNT_VALUE : transferTarget.accountId
 
   const merchantSearch = useDebouncedReferenceSearch(REFERENCE_SEARCH_DEBOUNCE_MS)
   const merchantQuery = useInfiniteMerchants(
@@ -76,7 +112,17 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
     .filter((tag) => !tagIds.includes(tag.id))
     .map((tag) => ({ value: tag.id, label: tag.name }))
 
-  const choice = { categoryId, merchantId, tagIds }
+  const choice = {
+    categoryId,
+    merchantId,
+    tagIds,
+    accountId,
+    date,
+    note,
+    clearsNote,
+    transferTarget,
+    categoryRecordsTransferTarget,
+  }
   const overCap = selectedIds.length > MAX_BULK_EDIT_TRANSACTIONS
   const setsSomething = hasBulkEditChoice(choice)
 
@@ -89,96 +135,159 @@ export function BulkEditBar({ selectedIds, onApply, onCancel }: BulkEditBarProps
       role="region"
       aria-label="Edit the selected transactions"
     >
-      <div className="mx-auto flex max-w-6xl flex-wrap items-center gap-2">
-        <p className="text-sm font-medium">
-          {selectedIds.length} selected
-        </p>
+      <div className="mx-auto flex max-w-6xl flex-col gap-2">
+        <div className="grid gap-2 min-[750px]:grid-cols-2">
+          <Dropdown
+            options={categoryOptions}
+            value={categoryId}
+            onChange={setCategoryId}
+            placeholder="Category"
+            searchable
+          />
 
-        <Dropdown
-          options={categoryOptions}
-          value={categoryId}
-          onChange={setCategoryId}
-          placeholder="Category"
-          searchable
-          className="min-w-40 flex-1"
-        />
+          <Dropdown
+            options={merchantOptions}
+            value={merchantId}
+            selectedOption={merchant ?? undefined}
+            onChange={(value) => setMerchant(
+              merchantOptions.find((option) => option.value === value) ?? null,
+            )}
+            placeholder="Merchant"
+            searchable
+            filterOptions={false}
+            searchValue={merchantSearch.search}
+            onSearchChange={merchantSearch.setSearch}
+            isLoading={merchantQuery.isFetching}
+            hasMore={merchantQuery.hasNextPage}
+            onLoadMore={merchantQuery.fetchNextPage}
+          />
 
-        <Dropdown
-          options={merchantOptions}
-          value={merchantId}
-          selectedOption={merchant ?? undefined}
-          onChange={(value) => setMerchant(
-            merchantOptions.find((option) => option.value === value) ?? null,
+          <Dropdown
+            options={tagOptions}
+            value=""
+            onChange={(value) => {
+              const picked = tagOptions.find((option) => option.value === value)
+              if (picked) setChosenTags((current) => [...current, picked])
+            }}
+            placeholder="Add a tag"
+            searchable
+            filterOptions={false}
+            searchValue={tagSearch.search}
+            onSearchChange={tagSearch.setSearch}
+            isLoading={tagQuery.isFetching}
+            hasMore={tagQuery.hasNextPage}
+            onLoadMore={tagQuery.fetchNextPage}
+          />
+
+          <Dropdown
+            options={accountOptions}
+            value={accountId}
+            onChange={setAccountId}
+            placeholder="Move to account"
+            searchable
+            disabled={accountOptions.length === 0}
+          />
+
+          <input
+            type="date"
+            className="app-input app-date-field h-9"
+            aria-label="Set the date"
+            value={date}
+            onChange={(event) => setDate(event.target.value)}
+          />
+
+          <div className="flex items-center gap-2">
+            <input
+              type="text"
+              className="app-input h-9 min-w-0 flex-1"
+              aria-label="Set the note"
+              placeholder="Note"
+              value={note}
+              disabled={clearsNote}
+              onChange={(event) => setNote(event.target.value)}
+            />
+            <label className="flex shrink-0 items-center gap-1 text-xs">
+              <input
+                type="checkbox"
+                checked={clearsNote}
+                onChange={(event) => setClearsNote(event.target.checked)}
+              />
+              Clear
+            </label>
+          </div>
+
+          {categoryRecordsTransferTarget && (
+            <Dropdown
+              options={transferTargetOptions}
+              value={transferTargetValue}
+              onChange={(value) => setTransferTarget(
+                value === OUTSIDE_ACCOUNT_VALUE
+                  ? { scope: 'outside' }
+                  : { scope: 'tracked', accountId: value },
+              )}
+              placeholder="Where the money went"
+              searchable
+            />
           )}
-          placeholder="Merchant"
-          searchable
-          filterOptions={false}
-          searchValue={merchantSearch.search}
-          onSearchChange={merchantSearch.setSearch}
-          isLoading={merchantQuery.isFetching}
-          hasMore={merchantQuery.hasNextPage}
-          onLoadMore={merchantQuery.fetchNextPage}
-          className="min-w-40 flex-1"
-        />
-
-        <Dropdown
-          options={tagOptions}
-          value=""
-          onChange={(value) => {
-            const picked = tagOptions.find((option) => option.value === value)
-            if (picked) setChosenTags((current) => [...current, picked])
-          }}
-          placeholder="Add a tag"
-          searchable
-          filterOptions={false}
-          searchValue={tagSearch.search}
-          onSearchChange={tagSearch.setSearch}
-          isLoading={tagQuery.isFetching}
-          hasMore={tagQuery.hasNextPage}
-          onLoadMore={tagQuery.fetchNextPage}
-          className="min-w-40 flex-1"
-        />
-
-        <button
-          type="button"
-          className="app-primary-button h-9 px-4 text-sm"
-          disabled={!setsSomething || overCap}
-          onClick={() => onApply(buildBulkEditFields(choice))}
-        >
-          Apply
-        </button>
-
-        <button type="button" className="app-secondary-button h-9 px-3 text-sm" onClick={onCancel}>
-          Cancel
-        </button>
-      </div>
-
-      {chosenTags.length > 0 && (
-        <div className="mx-auto mt-2 flex max-w-6xl flex-wrap gap-1">
-          {chosenTags.map((tag) => (
-            <span
-              key={tag.value}
-              className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
-              style={{ background: 'var(--app-accent-soft)' }}
-            >
-              {tag.label}
-              <button
-                type="button"
-                aria-label={`Remove ${tag.label}`}
-                onClick={() => setChosenTags((current) => current.filter((item) => item.value !== tag.value))}
-              >
-                <X size={12} aria-hidden />
-              </button>
-            </span>
-          ))}
         </div>
-      )}
 
-      {overCap && (
-        <p className="mx-auto mt-2 max-w-6xl text-xs" style={{ color: 'var(--app-negative)' }}>
-          One edit covers at most {MAX_BULK_EDIT_TRANSACTIONS} transactions. Deselect some to continue.
-        </p>
-      )}
+        {chosenTags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {chosenTags.map((tag) => (
+              <span
+                key={tag.value}
+                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
+                style={{ background: 'var(--app-accent-soft)' }}
+              >
+                {tag.label}
+                <button
+                  type="button"
+                  aria-label={`Remove ${tag.label}`}
+                  onClick={() => setChosenTags((current) => current.filter((item) => item.value !== tag.value))}
+                >
+                  <X size={12} aria-hidden />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {selectedCurrencies.length > 1 && (
+          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
+            The selected transactions are in more than one currency, so they cannot move to another
+            account together. Narrow the selection to one currency first.
+          </p>
+        )}
+
+        {categoryRecordsTransferTarget && transferTarget === null && (
+          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
+            A transfer records where the money went, so answer that before applying.
+          </p>
+        )}
+
+        {overCap && (
+          <p className="text-xs" style={{ color: 'var(--app-negative)' }}>
+            One edit covers at most {MAX_BULK_EDIT_TRANSACTIONS} transactions. Deselect some to continue.
+          </p>
+        )}
+
+        <div className="flex items-center gap-2">
+          <p className="mr-auto text-sm font-medium">{selectedIds.length} selected</p>
+
+          <button
+            type="button"
+            className="app-primary-button h-9 px-4 text-sm"
+            disabled={!setsSomething || overCap}
+            onClick={() => onApply(buildBulkEditFields(choice))}
+          >
+            Apply
+          </button>
+
+          <button type="button" className="app-secondary-button h-9 px-3 text-sm" onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
@@ -1,5 +1,6 @@
 import { useId } from 'react'
-import { ModalShell } from '@/components/modal/Shell'
+import { ModalTitledPanel } from '@/components/modal/TitledPanel'
+import { WarningCallout } from '@/components/WarningCallout'
 
 interface BulkEditConfirmProps {
   open: boolean
@@ -27,50 +28,49 @@ export function BulkEditConfirm({
   const titleId = useId()
 
   return (
-    <ModalShell
+    <ModalTitledPanel
       open={open}
       onClose={onCancel}
       titleId={titleId}
-      panelClassName="app-modal-panel w-full max-w-md p-5"
-      // Opened from the edit modal rather than from the page, so it stacks above it rather than
-      // landing on top only because its portal node was appended later
+      eyebrow="Bulk edit"
+      title={`Change ${count} ${count === 1 ? 'transaction' : 'transactions'}?`}
+      widthClassName="max-w-md"
       level="stacked"
       closeDisabled={isApplying}
+      footer={(
+        // Row-reverse keeps Cancel ahead of Confirm in the DOM, so the first stops a Tab reaches,
+        // the close button and then Cancel, both abandon the batch, while drawing Cancel at the
+        // right beside the primary button
+        <div
+          className="flex shrink-0 flex-row-reverse justify-between gap-2 px-4 py-4 min-[1050px]:px-7"
+          style={{ borderTop: '1px solid var(--app-border)' }}
+        >
+          <button
+            type="button"
+            className="app-secondary-button h-9 px-3 text-sm"
+            onClick={onCancel}
+            disabled={isApplying}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="app-primary-button h-9 px-4 text-sm"
+            onClick={onConfirm}
+            disabled={isApplying}
+          >
+            {isApplying ? <div className="app-spinner" /> : 'Confirm'}
+          </button>
+        </div>
+      )}
     >
-      <h2 id={titleId} className="text-lg font-semibold">
-        Change {count} {count === 1 ? 'transaction' : 'transactions'}?
-      </h2>
-
-      <p className="mt-2 text-sm" style={{ color: 'var(--app-negative)' }}>
-        This cannot be undone.
-      </p>
+      <WarningCallout>This cannot be undone.</WarningCallout>
 
       {error && (
-        <p className="mt-3 text-sm" style={{ color: 'var(--app-negative)' }}>
+        <p className="mt-3 text-sm" role="alert" style={{ color: 'var(--app-negative)' }}>
           {error}
         </p>
       )}
-
-      {/* Row-reverse keeps Cancel first in the DOM, so it is still the first Tab stop and Tab then
-          Enter abandons the batch, while drawing it at the bottom-right beside the primary button */}
-      <div className="mt-5 flex flex-row-reverse justify-between gap-2">
-        <button
-          type="button"
-          className="app-secondary-button h-9 px-3 text-sm"
-          onClick={onCancel}
-          disabled={isApplying}
-        >
-          Cancel
-        </button>
-        <button
-          type="button"
-          className="app-primary-button h-9 px-4 text-sm"
-          onClick={onConfirm}
-          disabled={isApplying}
-        >
-          {isApplying ? <div className="app-spinner" /> : 'Confirm'}
-        </button>
-      </div>
-    </ModalShell>
+    </ModalTitledPanel>
   )
 }

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
@@ -11,7 +11,7 @@ interface BulkEditConfirmProps {
 }
 
 /**
- * Asks before a bulk edit is written, whatever the size of the selection
+ * Asks before a bulk edit is written, whatever the size of the selection, over the edit modal
  *
  * A refusal keeps this open and shows what the server said, since the batch is applied whole or not
  * at all and the user has to know that nothing changed.
@@ -32,6 +32,9 @@ export function BulkEditConfirm({
       onClose={onCancel}
       titleId={titleId}
       panelClassName="app-modal-panel w-full max-w-md p-5"
+      // Opened from the edit modal rather than from the page, so it stacks above it rather than
+      // landing on top only because its portal node was appended later
+      level="stacked"
       closeDisabled={isApplying}
     >
       <h2 id={titleId} className="text-lg font-semibold">

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
@@ -46,7 +46,7 @@ export function BulkEditConfirm({
         <ModalFormFooter
           submitLabel="Confirm"
           submitDisabled={isApplying}
-          submitWidthClassName="w-full sm:w-32"
+          submitWidthClassName="w-full sm:w-auto"
           error={error}
           level="stacked"
           onCancel={onCancel}

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
@@ -1,4 +1,6 @@
 import { useId } from 'react'
+import { PencilLine } from 'lucide-react'
+import { ModalFormFooter } from '@/components/modal/FormFooter'
 import { ModalTitledPanel } from '@/components/modal/TitledPanel'
 import { WarningCallout } from '@/components/WarningCallout'
 
@@ -15,7 +17,9 @@ interface BulkEditConfirmProps {
  * Asks before a bulk edit is written, whatever the size of the selection, over the edit modal
  *
  * A refusal keeps this open and shows what the server said, since the batch is applied whole or not
- * at all and the user has to know that nothing changed.
+ * at all and the user has to know that nothing changed. Styled like the Add Merchant dialog opened
+ * from the transaction form, down to its footer, so a second confirmation stacked over an edit modal
+ * reads as the same kind of dialog rather than a different one.
  */
 export function BulkEditConfirm({
   open,
@@ -34,43 +38,24 @@ export function BulkEditConfirm({
       titleId={titleId}
       eyebrow="Bulk edit"
       title={`Change ${count} ${count === 1 ? 'transaction' : 'transactions'}?`}
-      widthClassName="max-w-md"
+      RailIcon={PencilLine}
+      railLabel="Bulk edit"
       level="stacked"
       closeDisabled={isApplying}
       footer={(
-        // Row-reverse keeps Cancel ahead of Confirm in the DOM, so the first stops a Tab reaches,
-        // the close button and then Cancel, both abandon the batch, while drawing Cancel at the
-        // right beside the primary button
-        <div
-          className="flex shrink-0 flex-row-reverse justify-between gap-2 px-4 py-4 min-[1050px]:px-7"
-          style={{ borderTop: '1px solid var(--app-border)' }}
-        >
-          <button
-            type="button"
-            className="app-secondary-button h-9 px-3 text-sm"
-            onClick={onCancel}
-            disabled={isApplying}
-          >
-            Cancel
-          </button>
-          <button
-            type="button"
-            className="app-primary-button h-9 px-4 text-sm"
-            onClick={onConfirm}
-            disabled={isApplying}
-          >
-            {isApplying ? <div className="app-spinner" /> : 'Confirm'}
-          </button>
-        </div>
+        <ModalFormFooter
+          submitLabel="Confirm"
+          submitDisabled={isApplying}
+          submitWidthClassName="w-full sm:w-32"
+          error={error}
+          level="stacked"
+          onCancel={onCancel}
+          onPrimary={onConfirm}
+          primaryOnLeft
+        />
       )}
     >
       <WarningCallout>This cannot be undone.</WarningCallout>
-
-      {error && (
-        <p className="mt-3 text-sm" role="alert" style={{ color: 'var(--app-negative)' }}>
-          {error}
-        </p>
-      )}
     </ModalTitledPanel>
   )
 }

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
@@ -63,7 +63,7 @@ export function BulkEditConfirm({
           onClick={onConfirm}
           disabled={isApplying}
         >
-          {isApplying ? <div className="app-spinner" /> : 'Change them'}
+          {isApplying ? <div className="app-spinner" /> : count === 1 ? 'Change it' : 'Change them'}
         </button>
       </div>
     </ModalShell>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
@@ -1,0 +1,71 @@
+import { useId } from 'react'
+import { ModalShell } from '@/components/modal/Shell'
+
+interface BulkEditConfirmProps {
+  open: boolean
+  count: number
+  error: string | null
+  isApplying: boolean
+  onConfirm: () => void
+  onCancel: () => void
+}
+
+/**
+ * Asks before a bulk edit is written, whatever the size of the selection
+ *
+ * A refusal keeps this open and shows what the server said, since the batch is applied whole or not
+ * at all and the user has to know that nothing changed.
+ */
+export function BulkEditConfirm({
+  open,
+  count,
+  error,
+  isApplying,
+  onConfirm,
+  onCancel,
+}: BulkEditConfirmProps) {
+  const titleId = useId()
+
+  return (
+    <ModalShell
+      open={open}
+      onClose={onCancel}
+      titleId={titleId}
+      panelClassName="app-modal-panel w-full max-w-md p-5"
+      closeDisabled={isApplying}
+    >
+      <h2 id={titleId} className="text-lg font-semibold">
+        Change {count} {count === 1 ? 'transaction' : 'transactions'}?
+      </h2>
+
+      <p className="mt-2 text-sm" style={{ color: 'var(--app-text-subtle)' }}>
+        This cannot be undone.
+      </p>
+
+      {error && (
+        <p className="mt-3 text-sm" style={{ color: 'var(--app-negative)' }}>
+          {error}
+        </p>
+      )}
+
+      <div className="mt-5 flex justify-end gap-2">
+        <button
+          type="button"
+          className="app-secondary-button h-9 px-3 text-sm"
+          onClick={onCancel}
+          disabled={isApplying}
+        >
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="app-primary-button h-9 px-4 text-sm"
+          onClick={onConfirm}
+          disabled={isApplying}
+        >
+          {isApplying ? <div className="app-spinner" /> : 'Change them'}
+        </button>
+      </div>
+    </ModalShell>
+  )
+}

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditConfirm.tsx
@@ -41,7 +41,7 @@ export function BulkEditConfirm({
         Change {count} {count === 1 ? 'transaction' : 'transactions'}?
       </h2>
 
-      <p className="mt-2 text-sm" style={{ color: 'var(--app-text-subtle)' }}>
+      <p className="mt-2 text-sm" style={{ color: 'var(--app-negative)' }}>
         This cannot be undone.
       </p>
 
@@ -51,7 +51,9 @@ export function BulkEditConfirm({
         </p>
       )}
 
-      <div className="mt-5 flex justify-end gap-2">
+      {/* Row-reverse keeps Cancel first in the DOM, so it is still the first Tab stop and Tab then
+          Enter abandons the batch, while drawing it at the bottom-right beside the primary button */}
+      <div className="mt-5 flex flex-row-reverse justify-between gap-2">
         <button
           type="button"
           className="app-secondary-button h-9 px-3 text-sm"
@@ -66,7 +68,7 @@ export function BulkEditConfirm({
           onClick={onConfirm}
           disabled={isApplying}
         >
-          {isApplying ? <div className="app-spinner" /> : count === 1 ? 'Change it' : 'Change them'}
+          {isApplying ? <div className="app-spinner" /> : 'Confirm'}
         </button>
       </div>
     </ModalShell>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -335,7 +335,7 @@ export function BulkEditModal({
     directionIsImplied: direction.source === 'implied',
     endsAreOffered,
   }
-  const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget)
+  const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget, accounts)
   const canApply = canApplyBulkEdit(rows, choice, blockers)
 
   const transactionsWord = rows.length === 1 ? 'transaction' : 'transactions'

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -1,5 +1,5 @@
 import { useId, useMemo, useState, type ReactNode } from 'react'
-import { PencilLine, X } from 'lucide-react'
+import { PencilLine } from 'lucide-react'
 import { useCategories } from '@/api/categories'
 import { useInfiniteMerchants } from '@/api/merchants'
 import { useInfiniteTags } from '@/api/tags'
@@ -20,8 +20,10 @@ import {
   getBulkEditBlockers,
   getBulkMoveTargets,
   getTransferEndTargets,
+  toggleChosenTag,
   type BulkEditChoice,
   type BulkEditFields,
+  type ChosenTagOption,
   type SelectedTransactionFacts,
   type TransferEndChoice,
 } from '@/pages/transactions/components/bulk-edit/selection'
@@ -42,10 +44,10 @@ const MAX_NOTE_LENGTH = 500
 // Leaving it alone is an option of its own here, unlike on the single-transaction form, where every
 // transaction points one way or the other and none of them can abstain
 const DIRECTION_OPTIONS = [
-  { value: 'unchanged', label: 'Leave as it is' },
+  { value: 'unchanged', label: 'Leave as is' },
   { value: 'debit', label: 'Money out' },
   { value: 'credit', label: 'Money in' },
-  { value: 'reverse', label: 'Turn around' },
+  { value: 'reverse', label: 'Reverse' },
 ] as const
 
 /** Turns a dropdown's raw string value into the end choice the panel holds */
@@ -109,7 +111,7 @@ export function BulkEditModal({
   // resets its search, which refetches the first page of records, and a record the search had found
   // is not in it, so a label read back off the loaded page would turn into an identifier
   const [merchant, setMerchant] = useState<{ value: string; label: string } | null>(null)
-  const [chosenTags, setChosenTags] = useState<{ value: string; label: string }[]>([])
+  const [chosenTags, setChosenTags] = useState<ChosenTagOption[]>([])
   const merchantId = merchant?.value ?? ''
   const tagIds = chosenTags.map((tag) => tag.value)
 
@@ -132,7 +134,7 @@ export function BulkEditModal({
 
   const endTargets = useMemo(() => getTransferEndTargets(accounts), [accounts])
   const endOptions = [
-    { value: '', label: 'Leave it as it is' },
+    { value: '', label: 'Leave as is' },
     { value: OUTSIDE_ACCOUNT_VALUE, label: OUTSIDE_ACCOUNT_LABEL },
     ...endTargets.map((account) => ({ value: account.id, label: account.name ?? 'Account' })),
   ]
@@ -176,9 +178,21 @@ export function BulkEditModal({
   const tagSearch = useDebouncedReferenceSearch(REFERENCE_SEARCH_DEBOUNCE_MS)
   const tagQuery = useInfiniteTags({ q: tagSearch.activeSearchText || undefined }, REFERENCE_PAGE_SIZE)
   const tags = tagQuery.data?.pages.flat() ?? []
-  const tagOptions = tags
-    .filter((tag) => !tagIds.includes(tag.id))
-    .map((tag) => ({ value: tag.id, label: tag.name }))
+
+  // Chosen tags lead the list, ticked, ahead of the search results, so one can always be unticked
+  // whatever the search box holds. Search results already chosen are dropped rather than repeated
+  const tagOptions = [
+    ...chosenTags,
+    ...tags.filter((tag) => !tagIds.includes(tag.id)).map((tag) => ({ value: tag.id, label: tag.name })),
+  ]
+
+  // The trigger shows this while any tag is chosen, since the dropdown's own value stays blank so
+  // a pick never closes the list. getSelectedDropdownOption only keeps it when its value matches
+  // the blank value passed below, which is also why it goes undefined rather than an empty label
+  // once every tag is unticked
+  const chosenTagsOption = chosenTags.length > 0
+    ? { value: '', label: chosenTags.map((tag) => tag.label).join(', ') }
+    : undefined
 
   const choice: BulkEditChoice = {
     categoryId,
@@ -296,7 +310,7 @@ export function BulkEditModal({
                 options={accountOptions}
                 value={accountId}
                 onChange={changeMoveAccount}
-                placeholder={accountOptions.length === 0 ? 'No account it can move to' : 'Leave as it is'}
+                placeholder={accountOptions.length === 0 ? 'No account it can move to' : 'Leave as is'}
                 searchable
                 disabled={accountOptions.length === 0 || sendsAnEnd}
               />
@@ -312,7 +326,7 @@ export function BulkEditModal({
                 onChange={(value) => setMerchant(
                   merchantOptions.find((option) => option.value === value) ?? null,
                 )}
-                placeholder="Leave as it is"
+                placeholder="Leave as is"
                 searchable
                 filterOptions={false}
                 searchValue={merchantSearch.search}
@@ -330,7 +344,7 @@ export function BulkEditModal({
                 options={categoryOptions}
                 value={categoryId}
                 onChange={setCategoryId}
-                placeholder="Leave as it is"
+                placeholder="Leave as is"
                 searchable
               />
             </div>
@@ -341,11 +355,14 @@ export function BulkEditModal({
                 id="bulk-tags"
                 options={tagOptions}
                 value=""
+                selectedOption={chosenTagsOption}
+                selectedValues={tagIds}
+                closeOnSelect={false}
                 onChange={(value) => {
                   const picked = tagOptions.find((option) => option.value === value)
-                  if (picked) setChosenTags((current) => [...current, picked])
+                  if (picked) setChosenTags((current) => toggleChosenTag(current, picked))
                 }}
-                placeholder="Leave them as they are"
+                placeholder="Leave as is"
                 searchable
                 filterOptions={false}
                 searchValue={tagSearch.search}
@@ -354,26 +371,6 @@ export function BulkEditModal({
                 hasMore={tagQuery.hasNextPage}
                 onLoadMore={tagQuery.fetchNextPage}
               />
-              {chosenTags.length > 0 && (
-                <div className="flex flex-wrap gap-1 pt-2">
-                  {chosenTags.map((tag) => (
-                    <span
-                      key={tag.value}
-                      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
-                      style={{ background: 'var(--app-accent-soft)' }}
-                    >
-                      {tag.label}
-                      <button
-                        type="button"
-                        aria-label={`Remove ${tag.label}`}
-                        onClick={() => setChosenTags((current) => current.filter((item) => item.value !== tag.value))}
-                      >
-                        <X size={12} aria-hidden />
-                      </button>
-                    </span>
-                  ))}
-                </div>
-              )}
             </div>
 
             {endsAreOffered && (
@@ -385,7 +382,8 @@ export function BulkEditModal({
                     options={endOptions}
                     value={transferEndValue(transferFrom)}
                     onChange={(value) => changeTransferEnd(setTransferFrom, value)}
-                    placeholder="Leave it as it is"
+                    placeholder="Leave as is"
+                    blankOptionIsPlaceholder
                     searchable
                     disabled={Boolean(accountId)}
                   />
@@ -398,7 +396,8 @@ export function BulkEditModal({
                     options={endOptions}
                     value={transferEndValue(transferTo)}
                     onChange={(value) => changeTransferEnd(setTransferTo, value)}
-                    placeholder="Leave it as it is"
+                    placeholder="Leave as is"
+                    blankOptionIsPlaceholder
                     searchable
                     disabled={Boolean(accountId)}
                   />
@@ -440,7 +439,7 @@ export function BulkEditModal({
               id="bulk-note"
               type="text"
               className="app-input disabled:cursor-not-allowed disabled:opacity-60"
-              placeholder={clearsNote ? 'The note comes off' : 'Leave it as it is'}
+              placeholder={clearsNote ? 'The note comes off' : 'Leave as is'}
               value={note}
               disabled={clearsNote}
               onChange={(event) => setNote(event.target.value)}

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -19,6 +19,8 @@ import {
   canApplyBulkEdit,
   doesAnyResultingCategoryRecordTransferTarget,
   doesChosenCategoryRecordTransferTarget,
+  endsAfterDirectionClick,
+  endsAfterEndPick,
   getBulkEditBlockers,
   getBulkMoveTargets,
   getTransferEndTargets,
@@ -138,6 +140,22 @@ export function BulkEditModal({
     : undefined
   const endsAreOffered = doesAnyResultingCategoryRecordTransferTarget(chosenCategory, rows)
 
+  // Adjusted during render rather than in an effect, following React's own guidance for state that
+  // has to change in response to a prop, since a setState call in an effect body would cost this
+  // component an extra commit for every category change. A category change can turn a row into a
+  // transfer row or out of one, which is what decides each row's own side, so an outside end already
+  // on screen is re-checked against the new pairing the moment the category settles rather than
+  // waiting for the user to touch a pill or an end again
+  const [lastCheckedCategoryRule, setLastCheckedCategoryRule] = useState(chosenCategoryRecordsTransferTarget)
+  if (chosenCategoryRecordsTransferTarget !== lastCheckedCategoryRule) {
+    setLastCheckedCategoryRule(chosenCategoryRecordsTransferTarget)
+    const { from: nextFrom, to: nextTo } = endsAfterDirectionClick(
+      direction.value, transferFrom, transferTo, rows, chosenCategoryRecordsTransferTarget,
+    )
+    if (nextFrom !== transferFrom) setTransferFrom(nextFrom)
+    if (nextTo !== transferTo) setTransferTo(nextTo)
+  }
+
   const moveTargets = useMemo(
     () => getBulkMoveTargets(accounts, selectedCurrencies),
     [accounts, selectedCurrencies],
@@ -169,17 +187,35 @@ export function BulkEditModal({
    * Applies a From or To dropdown's new value, moving the account picker out of the way once either
    * end holds a real answer, then updates the direction pills against the new pairing. The
    * implication reads the end just changed and the other end's current value rather than state that
-   * has not updated yet
+   * has not updated yet. Routed through endsAfterEndPick first, so picking outside on the end still
+   * left as it is drops that one back to Leave as is rather than leaving both sides untracked
    */
   function changeTransferEnd(end: 'from' | 'to', value: string) {
-    const next = parseTransferEndValue(value, accounts)
-    if (end === 'from') setTransferFrom(next)
-    else setTransferTo(next)
-    if (next !== null) setAccountId('')
+    const picked = parseTransferEndValue(value, accounts)
+    const pickedFrom = end === 'from' ? picked : transferFrom
+    const pickedTo = end === 'to' ? picked : transferTo
+    const { from: nextFrom, to: nextTo } = endsAfterEndPick(pickedFrom, pickedTo, end)
 
-    const nextFrom = end === 'from' ? next : transferFrom
-    const nextTo = end === 'to' ? next : transferTo
+    setTransferFrom(nextFrom)
+    setTransferTo(nextTo)
+    if (picked !== null) setAccountId('')
+
     applyDirectionChange(impliedDirection(rows, nextFrom, nextTo, chosenCategoryRecordsTransferTarget))
+  }
+
+  /**
+   * Applies a direction pill's new value, first reverting whichever end the new direction would put
+   * outside the tracked accounts on some transfer row's own side, since a pick made from a stale
+   * pairing of ends could otherwise leave one of them with nowhere real to sit
+   */
+  function changeDirection(value: BulkDirectionChange | 'unchanged') {
+    const nextValue = value === 'unchanged' ? null : value
+    const { from: nextFrom, to: nextTo } = endsAfterDirectionClick(
+      nextValue, transferFrom, transferTo, rows, chosenCategoryRecordsTransferTarget,
+    )
+    setTransferFrom(nextFrom)
+    setTransferTo(nextTo)
+    setDirection({ value: nextValue, source: 'user' })
   }
 
   /**
@@ -243,6 +279,7 @@ export function BulkEditModal({
     transferFrom,
     transferTo,
     direction: effectiveDirection,
+    directionIsImplied: direction.source === 'implied',
     endsAreOffered,
   }
   const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget)
@@ -271,8 +308,8 @@ export function BulkEditModal({
   if (spansMultipleCurrencies) {
     moveAccountIcon = (
       <IconTooltip label="Multiple currencies" level="warn" widthClassName="w-72">
-        These transactions are in more than one currency, so they cannot move to one account
-        together. Narrow the selection to a single currency first.
+        The selected transactions span more than one currency, so they cannot move to one account
+        together.
       </IconTooltip>
     )
   } else if (hasNoAccountForCurrency) {
@@ -336,7 +373,7 @@ export function BulkEditModal({
                 options={accountOptions}
                 value={accountId}
                 onChange={changeMoveAccount}
-                placeholder={accountOptions.length === 0 ? 'No account it can move to' : 'Leave as is'}
+                placeholder={accountOptions.length === 0 ? 'No account to move to' : 'Leave as is'}
                 searchable
                 disabled={accountOptions.length === 0 || sendsAnEnd}
               />
@@ -362,7 +399,7 @@ export function BulkEditModal({
                   value={effectiveDirection ?? 'unchanged'}
                   options={DIRECTION_OPTIONS}
                   ariaLabel="Set which way the money moves"
-                  onChange={(value) => setDirection({ value: value === 'unchanged' ? null : value, source: 'user' })}
+                  onChange={changeDirection}
                 />
               </div>
             </div>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -9,6 +9,7 @@ import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow'
 import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import DateField from '@/components/date-field/DateField'
 import Dropdown from '@/components/dropdown/Dropdown'
+import { InfoCallout } from '@/components/InfoCallout'
 import { ModalTitledPanel } from '@/components/modal/TitledPanel'
 import IconTooltip from '@/components/tooltips/IconTooltip'
 import { DIRECTION_OPTIONS, EASE } from '@/pages/transactions/components/transaction-modal/constants'
@@ -25,6 +26,7 @@ import {
   getBulkMoveTargets,
   getTransferEndTargets,
   impliedDirection,
+  isMixedSelection,
   nextDirectionAfterEndChange,
   toggleChosenTag,
   type BulkDirectionChoice,
@@ -383,6 +385,13 @@ export function BulkEditModal({
       }
     >
       <div className="space-y-5">
+        {isMixedSelection(rows) && (
+          <InfoCallout>
+            You selected both transfers and other transactions. We recommend editing them separately
+            to avoid unintended changes to either kind.
+          </InfoCallout>
+        )}
+
         <CreateModalSectionFrame step="01" title="Account & Direction">
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="sm:col-span-2">

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -133,6 +133,12 @@ export function BulkEditModal({
   const { data: categories } = useCategories()
   const categoryOptions = useMemo(() => buildCategoryOptions(categories ?? []), [categories])
 
+  // Leading blank entry lets a pick be undone without closing the modal, ahead of every kind group
+  const categoryDropdownOptions = useMemo(
+    () => [{ value: '', label: 'Leave as is' }, ...categoryOptions],
+    [categoryOptions],
+  )
+
   const chosenCategory = categories?.find((category) => category.id === categoryId)
 
   // Undefined while no category is chosen, which is what says each row keeps its own
@@ -162,6 +168,14 @@ export function BulkEditModal({
     [accounts, selectedCurrencies],
   )
   const accountOptions = moveTargets.map((account) => ({ value: account.id, label: account.name ?? 'Account' }))
+
+  // Leading blank entry lets a pick be undone without closing the modal, matching From and To, but
+  // only when there is an account to move to. Adding it unconditionally would give an empty
+  // accountOptions a blank entry that matches the trigger's empty value, hiding the placeholder
+  // computed below for a currency with no other open account
+  const moveAccountOptions = accountOptions.length > 0
+    ? [{ value: '', label: 'Leave as is' }, ...accountOptions]
+    : []
 
   const endTargets = useMemo(() => getTransferEndTargets(accounts), [accounts])
   const endOptions = [
@@ -242,6 +256,10 @@ export function BulkEditModal({
   )
   const merchants = merchantQuery.data?.pages.flat() ?? []
   const merchantOptions = merchants.map((record) => ({ value: record.id, label: record.name }))
+
+  // Leading blank entry lets a pick be undone without closing the modal, ahead of the search
+  // results whatever the search text holds
+  const merchantDropdownOptions = [{ value: '', label: 'Leave as is' }, ...merchantOptions]
 
   const tagSearch = useDebouncedReferenceSearch(REFERENCE_SEARCH_DEBOUNCE_MS)
   const tagQuery = useInfiniteTags({ q: tagSearch.activeSearchText || undefined }, REFERENCE_PAGE_SIZE)
@@ -371,10 +389,11 @@ export function BulkEditModal({
               <CreateModalFieldLabelRow htmlFor="bulk-account" label="Move to account" accessory={moveAccountIcon} />
               <Dropdown
                 id="bulk-account"
-                options={accountOptions}
+                options={moveAccountOptions}
                 value={accountId}
                 onChange={changeMoveAccount}
                 placeholder={accountOptions.length === 0 ? 'No account to move to' : 'Leave as is'}
+                blankOptionIsPlaceholder
                 searchable
                 disabled={accountOptions.length === 0 || sendsAnEnd}
               />
@@ -455,13 +474,14 @@ export function BulkEditModal({
               <CreateModalFieldLabelRow htmlFor="bulk-merchant" label="Merchant" />
               <Dropdown
                 id="bulk-merchant"
-                options={merchantOptions}
+                options={merchantDropdownOptions}
                 value={merchantId}
                 selectedOption={merchant ?? undefined}
                 onChange={(value) => setMerchant(
-                  merchantOptions.find((option) => option.value === value) ?? null,
+                  value === '' ? null : merchantOptions.find((option) => option.value === value) ?? null,
                 )}
                 placeholder="Leave as is"
+                blankOptionIsPlaceholder
                 searchable
                 filterOptions={false}
                 searchValue={merchantSearch.search}
@@ -476,10 +496,11 @@ export function BulkEditModal({
               <CreateModalFieldLabelRow htmlFor="bulk-category" label="Category" />
               <Dropdown
                 id="bulk-category"
-                options={categoryOptions}
+                options={categoryDropdownOptions}
                 value={categoryId}
                 onChange={setCategoryId}
                 placeholder="Leave as is"
+                blankOptionIsPlaceholder
                 searchable
               />
             </div>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -1,16 +1,20 @@
-import { useMemo, useState } from 'react'
-import { X } from 'lucide-react'
+import { useId, useMemo, useState } from 'react'
+import { PencilLine, X } from 'lucide-react'
 import { useCategories } from '@/api/categories'
 import { useInfiniteMerchants } from '@/api/merchants'
 import { useInfiniteTags } from '@/api/tags'
 import Dropdown from '@/components/dropdown/Dropdown'
+import { ModalTitledPanel } from '@/components/modal/TitledPanel'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   buildBulkEditFields,
+  canApplyBulkEdit,
   doesChosenCategoryRecordTransferTarget,
+  doEveryResultingCategoryRecordTransferTarget,
+  getBulkEditBlockers,
   getBulkMoveTargets,
-  hasBulkEditChoice,
   type BulkEditFields,
+  type SelectedTransactionFacts,
   type TransferTargetChoice,
 } from '@/pages/transactions/components/bulk-edit/selection'
 import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
@@ -21,30 +25,40 @@ import { OUTSIDE_ACCOUNT_LABEL, OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
 const REFERENCE_SEARCH_DEBOUNCE_MS = 250
 const REFERENCE_PAGE_SIZE = 20
 
-interface BulkEditBarProps {
-  selectedIds: string[]
+interface BulkEditModalProps {
+  open: boolean
+  onClose: () => void
+
+  /** Runs once the close animation has finished, so the caller can unmount and reset the controls */
+  onExitComplete: () => void
+
+  /** The selected transactions, as the rules about what an edit may do to them see them */
+  rows: SelectedTransactionFacts[]
 
   /** Currencies of the selected transactions, which is what limits where they can move to */
   selectedCurrencies: string[]
 
   accounts: TransactionListAccount[]
   onApply: (payload: BulkEditFields) => void
-  onCancel: () => void
 }
 
 /**
- * The controls for a bulk edit, held at the bottom of the list
+ * Sets one set of details across every selected transaction
  *
- * At the bottom rather than in the toolbar, because the toolbar publishes its height to every
- * sticky date heading and a panel added to it would move all of them.
+ * Every control starts empty, meaning leave that field alone, and only the ones filled in are sent. The
+ * server writes the batch whole or not at all, so the refusals it would answer with are counted here and
+ * hold the button until they are settled.
  */
-export function BulkEditBar({
-  selectedIds,
+export function BulkEditModal({
+  open,
+  onClose,
+  onExitComplete,
+  rows,
   selectedCurrencies,
   accounts,
   onApply,
-  onCancel,
-}: BulkEditBarProps) {
+}: BulkEditModalProps) {
+  const titleId = useId()
   const [categoryId, setCategoryId] = useState('')
   const [accountId, setAccountId] = useState('')
   const [date, setDate] = useState('')
@@ -64,7 +78,13 @@ export function BulkEditBar({
   const categoryOptions = useMemo(() => buildCategoryOptions(categories ?? []), [categories])
 
   const chosenCategory = categories?.find((category) => category.id === categoryId)
-  const categoryRecordsTransferTarget = doesChosenCategoryRecordTransferTarget(chosenCategory)
+
+  // Undefined while no category is chosen, which is what says each row keeps its own
+  const chosenCategoryRecordsTransferTarget = chosenCategory
+    ? doesChosenCategoryRecordTransferTarget(chosenCategory)
+    : undefined
+  const resultingCategoriesRecordTransferTarget =
+    doEveryResultingCategoryRecordTransferTarget(chosenCategory, rows)
 
   const moveTargets = useMemo(
     () => getBulkMoveTargets(accounts, selectedCurrencies),
@@ -104,22 +124,49 @@ export function BulkEditBar({
     note,
     clearsNote,
     transferTarget,
-    categoryRecordsTransferTarget,
+    resultingCategoriesRecordTransferTarget,
   }
-  const overCap = selectedIds.length > MAX_BULK_EDIT_TRANSACTIONS
-  const setsSomething = hasBulkEditChoice(choice)
+  const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget)
+  const overCap = rows.length > MAX_BULK_EDIT_TRANSACTIONS
+  const canApply = canApplyBulkEdit(rows, choice, blockers)
+
+  const transactionsWord = rows.length === 1 ? 'transaction' : 'transactions'
 
   return (
-    <div
-      // Sticky rather than fixed, so it takes the width of the page content instead of the whole
-      // viewport, keeps clear of the sidebar, and lands after the last row rather than covering it
-      className="sticky bottom-0 z-30 border-t px-3 py-3"
-      style={{ background: 'var(--app-surface-soft)', borderColor: 'var(--app-border)' }}
-      role="region"
-      aria-label="Edit the selected transactions"
+    <ModalTitledPanel
+      open={open}
+      onClose={onClose}
+      onExitComplete={onExitComplete}
+      titleId={titleId}
+      eyebrow="Bulk edit"
+      title={`Edit ${rows.length} ${transactionsWord}`}
+      RailIcon={PencilLine}
+      railLabel="Bulk edit"
+      footer={
+        <div
+          className="flex shrink-0 items-center justify-end gap-2 px-4 py-4 min-[1050px]:px-8"
+          style={{ borderTop: '1px solid var(--app-border)' }}
+        >
+          <button type="button" className="app-secondary-button h-9 px-3 text-sm" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="app-primary-button h-9 px-4 text-sm"
+            disabled={!canApply}
+            onClick={() => onApply(buildBulkEditFields(choice))}
+          >
+            Apply
+          </button>
+        </div>
+      }
     >
-      <div className="mx-auto flex max-w-6xl flex-col gap-2">
-        <div className="grid gap-2 min-[750px]:grid-cols-2">
+      <div className="flex flex-col gap-3">
+        <p className="text-sm" style={{ color: 'var(--app-text-subtle)' }}>
+          A control left alone leaves that detail as it is on every selected transaction.
+        </p>
+
+        <div className="grid gap-3 min-[750px]:grid-cols-2">
           <Dropdown
             options={categoryOptions}
             value={categoryId}
@@ -199,7 +246,7 @@ export function BulkEditBar({
             </label>
           </div>
 
-          {categoryRecordsTransferTarget && (
+          {resultingCategoriesRecordTransferTarget && (
             <Dropdown
               options={transferTargetOptions}
               value={transferTargetValue}
@@ -235,16 +282,37 @@ export function BulkEditBar({
           </div>
         )}
 
+        {/* Each of these is a refusal the server answers for the whole batch, so it says what to do
+            about it here. Unticking a row is not one of the options, since every row behind this panel
+            is out of reach while it is open */}
+        {blockers.withoutMerchant.length > 0 && (
+          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
+            {blockers.withoutMerchant.length} selected {blockers.withoutMerchant.length === 1 ? 'transaction has' : 'transactions have'} no
+            merchant recorded. Set one here, or close this and untick them.
+          </p>
+        )}
+
+        {blockers.unansweredFarSide.length > 0 && (
+          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
+            {blockers.unansweredFarSide.length} selected {blockers.unansweredFarSide.length === 1 ? 'transfer does' : 'transfers do'} not
+            record where the money went.{' '}
+            {resultingCategoriesRecordTransferTarget
+              ? 'Answer that here, or close this and untick them.'
+              : 'Close this and untick them, since the others in this selection are not transfers.'}
+          </p>
+        )}
+
+        {blockers.ownAccountFarSide.length > 0 && (
+          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
+            {blockers.ownAccountFarSide.length} selected {blockers.ownAccountFarSide.length === 1 ? 'transaction would' : 'transactions would'} end
+            up recording the account it already sits in. Pick a different account, or close this and untick them.
+          </p>
+        )}
+
         {selectedCurrencies.length > 1 && (
           <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
             The selected transactions are in more than one currency, so they cannot move to another
             account together. Narrow the selection to one currency first.
-          </p>
-        )}
-
-        {categoryRecordsTransferTarget && transferTarget === null && (
-          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-            A transfer records where the money went, so answer that before applying.
           </p>
         )}
 
@@ -253,24 +321,7 @@ export function BulkEditBar({
             One edit covers at most {MAX_BULK_EDIT_TRANSACTIONS} transactions. Deselect some to continue.
           </p>
         )}
-
-        <div className="flex items-center gap-2">
-          <p className="mr-auto text-sm font-medium">{selectedIds.length} selected</p>
-
-          <button
-            type="button"
-            className="app-primary-button h-9 px-4 text-sm"
-            disabled={!setsSomething || overCap}
-            onClick={() => onApply(buildBulkEditFields(choice))}
-          >
-            Apply
-          </button>
-
-          <button type="button" className="app-secondary-button h-9 px-3 text-sm" onClick={onCancel}>
-            Cancel
-          </button>
-        </div>
       </div>
-    </div>
+    </ModalTitledPanel>
   )
 }

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -11,7 +11,7 @@ import DateField from '@/components/date-field/DateField'
 import Dropdown from '@/components/dropdown/Dropdown'
 import { ModalTitledPanel } from '@/components/modal/TitledPanel'
 import IconTooltip from '@/components/tooltips/IconTooltip'
-import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
+import { DIRECTION_OPTIONS, EASE } from '@/pages/transactions/components/transaction-modal/constants'
 import TransactionModalPillSelector from '@/pages/transactions/components/transaction-modal/controls/PillSelector'
 import BulkEditSummaryPanel from '@/pages/transactions/components/bulk-edit/BulkEditSummary'
 import {
@@ -49,13 +49,14 @@ const REFERENCE_PAGE_SIZE = 20
 const MAX_NOTE_LENGTH = 500
 
 // Leaving it alone is an option of its own here, unlike on the single-transaction form, where every
-// transaction points one way or the other and none of them can abstain
-const DIRECTION_OPTIONS = [
+// transaction points one way or the other and none of them can abstain. Debit and Credit come from
+// the single-transaction form's own list, so the two pill sets cannot end up naming the same values
+// differently
+const BULK_DIRECTION_OPTIONS: { value: BulkDirectionChange | 'unchanged'; label: string }[] = [
   { value: 'unchanged', label: 'Leave as is' },
-  { value: 'debit', label: 'Money out' },
-  { value: 'credit', label: 'Money in' },
+  ...DIRECTION_OPTIONS,
   { value: 'reverse', label: 'Reverse' },
-] as const
+]
 
 /** Turns a dropdown's raw string value into the end choice the panel holds */
 function parseTransferEndValue(value: string, accounts: TransactionListAccount[]): TransferEndChoice | null {
@@ -364,7 +365,7 @@ export function BulkEditModal({
       }
     >
       <div className="space-y-5">
-        <CreateModalSectionFrame step="01" title="Type & Direction">
+        <CreateModalSectionFrame step="01" title="Account & Direction">
           <div className="grid gap-3 sm:grid-cols-2">
             <div className="sm:col-span-2">
               <CreateModalFieldLabelRow htmlFor="bulk-account" label="Move to account" accessory={moveAccountIcon} />
@@ -380,7 +381,7 @@ export function BulkEditModal({
             </div>
 
             <div className="sm:col-span-2">
-              <CreateModalFieldLabelRow label="Which way the money moves" />
+              <CreateModalFieldLabelRow label="Direction" />
               <div className="relative rounded-lg">
                 <AnimatePresence initial={false}>
                   {directionHighlightKey > 0 && (
@@ -397,8 +398,8 @@ export function BulkEditModal({
                 </AnimatePresence>
                 <TransactionModalPillSelector
                   value={effectiveDirection ?? 'unchanged'}
-                  options={DIRECTION_OPTIONS}
-                  ariaLabel="Set which way the money moves"
+                  options={BULK_DIRECTION_OPTIONS}
+                  ariaLabel="Transaction direction"
                   onChange={changeDirection}
                 />
               </div>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -28,6 +28,7 @@ import {
   impliedDirection,
   isMixedSelection,
   nextDirectionAfterEndChange,
+  rowFactsKey,
   toggleChosenTag,
   type BulkDirectionChoice,
   type BulkEditChoice,
@@ -154,15 +155,28 @@ export function BulkEditModal({
   // component an extra commit for every category change. A category change can turn a row into a
   // transfer row or out of one, which is what decides each row's own side, so an outside end already
   // on screen is re-checked against the new pairing the moment the category settles rather than
-  // waiting for the user to touch a pill or an end again
+  // waiting for the user to touch a pill or an end again. Keyed on rowFactsKey rather than on rows
+  // itself, since rows is a useMemo in ListSection.tsx over the displayed transactions and any
+  // refetch, an unrelated window focus included, rebuilds it with a new reference even when every
+  // fact the rules below read is unchanged. Keying on the reference would rerun this correction on
+  // that refetch and let an implied direction overwrite a direction the user had chosen
   const [lastCheckedCategoryRule, setLastCheckedCategoryRule] = useState(chosenCategoryRecordsTransferTarget)
-  if (chosenCategoryRecordsTransferTarget !== lastCheckedCategoryRule) {
+  const rowsKey = useMemo(() => rowFactsKey(rows), [rows])
+  const [lastCheckedRowsKey, setLastCheckedRowsKey] = useState(rowsKey)
+  if (chosenCategoryRecordsTransferTarget !== lastCheckedCategoryRule || rowsKey !== lastCheckedRowsKey) {
     setLastCheckedCategoryRule(chosenCategoryRecordsTransferTarget)
-    const { from: nextFrom, to: nextTo } = endsAfterDirectionClick(
+    setLastCheckedRowsKey(rowsKey)
+
+    const { from: correctedFrom, to: correctedTo } = endsAfterDirectionClick(
       direction.value, transferFrom, transferTo, rows, chosenCategoryRecordsTransferTarget,
     )
-    if (nextFrom !== transferFrom) setTransferFrom(nextFrom)
-    if (nextTo !== transferTo) setTransferTo(nextTo)
+    const impliedByCorrectedEnds = impliedDirection(rows, correctedFrom, correctedTo, chosenCategoryRecordsTransferTarget)
+    const nextDirection = nextDirectionAfterEndChange(direction, impliedByCorrectedEnds)
+    if (nextDirection.value !== direction.value) setDirectionHighlightKey((key) => key + 1)
+
+    if (correctedFrom !== transferFrom) setTransferFrom(correctedFrom)
+    if (correctedTo !== transferTo) setTransferTo(correctedTo)
+    setDirection(nextDirection)
   }
 
   const moveTargets = useMemo(
@@ -223,9 +237,17 @@ export function BulkEditModal({
   /**
    * Applies a direction pill's new value, first reverting whichever end the new direction would put
    * outside the tracked accounts on some transfer row's own side, since a pick made from a stale
-   * pairing of ends could otherwise leave one of them with nowhere real to sit
+   * pairing of ends could otherwise leave one of them with nowhere real to sit.
+   *
+   * A click on the value the pills already show is a no-op, read off effectiveDirection rather than
+   * off the held direction, since an implied direction whose controls have gone displays Leave as
+   * is and a click there has nothing to widen. Without the guard, clicking a lit pill again would
+   * turn an implied direction, which only reaches the transfer rows, into one the user chose, which
+   * reaches every selected row, with nothing on screen to show the change
    */
   function changeDirection(value: BulkDirectionChange | 'unchanged') {
+    if (value === (effectiveDirection ?? 'unchanged')) return
+
     const nextValue = value === 'unchanged' ? null : value
     const { from: nextFrom, to: nextTo } = endsAfterDirectionClick(
       nextValue, transferFrom, transferTo, rows, chosenCategoryRecordsTransferTarget,
@@ -247,6 +269,16 @@ export function BulkEditModal({
       setTransferTo(null)
       applyDirectionChange(null)
     }
+  }
+
+  /**
+   * Flips whether the note comes off, clearing any typed text along with it so the disabled input
+   * cannot keep showing text the edit no longer sends
+   */
+  function toggleClearsNote() {
+    const next = !clearsNote
+    setClearsNote(next)
+    if (next) setNote('')
   }
 
   const accountName = (id: string) => accounts.find((account) => account.id === id)?.name ?? 'Account'
@@ -547,9 +579,9 @@ export function BulkEditModal({
                     <Checkbox
                       checked={clearsNote}
                       label="Take the note off instead"
-                      onChange={() => setClearsNote((current) => !current)}
+                      onChange={toggleClearsNote}
                     />
-                    <span aria-hidden onClick={() => setClearsNote((current) => !current)}>
+                    <span aria-hidden onClick={toggleClearsNote}>
                       Take the note off instead
                     </span>
                   </div>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -9,18 +9,25 @@ import DateField from '@/components/date-field/DateField'
 import Dropdown from '@/components/dropdown/Dropdown'
 import { ModalTitledPanel } from '@/components/modal/TitledPanel'
 import CategoryNoticeLine from '@/pages/transactions/components/transaction-modal/controls/CategoryNoticeLine'
+import TransactionModalPillSelector from '@/pages/transactions/components/transaction-modal/controls/PillSelector'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   buildBulkEditFields,
   canApplyBulkEdit,
+  countTransferEndEffects,
+  doesAnyResultingCategoryRecordTransferTarget,
   doesChosenCategoryRecordTransferTarget,
-  doEveryResultingCategoryRecordTransferTarget,
   getBulkEditBlockers,
   getBulkMoveTargets,
+  getTransferEndTargets,
+  resolveTransferEnds,
+  type BulkEditChoice,
   type BulkEditFields,
   type SelectedTransactionFacts,
-  type TransferTargetChoice,
+  type TransferEndChoice,
+  type TransferEndEffect,
 } from '@/pages/transactions/components/bulk-edit/selection'
+import type { BulkDirectionChange } from '@/api/transactions'
 import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
 import { buildCategoryOptions } from '@/pages/transactions/components/transaction-modal/utils/categories'
@@ -32,6 +39,103 @@ const REFERENCE_PAGE_SIZE = 20
 // The cap the single-transaction form puts on the same field, so one edit cannot write a note the
 // other screen would refuse
 const MAX_NOTE_LENGTH = 500
+
+// Leaving it alone is an option of its own here, unlike on the single-transaction form, where every
+// transaction points one way or the other and none of them can abstain
+const DIRECTION_OPTIONS = [
+  { value: 'unchanged', label: 'Leave as it is' },
+  { value: 'debit', label: 'Money out' },
+  { value: 'credit', label: 'Money in' },
+  { value: 'reverse', label: 'Turn around' },
+] as const
+
+/** Turns a dropdown's raw string value into the end choice the panel holds */
+function parseTransferEndValue(value: string, accounts: TransactionListAccount[]): TransferEndChoice | null {
+  if (value === '') return null
+  if (value === OUTSIDE_ACCOUNT_VALUE) return { scope: 'outside' }
+  const currency = accounts.find((account) => account.id === value)?.currency ?? ''
+  return { scope: 'tracked', accountId: value, currency }
+}
+
+/** Turns an end choice back into the string a dropdown shows as selected */
+function transferEndValue(choice: TransferEndChoice | null): string {
+  if (choice === null) return ''
+  return choice.scope === 'outside' ? OUTSIDE_ACCOUNT_VALUE : choice.accountId
+}
+
+/**
+ * Renders the move and record-only notice lines for one end of a transfer edit, in the singular or
+ * plural the count calls for
+ *
+ * A move notice only makes sense for a tracked account, since a row can never move into "outside
+ * this app"; a row whose own end resolves to outside is refused instead, by the sitsOutside blocker
+ */
+function TransferEndEffectNotice({
+  effect,
+  choice,
+  accountName,
+}: {
+  effect: TransferEndEffect
+  choice: TransferEndChoice | null
+  accountName: string
+}) {
+  return (
+    <>
+      <CategoryNoticeLine show={choice?.scope === 'tracked' && effect.moves > 0}>
+        {effect.moves}
+        {effect.moves === 1 ? ' selected transaction moves into ' : ' selected transactions move into '}
+        {accountName}.
+      </CategoryNoticeLine>
+      <CategoryNoticeLine show={effect.recordsOnly > 0}>
+        {effect.recordsOnly}
+        {effect.recordsOnly === 1 ? ' selected transaction records ' : ' selected transactions record '}
+        {choice?.scope === 'outside' ? 'the other side as outside this app.' : `${accountName} as the other side.`}
+      </CategoryNoticeLine>
+    </>
+  )
+}
+
+/** One currency an own end would move blocked rows into, and how many rows share the pairing */
+interface CurrencyMismatch {
+  rowCurrency: string
+  targetCurrency: string
+  count: number
+}
+
+/**
+ * Groups the rows blocked for sitting in another currency than the end they would move into, by the
+ * pair of currencies involved, so the notice can name the right ones rather than assuming the
+ * selection holds only one
+ *
+ * @param rows The selected transactions
+ * @param blockedIds The row ids getBulkEditBlockers listed as ownSideInAnotherCurrency
+ * @param choice What the edit holds
+ * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other
+ *     side, or undefined while the edit sets no category and each row keeps its own
+ */
+function groupCurrencyMismatches(
+  rows: SelectedTransactionFacts[],
+  blockedIds: string[],
+  choice: BulkEditChoice,
+  chosenCategoryRecordsTransferTarget: boolean | undefined,
+): CurrencyMismatch[] {
+  const blocked = new Set(blockedIds)
+  const groups = new Map<string, CurrencyMismatch>()
+
+  for (const row of rows) {
+    if (!blocked.has(row.id)) continue
+    const endsUpRecordingFarSide = chosenCategoryRecordsTransferTarget ?? row.recordsFarSide
+    const { ownEnd } = resolveTransferEnds(row, choice, endsUpRecordingFarSide)
+    if (ownEnd?.scope !== 'tracked') continue
+
+    const key = `${row.currency}-${ownEnd.currency}`
+    const existing = groups.get(key)
+    if (existing) existing.count += 1
+    else groups.set(key, { rowCurrency: row.currency, targetCurrency: ownEnd.currency, count: 1 })
+  }
+
+  return [...groups.values()]
+}
 
 interface BulkEditModalProps {
   open: boolean
@@ -72,7 +176,9 @@ export function BulkEditModal({
   const [date, setDate] = useState('')
   const [note, setNote] = useState('')
   const [clearsNote, setClearsNote] = useState(false)
-  const [transferTarget, setTransferTarget] = useState<TransferTargetChoice | null>(null)
+  const [transferFrom, setTransferFrom] = useState<TransferEndChoice | null>(null)
+  const [transferTo, setTransferTo] = useState<TransferEndChoice | null>(null)
+  const [direction, setDirection] = useState<BulkDirectionChange | null>(null)
 
   // The chosen merchant and tags are held with the label they were picked under. Closing a dropdown
   // resets its search, which refetches the first page of records, and a record the search had found
@@ -91,8 +197,7 @@ export function BulkEditModal({
   const chosenCategoryRecordsTransferTarget = chosenCategory
     ? doesChosenCategoryRecordTransferTarget(chosenCategory)
     : undefined
-  const resultingCategoriesRecordTransferTarget =
-    doEveryResultingCategoryRecordTransferTarget(chosenCategory, rows)
+  const endsAreOffered = doesAnyResultingCategoryRecordTransferTarget(chosenCategory, rows)
 
   const moveTargets = useMemo(
     () => getBulkMoveTargets(accounts, selectedCurrencies),
@@ -100,13 +205,40 @@ export function BulkEditModal({
   )
   const accountOptions = moveTargets.map((account) => ({ value: account.id, label: account.name ?? 'Account' }))
 
-  const transferTargetOptions = [
+  const endTargets = useMemo(() => getTransferEndTargets(accounts), [accounts])
+  const endOptions = [
+    { value: '', label: 'Leave it as it is' },
     { value: OUTSIDE_ACCOUNT_VALUE, label: OUTSIDE_ACCOUNT_LABEL },
-    ...accounts.map((account) => ({ value: account.id, label: account.name ?? 'Account' })),
+    ...endTargets.map((account) => ({ value: account.id, label: account.name ?? 'Account' })),
   ]
-  const transferTargetValue = transferTarget === null
-    ? ''
-    : transferTarget.scope === 'outside' ? OUTSIDE_ACCOUNT_VALUE : transferTarget.accountId
+  // Read alongside endsAreOffered rather than on its own, so an end chosen under a category that
+  // no longer offers the controls cannot hold the move field disabled with no way on screen to
+  // clear it
+  const sendsAnEnd = endsAreOffered && (transferFrom !== null || transferTo !== null)
+
+  /**
+   * Applies a From or To dropdown's new value, moving the account picker out of the way once either
+   * end holds a real answer
+   */
+  function changeTransferEnd(setEnd: (choice: TransferEndChoice | null) => void, value: string) {
+    const next = parseTransferEndValue(value, accounts)
+    setEnd(next)
+    if (next !== null) setAccountId('')
+  }
+
+  /**
+   * Applies the Move to account picker's new value, clearing both ends so the two controls cannot
+   * disagree about which account a row moves into
+   */
+  function changeMoveAccount(value: string) {
+    setAccountId(value)
+    if (value) {
+      setTransferFrom(null)
+      setTransferTo(null)
+    }
+  }
+
+  const accountName = (id: string) => accounts.find((account) => account.id === id)?.name ?? 'Account'
 
   const merchantSearch = useDebouncedReferenceSearch(REFERENCE_SEARCH_DEBOUNCE_MS)
   const merchantQuery = useInfiniteMerchants(
@@ -123,7 +255,7 @@ export function BulkEditModal({
     .filter((tag) => !tagIds.includes(tag.id))
     .map((tag) => ({ value: tag.id, label: tag.name }))
 
-  const choice = {
+  const choice: BulkEditChoice = {
     categoryId,
     merchantId,
     tagIds,
@@ -131,10 +263,19 @@ export function BulkEditModal({
     date,
     note,
     clearsNote,
-    transferTarget,
-    resultingCategoriesRecordTransferTarget,
+    transferFrom,
+    transferTo,
+    direction,
+    endsAreOffered,
   }
   const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget)
+  const endEffects = countTransferEndEffects(rows, choice, chosenCategoryRecordsTransferTarget)
+  const currencyMismatches = groupCurrencyMismatches(
+    rows,
+    blockers.ownSideInAnotherCurrency,
+    choice,
+    chosenCategoryRecordsTransferTarget,
+  )
   const overCap = rows.length > MAX_BULK_EDIT_TRANSACTIONS
   const canApply = canApplyBulkEdit(rows, choice, blockers)
 
@@ -174,7 +315,22 @@ export function BulkEditModal({
           A control left alone leaves that detail as it is on every selected transaction.
         </p>
 
-        <CreateModalSectionFrame step="01" title="Source/Destination">
+        <CreateModalSectionFrame step="01" title="Type & Direction">
+          <div>
+            <CreateModalFieldLabelRow label="Which way the money moves" />
+            <TransactionModalPillSelector
+              value={direction ?? 'unchanged'}
+              options={DIRECTION_OPTIONS}
+              ariaLabel="Set which way the money moves"
+              onChange={(value) => setDirection(value === 'unchanged' ? null : value)}
+            />
+            <CategoryNoticeLine show={endsAreOffered}>
+              A transfer&apos;s other half is a separate row. This changes only the rows selected.
+            </CategoryNoticeLine>
+          </div>
+        </CreateModalSectionFrame>
+
+        <CreateModalSectionFrame step="02" title="Source/Destination">
           <div className="grid gap-3 sm:grid-cols-2">
             <div>
               <CreateModalFieldLabelRow htmlFor="bulk-account" label="Move to account" />
@@ -182,10 +338,10 @@ export function BulkEditModal({
                 id="bulk-account"
                 options={accountOptions}
                 value={accountId}
-                onChange={setAccountId}
+                onChange={changeMoveAccount}
                 placeholder={accountOptions.length === 0 ? 'No account it can move to' : 'Leave as it is'}
                 searchable
-                disabled={accountOptions.length === 0}
+                disabled={accountOptions.length === 0 || sendsAnEnd}
               />
               <CategoryNoticeLine show={selectedCurrencies.length > 1}>
                 These transactions are in more than one currency, so they cannot move to one account
@@ -273,49 +429,90 @@ export function BulkEditModal({
               )}
             </div>
 
-            {resultingCategoriesRecordTransferTarget && (
-              <div className="sm:col-span-2">
-                <CreateModalFieldLabelRow htmlFor="bulk-transfer-target" label="Where the money went" />
-                <Dropdown
-                  id="bulk-transfer-target"
-                  options={transferTargetOptions}
-                  value={transferTargetValue}
-                  onChange={(value) => setTransferTarget(
-                    value === OUTSIDE_ACCOUNT_VALUE
-                      ? { scope: 'outside' }
-                      : { scope: 'tracked', accountId: value },
-                  )}
-                  placeholder="Leave it as it is"
-                  searchable
-                />
-              </div>
+            {endsAreOffered && (
+              <>
+                <div>
+                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-from" label="From" />
+                  <Dropdown
+                    id="bulk-transfer-from"
+                    options={endOptions}
+                    value={transferEndValue(transferFrom)}
+                    onChange={(value) => changeTransferEnd(setTransferFrom, value)}
+                    placeholder="Leave it as it is"
+                    searchable
+                    disabled={Boolean(accountId)}
+                  />
+                </div>
+
+                <div>
+                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-to" label="To" />
+                  <Dropdown
+                    id="bulk-transfer-to"
+                    options={endOptions}
+                    value={transferEndValue(transferTo)}
+                    onChange={(value) => changeTransferEnd(setTransferTo, value)}
+                    placeholder="Leave it as it is"
+                    searchable
+                    disabled={Boolean(accountId)}
+                  />
+                </div>
+
+                <div className="sm:col-span-2">
+                  <TransferEndEffectNotice
+                    effect={endEffects.from}
+                    choice={transferFrom}
+                    accountName={transferFrom?.scope === 'tracked' ? accountName(transferFrom.accountId) : ''}
+                  />
+                  <TransferEndEffectNotice
+                    effect={endEffects.to}
+                    choice={transferTo}
+                    accountName={transferTo?.scope === 'tracked' ? accountName(transferTo.accountId) : ''}
+                  />
+                  <CategoryNoticeLine show={sendsAnEnd && endEffects.leftAlone > 0}>
+                    {endEffects.leftAlone}
+                    {endEffects.leftAlone === 1
+                      ? ' selected transaction is not a transfer and is left as it is.'
+                      : ' selected transactions are not transfers and are left as they are.'}
+                  </CategoryNoticeLine>
+                </div>
+              </>
             )}
 
-            {/* Outside the field above, since the rows that need an answer are counted whether or not
-                that field is offered, and it is offered only where every selected row records one */}
             <div className="sm:col-span-2">
+              <CategoryNoticeLine show={blockers.sitsOutside.length > 0}>
+                {blockers.sitsOutside.length}
+                {blockers.sitsOutside.length === 1
+                  ? ' selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one, or close this and untick it.'
+                  : ' selected transactions would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one, or close this and untick them.'}
+              </CategoryNoticeLine>
+
+              {currencyMismatches.map((mismatch) => (
+                <CategoryNoticeLine key={`${mismatch.rowCurrency}-${mismatch.targetCurrency}`} show>
+                  {mismatch.count}
+                  {mismatch.count === 1
+                    ? ` selected transaction is in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick it.`
+                    : ` selected transactions are in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick them.`}
+                </CategoryNoticeLine>
+              ))}
+
               <CategoryNoticeLine show={blockers.unansweredFarSide.length > 0}>
                 {blockers.unansweredFarSide.length}
                 {blockers.unansweredFarSide.length === 1
-                  ? ' selected transfer does not record where the money went.'
-                  : ' selected transfers do not record where the money went.'}
-                {resultingCategoriesRecordTransferTarget
-                  ? ' Answer that here, or close this and untick them.'
-                  : ' Close this and untick them, since the rest of this selection are not transfers.'}
+                  ? ' selected transfer does not record where the money went. Answer that here, or close this and untick it.'
+                  : ' selected transfers do not record where the money went. Answer that here, or close this and untick them.'}
               </CategoryNoticeLine>
 
               <CategoryNoticeLine show={blockers.ownAccountFarSide.length > 0}>
                 {blockers.ownAccountFarSide.length}
                 {blockers.ownAccountFarSide.length === 1
-                  ? ' selected transaction would end up recording the account it already sits in.'
-                  : ' selected transactions would end up recording the account they already sit in.'}
-                {' Pick a different account, or close this and untick them.'}
+                  ? ' selected transaction would end up recording the account it already sits in. Pick a different account, or close this and untick it.'
+                  : ' selected transactions would end up recording the account they already sit in. Pick a different account, or close this and untick them.'}
               </CategoryNoticeLine>
             </div>
           </div>
         </CreateModalSectionFrame>
 
-        <CreateModalSectionFrame step="02" title="Details">
+        <CreateModalSectionFrame step="03" title="Details">
           <div className="sm:max-w-[11rem]">
             <CreateModalFieldLabelRow htmlFor="bulk-date" label="Date" />
             <DateField

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -3,8 +3,12 @@ import { PencilLine, X } from 'lucide-react'
 import { useCategories } from '@/api/categories'
 import { useInfiniteMerchants } from '@/api/merchants'
 import { useInfiniteTags } from '@/api/tags'
+import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow'
+import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
+import DateField from '@/components/date-field/DateField'
 import Dropdown from '@/components/dropdown/Dropdown'
 import { ModalTitledPanel } from '@/components/modal/TitledPanel'
+import CategoryNoticeLine from '@/pages/transactions/components/transaction-modal/controls/CategoryNoticeLine'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   buildBulkEditFields,
@@ -24,6 +28,10 @@ import { OUTSIDE_ACCOUNT_LABEL, OUTSIDE_ACCOUNT_VALUE } from '@/utils/transfers'
 
 const REFERENCE_SEARCH_DEBOUNCE_MS = 250
 const REFERENCE_PAGE_SIZE = 20
+
+// The cap the single-transaction form puts on the same field, so one edit cannot write a note the
+// other screen would refuse
+const MAX_NOTE_LENGTH = 500
 
 interface BulkEditModalProps {
   open: boolean
@@ -161,166 +169,194 @@ export function BulkEditModal({
         </div>
       }
     >
-      <div className="flex flex-col gap-3">
+      <div className="space-y-5">
         <p className="text-sm" style={{ color: 'var(--app-text-subtle)' }}>
           A control left alone leaves that detail as it is on every selected transaction.
         </p>
 
-        <div className="grid gap-3 min-[750px]:grid-cols-2">
-          <Dropdown
-            options={categoryOptions}
-            value={categoryId}
-            onChange={setCategoryId}
-            placeholder="Category"
-            searchable
-          />
+        <CreateModalSectionFrame step="01" title="Source/Destination">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <CreateModalFieldLabelRow htmlFor="bulk-account" label="Move to account" />
+              <Dropdown
+                id="bulk-account"
+                options={accountOptions}
+                value={accountId}
+                onChange={setAccountId}
+                placeholder={accountOptions.length === 0 ? 'No account it can move to' : 'Leave as it is'}
+                searchable
+                disabled={accountOptions.length === 0}
+              />
+              <CategoryNoticeLine show={selectedCurrencies.length > 1}>
+                These transactions are in more than one currency, so they cannot move to one account
+                together. Narrow the selection to a single currency first.
+              </CategoryNoticeLine>
+            </div>
 
-          <Dropdown
-            options={merchantOptions}
-            value={merchantId}
-            selectedOption={merchant ?? undefined}
-            onChange={(value) => setMerchant(
-              merchantOptions.find((option) => option.value === value) ?? null,
+            <div>
+              <CreateModalFieldLabelRow htmlFor="bulk-merchant" label="Merchant" />
+              <Dropdown
+                id="bulk-merchant"
+                options={merchantOptions}
+                value={merchantId}
+                selectedOption={merchant ?? undefined}
+                onChange={(value) => setMerchant(
+                  merchantOptions.find((option) => option.value === value) ?? null,
+                )}
+                placeholder="Leave as it is"
+                searchable
+                filterOptions={false}
+                searchValue={merchantSearch.search}
+                onSearchChange={merchantSearch.setSearch}
+                isLoading={merchantQuery.isFetching}
+                hasMore={merchantQuery.hasNextPage}
+                onLoadMore={merchantQuery.fetchNextPage}
+              />
+              <CategoryNoticeLine show={blockers.withoutMerchant.length > 0}>
+                {blockers.withoutMerchant.length}
+                {blockers.withoutMerchant.length === 1
+                  ? ' selected transaction has no merchant recorded, and cannot be changed until it does. Set one here, or close this and untick it.'
+                  : ' selected transactions have no merchant recorded, and cannot be changed until they do. Set one here, or close this and untick them.'}
+              </CategoryNoticeLine>
+            </div>
+
+            <div>
+              <CreateModalFieldLabelRow htmlFor="bulk-category" label="Category" />
+              <Dropdown
+                id="bulk-category"
+                options={categoryOptions}
+                value={categoryId}
+                onChange={setCategoryId}
+                placeholder="Leave as it is"
+                searchable
+              />
+            </div>
+
+            <div>
+              <CreateModalFieldLabelRow htmlFor="bulk-tags" label="Add a tag" />
+              <Dropdown
+                id="bulk-tags"
+                options={tagOptions}
+                value=""
+                onChange={(value) => {
+                  const picked = tagOptions.find((option) => option.value === value)
+                  if (picked) setChosenTags((current) => [...current, picked])
+                }}
+                placeholder="Leave them as they are"
+                searchable
+                filterOptions={false}
+                searchValue={tagSearch.search}
+                onSearchChange={tagSearch.setSearch}
+                isLoading={tagQuery.isFetching}
+                hasMore={tagQuery.hasNextPage}
+                onLoadMore={tagQuery.fetchNextPage}
+              />
+              {chosenTags.length > 0 && (
+                <div className="flex flex-wrap gap-1 pt-2">
+                  {chosenTags.map((tag) => (
+                    <span
+                      key={tag.value}
+                      className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
+                      style={{ background: 'var(--app-accent-soft)' }}
+                    >
+                      {tag.label}
+                      <button
+                        type="button"
+                        aria-label={`Remove ${tag.label}`}
+                        onClick={() => setChosenTags((current) => current.filter((item) => item.value !== tag.value))}
+                      >
+                        <X size={12} aria-hidden />
+                      </button>
+                    </span>
+                  ))}
+                </div>
+              )}
+            </div>
+
+            {resultingCategoriesRecordTransferTarget && (
+              <div className="sm:col-span-2">
+                <CreateModalFieldLabelRow htmlFor="bulk-transfer-target" label="Where the money went" />
+                <Dropdown
+                  id="bulk-transfer-target"
+                  options={transferTargetOptions}
+                  value={transferTargetValue}
+                  onChange={(value) => setTransferTarget(
+                    value === OUTSIDE_ACCOUNT_VALUE
+                      ? { scope: 'outside' }
+                      : { scope: 'tracked', accountId: value },
+                  )}
+                  placeholder="Leave it as it is"
+                  searchable
+                />
+              </div>
             )}
-            placeholder="Merchant"
-            searchable
-            filterOptions={false}
-            searchValue={merchantSearch.search}
-            onSearchChange={merchantSearch.setSearch}
-            isLoading={merchantQuery.isFetching}
-            hasMore={merchantQuery.hasNextPage}
-            onLoadMore={merchantQuery.fetchNextPage}
-          />
 
-          <Dropdown
-            options={tagOptions}
-            value=""
-            onChange={(value) => {
-              const picked = tagOptions.find((option) => option.value === value)
-              if (picked) setChosenTags((current) => [...current, picked])
-            }}
-            placeholder="Add a tag"
-            searchable
-            filterOptions={false}
-            searchValue={tagSearch.search}
-            onSearchChange={tagSearch.setSearch}
-            isLoading={tagQuery.isFetching}
-            hasMore={tagQuery.hasNextPage}
-            onLoadMore={tagQuery.fetchNextPage}
-          />
+            {/* Outside the field above, since the rows that need an answer are counted whether or not
+                that field is offered, and it is offered only where every selected row records one */}
+            <div className="sm:col-span-2">
+              <CategoryNoticeLine show={blockers.unansweredFarSide.length > 0}>
+                {blockers.unansweredFarSide.length}
+                {blockers.unansweredFarSide.length === 1
+                  ? ' selected transfer does not record where the money went.'
+                  : ' selected transfers do not record where the money went.'}
+                {resultingCategoriesRecordTransferTarget
+                  ? ' Answer that here, or close this and untick them.'
+                  : ' Close this and untick them, since the rest of this selection are not transfers.'}
+              </CategoryNoticeLine>
 
-          <Dropdown
-            options={accountOptions}
-            value={accountId}
-            onChange={setAccountId}
-            placeholder="Move to account"
-            searchable
-            disabled={accountOptions.length === 0}
-          />
+              <CategoryNoticeLine show={blockers.ownAccountFarSide.length > 0}>
+                {blockers.ownAccountFarSide.length}
+                {blockers.ownAccountFarSide.length === 1
+                  ? ' selected transaction would end up recording the account it already sits in.'
+                  : ' selected transactions would end up recording the account they already sit in.'}
+                {' Pick a different account, or close this and untick them.'}
+              </CategoryNoticeLine>
+            </div>
+          </div>
+        </CreateModalSectionFrame>
 
-          <input
-            type="date"
-            className="app-input app-date-field h-9"
-            aria-label="Set the date"
-            value={date}
-            onChange={(event) => setDate(event.target.value)}
-          />
+        <CreateModalSectionFrame step="02" title="Details">
+          <div className="sm:max-w-[11rem]">
+            <CreateModalFieldLabelRow htmlFor="bulk-date" label="Date" />
+            <DateField
+              id="bulk-date"
+              ariaLabel="Date"
+              value={date}
+              onChange={setDate}
+            />
+          </div>
 
-          <div className="flex items-center gap-2">
+          <div>
+            <CreateModalFieldLabelRow
+              htmlFor="bulk-note"
+              label="Note"
+              action={(
+                <label className="flex items-center gap-1.5 text-xs">
+                  <input
+                    type="checkbox"
+                    checked={clearsNote}
+                    onChange={(event) => setClearsNote(event.target.checked)}
+                  />
+                  Take the note off instead
+                </label>
+              )}
+            />
             <input
+              id="bulk-note"
               type="text"
-              className="app-input h-9 min-w-0 flex-1"
-              aria-label="Set the note"
-              placeholder="Note"
+              className="app-input disabled:cursor-not-allowed disabled:opacity-60"
+              placeholder={clearsNote ? 'The note comes off' : 'Leave it as it is'}
               value={note}
               disabled={clearsNote}
               onChange={(event) => setNote(event.target.value)}
+              maxLength={MAX_NOTE_LENGTH}
             />
-            <label className="flex shrink-0 items-center gap-1 text-xs">
-              <input
-                type="checkbox"
-                checked={clearsNote}
-                onChange={(event) => setClearsNote(event.target.checked)}
-              />
-              Clear
-            </label>
           </div>
+        </CreateModalSectionFrame>
 
-          {resultingCategoriesRecordTransferTarget && (
-            <Dropdown
-              options={transferTargetOptions}
-              value={transferTargetValue}
-              onChange={(value) => setTransferTarget(
-                value === OUTSIDE_ACCOUNT_VALUE
-                  ? { scope: 'outside' }
-                  : { scope: 'tracked', accountId: value },
-              )}
-              placeholder="Where the money went"
-              searchable
-            />
-          )}
-        </div>
-
-        {chosenTags.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {chosenTags.map((tag) => (
-              <span
-                key={tag.value}
-                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
-                style={{ background: 'var(--app-accent-soft)' }}
-              >
-                {tag.label}
-                <button
-                  type="button"
-                  aria-label={`Remove ${tag.label}`}
-                  onClick={() => setChosenTags((current) => current.filter((item) => item.value !== tag.value))}
-                >
-                  <X size={12} aria-hidden />
-                </button>
-              </span>
-            ))}
-          </div>
-        )}
-
-        {/* Each of these is a refusal the server answers for the whole batch, so it says what to do
-            about it here. Unticking a row is not one of the options, since every row behind this panel
-            is out of reach while it is open */}
-        {blockers.withoutMerchant.length > 0 && (
-          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-            {blockers.withoutMerchant.length} selected {blockers.withoutMerchant.length === 1 ? 'transaction has' : 'transactions have'} no
-            merchant recorded. Set one here, or close this and untick them.
-          </p>
-        )}
-
-        {blockers.unansweredFarSide.length > 0 && (
-          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-            {blockers.unansweredFarSide.length} selected {blockers.unansweredFarSide.length === 1 ? 'transfer does' : 'transfers do'} not
-            record where the money went.{' '}
-            {resultingCategoriesRecordTransferTarget
-              ? 'Answer that here, or close this and untick them.'
-              : 'Close this and untick them, since the others in this selection are not transfers.'}
-          </p>
-        )}
-
-        {blockers.ownAccountFarSide.length > 0 && (
-          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-            {blockers.ownAccountFarSide.length} selected {blockers.ownAccountFarSide.length === 1 ? 'transaction would' : 'transactions would'} end
-            up recording the account it already sits in. Pick a different account, or close this and untick them.
-          </p>
-        )}
-
-        {selectedCurrencies.length > 1 && (
-          <p className="text-xs" style={{ color: 'var(--app-text-subtle)' }}>
-            The selected transactions are in more than one currency, so they cannot move to another
-            account together. Narrow the selection to one currency first.
-          </p>
-        )}
-
-        {overCap && (
-          <p className="text-xs" style={{ color: 'var(--app-negative)' }}>
-            One edit covers at most {MAX_BULK_EDIT_TRANSACTIONS} transactions. Deselect some to continue.
-          </p>
-        )}
+        <CategoryNoticeLine show={overCap}>
+          One edit covers at most {MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.
+        </CategoryNoticeLine>
       </div>
     </ModalTitledPanel>
   )

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -1,4 +1,5 @@
 import { useId, useMemo, useState, type ReactNode } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
 import { PencilLine } from 'lucide-react'
 import { useCategories } from '@/api/categories'
 import { useInfiniteMerchants } from '@/api/merchants'
@@ -10,6 +11,7 @@ import DateField from '@/components/date-field/DateField'
 import Dropdown from '@/components/dropdown/Dropdown'
 import { ModalTitledPanel } from '@/components/modal/TitledPanel'
 import IconTooltip from '@/components/tooltips/IconTooltip'
+import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
 import TransactionModalPillSelector from '@/pages/transactions/components/transaction-modal/controls/PillSelector'
 import BulkEditSummaryPanel from '@/pages/transactions/components/bulk-edit/BulkEditSummary'
 import {
@@ -20,7 +22,10 @@ import {
   getBulkEditBlockers,
   getBulkMoveTargets,
   getTransferEndTargets,
+  impliedDirection,
+  nextDirectionAfterEndChange,
   toggleChosenTag,
+  type BulkDirectionChoice,
   type BulkEditChoice,
   type BulkEditFields,
   type ChosenTagOption,
@@ -105,7 +110,14 @@ export function BulkEditModal({
   const [clearsNote, setClearsNote] = useState(false)
   const [transferFrom, setTransferFrom] = useState<TransferEndChoice | null>(null)
   const [transferTo, setTransferTo] = useState<TransferEndChoice | null>(null)
-  const [direction, setDirection] = useState<BulkDirectionChange | null>(null)
+
+  // Nothing set reads as implied, so the first end change to imply a direction lands the same way a
+  // later one clearing it does, rather than the initial state needing its own case
+  const [direction, setDirection] = useState<BulkDirectionChoice>({ value: null, source: 'implied' })
+
+  // Bumped whenever the rule, rather than a pill the user clicked, changes what the pills show, so
+  // the pulse below only draws the eye to a change the user did not make themselves
+  const [directionHighlightKey, setDirectionHighlightKey] = useState(0)
 
   // The chosen merchant and tags are held with the label they were picked under. Closing a dropdown
   // resets its search, which refetches the first page of records, and a record the search had found
@@ -144,24 +156,43 @@ export function BulkEditModal({
   const sendsAnEnd = endsAreOffered && (transferFrom !== null || transferTo !== null)
 
   /**
-   * Applies a From or To dropdown's new value, moving the account picker out of the way once either
-   * end holds a real answer
+   * Applies what the changed pairing of ends implies to the direction pills, pulsing them when the
+   * rule actually moves what they show
    */
-  function changeTransferEnd(setEnd: (choice: TransferEndChoice | null) => void, value: string) {
+  function applyDirectionChange(implied: BulkDirectionChange | null) {
+    const next = nextDirectionAfterEndChange(direction, implied)
+    if (next.value !== direction.value) setDirectionHighlightKey((key) => key + 1)
+    setDirection(next)
+  }
+
+  /**
+   * Applies a From or To dropdown's new value, moving the account picker out of the way once either
+   * end holds a real answer, then updates the direction pills against the new pairing. The
+   * implication reads the end just changed and the other end's current value rather than state that
+   * has not updated yet
+   */
+  function changeTransferEnd(end: 'from' | 'to', value: string) {
     const next = parseTransferEndValue(value, accounts)
-    setEnd(next)
+    if (end === 'from') setTransferFrom(next)
+    else setTransferTo(next)
     if (next !== null) setAccountId('')
+
+    const nextFrom = end === 'from' ? next : transferFrom
+    const nextTo = end === 'to' ? next : transferTo
+    applyDirectionChange(impliedDirection(rows, nextFrom, nextTo, chosenCategoryRecordsTransferTarget))
   }
 
   /**
    * Applies the Move to account picker's new value, clearing both ends so the two controls cannot
-   * disagree about which account a row moves into
+   * disagree about which account a row moves into, and running the clear through the same direction
+   * rule as an end change, with nothing implied
    */
   function changeMoveAccount(value: string) {
     setAccountId(value)
     if (value) {
       setTransferFrom(null)
       setTransferTo(null)
+      applyDirectionChange(null)
     }
   }
 
@@ -194,6 +225,13 @@ export function BulkEditModal({
     ? { value: '', label: chosenTags.map((tag) => tag.label).join(', ') }
     : undefined
 
+  // An implied direction is tied to the pairing of ends that produced it, so it drops out once
+  // endsAreOffered goes false, as when a category change turns the controls off, rather than
+  // outliving the controls it came from. A direction the user picked has no such tie and stays
+  const effectiveDirection: BulkDirectionChange | null = direction.source === 'implied' && !endsAreOffered
+    ? null
+    : direction.value
+
   const choice: BulkEditChoice = {
     categoryId,
     merchantId,
@@ -204,7 +242,7 @@ export function BulkEditModal({
     clearsNote,
     transferFrom,
     transferTo,
-    direction,
+    direction: effectiveDirection,
     endsAreOffered,
   }
   const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget)
@@ -290,20 +328,8 @@ export function BulkEditModal({
     >
       <div className="space-y-5">
         <CreateModalSectionFrame step="01" title="Type & Direction">
-          <div>
-            <CreateModalFieldLabelRow label="Which way the money moves" />
-            <TransactionModalPillSelector
-              value={direction ?? 'unchanged'}
-              options={DIRECTION_OPTIONS}
-              ariaLabel="Set which way the money moves"
-              onChange={(value) => setDirection(value === 'unchanged' ? null : value)}
-            />
-          </div>
-        </CreateModalSectionFrame>
-
-        <CreateModalSectionFrame step="02" title="Source/Destination">
           <div className="grid gap-3 sm:grid-cols-2">
-            <div>
+            <div className="sm:col-span-2">
               <CreateModalFieldLabelRow htmlFor="bulk-account" label="Move to account" accessory={moveAccountIcon} />
               <Dropdown
                 id="bulk-account"
@@ -313,6 +339,77 @@ export function BulkEditModal({
                 placeholder={accountOptions.length === 0 ? 'No account it can move to' : 'Leave as is'}
                 searchable
                 disabled={accountOptions.length === 0 || sendsAnEnd}
+              />
+            </div>
+
+            <div className="sm:col-span-2">
+              <CreateModalFieldLabelRow label="Which way the money moves" />
+              <div className="relative rounded-lg">
+                <AnimatePresence initial={false}>
+                  {directionHighlightKey > 0 && (
+                    <motion.span
+                      key={directionHighlightKey}
+                      className="pointer-events-none absolute inset-0 rounded-lg"
+                      initial={{ boxShadow: '0 0 0 0 var(--app-accent-soft)' }}
+                      animate={{ boxShadow: ['0 0 0 0 var(--app-accent-soft)', '0 0 0 3px var(--app-accent-soft)', '0 0 0 0 var(--app-accent-soft)'] }}
+                      exit={{ opacity: 0 }}
+                      transition={{ duration: 0.45, ease: EASE }}
+                      aria-hidden
+                    />
+                  )}
+                </AnimatePresence>
+                <TransactionModalPillSelector
+                  value={effectiveDirection ?? 'unchanged'}
+                  options={DIRECTION_OPTIONS}
+                  ariaLabel="Set which way the money moves"
+                  onChange={(value) => setDirection({ value: value === 'unchanged' ? null : value, source: 'user' })}
+                />
+              </div>
+            </div>
+
+            {endsAreOffered && (
+              <>
+                <div>
+                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-from" label="From" accessory={clearedByMoveAccountIcon} />
+                  <Dropdown
+                    id="bulk-transfer-from"
+                    options={endOptions}
+                    value={transferEndValue(transferFrom)}
+                    onChange={(value) => changeTransferEnd('from', value)}
+                    placeholder="Leave as is"
+                    blankOptionIsPlaceholder
+                    searchable
+                    disabled={Boolean(accountId)}
+                  />
+                </div>
+
+                <div>
+                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-to" label="To" accessory={clearedByMoveAccountIcon} />
+                  <Dropdown
+                    id="bulk-transfer-to"
+                    options={endOptions}
+                    value={transferEndValue(transferTo)}
+                    onChange={(value) => changeTransferEnd('to', value)}
+                    placeholder="Leave as is"
+                    blankOptionIsPlaceholder
+                    searchable
+                    disabled={Boolean(accountId)}
+                  />
+                </div>
+              </>
+            )}
+          </div>
+        </CreateModalSectionFrame>
+
+        <CreateModalSectionFrame step="02" title="Details">
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <CreateModalFieldLabelRow htmlFor="bulk-date" label="Date" />
+              <DateField
+                id="bulk-date"
+                ariaLabel="Date"
+                value={date}
+                onChange={setDate}
               />
             </div>
 
@@ -373,82 +470,38 @@ export function BulkEditModal({
               />
             </div>
 
-            {endsAreOffered && (
-              <>
-                <div>
-                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-from" label="From" accessory={clearedByMoveAccountIcon} />
-                  <Dropdown
-                    id="bulk-transfer-from"
-                    options={endOptions}
-                    value={transferEndValue(transferFrom)}
-                    onChange={(value) => changeTransferEnd(setTransferFrom, value)}
-                    placeholder="Leave as is"
-                    blankOptionIsPlaceholder
-                    searchable
-                    disabled={Boolean(accountId)}
-                  />
-                </div>
-
-                <div>
-                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-to" label="To" accessory={clearedByMoveAccountIcon} />
-                  <Dropdown
-                    id="bulk-transfer-to"
-                    options={endOptions}
-                    value={transferEndValue(transferTo)}
-                    onChange={(value) => changeTransferEnd(setTransferTo, value)}
-                    placeholder="Leave as is"
-                    blankOptionIsPlaceholder
-                    searchable
-                    disabled={Boolean(accountId)}
-                  />
-                </div>
-              </>
-            )}
+            <div className="sm:col-span-2">
+              <CreateModalFieldLabelRow
+                htmlFor="bulk-note"
+                label="Note"
+                action={(
+                  <div className="flex items-center gap-1.5 text-xs">
+                    <Checkbox
+                      checked={clearsNote}
+                      label="Take the note off instead"
+                      onChange={() => setClearsNote((current) => !current)}
+                    />
+                    <span aria-hidden onClick={() => setClearsNote((current) => !current)}>
+                      Take the note off instead
+                    </span>
+                  </div>
+                )}
+              />
+              <input
+                id="bulk-note"
+                type="text"
+                className="app-input disabled:cursor-not-allowed disabled:opacity-60"
+                placeholder={clearsNote ? 'The note comes off' : 'Leave as is'}
+                value={note}
+                disabled={clearsNote}
+                onChange={(event) => setNote(event.target.value)}
+                maxLength={MAX_NOTE_LENGTH}
+              />
+            </div>
           </div>
         </CreateModalSectionFrame>
 
-        <CreateModalSectionFrame step="03" title="Details">
-          <div className="sm:max-w-[11rem]">
-            <CreateModalFieldLabelRow htmlFor="bulk-date" label="Date" />
-            <DateField
-              id="bulk-date"
-              ariaLabel="Date"
-              value={date}
-              onChange={setDate}
-            />
-          </div>
-
-          <div>
-            <CreateModalFieldLabelRow
-              htmlFor="bulk-note"
-              label="Note"
-              action={(
-                <div className="flex items-center gap-1.5 text-xs">
-                  <Checkbox
-                    checked={clearsNote}
-                    label="Take the note off instead"
-                    onChange={() => setClearsNote((current) => !current)}
-                  />
-                  <span aria-hidden onClick={() => setClearsNote((current) => !current)}>
-                    Take the note off instead
-                  </span>
-                </div>
-              )}
-            />
-            <input
-              id="bulk-note"
-              type="text"
-              className="app-input disabled:cursor-not-allowed disabled:opacity-60"
-              placeholder={clearsNote ? 'The note comes off' : 'Leave as is'}
-              value={note}
-              disabled={clearsNote}
-              onChange={(event) => setNote(event.target.value)}
-              maxLength={MAX_NOTE_LENGTH}
-            />
-          </div>
-        </CreateModalSectionFrame>
-
-        <CreateModalSectionFrame step="04" title="What changes">
+        <CreateModalSectionFrame step="03" title="What changes">
           <BulkEditSummaryPanel summary={summary} />
         </CreateModalSectionFrame>
       </div>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditModal.tsx
@@ -1,32 +1,31 @@
-import { useId, useMemo, useState } from 'react'
+import { useId, useMemo, useState, type ReactNode } from 'react'
 import { PencilLine, X } from 'lucide-react'
 import { useCategories } from '@/api/categories'
 import { useInfiniteMerchants } from '@/api/merchants'
 import { useInfiniteTags } from '@/api/tags'
+import { Checkbox } from '@/components/forms/Checkbox'
 import CreateModalFieldLabelRow from '@/components/create-modal/FieldLabelRow'
 import CreateModalSectionFrame from '@/components/create-modal/SectionFrame'
 import DateField from '@/components/date-field/DateField'
 import Dropdown from '@/components/dropdown/Dropdown'
 import { ModalTitledPanel } from '@/components/modal/TitledPanel'
-import CategoryNoticeLine from '@/pages/transactions/components/transaction-modal/controls/CategoryNoticeLine'
+import IconTooltip from '@/components/tooltips/IconTooltip'
 import TransactionModalPillSelector from '@/pages/transactions/components/transaction-modal/controls/PillSelector'
-import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
+import BulkEditSummaryPanel from '@/pages/transactions/components/bulk-edit/BulkEditSummary'
 import {
   buildBulkEditFields,
   canApplyBulkEdit,
-  countTransferEndEffects,
   doesAnyResultingCategoryRecordTransferTarget,
   doesChosenCategoryRecordTransferTarget,
   getBulkEditBlockers,
   getBulkMoveTargets,
   getTransferEndTargets,
-  resolveTransferEnds,
   type BulkEditChoice,
   type BulkEditFields,
   type SelectedTransactionFacts,
   type TransferEndChoice,
-  type TransferEndEffect,
 } from '@/pages/transactions/components/bulk-edit/selection'
+import { describeBulkEdit, type BulkEditSummaryLabels } from '@/pages/transactions/components/bulk-edit/summary'
 import type { BulkDirectionChange } from '@/api/transactions'
 import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
 import { useDebouncedReferenceSearch } from '@/pages/transactions/components/transaction-modal/hooks/useDebouncedReferenceSearch'
@@ -61,80 +60,6 @@ function parseTransferEndValue(value: string, accounts: TransactionListAccount[]
 function transferEndValue(choice: TransferEndChoice | null): string {
   if (choice === null) return ''
   return choice.scope === 'outside' ? OUTSIDE_ACCOUNT_VALUE : choice.accountId
-}
-
-/**
- * Renders the move and record-only notice lines for one end of a transfer edit, in the singular or
- * plural the count calls for
- *
- * A move notice only makes sense for a tracked account, since a row can never move into "outside
- * this app"; a row whose own end resolves to outside is refused instead, by the sitsOutside blocker
- */
-function TransferEndEffectNotice({
-  effect,
-  choice,
-  accountName,
-}: {
-  effect: TransferEndEffect
-  choice: TransferEndChoice | null
-  accountName: string
-}) {
-  return (
-    <>
-      <CategoryNoticeLine show={choice?.scope === 'tracked' && effect.moves > 0}>
-        {effect.moves}
-        {effect.moves === 1 ? ' selected transaction moves into ' : ' selected transactions move into '}
-        {accountName}.
-      </CategoryNoticeLine>
-      <CategoryNoticeLine show={effect.recordsOnly > 0}>
-        {effect.recordsOnly}
-        {effect.recordsOnly === 1 ? ' selected transaction records ' : ' selected transactions record '}
-        {choice?.scope === 'outside' ? 'the other side as outside this app.' : `${accountName} as the other side.`}
-      </CategoryNoticeLine>
-    </>
-  )
-}
-
-/** One currency an own end would move blocked rows into, and how many rows share the pairing */
-interface CurrencyMismatch {
-  rowCurrency: string
-  targetCurrency: string
-  count: number
-}
-
-/**
- * Groups the rows blocked for sitting in another currency than the end they would move into, by the
- * pair of currencies involved, so the notice can name the right ones rather than assuming the
- * selection holds only one
- *
- * @param rows The selected transactions
- * @param blockedIds The row ids getBulkEditBlockers listed as ownSideInAnotherCurrency
- * @param choice What the edit holds
- * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other
- *     side, or undefined while the edit sets no category and each row keeps its own
- */
-function groupCurrencyMismatches(
-  rows: SelectedTransactionFacts[],
-  blockedIds: string[],
-  choice: BulkEditChoice,
-  chosenCategoryRecordsTransferTarget: boolean | undefined,
-): CurrencyMismatch[] {
-  const blocked = new Set(blockedIds)
-  const groups = new Map<string, CurrencyMismatch>()
-
-  for (const row of rows) {
-    if (!blocked.has(row.id)) continue
-    const endsUpRecordingFarSide = chosenCategoryRecordsTransferTarget ?? row.recordsFarSide
-    const { ownEnd } = resolveTransferEnds(row, choice, endsUpRecordingFarSide)
-    if (ownEnd?.scope !== 'tracked') continue
-
-    const key = `${row.currency}-${ownEnd.currency}`
-    const existing = groups.get(key)
-    if (existing) existing.count += 1
-    else groups.set(key, { rowCurrency: row.currency, targetCurrency: ownEnd.currency, count: 1 })
-  }
-
-  return [...groups.values()]
 }
 
 interface BulkEditModalProps {
@@ -269,17 +194,56 @@ export function BulkEditModal({
     endsAreOffered,
   }
   const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget)
-  const endEffects = countTransferEndEffects(rows, choice, chosenCategoryRecordsTransferTarget)
-  const currencyMismatches = groupCurrencyMismatches(
-    rows,
-    blockers.ownSideInAnotherCurrency,
-    choice,
-    chosenCategoryRecordsTransferTarget,
-  )
-  const overCap = rows.length > MAX_BULK_EDIT_TRANSACTIONS
   const canApply = canApplyBulkEdit(rows, choice, blockers)
 
   const transactionsWord = rows.length === 1 ? 'transaction' : 'transactions'
+
+  // Display text the panel resolves ids against, read off the same state the dropdowns already
+  // hold rather than looked up again, so the summary can never name an account, category, merchant
+  // or tag differently than the control that chose it
+  const summaryLabels: BulkEditSummaryLabels = {
+    accountLabelById: accountName,
+    categoryLabel: chosenCategory?.name ?? '',
+    merchantLabel: merchant?.label ?? '',
+    tagLabels: chosenTags.map((tag) => tag.label),
+  }
+  const summary = describeBulkEdit(choice, rows, blockers, summaryLabels, chosenCategoryRecordsTransferTarget)
+
+  const spansMultipleCurrencies = selectedCurrencies.length > 1
+  const hasNoAccountForCurrency = selectedCurrencies.length === 1 && accountOptions.length === 0
+
+  // At most one icon beside Move to account, in the order its disabled reasons take priority: a
+  // selection spanning currencies refuses every account, then a single currency with nothing open
+  // to hold it, then an end already answering where the money moves instead
+  let moveAccountIcon: ReactNode = null
+  if (spansMultipleCurrencies) {
+    moveAccountIcon = (
+      <IconTooltip label="Multiple currencies" level="warn" widthClassName="w-72">
+        These transactions are in more than one currency, so they cannot move to one account
+        together. Narrow the selection to a single currency first.
+      </IconTooltip>
+    )
+  } else if (hasNoAccountForCurrency) {
+    moveAccountIcon = (
+      <IconTooltip label="No account for this currency" level="warn">
+        No open account holds this currency.
+      </IconTooltip>
+    )
+  } else if (sendsAnEnd) {
+    moveAccountIcon = (
+      <IconTooltip label="Cleared by From or To" level="info">
+        Cleared while From or To is set.
+      </IconTooltip>
+    )
+  }
+
+  // From and To disable themselves the moment Move to account holds a value, so both carry the
+  // same explanation rather than only the one nearer the control
+  const clearedByMoveAccountIcon = accountId ? (
+    <IconTooltip label="Cleared by Move to account" level="info">
+      Cleared while Move to account is set.
+    </IconTooltip>
+  ) : null
 
   return (
     <ModalTitledPanel
@@ -311,10 +275,6 @@ export function BulkEditModal({
       }
     >
       <div className="space-y-5">
-        <p className="text-sm" style={{ color: 'var(--app-text-subtle)' }}>
-          A control left alone leaves that detail as it is on every selected transaction.
-        </p>
-
         <CreateModalSectionFrame step="01" title="Type & Direction">
           <div>
             <CreateModalFieldLabelRow label="Which way the money moves" />
@@ -324,16 +284,13 @@ export function BulkEditModal({
               ariaLabel="Set which way the money moves"
               onChange={(value) => setDirection(value === 'unchanged' ? null : value)}
             />
-            <CategoryNoticeLine show={endsAreOffered}>
-              A transfer&apos;s other half is a separate row. This changes only the rows selected.
-            </CategoryNoticeLine>
           </div>
         </CreateModalSectionFrame>
 
         <CreateModalSectionFrame step="02" title="Source/Destination">
           <div className="grid gap-3 sm:grid-cols-2">
             <div>
-              <CreateModalFieldLabelRow htmlFor="bulk-account" label="Move to account" />
+              <CreateModalFieldLabelRow htmlFor="bulk-account" label="Move to account" accessory={moveAccountIcon} />
               <Dropdown
                 id="bulk-account"
                 options={accountOptions}
@@ -343,10 +300,6 @@ export function BulkEditModal({
                 searchable
                 disabled={accountOptions.length === 0 || sendsAnEnd}
               />
-              <CategoryNoticeLine show={selectedCurrencies.length > 1}>
-                These transactions are in more than one currency, so they cannot move to one account
-                together. Narrow the selection to a single currency first.
-              </CategoryNoticeLine>
             </div>
 
             <div>
@@ -368,12 +321,6 @@ export function BulkEditModal({
                 hasMore={merchantQuery.hasNextPage}
                 onLoadMore={merchantQuery.fetchNextPage}
               />
-              <CategoryNoticeLine show={blockers.withoutMerchant.length > 0}>
-                {blockers.withoutMerchant.length}
-                {blockers.withoutMerchant.length === 1
-                  ? ' selected transaction has no merchant recorded, and cannot be changed until it does. Set one here, or close this and untick it.'
-                  : ' selected transactions have no merchant recorded, and cannot be changed until they do. Set one here, or close this and untick them.'}
-              </CategoryNoticeLine>
             </div>
 
             <div>
@@ -432,7 +379,7 @@ export function BulkEditModal({
             {endsAreOffered && (
               <>
                 <div>
-                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-from" label="From" />
+                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-from" label="From" accessory={clearedByMoveAccountIcon} />
                   <Dropdown
                     id="bulk-transfer-from"
                     options={endOptions}
@@ -445,7 +392,7 @@ export function BulkEditModal({
                 </div>
 
                 <div>
-                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-to" label="To" />
+                  <CreateModalFieldLabelRow htmlFor="bulk-transfer-to" label="To" accessory={clearedByMoveAccountIcon} />
                   <Dropdown
                     id="bulk-transfer-to"
                     options={endOptions}
@@ -456,59 +403,8 @@ export function BulkEditModal({
                     disabled={Boolean(accountId)}
                   />
                 </div>
-
-                <div className="sm:col-span-2">
-                  <TransferEndEffectNotice
-                    effect={endEffects.from}
-                    choice={transferFrom}
-                    accountName={transferFrom?.scope === 'tracked' ? accountName(transferFrom.accountId) : ''}
-                  />
-                  <TransferEndEffectNotice
-                    effect={endEffects.to}
-                    choice={transferTo}
-                    accountName={transferTo?.scope === 'tracked' ? accountName(transferTo.accountId) : ''}
-                  />
-                  <CategoryNoticeLine show={sendsAnEnd && endEffects.leftAlone > 0}>
-                    {endEffects.leftAlone}
-                    {endEffects.leftAlone === 1
-                      ? ' selected transaction is not a transfer and is left as it is.'
-                      : ' selected transactions are not transfers and are left as they are.'}
-                  </CategoryNoticeLine>
-                </div>
               </>
             )}
-
-            <div className="sm:col-span-2">
-              <CategoryNoticeLine show={blockers.sitsOutside.length > 0}>
-                {blockers.sitsOutside.length}
-                {blockers.sitsOutside.length === 1
-                  ? ' selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one, or close this and untick it.'
-                  : ' selected transactions would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one, or close this and untick them.'}
-              </CategoryNoticeLine>
-
-              {currencyMismatches.map((mismatch) => (
-                <CategoryNoticeLine key={`${mismatch.rowCurrency}-${mismatch.targetCurrency}`} show>
-                  {mismatch.count}
-                  {mismatch.count === 1
-                    ? ` selected transaction is in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick it.`
-                    : ` selected transactions are in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick them.`}
-                </CategoryNoticeLine>
-              ))}
-
-              <CategoryNoticeLine show={blockers.unansweredFarSide.length > 0}>
-                {blockers.unansweredFarSide.length}
-                {blockers.unansweredFarSide.length === 1
-                  ? ' selected transfer does not record where the money went. Answer that here, or close this and untick it.'
-                  : ' selected transfers do not record where the money went. Answer that here, or close this and untick them.'}
-              </CategoryNoticeLine>
-
-              <CategoryNoticeLine show={blockers.ownAccountFarSide.length > 0}>
-                {blockers.ownAccountFarSide.length}
-                {blockers.ownAccountFarSide.length === 1
-                  ? ' selected transaction would end up recording the account it already sits in. Pick a different account, or close this and untick it.'
-                  : ' selected transactions would end up recording the account they already sit in. Pick a different account, or close this and untick them.'}
-              </CategoryNoticeLine>
-            </div>
           </div>
         </CreateModalSectionFrame>
 
@@ -528,14 +424,16 @@ export function BulkEditModal({
               htmlFor="bulk-note"
               label="Note"
               action={(
-                <label className="flex items-center gap-1.5 text-xs">
-                  <input
-                    type="checkbox"
+                <div className="flex items-center gap-1.5 text-xs">
+                  <Checkbox
                     checked={clearsNote}
-                    onChange={(event) => setClearsNote(event.target.checked)}
+                    label="Take the note off instead"
+                    onChange={() => setClearsNote((current) => !current)}
                   />
-                  Take the note off instead
-                </label>
+                  <span aria-hidden onClick={() => setClearsNote((current) => !current)}>
+                    Take the note off instead
+                  </span>
+                </div>
               )}
             />
             <input
@@ -551,9 +449,9 @@ export function BulkEditModal({
           </div>
         </CreateModalSectionFrame>
 
-        <CategoryNoticeLine show={overCap}>
-          One edit covers at most {MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.
-        </CategoryNoticeLine>
+        <CreateModalSectionFrame step="04" title="What changes">
+          <BulkEditSummaryPanel summary={summary} />
+        </CreateModalSectionFrame>
       </div>
     </ModalTitledPanel>
   )

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -1,6 +1,6 @@
 import { useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
-import { ArrowRight, Info, TriangleAlert } from 'lucide-react'
+import { ArrowRight, CornerDownRight, Info, TriangleAlert } from 'lucide-react'
 import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
 import type { BulkEditSummary as BulkEditSummaryResult } from '@/pages/transactions/components/bulk-edit/summary'
 
@@ -39,9 +39,17 @@ function SummaryRow({ label, value, detail }: { label: string; value: string; de
         </span>
       </div>
       {detail && (
-        <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
-          {detail}
-        </p>
+        <div className="flex items-start gap-1.5 pl-3">
+          <CornerDownRight
+            size={12}
+            className="mt-0.5 shrink-0"
+            aria-hidden
+            style={{ color: 'var(--app-text-muted)' }}
+          />
+          <p className="text-sm italic" style={{ color: 'var(--app-text-muted)' }}>
+            {detail}
+          </p>
+        </div>
       )}
     </div>
   )

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -85,7 +85,7 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
         key: 'empty',
         node: (
           <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
-            Nothing changes yet. Set a detail above.
+            You will see a preview of what changes once you make the selections above.
           </p>
         ),
       }]

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { ArrowRight, Info, TriangleAlert } from 'lucide-react'
 import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
@@ -65,74 +65,83 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
 
   const contentRef = useRef<HTMLDivElement>(null)
   // Null until the first measurement lands, which is what lets the box render unconstrained at
-  // mount. That first measurement then reports the same height the unconstrained box already has,
-  // so easing to it moves nothing, and only a later measurement, taken after a row changes the
-  // content, actually has a different height to ease towards
+  // mount, then the same pixels the unconstrained box already had, so nothing visibly moves
   const [measuredHeight, setMeasuredHeight] = useState<number | null>(null)
-  const [isEasingHeight, setIsEasingHeight] = useState(false)
 
+  // Tracks size changes React did not cause, such as text wrapping at a narrower viewport
   useLayoutEffect(() => {
     const node = contentRef.current
     if (!node) return undefined
 
-    const observer = new ResizeObserver(() => setMeasuredHeight(node.offsetHeight))
+    const observer = new ResizeObserver(() => setMeasuredHeight(node.getBoundingClientRect().height))
     observer.observe(node)
     return () => observer.disconnect()
   }, [])
 
-  const items: SummaryListItem[] = isEmpty
-    ? [{
-        key: 'empty',
-        node: (
-          <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
-            You will see a preview of what changes once you make the selections above.
-          </p>
-        ),
-      }]
-    : [
-        ...rows.map((row) => ({
-          key: row.label,
-          node: <SummaryRow label={row.label} value={row.value} detail={row.detail} />,
-        })),
+  const items: SummaryListItem[] = useMemo(
+    () =>
+      isEmpty
+        ? [{
+            key: 'empty',
+            node: (
+              <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                You will see a preview of what changes once you make the selections above.
+              </p>
+            ),
+          }]
+        : [
+            ...rows.map((row) => ({
+              key: row.label,
+              node: <SummaryRow label={row.label} value={row.value} detail={row.detail} />,
+            })),
 
-        // Reaching this branch already means a row or a warning is standing, which is the same
-        // gate a note needs, so nothing further conditions it here
-        ...notes.map((note) => ({
-          key: note.key,
-          node: (
-            <div className="flex items-start gap-1.5 text-sm" style={{ color: 'var(--app-text-muted)' }}>
-              <Info size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
-              <span>{note.text}</span>
-            </div>
-          ),
-        })),
+            // Reaching this branch already means a row or a warning is standing, which is the same
+            // gate a note needs, so nothing further conditions it here
+            ...notes.map((note) => ({
+              key: note.key,
+              node: (
+                <div className="flex items-start gap-1.5 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                  <Info size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
+                  <span>{note.text}</span>
+                </div>
+              ),
+            })),
 
-        // Only the first warning carries the rule that sets the group apart from the rows and
-        // notes above it, since later ones sit directly under the one before
-        ...warnings.map((warning, index) => ({
-          key: warning.key,
-          node: (
-            <div
-              className="flex items-start gap-1.5 text-sm"
-              style={{
-                color: 'var(--app-warning-text)',
-                ...(index === 0 ? { borderTop: '1px solid var(--app-border)', paddingTop: '0.75rem' } : {}),
-              }}
-            >
-              <TriangleAlert size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
-              <span>{warning.text}</span>
-            </div>
-          ),
-        })),
-      ]
+            // Only the first warning carries the rule that sets the group apart from the rows and
+            // notes above it, since later ones sit directly under the one before
+            ...warnings.map((warning, index) => ({
+              key: warning.key,
+              node: (
+                <div
+                  className="flex items-start gap-1.5 text-sm"
+                  style={{
+                    color: 'var(--app-warning-text)',
+                    ...(index === 0 ? { borderTop: '1px solid var(--app-border)', paddingTop: '0.75rem' } : {}),
+                  }}
+                >
+                  <TriangleAlert size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
+                  <span>{warning.text}</span>
+                </div>
+              ),
+            })),
+          ],
+    [isEmpty, rows, notes, warnings],
+  )
+
+  // Re-measures whenever the rendered list changes, landing the new target before the browser
+  // paints the frame that changed the content, so the tween starts on the very next frame rather
+  // than one paint later
+  useLayoutEffect(() => {
+    const node = contentRef.current
+    if (!node) return
+    setMeasuredHeight(node.getBoundingClientRect().height)
+  }, [items])
 
   return (
     <motion.div
       animate={{ height: measuredHeight ?? 'auto' }}
       transition={ITEM_TRANSITION}
-      style={{ overflow: isEasingHeight ? 'hidden' : 'visible' }}
-      onAnimationStart={() => setIsEasingHeight(true)}
-      onAnimationComplete={() => setIsEasingHeight(false)}
+      style={{ overflow: 'hidden' }}
     >
       <div ref={contentRef} className="relative flex flex-col gap-3" aria-live="polite">
         <AnimatePresence initial={false} mode="popLayout">

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -66,7 +66,11 @@ function SummaryRow({ label, value, detail }: { label: string; value: string; de
  * their kind, so a count changing in place rewrites a line's text without replaying its entrance.
  * Warnings sit under a rule below the rows and notes, since they are what holds Apply disabled
  * rather than a description of what the edit does. A viewer who asks the system for reduced
- * motion gets the same rows with the height tween, the fade and the layout shift all skipped
+ * motion gets the same rows with the height tween, the fade and the layout shift all skipped.
+ *
+ * Only the note and warning lines announce themselves, on their own wrappers rather than one live
+ * region around the whole list, since a plain row's value changing on every keystroke in Note or
+ * Date is not something a screen reader needs read out
  */
 export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
   const { rows, notes, warnings } = summary
@@ -114,7 +118,11 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
             ...notes.map((note) => ({
               key: note.key,
               node: (
-                <div className="flex items-start gap-1.5 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                <div
+                  className="flex items-start gap-1.5 text-sm"
+                  style={{ color: 'var(--app-text-muted)' }}
+                  aria-live="polite"
+                >
                   <Info size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
                   <span>{note.text}</span>
                 </div>
@@ -134,6 +142,7 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
                     color: 'var(--app-negative)',
                     ...(index === 0 ? { borderTop: '1px solid var(--app-border)', paddingTop: '0.75rem' } : {}),
                   }}
+                  aria-live="polite"
                 >
                   <TriangleAlert size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
                   <span>{warning.text}</span>
@@ -159,7 +168,7 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
       transition={itemTransition}
       style={{ overflow: 'hidden' }}
     >
-      <div ref={contentRef} className="relative flex flex-col gap-3" aria-live="polite">
+      <div ref={contentRef} className="relative flex flex-col gap-3">
         <AnimatePresence initial={false} mode="popLayout">
           {items.map((item) => (
             <motion.div

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -1,4 +1,7 @@
-import { Info, TriangleAlert } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { AnimatePresence, motion } from 'motion/react'
+import { ArrowRight, Info, TriangleAlert } from 'lucide-react'
+import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
 import type { BulkEditSummary as BulkEditSummaryResult } from '@/pages/transactions/components/bulk-edit/summary'
 
 interface BulkEditSummaryProps {
@@ -6,64 +9,122 @@ interface BulkEditSummaryProps {
 }
 
 /**
+ * One line in the animated list, keyed by what it represents rather than by its rendered content,
+ * so a row or a warning whose count changes in place is not read as a new line replacing the old
+ */
+interface SummaryListItem {
+  key: string
+  node: ReactNode
+}
+
+const ITEM_TRANSITION = { duration: 0.18, ease: EASE }
+
+/**
+ * Renders one row's label, an arrow connecting it to the value, and the value itself, wrapping
+ * rather than crowding out the connector when the value runs long
+ */
+function SummaryRow({ label, value, detail }: { label: string; value: string; detail?: string }) {
+  return (
+    <div>
+      <div className="flex items-center gap-3">
+        <span className="shrink-0 text-sm font-medium" style={{ color: 'var(--app-text-muted)' }}>
+          {label}
+        </span>
+        <span aria-hidden className="flex flex-1 min-w-6 items-center">
+          <span className="w-full" style={{ borderTop: '1px dashed var(--app-border)' }} />
+          <ArrowRight size={12} className="shrink-0" style={{ color: 'var(--app-text-muted)' }} />
+        </span>
+        <span className="min-w-0 text-right text-sm font-semibold" style={{ color: 'var(--app-text)' }}>
+          {value}
+        </span>
+      </div>
+      {detail && (
+        <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+          {detail}
+        </p>
+      )}
+    </div>
+  )
+}
+
+/**
  * Renders what a bulk edit would do to the selected transactions: a row per detail it sends, a note
  * for anything it passes over, and a warning for anything the server would refuse
  *
- * Warnings sit under a rule below the rows and notes, since they are what holds Apply disabled
- * rather than a description of what the edit does
+ * Every row, note and warning is one item of a single animated list, so a detail appearing or
+ * settling grows and shrinks the panel around it rather than snapping to its new height. Rows are
+ * keyed by their label and notes and warnings by their kind, so a count changing in place rewrites
+ * a line's text without replaying its entrance. Warnings sit under a rule below the rows and notes,
+ * since they are what holds Apply disabled rather than a description of what the edit does
  */
 export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
   const { rows, notes, warnings } = summary
+  const isEmpty = rows.length === 0 && warnings.length === 0
 
-  if (rows.length === 0 && warnings.length === 0) {
-    return (
-      <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
-        Nothing changes yet. Set a detail above.
-      </p>
-    )
-  }
+  const items: SummaryListItem[] = isEmpty
+    ? [{
+        key: 'empty',
+        node: (
+          <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+            Nothing changes yet. Set a detail above.
+          </p>
+        ),
+      }]
+    : [
+        ...rows.map((row) => ({
+          key: row.label,
+          node: <SummaryRow label={row.label} value={row.value} detail={row.detail} />,
+        })),
+
+        // Reaching this branch already means a row or a warning is standing, which is the same
+        // gate a note needs, so nothing further conditions it here
+        ...notes.map((note) => ({
+          key: note.key,
+          node: (
+            <div className="flex items-start gap-1.5 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+              <Info size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
+              <span>{note.text}</span>
+            </div>
+          ),
+        })),
+
+        // Only the first warning carries the rule that sets the group apart from the rows and
+        // notes above it, since later ones sit directly under the one before
+        ...warnings.map((warning, index) => ({
+          key: warning.key,
+          node: (
+            <div
+              className="flex items-start gap-1.5 text-sm"
+              style={{
+                color: 'var(--app-warning-text)',
+                ...(index === 0 ? { borderTop: '1px solid var(--app-border)', paddingTop: '0.75rem' } : {}),
+              }}
+            >
+              <TriangleAlert size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
+              <span>{warning.text}</span>
+            </div>
+          ),
+        })),
+      ]
 
   return (
-    <div className="space-y-3">
-      {rows.length > 0 && (
-        <div className="space-y-2">
-          {rows.map((row) => (
-            <div key={row.label}>
-              <div className="flex items-baseline justify-between gap-3">
-                <span className="text-sm font-medium" style={{ color: 'var(--app-text-muted)' }}>
-                  {row.label}
-                </span>
-                <span className="text-sm font-semibold" style={{ color: 'var(--app-text)' }}>
-                  {row.value}
-                </span>
-              </div>
-              {row.detail && (
-                <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
-                  {row.detail}
-                </p>
-              )}
-            </div>
+    <motion.div layout animate={{ height: 'auto' }} transition={ITEM_TRANSITION} style={{ overflow: 'hidden' }}>
+      <div className="relative flex flex-col gap-3">
+        <AnimatePresence initial={false} mode="popLayout">
+          {items.map((item) => (
+            <motion.div
+              key={item.key}
+              layout
+              initial={{ opacity: 0, y: -4 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -4 }}
+              transition={ITEM_TRANSITION}
+            >
+              {item.node}
+            </motion.div>
           ))}
-        </div>
-      )}
-
-      {notes.map((note) => (
-        <div key={note} className="flex items-start gap-1.5 text-sm" style={{ color: 'var(--app-text-muted)' }}>
-          <Info size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
-          <span>{note}</span>
-        </div>
-      ))}
-
-      {warnings.length > 0 && (
-        <div className="space-y-1.5 pt-3" style={{ borderTop: '1px solid var(--app-border)' }}>
-          {warnings.map((warning) => (
-            <div key={warning} className="flex items-start gap-1.5 text-sm" style={{ color: 'var(--app-warning-text)' }}>
-              <TriangleAlert size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
-              <span>{warning}</span>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+        </AnimatePresence>
+      </div>
+    </motion.div>
   )
 }

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -1,5 +1,5 @@
 import { useLayoutEffect, useMemo, useRef, useState, type ReactNode } from 'react'
-import { AnimatePresence, motion } from 'motion/react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { ArrowRight, CornerDownRight, Info, TriangleAlert } from 'lucide-react'
 import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
 import type { BulkEditSummary as BulkEditSummaryResult } from '@/pages/transactions/components/bulk-edit/summary'
@@ -65,11 +65,17 @@ function SummaryRow({ label, value, detail }: { label: string; value: string; de
  * panel would carry them out of place. Rows are keyed by their label and notes and warnings by
  * their kind, so a count changing in place rewrites a line's text without replaying its entrance.
  * Warnings sit under a rule below the rows and notes, since they are what holds Apply disabled
- * rather than a description of what the edit does
+ * rather than a description of what the edit does. A viewer who asks the system for reduced
+ * motion gets the same rows with the height tween, the fade and the layout shift all skipped
  */
 export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
   const { rows, notes, warnings } = summary
   const isEmpty = rows.length === 0 && warnings.length === 0
+
+  // Reduced motion drops the tween entirely rather than merely shortening it, matching how the
+  // toolbar and fund flow lists gate their own height animations
+  const shouldReduceMotion = useReducedMotion()
+  const itemTransition = shouldReduceMotion ? { duration: 0 } : ITEM_TRANSITION
 
   const contentRef = useRef<HTMLDivElement>(null)
   // Null until the first measurement lands, which is what lets the box render unconstrained at
@@ -150,7 +156,7 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
   return (
     <motion.div
       animate={{ height: measuredHeight ?? 'auto' }}
-      transition={ITEM_TRANSITION}
+      transition={itemTransition}
       style={{ overflow: 'hidden' }}
     >
       <div ref={contentRef} className="relative flex flex-col gap-3" aria-live="polite">
@@ -158,11 +164,11 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
           {items.map((item) => (
             <motion.div
               key={item.key}
-              layout
-              initial={{ opacity: 0, y: -4 }}
+              layout={!shouldReduceMotion}
+              initial={shouldReduceMotion ? false : { opacity: 0, y: -4 }}
               animate={{ opacity: 1, y: 0 }}
-              exit={{ opacity: 0, y: -4 }}
-              transition={ITEM_TRANSITION}
+              exit={shouldReduceMotion ? { opacity: 0 } : { opacity: 0, y: -4 }}
+              transition={itemTransition}
             >
               {item.node}
             </motion.div>

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -1,0 +1,69 @@
+import { Info, TriangleAlert } from 'lucide-react'
+import type { BulkEditSummary as BulkEditSummaryResult } from '@/pages/transactions/components/bulk-edit/summary'
+
+interface BulkEditSummaryProps {
+  summary: BulkEditSummaryResult
+}
+
+/**
+ * Renders what a bulk edit would do to the selected transactions: a row per detail it sends, a note
+ * for anything it passes over, and a warning for anything the server would refuse
+ *
+ * Warnings sit under a rule below the rows and notes, since they are what holds Apply disabled
+ * rather than a description of what the edit does
+ */
+export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
+  const { rows, notes, warnings } = summary
+
+  if (rows.length === 0 && warnings.length === 0) {
+    return (
+      <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+        Nothing changes yet. Set a detail above.
+      </p>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.length > 0 && (
+        <div className="space-y-2">
+          {rows.map((row) => (
+            <div key={row.label}>
+              <div className="flex items-baseline justify-between gap-3">
+                <span className="text-sm font-medium" style={{ color: 'var(--app-text-muted)' }}>
+                  {row.label}
+                </span>
+                <span className="text-sm font-semibold" style={{ color: 'var(--app-text)' }}>
+                  {row.value}
+                </span>
+              </div>
+              {row.detail && (
+                <p className="text-sm" style={{ color: 'var(--app-text-muted)' }}>
+                  {row.detail}
+                </p>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {notes.map((note) => (
+        <div key={note} className="flex items-start gap-1.5 text-sm" style={{ color: 'var(--app-text-muted)' }}>
+          <Info size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
+          <span>{note}</span>
+        </div>
+      ))}
+
+      {warnings.length > 0 && (
+        <div className="space-y-1.5 pt-3" style={{ borderTop: '1px solid var(--app-border)' }}>
+          {warnings.map((warning) => (
+            <div key={warning} className="flex items-start gap-1.5 text-sm" style={{ color: 'var(--app-warning-text)' }}>
+              <TriangleAlert size={15} strokeWidth={2.5} className="mt-0.5 shrink-0" aria-hidden />
+              <span>{warning}</span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -116,14 +116,16 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
             })),
 
             // Only the first warning carries the rule that sets the group apart from the rows and
-            // notes above it, since later ones sit directly under the one before
+            // notes above it, since later ones sit directly under the one before. Every warning
+            // describeBulkEdit produces backs a blocker that holds Apply disabled, so all of them
+            // draw in the same negative colour as the icon beside them
             ...warnings.map((warning, index) => ({
               key: warning.key,
               node: (
                 <div
                   className="flex items-start gap-1.5 text-sm"
                   style={{
-                    color: 'var(--app-warning-text)',
+                    color: 'var(--app-negative)',
                     ...(index === 0 ? { borderTop: '1px solid var(--app-border)', paddingTop: '0.75rem' } : {}),
                   }}
                 >

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { AnimatePresence, motion } from 'motion/react'
 import { ArrowRight, Info, TriangleAlert } from 'lucide-react'
 import { EASE } from '@/pages/transactions/components/transaction-modal/constants'
@@ -51,15 +51,34 @@ function SummaryRow({ label, value, detail }: { label: string; value: string; de
  * Renders what a bulk edit would do to the selected transactions: a row per detail it sends, a note
  * for anything it passes over, and a warning for anything the server would refuse
  *
- * Every row, note and warning is one item of a single animated list, so a detail appearing or
- * settling grows and shrinks the panel around it rather than snapping to its new height. Rows are
- * keyed by their label and notes and warnings by their kind, so a count changing in place rewrites
- * a line's text without replaying its entrance. Warnings sit under a rule below the rows and notes,
- * since they are what holds Apply disabled rather than a description of what the edit does
+ * The box eases between its own measured heights as a row appears, settles or leaves, rather than
+ * jumping in one frame, and the content-sized panel around it follows along. The panel itself is
+ * never animated, since the drop-downs inside it track their trigger while it is open and a moving
+ * panel would carry them out of place. Rows are keyed by their label and notes and warnings by
+ * their kind, so a count changing in place rewrites a line's text without replaying its entrance.
+ * Warnings sit under a rule below the rows and notes, since they are what holds Apply disabled
+ * rather than a description of what the edit does
  */
 export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
   const { rows, notes, warnings } = summary
   const isEmpty = rows.length === 0 && warnings.length === 0
+
+  const contentRef = useRef<HTMLDivElement>(null)
+  // Null until the first measurement lands, which is what lets the box render unconstrained at
+  // mount. That first measurement then reports the same height the unconstrained box already has,
+  // so easing to it moves nothing, and only a later measurement, taken after a row changes the
+  // content, actually has a different height to ease towards
+  const [measuredHeight, setMeasuredHeight] = useState<number | null>(null)
+  const [isEasingHeight, setIsEasingHeight] = useState(false)
+
+  useLayoutEffect(() => {
+    const node = contentRef.current
+    if (!node) return undefined
+
+    const observer = new ResizeObserver(() => setMeasuredHeight(node.offsetHeight))
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
 
   const items: SummaryListItem[] = isEmpty
     ? [{
@@ -108,8 +127,14 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
       ]
 
   return (
-    <motion.div layout animate={{ height: 'auto' }} transition={ITEM_TRANSITION} style={{ overflow: 'hidden' }}>
-      <div className="relative flex flex-col gap-3">
+    <motion.div
+      animate={{ height: measuredHeight ?? 'auto' }}
+      transition={ITEM_TRANSITION}
+      style={{ overflow: isEasingHeight ? 'hidden' : 'visible' }}
+      onAnimationStart={() => setIsEasingHeight(true)}
+      onAnimationComplete={() => setIsEasingHeight(false)}
+    >
+      <div ref={contentRef} className="relative flex flex-col gap-3">
         <AnimatePresence initial={false} mode="popLayout">
           {items.map((item) => (
             <motion.div

--- a/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
+++ b/frontend/src/pages/transactions/components/bulk-edit/BulkEditSummary.tsx
@@ -134,7 +134,7 @@ export default function BulkEditSummary({ summary }: BulkEditSummaryProps) {
       onAnimationStart={() => setIsEasingHeight(true)}
       onAnimationComplete={() => setIsEasingHeight(false)}
     >
-      <div ref={contentRef} className="relative flex flex-col gap-3">
+      <div ref={contentRef} className="relative flex flex-col gap-3" aria-live="polite">
         <AnimatePresence initial={false} mode="popLayout">
           {items.map((item) => (
             <motion.div

--- a/frontend/src/pages/transactions/components/bulk-edit/confirmation.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/confirmation.ts
@@ -1,0 +1,55 @@
+import type { Transaction } from '@/api/transactions'
+
+type ConfirmationTransaction = Pick<
+  Transaction,
+  | 'id'
+  | 'updated_at'
+  | 'account_id'
+  | 'dt'
+  | 'merchant_id'
+  | 'category_id'
+  | 'amount'
+  | 'currency'
+  | 'fx_rate'
+  | 'notes'
+  | 'counterparty_account_id'
+  | 'counterparty_account_scope'
+  | 'tag_ids'
+>
+
+/**
+ * Returns a stable signature of the stored values for the selected transactions
+ *
+ * Missing selected rows remain in the signature so a refetch can invalidate confirmation before
+ * the selection state removes them. Display labels and calculated currency amounts stay out because
+ * they do not change the transaction being confirmed
+ */
+export function selectedTransactionsSignature(
+  transactions: readonly ConfirmationTransaction[],
+  selectedIds: readonly string[],
+): string {
+  const transactionsById = new Map(transactions.map((transaction) => [transaction.id, transaction]))
+
+  return JSON.stringify(
+    [...selectedIds].sort().map((id) => {
+      const transaction = transactionsById.get(id)
+      if (!transaction) return [id, null]
+
+      return [
+        transaction.id,
+        transaction.updated_at,
+        transaction.account_id,
+        transaction.dt,
+        transaction.merchant_id,
+        transaction.category_id,
+        transaction.amount,
+        transaction.currency,
+        transaction.fx_rate,
+        transaction.notes,
+        transaction.counterparty_account_id,
+        transaction.counterparty_account_scope,
+        [...transaction.tag_ids].sort(),
+      ]
+    }),
+  )
+}

--- a/frontend/src/pages/transactions/components/bulk-edit/constants.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/constants.ts
@@ -1,0 +1,7 @@
+/**
+ * Transactions one bulk edit may carry, matching the bound the endpoint enforces
+ *
+ * Held here as well so the bar can stop a larger selection before the confirmation, rather than
+ * letting the request be refused after the user has already agreed to it
+ */
+export const MAX_BULK_EDIT_TRANSACTIONS = 1000

--- a/frontend/src/pages/transactions/components/bulk-edit/constants.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/constants.ts
@@ -1,7 +1,7 @@
 /**
  * Transactions one bulk edit may carry, matching the bound the endpoint enforces
  *
- * Held here as well so the bar can stop a larger selection before the confirmation, rather than
+ * Held here as well so the modal can stop a larger selection before the confirmation, rather than
  * letting the request be refused after the user has already agreed to it
  */
 export const MAX_BULK_EDIT_TRANSACTIONS = 1000

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -1,6 +1,6 @@
 /**
- * Which transactions a bulk edit covers, what a pending shift-click would change it to, and what
- * the panel sends once the user presses Apply.
+ * Which transactions a bulk edit covers, what a pending shift-click or day tick would change it to,
+ * and what the panel sends once the user presses Apply.
  *
  * Every transition is a pure function of the state and the rows on screen, so the range, the anchor,
  * the pointer preview and the request body can all be checked without rendering anything.
@@ -147,12 +147,21 @@ export interface BulkSelectionState {
 
   /** The row the pointer is over while shift is held, or null when nothing is being previewed */
   hoveredId: string | null;
+
+  /**
+   * The transactions shown under the day heading the pointer is over, or null when no heading is
+   * being previewed. Held whether or not shift is down, since a day tick takes everything under one
+   * heading rather than a range with a far end to aim
+   */
+  hoveredGroupIds: string[] | null;
 }
 
 export type BulkSelectionAction =
   | { type: 'toggle'; id: string; rows: SelectableRow[] }
   | { type: 'extend'; id: string; rows: SelectableRow[] }
+  | { type: 'toggleGroup'; ids: string[]; rows: SelectableRow[] }
   | { type: 'hover'; id: string | null }
+  | { type: 'hoverGroup'; ids: string[] | null }
   | { type: 'keepDisplayed'; ids: string[] }
   | { type: 'clear' };
 
@@ -161,6 +170,7 @@ export const emptyBulkSelection: BulkSelectionState = {
   anchorId: null,
   baselineIds: new Set(),
   hoveredId: null,
+  hoveredGroupIds: null,
 };
 
 /**
@@ -197,8 +207,68 @@ export function resultingSelection(
 }
 
 /**
- * Returns what the selection would become if the pending shift-click happened, or null when nothing
- * is pending.
+ * Returns the transactions under one day heading that the app allows editing, in the order the
+ * heading shows them.
+ *
+ * @param ids The transactions shown under one heading
+ * @param rows Every row on screen, which is what says whether one can be edited
+ */
+function editableGroupIds(ids: string[], rows: SelectableRow[]): string[] {
+  return ids.filter((id) => rows.find((row) => row.id === id)?.isReadOnly === false);
+}
+
+/**
+ * Returns what the selection becomes when a day heading's tick is clicked, or null when the day
+ * shows nothing the app allows editing and the click changes nothing.
+ *
+ * A day already taken whole is dropped whole, and anything else is taken. Either way the ticks in
+ * other days are left as they are.
+ */
+export function groupResultingSelection(
+  selectedIds: Set<string>,
+  ids: string[],
+  rows: SelectableRow[],
+): Set<string> | null {
+  const editable = editableGroupIds(ids, rows);
+  if (editable.length === 0) return null;
+
+  const dropsTheDay = editable.every((id) => selectedIds.has(id));
+  const resulting = new Set(selectedIds);
+  for (const id of editable) {
+    if (dropsTheDay) resulting.delete(id);
+    else resulting.add(id);
+  }
+  return resulting;
+}
+
+/** How a day heading is marked, read against the rows it shows that the app allows editing */
+export type GroupSelectionMark = 'none' | 'some' | 'all' | 'unselectable';
+
+/**
+ * Returns how a day heading's tick is marked.
+ *
+ * Read against the transactions the heading shows rather than the whole calendar day, since the list
+ * loads a page at a time and the last heading on screen usually stands over only part of its day.
+ * Once a later page adds more of that day, a heading that read all falls back to some.
+ *
+ * A day showing nothing the app allows editing is unselectable rather than unticked, so the heading
+ * can offer a tick that is plainly off rather than one that refuses when clicked.
+ */
+export function groupSelectionMark(
+  ids: string[],
+  rows: SelectableRow[],
+  selectedIds: Set<string>,
+): GroupSelectionMark {
+  const editable = editableGroupIds(ids, rows);
+  if (editable.length === 0) return 'unselectable';
+  if (editable.every((id) => selectedIds.has(id))) return 'all';
+  if (editable.some((id) => selectedIds.has(id))) return 'some';
+  return 'none';
+}
+
+/**
+ * Returns what the selection would become if the pending click happened, or null when nothing is
+ * pending.
  *
  * This is the whole resulting set rather than only the rows a click would add, so the highlight can
  * show a row the click would drop losing its mark before anything is clicked.
@@ -207,11 +277,22 @@ export function previewSelection(
   state: BulkSelectionState,
   rows: SelectableRow[],
 ): Set<string> | null {
+  // The pointer is over a day heading or over a row, never both, so only one of these is ever set
+  if (state.hoveredGroupIds !== null) {
+    return groupResultingSelection(state.selectedIds, state.hoveredGroupIds, rows);
+  }
+
   if (state.hoveredId === null) return null;
   return resultingSelection(state, state.hoveredId, rows);
 }
 
-/** How one row is marked, once any pending shift-click is taken into account */
+/** Returns whether two hovered headings are the same one, so a repeated move changes no state */
+function isSameGroup(current: string[] | null, next: string[] | null): boolean {
+  if (current === null || next === null) return current === next;
+  return current.length === next.length && current.every((id, index) => id === next[index]);
+}
+
+/** How one row is marked, once any pending shift-click or day tick is taken into account */
 export type RowSelectionMark = 'none' | 'selected' | 'pending';
 
 /**
@@ -249,7 +330,13 @@ export function bulkSelectionReducer(
 
       // The clicked row becomes the anchor whichever way it went, and the ticks left behind become
       // the baseline the next range builds on
-      return { selectedIds, anchorId: action.id, baselineIds: new Set(selectedIds), hoveredId: null };
+      return {
+        selectedIds,
+        anchorId: action.id,
+        baselineIds: new Set(selectedIds),
+        hoveredId: null,
+        hoveredGroupIds: null,
+      };
     }
 
     case 'extend': {
@@ -257,12 +344,41 @@ export function bulkSelectionReducer(
       if (resulting === null) {
         return bulkSelectionReducer(state, { type: 'toggle', id: action.id, rows: action.rows });
       }
-      return { ...state, selectedIds: resulting, hoveredId: null };
+      return { ...state, selectedIds: resulting, hoveredId: null, hoveredGroupIds: null };
     }
 
-    case 'hover':
-      if (state.hoveredId === action.id) return state;
-      return { ...state, hoveredId: action.id };
+    case 'toggleGroup': {
+      const resulting = groupResultingSelection(state.selectedIds, action.ids, action.rows);
+      if (resulting === null) return state;
+
+      // No single row was clicked, so there is no anchor for a following shift-click to run from.
+      // The baseline goes with it rather than being left behind pointing at ticks that have gone
+      return {
+        selectedIds: resulting,
+        anchorId: null,
+        baselineIds: new Set(resulting),
+        hoveredId: null,
+        hoveredGroupIds: null,
+      };
+    }
+
+    case 'hover': {
+      // A row under the pointer means no day heading is under it, so a heading preview left behind
+      // goes with it. Clearing the row hover leaves the heading preview alone, since releasing shift
+      // clears the row hover and a day preview never depended on shift
+      const hoveredGroupIds = action.id === null ? state.hoveredGroupIds : null;
+      if (state.hoveredId === action.id && state.hoveredGroupIds === hoveredGroupIds) return state;
+      return { ...state, hoveredId: action.id, hoveredGroupIds };
+    }
+
+    case 'hoverGroup': {
+      // A heading under the pointer means no row is under it, so a row preview left behind goes with
+      // it. Without that, moving off the small tick onto the heading's own label would put the old
+      // range back up over rows the pointer is nowhere near
+      const hoveredId = action.ids === null ? state.hoveredId : null;
+      if (isSameGroup(state.hoveredGroupIds, action.ids) && state.hoveredId === hoveredId) return state;
+      return { ...state, hoveredGroupIds: action.ids, hoveredId };
+    }
 
     case 'keepDisplayed': {
       const displayed = new Set(action.ids);

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -151,13 +151,17 @@ export function buildBulkEditFields(choice: BulkEditChoice): BulkEditFields {
   // both would be two answers for the one column
   const sendsAnEnd = endsAreOffered && (transferFrom !== null || transferTo !== null)
 
+  // Trimmed before the emptiness check, so a note of only spaces reads the same as one never typed
+  // rather than sending whitespace the single-transaction form would refuse
+  const trimmedNote = note.trim()
+
   return {
     ...(categoryId ? { category_id: categoryId } : {}),
     ...(merchantId ? { merchant_id: merchantId } : {}),
     ...(tagIds.length ? { add_tag_ids: tagIds } : {}),
     ...(accountId && !sendsAnEnd ? { account_id: accountId } : {}),
     ...(date ? { dt: date } : {}),
-    ...(clearsNote ? { notes: null } : note ? { notes: note } : {}),
+    ...(clearsNote ? { notes: null } : trimmedNote ? { notes: trimmedNote } : {}),
 
     // An implied direction reaches only the transfer rows, as transfer_direction, so it cannot
     // touch the rows the ends leave alone, while a direction the user picked reaches every
@@ -209,6 +213,34 @@ export interface SelectedTransactionFacts {
 
   /** Money out when its amount is negative, money in otherwise, on the server and in the browser alike */
   direction: TransactionDirection;
+}
+
+/**
+ * Returns a string that changes only when a fact the implied-direction and end rules read on some
+ * row changes, id included so a row swapped for another with the same facts still counts as a
+ * change. `rows` itself is a new array reference on every refetch even when nothing here moved, so
+ * comparing this key across renders is what tells a real change in the facts apart from that.
+ *
+ * Covers id, accountId, currency, recordsFarSide, hasFarSideRecorded, farSideAccountId and
+ * direction, which is every field impliedDirection, endsAfterDirectionClick, resolveTransferEnds
+ * and resultingDirectionFor read off a row.
+ *
+ * @param rows The selected transactions
+ */
+export function rowFactsKey(rows: SelectedTransactionFacts[]): string {
+  return rows
+    .map((row) =>
+      [
+        row.id,
+        row.accountId,
+        row.currency,
+        row.recordsFarSide,
+        row.hasFarSideRecorded,
+        row.farSideAccountId ?? '',
+        row.direction,
+      ].join('|'),
+    )
+    .join(';');
 }
 
 /**
@@ -523,7 +555,11 @@ export interface BulkEditBlockers {
  * Each of these refuses the whole batch, and each is reachable without the user doing anything wrong:
  * a row recorded before merchants were required, a transfer recorded before the far account was, a row
  * whose far account and own account end up the same, an own end that would leave the row outside the
- * tracked accounts, and an own end in a currency the row does not hold.
+ * tracked accounts, and an own end in a currency the row does not hold. An own end that resolves to the
+ * account the row already sits in is exempt from that last one, since nothing moves and the server never
+ * touches the exchange rate for it; a real cross-currency move is refused here even for a row that
+ * already carries a rate the server would accept, a deliberate narrowing tighter than the server's own
+ * check.
  *
  * Not every refusal is modelled. A transfer pointing at an account the user can no longer open is one
  * the server alone can see, since a list fixed to one account carries no others to test against.
@@ -544,6 +580,11 @@ export function getBulkEditBlockers(
   const sitsOutside: string[] = [];
   const ownSideInAnotherCurrency: string[] = [];
 
+  // An end and a move both write account_id, on whichever rows resolve to be their own, so a stray
+  // Move to account choice never actually reaches the request once an end is set, the same rule
+  // buildBulkEditFields applies
+  const sendsAnEnd = choice.endsAreOffered && (choice.transferFrom !== null || choice.transferTo !== null);
+
   for (const row of rows) {
     if (!row.hasMerchant && !choice.merchantId) withoutMerchant.push(row.id);
 
@@ -560,7 +601,10 @@ export function getBulkEditBlockers(
       continue;
     }
 
-    if (ownEnd?.scope === 'tracked' && ownEnd.currency !== row.currency) {
+    // An own end that resolves to the row's own account moves nothing, so a currency mismatch here
+    // is never actually written and would only tell the user to fix a move that was never happening
+    const ownEndStaysPut = ownEnd?.scope === 'tracked' && ownEnd.accountId === row.accountId;
+    if (ownEnd?.scope === 'tracked' && ownEnd.currency !== row.currency && !ownEndStaysPut) {
       ownSideInAnotherCurrency.push(row.id);
       continue;
     }
@@ -570,7 +614,9 @@ export function getBulkEditBlockers(
       continue;
     }
 
-    const resultingOwnAccountId = ownEnd?.scope === 'tracked' ? ownEnd.accountId : (choice.accountId || row.accountId);
+    const resultingOwnAccountId = ownEnd?.scope === 'tracked'
+      ? ownEnd.accountId
+      : (!sendsAnEnd && choice.accountId ? choice.accountId : row.accountId);
     const resultingFarSideAccountId = farEnd === null
       ? row.farSideAccountId
       : farEnd.scope === 'tracked' ? farEnd.accountId : null;

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -6,6 +6,7 @@
  * the pointer preview and the request body can all be checked without rendering anything.
  */
 import type { Category } from '@/api/categories'
+import type { BulkDirectionChange, BulkTransferEnd, TransactionDirection } from '@/api/transactions'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   BALANCE_ADJUSTMENT_CATEGORY_NAME,
@@ -49,9 +50,28 @@ export function getBulkMoveTargets<T extends { is_archived?: boolean; closed_at?
   )
 }
 
-/** Where the other side of a transfer sits, or null when the panel has not been asked */
-export type TransferTargetChoice =
-  | { scope: 'tracked'; accountId: string }
+/**
+ * Returns the accounts a transfer's ends can be set to.
+ *
+ * Unlike a move, an end is not held to the selection's currency: the far end only records a fact,
+ * and the own end is checked against each row's own currency separately, in
+ * ownSideInAnotherCurrency below.
+ *
+ * @param accounts Every account the list knows about
+ */
+export function getTransferEndTargets<T extends { is_archived?: boolean; closed_at?: string | null }>(
+  accounts: T[],
+): T[] {
+  return accounts.filter((account) => !account.is_archived && !account.closed_at)
+}
+
+/**
+ * Where one end of a transfer sits, as the panel holds it. The currency travels with a tracked
+ * account so the blockers can compare it against each row without a separate account lookup;
+ * buildBulkEditFields strips it before the request is sent
+ */
+export type TransferEndChoice =
+  | { scope: 'tracked'; accountId: string; currency: string }
   | { scope: 'outside' }
 
 /** What the panel holds, before it becomes a request */
@@ -68,13 +88,22 @@ export interface BulkEditChoice {
   /** True when the note box is meant to take the note off rather than set one */
   clearsNote: boolean
 
-  transferTarget: TransferTargetChoice | null
+  /** Where the transfer's From end sits, or null to leave it as it is */
+  transferFrom: TransferEndChoice | null
+
+  /** Where the transfer's To end sits, or null to leave it as it is */
+  transferTo: TransferEndChoice | null
+
+  /** Which way every selected transaction should end up pointing, or null to leave each as it is */
+  direction: BulkDirectionChange | null
 
   /**
-   * True when every selected transaction ends up under a category that records the account on the
-   * other side of a transfer, which is what decides whether the answer can be sent at all
+   * True while any selected row ends up under a category that records the account on the other side
+   * of a transfer, which is what offers the From and To controls at all. Held beside the ends so a
+   * choice made before the selection or the category changed cannot be sent once the controls have
+   * gone
    */
-  resultingCategoriesRecordTransferTarget: boolean
+  endsAreOffered: boolean
 }
 
 /** The details a bulk request carries, which is everything in it except the transactions it covers */
@@ -85,8 +114,16 @@ export interface BulkEditFields {
   account_id?: string
   dt?: string
   notes?: string | null
-  counterparty_account_id?: string | null
-  counterparty_account_scope?: 'tracked' | 'outside' | null
+  transfer_from?: BulkTransferEnd
+  transfer_to?: BulkTransferEnd
+  direction?: BulkDirectionChange
+}
+
+/** Turns a panel-held end choice into the shape the request sends, dropping the currency it carries */
+function toBulkTransferEnd(choice: TransferEndChoice): BulkTransferEnd {
+  return choice.scope === 'tracked'
+    ? { scope: 'tracked', account_id: choice.accountId }
+    : { scope: 'outside' }
 }
 
 /**
@@ -97,23 +134,26 @@ export interface BulkEditFields {
  * than an empty string.
  */
 export function buildBulkEditFields(choice: BulkEditChoice): BulkEditFields {
-  const { categoryId, merchantId, tagIds, accountId, date, note, clearsNote, transferTarget } = choice
+  const { categoryId, merchantId, tagIds, accountId, date, note, clearsNote } = choice
+  const { transferFrom, transferTo, endsAreOffered, direction } = choice
+
+  // An end and a move both write account_id, on whichever rows resolve to be their own, so sending
+  // both would be two answers for the one column
+  const sendsAnEnd = endsAreOffered && (transferFrom !== null || transferTo !== null)
 
   return {
     ...(categoryId ? { category_id: categoryId } : {}),
     ...(merchantId ? { merchant_id: merchantId } : {}),
     ...(tagIds.length ? { add_tag_ids: tagIds } : {}),
-    ...(accountId ? { account_id: accountId } : {}),
+    ...(accountId && !sendsAnEnd ? { account_id: accountId } : {}),
     ...(date ? { dt: date } : {}),
     ...(clearsNote ? { notes: null } : note ? { notes: note } : {}),
-    // Only sent where every row ends up recording one. A target picked before the category was
-    // changed is otherwise still in the panel's state, invisible, and refuses the whole batch
-    ...(transferTarget && choice.resultingCategoriesRecordTransferTarget
-      ? {
-          counterparty_account_scope: transferTarget.scope,
-          counterparty_account_id: transferTarget.scope === 'tracked' ? transferTarget.accountId : null,
-        }
-      : {}),
+    ...(direction ? { direction } : {}),
+
+    // Only sent while the controls are on screen. An end picked before the category was changed
+    // away is otherwise still in the panel's state, invisible, and would refuse the whole batch
+    ...(endsAreOffered && transferFrom ? { transfer_from: toBulkTransferEnd(transferFrom) } : {}),
+    ...(endsAreOffered && transferTo ? { transfer_to: toBulkTransferEnd(transferTo) } : {}),
   }
 }
 
@@ -131,7 +171,7 @@ export function hasBulkEditChoice(choice: BulkEditChoice): boolean {
 export interface SelectedTransactionFacts {
   id: string;
 
-  /** The account it sits in, which a move changes */
+  /** The account it sits in, which an own end or a move would carry it out of */
   accountId: string;
 
   /** False for a row recorded before a merchant was required, which the server refuses to edit */
@@ -148,25 +188,139 @@ export interface SelectedTransactionFacts {
 
   /** The account recorded as the other side, absent where the money went outside the tracked accounts */
   farSideAccountId: string | null;
+
+  /** The currency the amount is denominated in */
+  currency: string;
+
+  /** Money out when its amount is negative, money in otherwise, on the server and in the browser alike */
+  direction: TransactionDirection;
 }
 
 /**
- * Returns whether every selected transaction ends up under a category that records the account on the
+ * Returns whether any selected transaction ends up under a category that records the account on the
  * other side of a transfer.
  *
- * The category a row ends up with is the chosen one where the edit sets one and its own otherwise. The
- * server sends the whole batch back where one row ends up recording no other side and the request
- * carries an answer for one, so the control is offered only where every row qualifies.
+ * The category a row ends up with is the chosen one where the edit sets one and its own otherwise.
+ * One row alone recording a far side is enough to offer the From and To controls, since a mixed
+ * selection still has to answer for the rows that need them and leaves the rest alone.
  *
  * @param chosenCategory The category the edit sets, or undefined while it sets none
  * @param rows The selected transactions
  */
-export function doEveryResultingCategoryRecordTransferTarget(
+export function doesAnyResultingCategoryRecordTransferTarget(
   chosenCategory: Category | undefined,
   rows: SelectedTransactionFacts[],
 ): boolean {
   if (chosenCategory) return doesChosenCategoryRecordTransferTarget(chosenCategory);
-  return rows.length > 0 && rows.every((row) => row.recordsFarSide);
+  return rows.some((row) => row.recordsFarSide);
+}
+
+/** Returns the opposite of a transaction's own direction, for an edit that turns a row around */
+function flipDirection(direction: TransactionDirection): TransactionDirection {
+  return direction === 'debit' ? 'credit' : 'debit';
+}
+
+/**
+ * Returns what a row ends up pointing, mirroring the service's resolution: the edit's direction
+ * where it sets one, the row's own flipped where the edit says reverse, the row's own otherwise
+ */
+function resultingDirectionFor(row: SelectedTransactionFacts, choice: BulkEditChoice): TransactionDirection {
+  if (choice.direction === 'reverse') return flipDirection(row.direction);
+  return choice.direction ?? row.direction;
+}
+
+/** What a row's own end and far end resolve to under an edit */
+export interface ResolvedTransferEnds {
+  ownEnd: TransferEndChoice | null;
+  farEnd: TransferEndChoice | null;
+}
+
+/**
+ * Returns what a row's own end and far end resolve to, mirroring the service's per-row resolution.
+ *
+ * Resulting direction decides which control answers which side: money out puts the row's own
+ * account on From and the far side on To, money in reverses that. A row whose resulting category
+ * records no far side ignores both ends, and an end the edit leaves unset leaves that side as it is.
+ *
+ * @param row The selected transaction
+ * @param choice What the edit holds
+ * @param endsUpRecordingFarSide Whether the row's resulting category records a far side at all
+ */
+export function resolveTransferEnds(
+  row: SelectedTransactionFacts,
+  choice: BulkEditChoice,
+  endsUpRecordingFarSide: boolean,
+): ResolvedTransferEnds {
+  if (!endsUpRecordingFarSide) return { ownEnd: null, farEnd: null };
+
+  return resultingDirectionFor(row, choice) === 'debit'
+    ? { ownEnd: choice.transferFrom, farEnd: choice.transferTo }
+    : { ownEnd: choice.transferTo, farEnd: choice.transferFrom };
+}
+
+/** How many selected rows one end of a transfer edit moves into it, or only records it on */
+export interface TransferEndEffect {
+  /** Rows whose own account this end sets, so the row itself moves */
+  moves: number;
+
+  /** Rows whose far side this end sets, without moving the row itself */
+  recordsOnly: number;
+}
+
+/** What a transfer end edit would do to the rows it covers, for the notice under each control */
+export interface TransferEndEffects {
+  from: TransferEndEffect;
+  to: TransferEndEffect;
+
+  /** Rows whose resulting category records no far side at all, which the ends cannot touch */
+  leftAlone: number;
+}
+
+/**
+ * Counts what a transfer end edit would do to each selected row.
+ *
+ * Each row's resulting direction decides which control answers its own side and which its far
+ * side, the same way resolveTransferEnds does. A control set on its own therefore still touches
+ * every transfer row: once as the move for the rows whose own side it answers, once as the record
+ * for the rest.
+ *
+ * @param rows The selected transactions
+ * @param choice What the edit holds
+ * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other
+ *     side, or undefined while the edit sets no category and each row keeps its own
+ */
+export function countTransferEndEffects(
+  rows: SelectedTransactionFacts[],
+  choice: BulkEditChoice,
+  chosenCategoryRecordsTransferTarget: boolean | undefined,
+): TransferEndEffects {
+  const effects: TransferEndEffects = {
+    from: { moves: 0, recordsOnly: 0 },
+    to: { moves: 0, recordsOnly: 0 },
+    leftAlone: 0,
+  };
+
+  for (const row of rows) {
+    const endsUpRecordingFarSide = chosenCategoryRecordsTransferTarget ?? row.recordsFarSide;
+    if (!endsUpRecordingFarSide) {
+      effects.leftAlone += 1;
+      continue;
+    }
+
+    // Money out puts From on the row's own account and To on the far side, money in the reverse
+    const fromIsOwn = resultingDirectionFor(row, choice) === 'debit';
+
+    if (choice.transferFrom !== null) {
+      if (fromIsOwn) effects.from.moves += 1;
+      else effects.from.recordsOnly += 1;
+    }
+    if (choice.transferTo !== null) {
+      if (fromIsOwn) effects.to.recordsOnly += 1;
+      else effects.to.moves += 1;
+    }
+  }
+
+  return effects;
 }
 
 /** The selected transactions an edit would have the server refuse the whole batch over */
@@ -179,6 +333,12 @@ export interface BulkEditBlockers {
 
   /** Rows that would end up recording the account they sit in as their own other side */
   ownAccountFarSide: string[];
+
+  /** Rows whose own end would resolve to outside the tracked accounts, where only a far end may sit */
+  sitsOutside: string[];
+
+  /** Rows whose own end would resolve to an account in another currency than the row's own */
+  ownSideInAnotherCurrency: string[];
 }
 
 /**
@@ -186,8 +346,9 @@ export interface BulkEditBlockers {
  * confirmed rather than after.
  *
  * Each of these refuses the whole batch, and each is reachable without the user doing anything wrong:
- * a row recorded before merchants were required, a transfer recorded before the far account was, and a
- * row whose far account and own account end up the same.
+ * a row recorded before merchants were required, a transfer recorded before the far account was, a row
+ * whose far account and own account end up the same, an own end that would leave the row outside the
+ * tracked accounts, and an own end in a currency the row does not hold.
  *
  * Not every refusal is modelled. A transfer pointing at an account the user can no longer open is one
  * the server alone can see, since a list fixed to one account carries no others to test against.
@@ -202,14 +363,11 @@ export function getBulkEditBlockers(
   choice: BulkEditChoice,
   chosenCategoryRecordsTransferTarget: boolean | undefined,
 ): BulkEditBlockers {
-  const sendsFarSide = choice.transferTarget !== null && choice.resultingCategoriesRecordTransferTarget;
-  const chosenFarSideAccountId = sendsFarSide && choice.transferTarget?.scope === 'tracked'
-    ? choice.transferTarget.accountId
-    : null;
-
   const withoutMerchant: string[] = [];
   const unansweredFarSide: string[] = [];
   const ownAccountFarSide: string[] = [];
+  const sitsOutside: string[] = [];
+  const ownSideInAnotherCurrency: string[] = [];
 
   for (const row of rows) {
     if (!row.hasMerchant && !choice.merchantId) withoutMerchant.push(row.id);
@@ -217,19 +375,37 @@ export function getBulkEditBlockers(
     const endsUpRecordingFarSide = chosenCategoryRecordsTransferTarget ?? row.recordsFarSide;
     if (!endsUpRecordingFarSide) continue;
 
-    if (!sendsFarSide && !row.hasFarSideRecorded) {
+    const { ownEnd, farEnd } = resolveTransferEnds(row, choice, endsUpRecordingFarSide);
+
+    // Read in the order the service refuses them: an own end outside the tracked accounts, then
+    // one in the wrong currency, then a far side still unanswered. Checking unanswered first would
+    // tell the user to answer a far side the server would refuse over the own end regardless
+    if (ownEnd?.scope === 'outside') {
+      sitsOutside.push(row.id);
+      continue;
+    }
+
+    if (ownEnd?.scope === 'tracked' && ownEnd.currency !== row.currency) {
+      ownSideInAnotherCurrency.push(row.id);
+      continue;
+    }
+
+    if (farEnd === null && !row.hasFarSideRecorded) {
       unansweredFarSide.push(row.id);
       continue;
     }
 
-    const resultingFarSideAccountId = sendsFarSide ? chosenFarSideAccountId : row.farSideAccountId;
-    const resultingAccountId = choice.accountId || row.accountId;
-    if (resultingFarSideAccountId !== null && resultingFarSideAccountId === resultingAccountId) {
+    const resultingOwnAccountId = ownEnd?.scope === 'tracked' ? ownEnd.accountId : (choice.accountId || row.accountId);
+    const resultingFarSideAccountId = farEnd === null
+      ? row.farSideAccountId
+      : farEnd.scope === 'tracked' ? farEnd.accountId : null;
+
+    if (resultingFarSideAccountId !== null && resultingFarSideAccountId === resultingOwnAccountId) {
       ownAccountFarSide.push(row.id);
     }
   }
 
-  return { withoutMerchant, unansweredFarSide, ownAccountFarSide };
+  return { withoutMerchant, unansweredFarSide, ownAccountFarSide, sitsOutside, ownSideInAnotherCurrency };
 }
 
 /**
@@ -254,6 +430,8 @@ export function canApplyBulkEdit(
     blockers.withoutMerchant.length === 0
     && blockers.unansweredFarSide.length === 0
     && blockers.ownAccountFarSide.length === 0
+    && blockers.sitsOutside.length === 0
+    && blockers.ownSideInAnotherCurrency.length === 0
   );
 }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -6,6 +6,7 @@
  * the pointer preview and the request body can all be checked without rendering anything.
  */
 import type { Category } from '@/api/categories'
+import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   BALANCE_ADJUSTMENT_CATEGORY_NAME,
   doesTransferRecordCounterpartyAccount,
@@ -69,8 +70,11 @@ export interface BulkEditChoice {
 
   transferTarget: TransferTargetChoice | null
 
-  /** True when the chosen category records the account on the other side of a transfer */
-  categoryRecordsTransferTarget: boolean
+  /**
+   * True when every selected transaction ends up under a category that records the account on the
+   * other side of a transfer, which is what decides whether the answer can be sent at all
+   */
+  resultingCategoriesRecordTransferTarget: boolean
 }
 
 /** The details a bulk request carries, which is everything in it except the transactions it covers */
@@ -102,9 +106,9 @@ export function buildBulkEditFields(choice: BulkEditChoice): BulkEditFields {
     ...(accountId ? { account_id: accountId } : {}),
     ...(date ? { dt: date } : {}),
     ...(clearsNote ? { notes: null } : note ? { notes: note } : {}),
-    // Only sent under a category that records one. A target picked before the category was changed
-    // is otherwise still in the panel's state, invisible, and refuses the whole batch
-    ...(transferTarget && choice.categoryRecordsTransferTarget
+    // Only sent where every row ends up recording one. A target picked before the category was
+    // changed is otherwise still in the panel's state, invisible, and refuses the whole batch
+    ...(transferTarget && choice.resultingCategoriesRecordTransferTarget
       ? {
           counterparty_account_scope: transferTarget.scope,
           counterparty_account_id: transferTarget.scope === 'tracked' ? transferTarget.accountId : null,
@@ -114,15 +118,143 @@ export function buildBulkEditFields(choice: BulkEditChoice): BulkEditFields {
 }
 
 /**
- * Returns whether the panel holds something the server would accept.
+ * Returns whether the edit fills in anything at all.
  *
- * Not derived from the fields alone: a category that records the other side of a transfer is a
- * field, but on its own it is a request the server refuses, so it does not count until the transfer
- * target is answered.
+ * Only that. Whether the server would take what it holds is a separate question, answered by
+ * getBulkEditBlockers against the rows the edit covers rather than against the edit alone.
  */
 export function hasBulkEditChoice(choice: BulkEditChoice): boolean {
-  if (choice.categoryRecordsTransferTarget && choice.transferTarget === null) return false
   return Object.keys(buildBulkEditFields(choice)).length > 0
+}
+
+/** One selected transaction, as the rules about what an edit may do to it see it */
+export interface SelectedTransactionFacts {
+  id: string;
+
+  /** The account it sits in, which a move changes */
+  accountId: string;
+
+  /** False for a row recorded before a merchant was required, which the server refuses to edit */
+  hasMerchant: boolean;
+
+  /** Whether its own category records the account on the other side of a transfer */
+  recordsFarSide: boolean;
+
+  /**
+   * Whether it has an answer for that other side. Read off the scope rather than off the account, the
+   * way the server reads it, so one recorded as going outside the tracked accounts is answered
+   */
+  hasFarSideRecorded: boolean;
+
+  /** The account recorded as the other side, absent where the money went outside the tracked accounts */
+  farSideAccountId: string | null;
+}
+
+/**
+ * Returns whether every selected transaction ends up under a category that records the account on the
+ * other side of a transfer.
+ *
+ * The category a row ends up with is the chosen one where the edit sets one and its own otherwise. The
+ * server sends the whole batch back where one row ends up recording no other side and the request
+ * carries an answer for one, so the control is offered only where every row qualifies.
+ *
+ * @param chosenCategory The category the edit sets, or undefined while it sets none
+ * @param rows The selected transactions
+ */
+export function doEveryResultingCategoryRecordTransferTarget(
+  chosenCategory: Category | undefined,
+  rows: SelectedTransactionFacts[],
+): boolean {
+  if (chosenCategory) return doesChosenCategoryRecordTransferTarget(chosenCategory);
+  return rows.length > 0 && rows.every((row) => row.recordsFarSide);
+}
+
+/** The selected transactions an edit would have the server refuse the whole batch over */
+export interface BulkEditBlockers {
+  /** Rows with no merchant recorded, which the server refuses to edit at all until one is set */
+  withoutMerchant: string[];
+
+  /** Transfers with no record of where the money went, which the edit has to answer */
+  unansweredFarSide: string[];
+
+  /** Rows that would end up recording the account they sit in as their own other side */
+  ownAccountFarSide: string[];
+}
+
+/**
+ * Returns the selected transactions the server would refuse, so the edit can be corrected before it is
+ * confirmed rather than after.
+ *
+ * Each of these refuses the whole batch, and each is reachable without the user doing anything wrong:
+ * a row recorded before merchants were required, a transfer recorded before the far account was, and a
+ * row whose far account and own account end up the same.
+ *
+ * Not every refusal is modelled. A transfer pointing at an account the user can no longer open is one
+ * the server alone can see, since a list fixed to one account carries no others to test against.
+ *
+ * @param rows The selected transactions
+ * @param choice What the edit holds
+ * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other side,
+ *     or undefined while the edit sets no category and each row keeps its own
+ */
+export function getBulkEditBlockers(
+  rows: SelectedTransactionFacts[],
+  choice: BulkEditChoice,
+  chosenCategoryRecordsTransferTarget: boolean | undefined,
+): BulkEditBlockers {
+  const sendsFarSide = choice.transferTarget !== null && choice.resultingCategoriesRecordTransferTarget;
+  const chosenFarSideAccountId = sendsFarSide && choice.transferTarget?.scope === 'tracked'
+    ? choice.transferTarget.accountId
+    : null;
+
+  const withoutMerchant: string[] = [];
+  const unansweredFarSide: string[] = [];
+  const ownAccountFarSide: string[] = [];
+
+  for (const row of rows) {
+    if (!row.hasMerchant && !choice.merchantId) withoutMerchant.push(row.id);
+
+    const endsUpRecordingFarSide = chosenCategoryRecordsTransferTarget ?? row.recordsFarSide;
+    if (!endsUpRecordingFarSide) continue;
+
+    if (!sendsFarSide && !row.hasFarSideRecorded) {
+      unansweredFarSide.push(row.id);
+      continue;
+    }
+
+    const resultingFarSideAccountId = sendsFarSide ? chosenFarSideAccountId : row.farSideAccountId;
+    const resultingAccountId = choice.accountId || row.accountId;
+    if (resultingFarSideAccountId !== null && resultingFarSideAccountId === resultingAccountId) {
+      ownAccountFarSide.push(row.id);
+    }
+  }
+
+  return { withoutMerchant, unansweredFarSide, ownAccountFarSide };
+}
+
+/**
+ * Returns whether the edit can be written.
+ *
+ * The empty case matters as much as the cap: a refetch that no longer carries the selected rows empties
+ * the selection, which can happen while the edit is open.
+ *
+ * @param rows The selected transactions
+ * @param choice What the edit holds
+ * @param blockers What the server would refuse, from getBulkEditBlockers
+ */
+export function canApplyBulkEdit(
+  rows: SelectedTransactionFacts[],
+  choice: BulkEditChoice,
+  blockers: BulkEditBlockers,
+): boolean {
+  if (rows.length === 0 || rows.length > MAX_BULK_EDIT_TRANSACTIONS) return false;
+  if (!hasBulkEditChoice(choice)) return false;
+
+  return (
+    blockers.withoutMerchant.length === 0
+    && blockers.unansweredFarSide.length === 0
+    && blockers.ownAccountFarSide.length === 0
+  );
 }
 
 /** One row as the selection sees it: an identifier, and whether the app allows editing it */

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -5,36 +5,78 @@
  * and the pointer preview can be checked without rendering anything.
  */
 
-/** What the bar holds, before it becomes a request */
+/** Where the other side of a transfer sits, or null when the panel has not been asked */
+export type TransferTargetChoice =
+  | { scope: 'tracked'; accountId: string }
+  | { scope: 'outside' }
+
+/** What the panel holds, before it becomes a request */
 export interface BulkEditChoice {
   categoryId: string
   merchantId: string
   tagIds: string[]
+  accountId: string
+  date: string
+
+  /** The text typed into the note box, which is empty both before typing and after clearing */
+  note: string
+
+  /** True when the note box is meant to take the note off rather than set one */
+  clearsNote: boolean
+
+  transferTarget: TransferTargetChoice | null
+
+  /** True when the chosen category records the account on the other side of a transfer */
+  categoryRecordsTransferTarget: boolean
 }
 
-/** The fields a bulk request carries, which is everything in it except the transactions it covers */
+/** The details a bulk request carries, which is everything in it except the transactions it covers */
 export interface BulkEditFields {
   category_id?: string
   merchant_id?: string
   add_tag_ids?: string[]
+  account_id?: string
+  dt?: string
+  notes?: string | null
+  counterparty_account_id?: string | null
+  counterparty_account_scope?: 'tracked' | 'outside' | null
 }
 
 /**
- * Turns what the bar holds into the fields a request carries.
+ * Turns what the panel holds into the details a request carries.
  *
- * A control left alone is left out rather than sent empty, since an empty value would read as a
- * change to make.
+ * A control left alone is left out rather than sent empty, because the server applies a field it
+ * was sent and leaves out a field it was not. That is also why clearing the note sends null rather
+ * than an empty string.
  */
-export function buildBulkEditFields({ categoryId, merchantId, tagIds }: BulkEditChoice): BulkEditFields {
+export function buildBulkEditFields(choice: BulkEditChoice): BulkEditFields {
+  const { categoryId, merchantId, tagIds, accountId, date, note, clearsNote, transferTarget } = choice
+
   return {
     ...(categoryId ? { category_id: categoryId } : {}),
     ...(merchantId ? { merchant_id: merchantId } : {}),
     ...(tagIds.length ? { add_tag_ids: tagIds } : {}),
+    ...(accountId ? { account_id: accountId } : {}),
+    ...(date ? { dt: date } : {}),
+    ...(clearsNote ? { notes: null } : note ? { notes: note } : {}),
+    ...(transferTarget
+      ? {
+          counterparty_account_scope: transferTarget.scope,
+          counterparty_account_id: transferTarget.scope === 'tracked' ? transferTarget.accountId : null,
+        }
+      : {}),
   }
 }
 
-/** Whether the bar holds anything to apply, which is what an apply needs before it can run */
+/**
+ * Returns whether the panel holds something the server would accept.
+ *
+ * Not derived from the fields alone: a category that records the other side of a transfer is a
+ * field, but on its own it is a request the server refuses, so it does not count until the transfer
+ * target is answered.
+ */
 export function hasBulkEditChoice(choice: BulkEditChoice): boolean {
+  if (choice.categoryRecordsTransferTarget && choice.transferTarget === null) return false
   return Object.keys(buildBulkEditFields(choice)).length > 0
 }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -215,6 +215,26 @@ export function doesAnyResultingCategoryRecordTransferTarget(
   return rows.some((row) => row.recordsFarSide);
 }
 
+/** One tag choice as the bulk edit panel holds it, with the label it was picked under */
+export interface ChosenTagOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Returns the chosen tags with one pick toggled: adds a tag that was not chosen and removes one
+ * that was, leaving the order of the rest as it stood
+ *
+ * @param chosen The tags chosen so far, in the order they were added
+ * @param option The tag the dropdown's pick resolved to
+ */
+export function toggleChosenTag(chosen: ChosenTagOption[], option: ChosenTagOption): ChosenTagOption[] {
+  if (chosen.some((tag) => tag.value === option.value)) {
+    return chosen.filter((tag) => tag.value !== option.value);
+  }
+  return [...chosen, option];
+}
+
 /** Returns the opposite of a transaction's own direction, for an edit that turns a row around */
 function flipDirection(direction: TransactionDirection): TransactionDirection {
   return direction === 'debit' ? 'credit' : 'debit';
@@ -469,7 +489,11 @@ export interface BulkSelectionState {
 export type BulkSelectionAction =
   | { type: 'toggle'; id: string; rows: SelectableRow[] }
   | { type: 'extend'; id: string; rows: SelectableRow[] }
-  | { type: 'toggleGroup'; ids: string[]; rows: SelectableRow[] }
+
+  // clearsHover is set for anything but a mouse click, such as a touch tap or a keyboard
+  // activation, since only a mouse leaves a pointer resting on the heading afterward for a later
+  // move to clear the preview
+  | { type: 'toggleGroup'; ids: string[]; rows: SelectableRow[]; clearsHover?: boolean }
   | { type: 'hover'; id: string | null }
   | { type: 'hoverGroup'; ids: string[] | null }
   | { type: 'keepDisplayed'; ids: string[] }
@@ -580,8 +604,10 @@ export function groupSelectionMark(
  * Returns what the selection would become if the pending click happened, or null when nothing is
  * pending.
  *
- * This is the whole resulting set rather than only the rows a click would add, so the highlight can
- * show a row the click would drop losing its mark before anything is clicked.
+ * The whole resulting set rather than only the rows a click would add, since rowSelectionMark reads
+ * it to tell an unselected row the click would add from one it would leave alone. A row already
+ * selected reads selected whatever the set holds for it, so the set need not distinguish a kept
+ * tick from one the click would drop.
  */
 export function previewSelection(
   state: BulkSelectionState,
@@ -608,17 +634,19 @@ export type RowSelectionMark = 'none' | 'selected' | 'pending';
 /**
  * Returns how a row is marked while a preview may be up.
  *
- * With a preview up the row is marked against the set the click would produce, so a ticked row the
- * click would drop is marked none rather than staying selected.
+ * A selected row always reads selected, whatever a pending shift-click or day tick would do to it,
+ * so what it reads changes only once a click actually lands rather than while the pointer merely
+ * rests nearby. The preview only lifts an unselected row to pending, for the one a pending click
+ * would add.
  */
 export function rowSelectionMark(
   id: string,
   selectedIds: Set<string>,
   preview: Set<string> | null,
 ): RowSelectionMark {
-  if (preview === null) return selectedIds.has(id) ? 'selected' : 'none';
-  if (!preview.has(id)) return 'none';
-  return selectedIds.has(id) ? 'selected' : 'pending';
+  if (selectedIds.has(id)) return 'selected';
+  if (preview !== null && preview.has(id)) return 'pending';
+  return 'none';
 }
 
 /**
@@ -662,13 +690,18 @@ export function bulkSelectionReducer(
       if (resulting === null) return state;
 
       // No single row was clicked, so there is no anchor for a following shift-click to run from.
-      // The baseline goes with it rather than being left behind pointing at ticks that have gone
+      // The baseline goes with it rather than being left behind pointing at ticks that have gone.
+      // The heading preview is kept and refreshed to the ids just toggled rather than cleared, so
+      // the rows the click just settled read against the tick's new state while the pointer keeps
+      // resting there, rather than losing their mark until the next pointer move sets it again. A
+      // touch tap or a keyboard activation has no such move to wait for, so either one clears the
+      // preview outright instead
       return {
         selectedIds: resulting,
         anchorId: null,
         baselineIds: new Set(resulting),
         hoveredId: null,
-        hoveredGroupIds: null,
+        hoveredGroupIds: action.clearsHover ? null : action.ids,
       };
     }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -63,7 +63,7 @@ export interface BulkSelectionState {
 }
 
 export type BulkSelectionAction =
-  | { type: 'toggle'; id: string }
+  | { type: 'toggle'; id: string; rows: SelectableRow[] }
   | { type: 'extend'; id: string; rows: SelectableRow[] }
   | { type: 'hover'; id: string | null }
   | { type: 'keepDisplayed'; ids: string[] }
@@ -152,6 +152,10 @@ export function bulkSelectionReducer(
 ): BulkSelectionState {
   switch (action.type) {
     case 'toggle': {
+      // Whether a row can be ticked is decided here rather than by each caller, so no route into
+      // the state can put a row the app will not edit into the selection
+      if (action.rows.find((row) => row.id === action.id)?.isReadOnly !== false) return state;
+
       const selectedIds = new Set(state.selectedIds);
       if (selectedIds.has(action.id)) selectedIds.delete(action.id);
       else selectedIds.add(action.id);
@@ -163,7 +167,9 @@ export function bulkSelectionReducer(
 
     case 'extend': {
       const resulting = resultingSelection(state, action.id, action.rows);
-      if (resulting === null) return bulkSelectionReducer(state, { type: 'toggle', id: action.id });
+      if (resulting === null) {
+        return bulkSelectionReducer(state, { type: 'toggle', id: action.id, rows: action.rows });
+      }
       return { ...state, selectedIds: resulting, hoveredId: null };
     }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -98,6 +98,13 @@ export interface BulkEditChoice {
   direction: BulkDirectionChange | null
 
   /**
+   * True while direction came from the From and To pairing rather than from a pill the user
+   * clicked, which is what decides whether the request sends transfer_direction, reaching only the
+   * transfer rows, or direction, reaching every selected row
+   */
+  directionIsImplied: boolean
+
+  /**
    * True while any selected row ends up under a category that records the account on the other side
    * of a transfer, which is what offers the From and To controls at all. Held beside the ends so a
    * choice made before the selection or the category changed cannot be sent once the controls have
@@ -117,6 +124,9 @@ export interface BulkEditFields {
   transfer_from?: BulkTransferEnd
   transfer_to?: BulkTransferEnd
   direction?: BulkDirectionChange
+
+  /** Which way the transfer rows in the batch should end up pointing, never sent beside direction */
+  transfer_direction?: BulkDirectionChange
 }
 
 /** Turns a panel-held end choice into the shape the request sends, dropping the currency it carries */
@@ -135,7 +145,7 @@ function toBulkTransferEnd(choice: TransferEndChoice): BulkTransferEnd {
  */
 export function buildBulkEditFields(choice: BulkEditChoice): BulkEditFields {
   const { categoryId, merchantId, tagIds, accountId, date, note, clearsNote } = choice
-  const { transferFrom, transferTo, endsAreOffered, direction } = choice
+  const { transferFrom, transferTo, endsAreOffered, direction, directionIsImplied } = choice
 
   // An end and a move both write account_id, on whichever rows resolve to be their own, so sending
   // both would be two answers for the one column
@@ -148,7 +158,12 @@ export function buildBulkEditFields(choice: BulkEditChoice): BulkEditFields {
     ...(accountId && !sendsAnEnd ? { account_id: accountId } : {}),
     ...(date ? { dt: date } : {}),
     ...(clearsNote ? { notes: null } : note ? { notes: note } : {}),
-    ...(direction ? { direction } : {}),
+
+    // An implied direction reaches only the transfer rows, as transfer_direction, so it cannot
+    // touch the rows the ends leave alone, while a direction the user picked reaches every
+    // selected row
+    ...(direction && directionIsImplied ? { transfer_direction: direction } : {}),
+    ...(direction && !directionIsImplied ? { direction } : {}),
 
     // Only sent while the controls are on screen. An end picked before the category was changed
     // away is otherwise still in the panel's state, invisible, and would refuse the whole batch
@@ -241,12 +256,12 @@ function flipDirection(direction: TransactionDirection): TransactionDirection {
 }
 
 /**
- * Returns what a row ends up pointing, mirroring the service's resolution: the edit's direction
- * where it sets one, the row's own flipped where the edit says reverse, the row's own otherwise
+ * Returns what a row ends up pointing, mirroring the service's resolution: the direction given
+ * where it sets one, the row's own flipped where it says reverse, the row's own otherwise
  */
-function resultingDirectionFor(row: SelectedTransactionFacts, choice: BulkEditChoice): TransactionDirection {
-  if (choice.direction === 'reverse') return flipDirection(row.direction);
-  return choice.direction ?? row.direction;
+function resultingDirectionFor(row: SelectedTransactionFacts, direction: BulkDirectionChange | null): TransactionDirection {
+  if (direction === 'reverse') return flipDirection(row.direction);
+  return direction ?? row.direction;
 }
 
 /** What a row's own end and far end resolve to under an edit */
@@ -273,7 +288,7 @@ export function resolveTransferEnds(
 ): ResolvedTransferEnds {
   if (!endsUpRecordingFarSide) return { ownEnd: null, farEnd: null };
 
-  return resultingDirectionFor(row, choice) === 'debit'
+  return resultingDirectionFor(row, choice.direction) === 'debit'
     ? { ownEnd: choice.transferFrom, farEnd: choice.transferTo }
     : { ownEnd: choice.transferTo, farEnd: choice.transferFrom };
 }
@@ -329,7 +344,7 @@ export function countTransferEndEffects(
     }
 
     // Money out puts From on the row's own account and To on the far side, money in the reverse
-    const fromIsOwn = resultingDirectionFor(row, choice) === 'debit';
+    const fromIsOwn = resultingDirectionFor(row, choice.direction) === 'debit';
     const ownChoice = fromIsOwn ? choice.transferFrom : choice.transferTo;
     const farChoice = fromIsOwn ? choice.transferTo : choice.transferFrom;
     const ownEffect = fromIsOwn ? effects.from : effects.to;
@@ -355,15 +370,16 @@ export interface BulkDirectionChoice {
 /**
  * Returns the direction the From and To ends imply, or null where they imply nothing.
  *
- * A direction is sent to every row in the batch, so this only answers once every selected row
- * would end up recording a far side under the edit, the chosen category's rule where one is chosen
- * and the row's own otherwise; a selection holding even one row that would not is left with nothing
- * implied. Home is the one account every selected row sits in, so a selection with no rows, or
- * spanning more than one account, has no home and implies nothing either. From there, To resolving
- * to home with From not implies money in, since the account records its own money arriving, From
- * resolving to home with To not implies money out the same way round, and any other pairing, both
- * ends resolving to home included, implies nothing: an implied direction never moves a row out of
- * the account it already sits in.
+ * transfer_direction reaches only the transfer rows, so this reads the transfer rows alone, the
+ * chosen category's rule where one is chosen and each row's own otherwise, and a selection with
+ * none of those implies nothing. An outside end says which way the money goes on its own, the same
+ * way a home end does: From set to outside implies money in, To set to outside implies money out,
+ * whether or not the transfer rows share a home account, and both ends outside implies nothing.
+ * Failing that, home is the one account every transfer row sits in, so a selection spanning more
+ * than one account has no home and implies nothing either. From there, To resolving to home with
+ * From not implies money in, since the account records its own money arriving, From resolving to
+ * home with To not implies money out the same way round, and any other pairing, both ends
+ * resolving to home included, implies nothing.
  *
  * @param rows The selected transactions
  * @param transferFrom Where the edit sets the From end, or null to leave it as it is
@@ -377,15 +393,17 @@ export function impliedDirection(
   transferTo: TransferEndChoice | null,
   chosenCategoryRecordsTransferTarget: boolean | undefined,
 ): BulkDirectionChange | null {
-  if (rows.length === 0) return null;
+  const transferRows = rows.filter((row) => chosenCategoryRecordsTransferTarget ?? row.recordsFarSide);
+  if (transferRows.length === 0) return null;
 
-  const everyRowRecordsFarSide = rows.every(
-    (row) => chosenCategoryRecordsTransferTarget ?? row.recordsFarSide,
-  );
-  if (!everyRowRecordsFarSide) return null;
+  const fromIsOutside = transferFrom?.scope === 'outside';
+  const toIsOutside = transferTo?.scope === 'outside';
+  if (fromIsOutside && toIsOutside) return null;
+  if (fromIsOutside) return 'credit';
+  if (toIsOutside) return 'debit';
 
-  const home = rows[0].accountId;
-  if (!rows.every((row) => row.accountId === home)) return null;
+  const home = transferRows[0].accountId;
+  if (!transferRows.every((row) => row.accountId === home)) return null;
 
   const toIsHome = transferTo?.scope === 'tracked' && transferTo.accountId === home;
   const fromIsHome = transferFrom?.scope === 'tracked' && transferFrom.accountId === home;
@@ -393,6 +411,66 @@ export function impliedDirection(
   if (toIsHome && !fromIsHome) return 'credit';
   if (fromIsHome && !toIsHome) return 'debit';
   return null;
+}
+
+/**
+ * Returns the ends after a From or To pick, reverting the other end to null once both would sit
+ * outside the tracked accounts, since a transfer with nothing tracked on either side has no account
+ * left to check a currency against or record a real far side on
+ *
+ * @param from Where the From end sits after the pick
+ * @param to Where the To end sits after the pick
+ * @param picked Which end the user just changed
+ */
+export function endsAfterEndPick(
+  from: TransferEndChoice | null,
+  to: TransferEndChoice | null,
+  picked: 'from' | 'to',
+): { from: TransferEndChoice | null; to: TransferEndChoice | null } {
+  const justPicked = picked === 'from' ? from : to;
+  const other = picked === 'from' ? to : from;
+  if (justPicked?.scope !== 'outside' || other?.scope !== 'outside') return { from, to };
+  return picked === 'from' ? { from, to: null } : { from: null, to };
+}
+
+/**
+ * Returns the ends after a direction pill is clicked or a category change reshapes which rows are
+ * transfers, reverting whichever end an outside choice would become a transfer row's own side,
+ * since an own side has to be a real account for the row to sit in.
+ *
+ * Each transfer row resolves its own side the way the service would: the clicked direction where
+ * it sets one, the row's own flipped for Reverse, the row's own for Leave as is. A selection whose
+ * rows resolve to different own sides can revert both ends where each is outside and is some row's
+ * own side.
+ *
+ * @param direction The direction just clicked, or the one already held while a category change is
+ *     what reshaped the transfer rows
+ * @param from Where the From end sits
+ * @param to Where the To end sits
+ * @param rows The selected transactions
+ * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other
+ *     side, or undefined while the edit sets no category and each row keeps its own
+ */
+export function endsAfterDirectionClick(
+  direction: BulkDirectionChange | null,
+  from: TransferEndChoice | null,
+  to: TransferEndChoice | null,
+  rows: SelectedTransactionFacts[],
+  chosenCategoryRecordsTransferTarget: boolean | undefined,
+): { from: TransferEndChoice | null; to: TransferEndChoice | null } {
+  let nextFrom = from;
+  let nextTo = to;
+
+  for (const row of rows) {
+    const endsUpRecordingFarSide = chosenCategoryRecordsTransferTarget ?? row.recordsFarSide;
+    if (!endsUpRecordingFarSide) continue;
+
+    const ownSideIsFrom = resultingDirectionFor(row, direction) === 'debit';
+    if (ownSideIsFrom && nextFrom?.scope === 'outside') nextFrom = null;
+    if (!ownSideIsFrom && nextTo?.scope === 'outside') nextTo = null;
+  }
+
+  return { from: nextFrom, to: nextTo };
 }
 
 /**
@@ -533,6 +611,27 @@ export interface SelectableRow {
   isReadOnly: boolean;
 }
 
+/**
+ * Returns whether a row's tick can be changed: never for a read-only row, and never to add an
+ * unselected row once the limit is reached. An already selected row stays changeable at the limit,
+ * since the tick still has to let it be dropped.
+ *
+ * @param id The row's id
+ * @param selectedIds Every row currently ticked
+ * @param isReadOnly Whether the app allows editing this row at all
+ * @param limit How many rows one bulk edit may cover
+ */
+export function isRowSelectable(
+  id: string,
+  selectedIds: Set<string>,
+  isReadOnly: boolean,
+  limit: number = MAX_BULK_EDIT_TRANSACTIONS,
+): boolean {
+  if (isReadOnly) return false;
+  if (!selectedIds.has(id) && selectedIds.size >= limit) return false;
+  return true;
+}
+
 export interface BulkSelectionState {
   /** Transactions the user has ticked */
   selectedIds: Set<string>;
@@ -599,16 +698,26 @@ function spanBetween(rows: SelectableRow[], anchorId: string, targetId: string):
 
 /**
  * Returns what the selection becomes when a shift-click lands on a row, or null with no anchor set.
+ *
+ * Takes the span in list order until the limit is reached, so a range longer than the room left
+ * simply stops rather than being refused outright.
+ *
+ * @param limit How many rows one bulk edit may cover
  */
 export function resultingSelection(
   state: BulkSelectionState,
   targetId: string,
   rows: SelectableRow[],
+  limit: number = MAX_BULK_EDIT_TRANSACTIONS,
 ): Set<string> | null {
   if (state.anchorId === null) return null;
 
   const resulting = new Set(state.baselineIds);
-  for (const id of spanBetween(rows, state.anchorId, targetId)) resulting.add(id);
+  for (const id of spanBetween(rows, state.anchorId, targetId)) {
+    if (resulting.has(id)) continue;
+    if (resulting.size >= limit) break;
+    resulting.add(id);
+  }
   return resulting;
 }
 
@@ -627,22 +736,37 @@ function editableGroupIds(ids: string[], rows: SelectableRow[]): string[] {
  * Returns what the selection becomes when a day heading's tick is clicked, or null when the day
  * shows nothing the app allows editing and the click changes nothing.
  *
- * A day already taken whole is dropped whole, and anything else is taken. Either way the ticks in
- * other days are left as they are.
+ * A day already taken whole is dropped whole. At the limit, a day with no room left for the rest of
+ * it is dropped down to the part that made it in instead, since that part is all the click can take
+ * back; a day with room left takes its rows in list order until the limit is reached. Either way the
+ * ticks in other days are left as they are.
+ *
+ * @param limit How many rows one bulk edit may cover
  */
 export function groupResultingSelection(
   selectedIds: Set<string>,
   ids: string[],
   rows: SelectableRow[],
+  limit: number = MAX_BULK_EDIT_TRANSACTIONS,
 ): Set<string> | null {
   const editable = editableGroupIds(ids, rows);
   if (editable.length === 0) return null;
 
-  const dropsTheDay = editable.every((id) => selectedIds.has(id));
+  const unselected = editable.filter((id) => !selectedIds.has(id));
+  const atLimit = selectedIds.size >= limit;
+  const someOfTheDayIsIn = editable.some((id) => selectedIds.has(id));
+
+  if (unselected.length === 0 || (atLimit && someOfTheDayIsIn)) {
+    const resulting = new Set(selectedIds);
+    for (const id of editable) resulting.delete(id);
+    return resulting;
+  }
+  if (atLimit) return null;
+
   const resulting = new Set(selectedIds);
-  for (const id of editable) {
-    if (dropsTheDay) resulting.delete(id);
-    else resulting.add(id);
+  for (const id of unselected) {
+    if (resulting.size >= limit) break;
+    resulting.add(id);
   }
   return resulting;
 }
@@ -658,17 +782,23 @@ export type GroupSelectionMark = 'none' | 'some' | 'all' | 'unselectable';
  * Once a later page adds more of that day, a heading that read all falls back to some.
  *
  * A day showing nothing the app allows editing is unselectable rather than unticked, so the heading
- * can offer a tick that is plainly off rather than one that refuses when clicked.
+ * can offer a tick that is plainly off rather than one that refuses when clicked. A day with none of
+ * its rows ticked reads unselectable the same way once the limit leaves no room to add any of them,
+ * since a click would refuse there too.
+ *
+ * @param limit How many rows one bulk edit may cover
  */
 export function groupSelectionMark(
   ids: string[],
   rows: SelectableRow[],
   selectedIds: Set<string>,
+  limit: number = MAX_BULK_EDIT_TRANSACTIONS,
 ): GroupSelectionMark {
   const editable = editableGroupIds(ids, rows);
   if (editable.length === 0) return 'unselectable';
   if (editable.every((id) => selectedIds.has(id))) return 'all';
   if (editable.some((id) => selectedIds.has(id))) return 'some';
+  if (selectedIds.size >= limit) return 'unselectable';
   return 'none';
 }
 
@@ -679,19 +809,23 @@ export function groupSelectionMark(
  * The whole resulting set rather than only the rows a click would add, since rowSelectionMark reads
  * it to tell an unselected row the click would add from one it would leave alone. A row already
  * selected reads selected whatever the set holds for it, so the set need not distinguish a kept
- * tick from one the click would drop.
+ * tick from one the click would drop. Marks pending only the rows the limit leaves room for, the
+ * same way the click itself would settle them.
+ *
+ * @param limit How many rows one bulk edit may cover
  */
 export function previewSelection(
   state: BulkSelectionState,
   rows: SelectableRow[],
+  limit: number = MAX_BULK_EDIT_TRANSACTIONS,
 ): Set<string> | null {
   // The pointer is over a day heading or over a row, never both, so only one of these is ever set
   if (state.hoveredGroupIds !== null) {
-    return groupResultingSelection(state.selectedIds, state.hoveredGroupIds, rows);
+    return groupResultingSelection(state.selectedIds, state.hoveredGroupIds, rows, limit);
   }
 
   if (state.hoveredId === null) return null;
-  return resultingSelection(state, state.hoveredId, rows);
+  return resultingSelection(state, state.hoveredId, rows, limit);
 }
 
 /** Returns whether two hovered headings are the same one, so a repeated move changes no state */
@@ -723,16 +857,23 @@ export function rowSelectionMark(
 
 /**
  * Applies one selection change.
+ *
+ * @param limit How many rows one bulk edit may cover
  */
 export function bulkSelectionReducer(
   state: BulkSelectionState,
   action: BulkSelectionAction,
+  limit: number = MAX_BULK_EDIT_TRANSACTIONS,
 ): BulkSelectionState {
   switch (action.type) {
     case 'toggle': {
       // Whether a row can be ticked is decided here rather than by each caller, so no route into
       // the state can put a row the app will not edit into the selection
       if (action.rows.find((row) => row.id === action.id)?.isReadOnly !== false) return state;
+
+      // Ticking a row already selected always frees a slot, so only adding a new one is held at
+      // the limit
+      if (!state.selectedIds.has(action.id) && state.selectedIds.size >= limit) return state;
 
       const selectedIds = new Set(state.selectedIds);
       if (selectedIds.has(action.id)) selectedIds.delete(action.id);
@@ -750,15 +891,15 @@ export function bulkSelectionReducer(
     }
 
     case 'extend': {
-      const resulting = resultingSelection(state, action.id, action.rows);
+      const resulting = resultingSelection(state, action.id, action.rows, limit);
       if (resulting === null) {
-        return bulkSelectionReducer(state, { type: 'toggle', id: action.id, rows: action.rows });
+        return bulkSelectionReducer(state, { type: 'toggle', id: action.id, rows: action.rows }, limit);
       }
       return { ...state, selectedIds: resulting, hoveredId: null, hoveredGroupIds: null };
     }
 
     case 'toggleGroup': {
-      const resulting = groupResultingSelection(state.selectedIds, action.ids, action.rows);
+      const resulting = groupResultingSelection(state.selectedIds, action.ids, action.rows, limit);
       if (resulting === null) return state;
 
       // No single row was clicked, so there is no anchor for a following shift-click to run from.

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -7,6 +7,7 @@
  */
 import type { Category } from '@/api/categories'
 import type { BulkDirectionChange, BulkTransferEnd, TransactionDirection } from '@/api/transactions'
+import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   BALANCE_ADJUSTMENT_CATEGORY_NAME,
@@ -40,13 +41,16 @@ export function doesChosenCategoryRecordTransferTarget(category: Category | unde
  * @param accounts Every account the list knows about
  * @param selectedCurrencies Currencies of the selected transactions, deduplicated
  */
-export function getBulkMoveTargets<T extends { is_archived?: boolean; closed_at?: string | null; currency?: string }>(
+export function getBulkMoveTargets<T extends { can_write?: boolean; is_archived?: boolean; closed_at?: string | null; currency?: string }>(
   accounts: T[],
   selectedCurrencies: string[],
 ): T[] {
   if (selectedCurrencies.length !== 1) return []
   return accounts.filter(
-    (account) => !account.is_archived && !account.closed_at && account.currency === selectedCurrencies[0],
+    (account) => account.can_write === true
+      && !account.is_archived
+      && !account.closed_at
+      && account.currency === selectedCurrencies[0],
   )
 }
 
@@ -211,6 +215,9 @@ export interface SelectedTransactionFacts {
   /** The currency the amount is denominated in */
   currency: string;
 
+  /** Whether the stored amount is zero, whose canonical direction remains credit under every edit */
+  isZeroAmount: boolean;
+
   /** Money out when its amount is negative, money in otherwise, on the server and in the browser alike */
   direction: TransactionDirection;
 }
@@ -221,9 +228,9 @@ export interface SelectedTransactionFacts {
  * change. `rows` itself is a new array reference on every refetch even when nothing here moved, so
  * comparing this key across renders is what tells a real change in the facts apart from that.
  *
- * Covers id, accountId, currency, recordsFarSide, hasFarSideRecorded, farSideAccountId and
- * direction, which is every field impliedDirection, endsAfterDirectionClick, resolveTransferEnds
- * and resultingDirectionFor read off a row.
+ * Covers id, accountId, currency, recordsFarSide, hasFarSideRecorded, farSideAccountId, zero state
+ * and direction, which is every field impliedDirection, endsAfterDirectionClick,
+ * resolveTransferEnds and resultingDirectionFor read off a row.
  *
  * @param rows The selected transactions
  */
@@ -237,6 +244,7 @@ export function rowFactsKey(rows: SelectedTransactionFacts[]): string {
         row.recordsFarSide,
         row.hasFarSideRecorded,
         row.farSideAccountId ?? '',
+        row.isZeroAmount,
         row.direction,
       ].join('|'),
     )
@@ -297,6 +305,7 @@ function flipDirection(direction: TransactionDirection): TransactionDirection {
  * where it sets one, the row's own flipped where it says reverse, the row's own otherwise
  */
 function resultingDirectionFor(row: SelectedTransactionFacts, direction: BulkDirectionChange | null): TransactionDirection {
+  if (row.isZeroAmount) return 'credit';
   if (direction === 'reverse') return flipDirection(row.direction);
   return direction ?? row.direction;
 }
@@ -546,23 +555,19 @@ export interface BulkEditBlockers {
 
   /** Rows whose own end would resolve to an account in another currency than the row's own */
   ownSideInAnotherCurrency: string[];
+
+  /** Rows whose source or resulting own account is no longer available for editing */
+  unavailableOwnAccount: string[];
 }
 
 /**
- * Returns the selected transactions the server would refuse, so the edit can be corrected before it is
- * confirmed rather than after.
+ * Returns selected transactions that fail the client-side eligibility checks represented here, so
+ * the edit can be corrected before confirmation.
  *
- * Each of these refuses the whole batch, and each is reachable without the user doing anything wrong:
- * a row recorded before merchants were required, a transfer recorded before the far account was, a row
- * whose far account and own account end up the same, an own end that would leave the row outside the
- * tracked accounts, and an own end in a currency the row does not hold. An own end that resolves to the
- * account the row already sits in is exempt from that last one, since nothing moves and the server never
- * touches the exchange rate for it; a real cross-currency move is refused here even for a row that
- * already carries a rate the server would accept, a deliberate narrowing tighter than the server's own
- * check.
- *
- * Not every refusal is modelled. A transfer pointing at an account the user can no longer open is one
- * the server alone can see, since a list fixed to one account carries no others to test against.
+ * These checks cover missing merchants or transfer ends, matching own and far accounts, an own end
+ * outside the tracked accounts, client-enforced currency limits, and source or destination accounts
+ * that current account data does not allow editing. An own end that resolves to the row's current
+ * account is exempt from the currency check because it does not move the row.
  *
  * @param rows The selected transactions
  * @param choice What the edit holds
@@ -573,12 +578,17 @@ export function getBulkEditBlockers(
   rows: SelectedTransactionFacts[],
   choice: BulkEditChoice,
   chosenCategoryRecordsTransferTarget: boolean | undefined,
+  currentAccounts?: TransactionListAccount[],
 ): BulkEditBlockers {
   const withoutMerchant: string[] = [];
   const unansweredFarSide: string[] = [];
   const ownAccountFarSide: string[] = [];
   const sitsOutside: string[] = [];
   const ownSideInAnotherCurrency: string[] = [];
+  const unavailableOwnAccount: string[] = [];
+  const accountMap = currentAccounts === undefined
+    ? null
+    : new Map(currentAccounts.map((account) => [account.id, account]))
 
   // An end and a move both write account_id, on whichever rows resolve to be their own, so a stray
   // Move to account choice never actually reaches the request once an end is set, the same rule
@@ -587,6 +597,18 @@ export function getBulkEditBlockers(
 
   for (const row of rows) {
     if (!row.hasMerchant && !choice.merchantId) withoutMerchant.push(row.id);
+
+    const sourceAccount = accountMap?.get(row.accountId)
+    if (accountMap && (sourceAccount?.can_write !== true || sourceAccount?.is_archived)) {
+      unavailableOwnAccount.push(row.id)
+    }
+
+    if (!sendsAnEnd && choice.accountId && accountMap) {
+      const destination = accountMap.get(choice.accountId)
+      if (destination?.can_write !== true || destination?.is_archived || Boolean(destination?.closed_at)) {
+        if (!unavailableOwnAccount.includes(row.id)) unavailableOwnAccount.push(row.id)
+      }
+    }
 
     const endsUpRecordingFarSide = chosenCategoryRecordsTransferTarget ?? row.recordsFarSide;
     if (!endsUpRecordingFarSide) continue;
@@ -609,6 +631,13 @@ export function getBulkEditBlockers(
       continue;
     }
 
+    if (ownEnd?.scope === 'tracked' && accountMap) {
+      const ownAccount = accountMap.get(ownEnd.accountId)
+      if (ownAccount?.can_write !== true || ownAccount?.is_archived || Boolean(ownAccount?.closed_at)) {
+        if (!unavailableOwnAccount.includes(row.id)) unavailableOwnAccount.push(row.id)
+      }
+    }
+
     if (farEnd === null && !row.hasFarSideRecorded) {
       unansweredFarSide.push(row.id);
       continue;
@@ -626,7 +655,14 @@ export function getBulkEditBlockers(
     }
   }
 
-  return { withoutMerchant, unansweredFarSide, ownAccountFarSide, sitsOutside, ownSideInAnotherCurrency };
+  return {
+    withoutMerchant,
+    unansweredFarSide,
+    ownAccountFarSide,
+    sitsOutside,
+    ownSideInAnotherCurrency,
+    unavailableOwnAccount,
+  };
 }
 
 /**
@@ -653,6 +689,7 @@ export function canApplyBulkEdit(
     && blockers.ownAccountFarSide.length === 0
     && blockers.sitsOutside.length === 0
     && blockers.ownSideInAnotherCurrency.length === 0
+    && blockers.unavailableOwnAccount.length === 0
   );
 }
 
@@ -660,6 +697,11 @@ export function canApplyBulkEdit(
 export interface SelectableRow {
   id: string;
   isReadOnly: boolean;
+}
+
+/** Returns the row ids that may remain in a selection after current account data is applied. */
+export function eligibleSelectionIds(rows: SelectableRow[]): string[] {
+  return rows.filter((row) => !row.isReadOnly).map((row) => row.id)
 }
 
 /**
@@ -991,13 +1033,20 @@ export function bulkSelectionReducer(
       const displayed = new Set(action.ids);
       const selectedIds = new Set([...state.selectedIds].filter((id) => displayed.has(id)));
 
-      // Returning the same state when nothing left the list keeps this safe to call on every settle
-      if (selectedIds.size === state.selectedIds.size) return state;
+      const baselineIds = new Set([...state.baselineIds].filter((id) => displayed.has(id)));
+      const anchorId = state.anchorId !== null && displayed.has(state.anchorId) ? state.anchorId : null;
+
+      // Eligibility can remove an unselected anchor or baseline entry without changing the tick count
+      if (
+        selectedIds.size === state.selectedIds.size
+        && baselineIds.size === state.baselineIds.size
+        && anchorId === state.anchorId
+      ) return state;
       return {
         ...state,
         selectedIds,
-        baselineIds: new Set([...state.baselineIds].filter((id) => displayed.has(id))),
-        anchorId: state.anchorId !== null && displayed.has(state.anchorId) ? state.anchorId : null,
+        baselineIds,
+        anchorId,
       };
     }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -230,6 +230,11 @@ export function doesAnyResultingCategoryRecordTransferTarget(
   return rows.some((row) => row.recordsFarSide);
 }
 
+/** Returns whether the selection holds at least one transfer and at least one other transaction */
+export function isMixedSelection(rows: SelectedTransactionFacts[]): boolean {
+  return rows.some((row) => row.recordsFarSide) && rows.some((row) => !row.recordsFarSide);
+}
+
 /** One tag choice as the bulk edit panel holds it, with the label it was picked under */
 export interface ChosenTagOption {
   value: string;

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -5,6 +5,39 @@
  * and the pointer preview can be checked without rendering anything.
  */
 
+/** What the bar holds, before it becomes a request */
+export interface BulkEditChoice {
+  categoryId: string
+  merchantId: string
+  tagIds: string[]
+}
+
+/** The fields a bulk request carries, which is everything in it except the transactions it covers */
+export interface BulkEditFields {
+  category_id?: string
+  merchant_id?: string
+  add_tag_ids?: string[]
+}
+
+/**
+ * Turns what the bar holds into the fields a request carries.
+ *
+ * A control left alone is left out rather than sent empty, since an empty value would read as a
+ * change to make.
+ */
+export function buildBulkEditFields({ categoryId, merchantId, tagIds }: BulkEditChoice): BulkEditFields {
+  return {
+    ...(categoryId ? { category_id: categoryId } : {}),
+    ...(merchantId ? { merchant_id: merchantId } : {}),
+    ...(tagIds.length ? { add_tag_ids: tagIds } : {}),
+  }
+}
+
+/** Whether the bar holds anything to apply, which is what an apply needs before it can run */
+export function hasBulkEditChoice(choice: BulkEditChoice): boolean {
+  return Object.keys(buildBulkEditFields(choice)).length > 0
+}
+
 /** One row as the selection sees it: an identifier, and whether the app allows editing it */
 export interface SelectableRow {
   id: string;

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -1,0 +1,158 @@
+/**
+ * Which transactions a bulk edit covers, and what a pending shift-click would change it to.
+ *
+ * Every transition is a pure function of the state and the rows on screen, so the range, the anchor
+ * and the pointer preview can be checked without rendering anything.
+ */
+
+/** One row as the selection sees it: an identifier, and whether the app allows editing it */
+export interface SelectableRow {
+  id: string;
+  isReadOnly: boolean;
+}
+
+export interface BulkSelectionState {
+  /** Transactions the user has ticked */
+  selectedIds: Set<string>;
+
+  /** The row a range runs from, set by the last click made without shift */
+  anchorId: string | null;
+
+  /**
+   * The ticks as they stood when the anchor was set. A shift-click rebuilds from these, which is
+   * what lets a second one re-aim the far end and drop the rows the first one took, while leaving
+   * a tick made before the anchor in place
+   */
+  baselineIds: Set<string>;
+
+  /** The row the pointer is over while shift is held, or null when nothing is being previewed */
+  hoveredId: string | null;
+}
+
+export type BulkSelectionAction =
+  | { type: 'toggle'; id: string }
+  | { type: 'extend'; id: string; rows: SelectableRow[] }
+  | { type: 'hover'; id: string | null }
+  | { type: 'keepDisplayed'; ids: string[] }
+  | { type: 'clear' };
+
+export const emptyBulkSelection: BulkSelectionState = {
+  selectedIds: new Set(),
+  anchorId: null,
+  baselineIds: new Set(),
+  hoveredId: null,
+};
+
+/**
+ * Returns the editable rows lying between two rows on screen, both ends included.
+ *
+ * Order comes from the rows as they appear rather than from dates or identifiers, so a range means
+ * what the user sees it mean. A row the app does not allow editing is stepped over.
+ */
+function spanBetween(rows: SelectableRow[], anchorId: string, targetId: string): string[] {
+  const anchorIndex = rows.findIndex((row) => row.id === anchorId);
+  const targetIndex = rows.findIndex((row) => row.id === targetId);
+  if (anchorIndex === -1 || targetIndex === -1) return [];
+
+  const [start, end] = anchorIndex <= targetIndex ? [anchorIndex, targetIndex] : [targetIndex, anchorIndex];
+  return rows
+    .slice(start, end + 1)
+    .filter((row) => !row.isReadOnly)
+    .map((row) => row.id);
+}
+
+/**
+ * Returns what the selection becomes when a shift-click lands on a row, or null with no anchor set.
+ */
+export function resultingSelection(
+  state: BulkSelectionState,
+  targetId: string,
+  rows: SelectableRow[],
+): Set<string> | null {
+  if (state.anchorId === null) return null;
+
+  const resulting = new Set(state.baselineIds);
+  for (const id of spanBetween(rows, state.anchorId, targetId)) resulting.add(id);
+  return resulting;
+}
+
+/**
+ * Returns what the selection would become if the pending shift-click happened, or null when nothing
+ * is pending.
+ *
+ * This is the whole resulting set rather than only the rows a click would add, so the highlight can
+ * show a row the click would drop losing its mark before anything is clicked.
+ */
+export function previewSelection(
+  state: BulkSelectionState,
+  rows: SelectableRow[],
+): Set<string> | null {
+  if (state.hoveredId === null) return null;
+  return resultingSelection(state, state.hoveredId, rows);
+}
+
+/** How one row is marked, once any pending shift-click is taken into account */
+export type RowSelectionMark = 'none' | 'selected' | 'pending';
+
+/**
+ * Returns how a row is marked while a preview may be up.
+ *
+ * With a preview up the row is marked against the set the click would produce, so a ticked row the
+ * click would drop is marked none rather than staying selected.
+ */
+export function rowSelectionMark(
+  id: string,
+  selectedIds: Set<string>,
+  preview: Set<string> | null,
+): RowSelectionMark {
+  if (preview === null) return selectedIds.has(id) ? 'selected' : 'none';
+  if (!preview.has(id)) return 'none';
+  return selectedIds.has(id) ? 'selected' : 'pending';
+}
+
+/**
+ * Applies one selection change.
+ */
+export function bulkSelectionReducer(
+  state: BulkSelectionState,
+  action: BulkSelectionAction,
+): BulkSelectionState {
+  switch (action.type) {
+    case 'toggle': {
+      const selectedIds = new Set(state.selectedIds);
+      if (selectedIds.has(action.id)) selectedIds.delete(action.id);
+      else selectedIds.add(action.id);
+
+      // The clicked row becomes the anchor whichever way it went, and the ticks left behind become
+      // the baseline the next range builds on
+      return { selectedIds, anchorId: action.id, baselineIds: new Set(selectedIds), hoveredId: null };
+    }
+
+    case 'extend': {
+      const resulting = resultingSelection(state, action.id, action.rows);
+      if (resulting === null) return bulkSelectionReducer(state, { type: 'toggle', id: action.id });
+      return { ...state, selectedIds: resulting, hoveredId: null };
+    }
+
+    case 'hover':
+      if (state.hoveredId === action.id) return state;
+      return { ...state, hoveredId: action.id };
+
+    case 'keepDisplayed': {
+      const displayed = new Set(action.ids);
+      const selectedIds = new Set([...state.selectedIds].filter((id) => displayed.has(id)));
+
+      // Returning the same state when nothing left the list keeps this safe to call on every settle
+      if (selectedIds.size === state.selectedIds.size) return state;
+      return {
+        ...state,
+        selectedIds,
+        baselineIds: new Set([...state.baselineIds].filter((id) => displayed.has(id))),
+        anchorId: state.anchorId !== null && displayed.has(state.anchorId) ? state.anchorId : null,
+      };
+    }
+
+    case 'clear':
+      return emptyBulkSelection;
+  }
+}

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -302,7 +302,8 @@ export interface TransferEndEffects {
  * Each row's resulting direction decides which control answers its own side and which its far
  * side, the same way resolveTransferEnds does. A control set on its own therefore still touches
  * every transfer row: once as the move for the rows whose own side it answers, once as the record
- * for the rest.
+ * for the rest. An own end set to the account the row already sits in neither moves nor records it,
+ * since the row is already there and the edit changes nothing about it.
  *
  * @param rows The selected transactions
  * @param choice What the edit holds
@@ -329,18 +330,89 @@ export function countTransferEndEffects(
 
     // Money out puts From on the row's own account and To on the far side, money in the reverse
     const fromIsOwn = resultingDirectionFor(row, choice) === 'debit';
+    const ownChoice = fromIsOwn ? choice.transferFrom : choice.transferTo;
+    const farChoice = fromIsOwn ? choice.transferTo : choice.transferFrom;
+    const ownEffect = fromIsOwn ? effects.from : effects.to;
+    const farEffect = fromIsOwn ? effects.to : effects.from;
 
-    if (choice.transferFrom !== null) {
-      if (fromIsOwn) effects.from.moves += 1;
-      else effects.from.recordsOnly += 1;
-    }
-    if (choice.transferTo !== null) {
-      if (fromIsOwn) effects.to.recordsOnly += 1;
-      else effects.to.moves += 1;
-    }
+    const ownEndStaysPut = ownChoice?.scope === 'tracked' && ownChoice.accountId === row.accountId;
+    if (ownChoice !== null && !ownEndStaysPut) ownEffect.moves += 1;
+    if (farChoice !== null) farEffect.recordsOnly += 1;
   }
 
   return effects;
+}
+
+/** Where the direction pills' value came from: a pill the user clicked, or the rule reading the ends */
+export type BulkDirectionSource = 'user' | 'implied';
+
+/** The direction the panel holds, together with what set it */
+export interface BulkDirectionChoice {
+  value: BulkDirectionChange | null;
+  source: BulkDirectionSource;
+}
+
+/**
+ * Returns the direction the From and To ends imply, or null where they imply nothing.
+ *
+ * A direction is sent to every row in the batch, so this only answers once every selected row
+ * would end up recording a far side under the edit, the chosen category's rule where one is chosen
+ * and the row's own otherwise; a selection holding even one row that would not is left with nothing
+ * implied. Home is the one account every selected row sits in, so a selection with no rows, or
+ * spanning more than one account, has no home and implies nothing either. From there, To resolving
+ * to home with From not implies money in, since the account records its own money arriving, From
+ * resolving to home with To not implies money out the same way round, and any other pairing, both
+ * ends resolving to home included, implies nothing: an implied direction never moves a row out of
+ * the account it already sits in.
+ *
+ * @param rows The selected transactions
+ * @param transferFrom Where the edit sets the From end, or null to leave it as it is
+ * @param transferTo Where the edit sets the To end, or null to leave it as it is
+ * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other
+ *     side, or undefined while the edit sets no category and each row keeps its own
+ */
+export function impliedDirection(
+  rows: SelectedTransactionFacts[],
+  transferFrom: TransferEndChoice | null,
+  transferTo: TransferEndChoice | null,
+  chosenCategoryRecordsTransferTarget: boolean | undefined,
+): BulkDirectionChange | null {
+  if (rows.length === 0) return null;
+
+  const everyRowRecordsFarSide = rows.every(
+    (row) => chosenCategoryRecordsTransferTarget ?? row.recordsFarSide,
+  );
+  if (!everyRowRecordsFarSide) return null;
+
+  const home = rows[0].accountId;
+  if (!rows.every((row) => row.accountId === home)) return null;
+
+  const toIsHome = transferTo?.scope === 'tracked' && transferTo.accountId === home;
+  const fromIsHome = transferFrom?.scope === 'tracked' && transferFrom.accountId === home;
+
+  if (toIsHome && !fromIsHome) return 'credit';
+  if (fromIsHome && !toIsHome) return 'debit';
+  return null;
+}
+
+/**
+ * Returns what the direction pills hold after a transfer end changes.
+ *
+ * An implication from the new pairing of ends replaces whatever the pills held, from any source and
+ * Reverse included, and is marked implied so a later change knows it was the rule and not the user
+ * that set it. No implication leaves a choice the user made alone, and clears an implied one back to
+ * nothing set, since the pairing that produced it no longer holds.
+ *
+ * @param current What the pills hold now
+ * @param implied What the changed pairing of ends implies, from impliedDirection
+ */
+export function nextDirectionAfterEndChange(
+  current: BulkDirectionChoice,
+  implied: BulkDirectionChange | null,
+): BulkDirectionChoice {
+  if (implied !== null) return { value: implied, source: 'implied' };
+  if (current.source === 'user') return current;
+  return { value: null, source: 'implied' };
 }
 
 /** The selected transactions an edit would have the server refuse the whole batch over */

--- a/frontend/src/pages/transactions/components/bulk-edit/selection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/selection.ts
@@ -1,9 +1,52 @@
 /**
- * Which transactions a bulk edit covers, and what a pending shift-click would change it to.
+ * Which transactions a bulk edit covers, what a pending shift-click would change it to, and what
+ * the panel sends once the user presses Apply.
  *
- * Every transition is a pure function of the state and the rows on screen, so the range, the anchor
- * and the pointer preview can be checked without rendering anything.
+ * Every transition is a pure function of the state and the rows on screen, so the range, the anchor,
+ * the pointer preview and the request body can all be checked without rendering anything.
  */
+import type { Category } from '@/api/categories'
+import {
+  BALANCE_ADJUSTMENT_CATEGORY_NAME,
+  doesTransferRecordCounterpartyAccount,
+} from '@/utils/transfers'
+
+/**
+ * Returns whether a chosen category records the account on the other side of a transfer.
+ *
+ * Reads the rule the server reads, which turns on the category's name alone. The transaction
+ * modal's own field hooks add a test for whether the category is a built-in one, so following
+ * those would offer a control for a request the server refuses.
+ *
+ * @param category The category the panel has chosen, or undefined while none is chosen
+ */
+export function doesChosenCategoryRecordTransferTarget(category: Category | undefined): boolean {
+  if (!category) return false
+  return doesTransferRecordCounterpartyAccount(
+    category.kind,
+    category.name === BALANCE_ADJUSTMENT_CATEGORY_NAME,
+  )
+}
+
+/**
+ * Returns the accounts a selection can move to.
+ *
+ * A move keeps each transaction's stored exchange rate, and almost no imported transaction has one,
+ * so an account in another currency would refuse the whole batch. A selection spanning currencies
+ * can move nowhere at all, which the panel says rather than leaving a refusal to be discovered.
+ *
+ * @param accounts Every account the list knows about
+ * @param selectedCurrencies Currencies of the selected transactions, deduplicated
+ */
+export function getBulkMoveTargets<T extends { is_archived?: boolean; closed_at?: string | null; currency?: string }>(
+  accounts: T[],
+  selectedCurrencies: string[],
+): T[] {
+  if (selectedCurrencies.length !== 1) return []
+  return accounts.filter(
+    (account) => !account.is_archived && !account.closed_at && account.currency === selectedCurrencies[0],
+  )
+}
 
 /** Where the other side of a transfer sits, or null when the panel has not been asked */
 export type TransferTargetChoice =
@@ -59,7 +102,9 @@ export function buildBulkEditFields(choice: BulkEditChoice): BulkEditFields {
     ...(accountId ? { account_id: accountId } : {}),
     ...(date ? { dt: date } : {}),
     ...(clearsNote ? { notes: null } : note ? { notes: note } : {}),
-    ...(transferTarget
+    // Only sent under a category that records one. A target picked before the category was changed
+    // is otherwise still in the panel's state, invisible, and refuses the whole batch
+    ...(transferTarget && choice.categoryRecordsTransferTarget
       ? {
           counterparty_account_scope: transferTarget.scope,
           counterparty_account_id: transferTarget.scope === 'tracked' ? transferTarget.accountId : null,

--- a/frontend/src/pages/transactions/components/bulk-edit/summary.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/summary.ts
@@ -106,8 +106,8 @@ export interface BulkEditSummary {
 }
 
 const DIRECTION_ROW_VALUES: Record<BulkDirectionChange, string> = {
-  debit: 'Money out',
-  credit: 'Money in',
+  debit: 'Debit',
+  credit: 'Credit',
   reverse: 'Reversed',
 }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/summary.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/summary.ts
@@ -7,7 +7,6 @@
  * and the Apply button can never disagree about what the server would refuse.
  */
 import type { BulkDirectionChange } from '@/api/transactions'
-import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   buildBulkEditFields,
   countTransferEndEffects,
@@ -113,6 +112,20 @@ const DIRECTION_ROW_VALUES: Record<BulkDirectionChange, string> = {
 }
 
 /**
+ * Returns the opening clause of a warning sentence: naming the whole selection once the count fills
+ * it, naming both numbers otherwise, and dropping the count entirely once only one row is selected,
+ * since "1 out of 1" says nothing "the selected" would not already
+ *
+ * @param count The rows the sentence is about
+ * @param total Every selected row
+ */
+export function shareOpening(count: number, total: number): string {
+  if (total === 1) return 'The selected'
+  if (count === total) return `All ${total} selected`
+  return `${count} out of ${total} selected`
+}
+
+/**
  * Renders the date the day headings would show for a "YYYY-MM-DD" string, falling back to the raw
  * string for one the calendar cannot parse, the same way a broken date still appears in the list
  * rather than disappearing behind it
@@ -123,32 +136,45 @@ function formatBulkEditDate(ymd: string): string {
 }
 
 /**
- * Renders one transfer end's detail line: what it moves and what it only records, in the singular
- * or plural the count calls for, mirroring the notice the modal showed under the control before it
- * moved into the panel
+ * Renders one transfer end's detail line: what it moves and what it only records, mirroring the
+ * notice the modal showed under the control before it moved into the panel
  *
- * A move clause only makes sense for a tracked account, since a row can never move into "outside
- * this app"; a row whose own end resolves to outside is refused instead, by the sitsOutside blocker,
- * so its detail carries only what it records. A row whose own end already sits in the account named
- * carries no clause at all, since countTransferEndEffects counts it as neither a move nor a record
+ * Each clause is hidden once its count reaches every selected row, since a change true of the whole
+ * selection needs no line singling any of it out. A move clause only makes sense for a tracked
+ * account, since a row can never move into "outside this app"; a row whose own end resolves to
+ * outside is refused instead, by the sitsOutside blocker, so its detail carries only what it
+ * records. A row whose own end already sits in the account named carries no clause at all, since
+ * countTransferEndEffects counts it as neither a move nor a record. The record clause reads which
+ * way the money crosses the far side this control just set: To reads as where it now goes, From as
+ * where it now comes from
  *
+ * @param end Which control this detail belongs to, since From and To phrase the record clause
+ *     differently
  * @param effect What the end would move and record, from countTransferEndEffects
  * @param choice What the control holds
  * @param accountLabel The tracked account's name, meaningless while the control is set to outside
+ * @param total Every selected row, which is what a clause matching in full is hidden against
  */
 function transferEndDetail(
+  end: 'from' | 'to',
   effect: TransferEndEffect,
   choice: TransferEndChoice | null,
   accountLabel: string,
+  total: number,
 ): string | undefined {
   const clauses: string[] = []
 
-  if (choice?.scope === 'tracked' && effect.moves > 0) {
-    clauses.push(`${effect.moves} ${effect.moves === 1 ? 'moves' : 'move'} into ${accountLabel}`)
+  if (choice?.scope === 'tracked' && effect.moves > 0 && effect.moves < total) {
+    clauses.push(`${effect.moves} out of ${total} ${effect.moves === 1 ? 'moves' : 'move'} into ${accountLabel}`)
   }
-  if (effect.recordsOnly > 0) {
-    const target = choice?.scope === 'outside' ? 'the other side as outside this app' : `${accountLabel} as the other side`
-    clauses.push(`${effect.recordsOnly} ${effect.recordsOnly === 1 ? 'records' : 'record'} ${target}`)
+  if (effect.recordsOnly > 0 && effect.recordsOnly < total) {
+    const verb = end === 'to'
+      ? (effect.recordsOnly === 1 ? 'goes' : 'go')
+      : (effect.recordsOnly === 1 ? 'comes' : 'come')
+    const target = end === 'to'
+      ? (choice?.scope === 'outside' ? 'outside this app' : `to ${accountLabel}`)
+      : (choice?.scope === 'outside' ? 'from outside this app' : `from ${accountLabel}`)
+    clauses.push(`${effect.recordsOnly} out of ${total} now ${verb} ${target}`)
   }
 
   return clauses.length > 0 ? clauses.join(', ') : undefined
@@ -173,8 +199,10 @@ function transferEndValueLabel(
  *
  * Row presence matches buildBulkEditFields exactly, built by reading its result rather than
  * re-deriving which controls are live, so a stale end held while endsAreOffered is false stays
- * absent here the same way it stays absent from the request. A row's detail says what the edit
- * would do; whether the row is then refused is the warnings' job instead.
+ * absent here the same way it stays absent from the request. The Direction row reads whichever of
+ * direction and the transfer-only direction the request carries, since either one means the pills
+ * show a value. A row's detail says what the edit would do; whether the row is then refused is the
+ * warnings' job instead.
  *
  * @param choice What the edit holds
  * @param rows The selected transactions
@@ -197,11 +225,20 @@ export function describeBulkEdit(
 
   const fields = buildBulkEditFields(choice)
   const effects = countTransferEndEffects(rows, choice, chosenCategoryRecordsTransferTarget)
+  const transferRowCount = rows.length - effects.leftAlone
 
   const summaryRows: BulkEditSummaryRow[] = []
 
-  if (fields.direction) {
-    summaryRows.push({ label: 'Direction', value: DIRECTION_ROW_VALUES[fields.direction] })
+  const directionValue = fields.direction ?? fields.transfer_direction
+  if (directionValue) {
+    const directionIsImplied = fields.transfer_direction !== undefined
+    summaryRows.push({
+      label: 'Direction',
+      value: DIRECTION_ROW_VALUES[directionValue],
+      detail: directionIsImplied && transferRowCount < rows.length
+        ? `applies to ${transferRowCount} out of ${rows.length} selected transactions`
+        : undefined,
+    })
   }
   if (fields.account_id !== undefined) {
     summaryRows.push({
@@ -224,9 +261,11 @@ export function describeBulkEdit(
       label: 'From',
       value: transferEndValueLabel(choice.transferFrom, labels.accountLabelById) ?? OUTSIDE_ACCOUNT_LABEL,
       detail: transferEndDetail(
+        'from',
         effects.from,
         choice.transferFrom,
         choice.transferFrom?.scope === 'tracked' ? labels.accountLabelById(choice.transferFrom.accountId) : '',
+        rows.length,
       ),
     })
   }
@@ -235,9 +274,11 @@ export function describeBulkEdit(
       label: 'To',
       value: transferEndValueLabel(choice.transferTo, labels.accountLabelById) ?? OUTSIDE_ACCOUNT_LABEL,
       detail: transferEndDetail(
+        'to',
         effects.to,
         choice.transferTo,
         choice.transferTo?.scope === 'tracked' ? labels.accountLabelById(choice.transferTo.accountId) : '',
+        rows.length,
       ),
     })
   }
@@ -249,57 +290,45 @@ export function describeBulkEdit(
   }
 
   const notes: BulkEditSummaryMessage[] = []
-  if (choice.endsAreOffered) {
+  const sendsAnEnd = choice.endsAreOffered && (choice.transferFrom !== null || choice.transferTo !== null)
+  if ((sendsAnEnd || directionValue !== undefined) && transferRowCount > 0) {
     notes.push({
       key: 'other-half',
-      text: "A transfer's other half is a separate row. This changes only the rows selected.",
+      text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
     })
   }
-  const sendsAnEnd = choice.endsAreOffered && (choice.transferFrom !== null || choice.transferTo !== null)
   if (sendsAnEnd && effects.leftAlone > 0) {
     notes.push({
       key: 'left-alone',
-      text: effects.leftAlone === 1
-        ? '1 selected transaction is not a transfer and is left as it is.'
-        : `${effects.leftAlone} selected transactions are not transfers and are left as they are.`,
+      text: `Changes to From and To apply only to ${transferRowCount} out of ${rows.length} selected transactions.`,
     })
   }
 
   const warnings: BulkEditSummaryMessage[] = []
   if (blockers.withoutMerchant.length > 0) {
     const count = blockers.withoutMerchant.length
+    const noun = rows.length === 1 ? 'transaction' : 'transactions'
+    const verb = count === 1 ? 'is' : 'are'
     warnings.push({
       key: 'without-merchant',
-      text: count === 1
-        ? '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.'
-        : `${count} selected transactions have no merchant recorded. Set a merchant above, or close this and untick them.`,
+      text: `${shareOpening(count, rows.length)} ${noun} ${verb} missing merchant information.`,
     })
   }
   if (blockers.unansweredFarSide.length > 0) {
     const count = blockers.unansweredFarSide.length
+    const noun = rows.length === 1 ? 'transfer' : 'transfers'
+    const verb = count === 1 ? 'is' : 'are'
     warnings.push({
       key: 'unanswered',
-      text: count === 1
-        ? '1 selected transfer does not record where the money went. Set From or To above, or close this and untick it.'
-        : `${count} selected transfers do not record where the money went. Set From or To above, or close this and untick them.`,
+      text: `${shareOpening(count, rows.length)} ${noun} ${verb} missing the To or From account.`,
     })
   }
   if (blockers.ownAccountFarSide.length > 0) {
     const count = blockers.ownAccountFarSide.length
+    const noun = rows.length === 1 ? 'transfer' : 'transfers'
     warnings.push({
       key: 'own-account',
-      text: count === 1
-        ? '1 selected transaction would end up recording the account it already sits in. Change From, To or Move to account, or close this and untick it.'
-        : `${count} selected transactions would end up recording the account they already sit in. Change From, To or Move to account, or close this and untick them.`,
-    })
-  }
-  if (blockers.sitsOutside.length > 0) {
-    const count = blockers.sitsOutside.length
-    warnings.push({
-      key: 'sits-outside',
-      text: count === 1
-        ? '1 selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick it.'
-        : `${count} selected transactions would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick them.`,
+      text: `${shareOpening(count, rows.length)} ${noun} can't have the same account on both sides.`,
     })
   }
   const currencyMismatches = groupCurrencyMismatches(
@@ -309,17 +338,11 @@ export function describeBulkEdit(
     chosenCategoryRecordsTransferTarget,
   )
   for (const mismatch of currencyMismatches) {
+    const noun = rows.length === 1 ? 'transaction' : 'transactions'
     warnings.push({
       key: `currency-${mismatch.rowCurrency}-${mismatch.targetCurrency}`,
-      text: mismatch.count === 1
-        ? `1 selected transaction is in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick it.`
-        : `${mismatch.count} selected transactions are in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick them.`,
-    })
-  }
-  if (rows.length > MAX_BULK_EDIT_TRANSACTIONS) {
-    warnings.push({
-      key: 'over-cap',
-      text: `One edit covers at most ${MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.`,
+      text: `${shareOpening(mismatch.count, rows.length)} ${noun} in ${mismatch.rowCurrency} `
+        + `can't move to a ${mismatch.targetCurrency} account.`,
     })
   }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/summary.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/summary.ts
@@ -114,7 +114,7 @@ const DIRECTION_ROW_VALUES: Record<BulkDirectionChange, string> = {
 /**
  * Returns the opening clause of a warning sentence: naming the whole selection once the count fills
  * it, naming both numbers otherwise, and dropping the count entirely once only one row is selected,
- * since "1 out of 1" says nothing "the selected" would not already
+ * since "1 of the 1" says nothing "the selected" would not already
  *
  * @param count The rows the sentence is about
  * @param total Every selected row
@@ -122,7 +122,7 @@ const DIRECTION_ROW_VALUES: Record<BulkDirectionChange, string> = {
 export function shareOpening(count: number, total: number): string {
   if (total === 1) return 'The selected'
   if (count === total) return `All ${total} selected`
-  return `${count} out of ${total} selected`
+  return `${count} of the ${total} selected`
 }
 
 /**
@@ -165,7 +165,7 @@ function transferEndDetail(
   const clauses: string[] = []
 
   if (choice?.scope === 'tracked' && effect.moves > 0 && effect.moves < total) {
-    clauses.push(`${effect.moves} out of ${total} ${effect.moves === 1 ? 'moves' : 'move'} into ${accountLabel}`)
+    clauses.push(`${effect.moves} of the ${total} ${effect.moves === 1 ? 'moves' : 'move'} into ${accountLabel}`)
   }
   if (effect.recordsOnly > 0 && effect.recordsOnly < total) {
     const verb = end === 'to'
@@ -174,7 +174,7 @@ function transferEndDetail(
     const target = end === 'to'
       ? (choice?.scope === 'outside' ? 'outside this app' : `to ${accountLabel}`)
       : (choice?.scope === 'outside' ? 'from outside this app' : `from ${accountLabel}`)
-    clauses.push(`${effect.recordsOnly} out of ${total} now ${verb} ${target}`)
+    clauses.push(`${effect.recordsOnly} of the ${total} now ${verb} ${target}`)
   }
 
   return clauses.length > 0 ? clauses.join(', ') : undefined
@@ -236,7 +236,7 @@ export function describeBulkEdit(
       label: 'Direction',
       value: DIRECTION_ROW_VALUES[directionValue],
       detail: directionIsImplied && transferRowCount < rows.length
-        ? `applies to ${transferRowCount} out of ${rows.length} selected transactions`
+        ? `applies to ${transferRowCount} of the ${rows.length} selected transactions`
         : undefined,
     })
   }
@@ -300,7 +300,7 @@ export function describeBulkEdit(
   if (sendsAnEnd && effects.leftAlone > 0) {
     notes.push({
       key: 'left-alone',
-      text: `Changes to From and To apply only to ${transferRowCount} out of ${rows.length} selected transactions.`,
+      text: `Changes to From and To apply only to ${transferRowCount} of the ${rows.length} selected transactions.`,
     })
   }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/summary.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/summary.ts
@@ -190,8 +190,8 @@ function transferEndValueLabel(
 
 /**
  * Returns what the summary panel shows for a bulk edit: one row per detail it sends, in the modal's
- * control order, a note for anything the edit passes over, and a warning per blocker the server
- * would refuse it over.
+ * control order, a note for anything the edit passes over, and a warning for each client-side
+ * eligibility blocker found for the current rows and account data.
  *
  * Row presence matches buildBulkEditFields exactly, built by reading its result rather than
  * re-deriving which controls are live, so a stale end held while endsAreOffered is false stays
@@ -202,7 +202,7 @@ function transferEndValueLabel(
  *
  * @param choice What the edit holds
  * @param rows The selected transactions
- * @param blockers What the server would refuse, from getBulkEditBlockers against this same choice
+ * @param blockers Current client-side eligibility blockers for this choice
  * @param labels Display text the modal has already resolved for the chosen ids
  * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other
  *     side, or undefined while the edit sets no category and each row keeps its own
@@ -228,11 +228,15 @@ export function describeBulkEdit(
   const directionValue = fields.direction ?? fields.transfer_direction
   if (directionValue) {
     const directionIsImplied = fields.transfer_direction !== undefined
+    const directionRowCount = rows.filter((row) =>
+      !row.isZeroAmount
+        && (!directionIsImplied || (chosenCategoryRecordsTransferTarget ?? row.recordsFarSide)),
+    ).length
     summaryRows.push({
       label: 'Direction',
-      value: DIRECTION_ROW_VALUES[directionValue],
-      detail: directionIsImplied && transferRowCount < rows.length
-        ? `applies to ${transferRowCount} of the ${rows.length} selected transactions`
+      value: directionRowCount === 0 ? 'Unchanged' : DIRECTION_ROW_VALUES[directionValue],
+      detail: directionRowCount < rows.length
+        ? `applies to ${directionRowCount} of the ${rows.length} selected transactions`
         : undefined,
     })
   }
@@ -313,6 +317,17 @@ export function describeBulkEdit(
       text: `Changes to From and To apply only to ${transferRowCount} of the ${rows.length} selected transactions.`,
     })
   }
+  if (directionValue !== undefined) {
+    const zeroCount = rows.filter((row) => row.isZeroAmount).length
+    if (zeroCount > 0) {
+      notes.push({
+        key: 'zero-direction',
+        text: zeroCount === 1
+          ? 'The zero amount remains Credit.'
+          : `${zeroCount} zero amounts remain Credit.`,
+      })
+    }
+  }
 
   const warnings: BulkEditSummaryMessage[] = []
   if (blockers.withoutMerchant.length > 0) {
@@ -353,6 +368,15 @@ export function describeBulkEdit(
       key: `currency-${mismatch.rowCurrency}-${mismatch.targetCurrency}`,
       text: `${shareOpening(mismatch.count, rows.length)} ${noun} in ${mismatch.rowCurrency} `
         + `can't move to a ${mismatch.targetCurrency} account.`,
+    })
+  }
+  if (blockers.unavailableOwnAccount.length > 0) {
+    const count = blockers.unavailableOwnAccount.length
+    const noun = rows.length === 1 ? 'transaction' : 'transactions'
+    const accountClause = count === 1 ? "its account isn't" : "their accounts aren't"
+    warnings.push({
+      key: 'unavailable-account',
+      text: `${shareOpening(count, rows.length)} ${noun} can't be edited because ${accountClause} available for editing.`,
     })
   }
 

--- a/frontend/src/pages/transactions/components/bulk-edit/summary.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/summary.ts
@@ -180,15 +180,11 @@ function transferEndDetail(
   return clauses.length > 0 ? clauses.join(', ') : undefined
 }
 
-/**
- * Returns the account's label or "Outside this app" for a transfer end choice, or undefined for one
- * the edit leaves unset
- */
+/** Returns the account's label or "Outside this app" for a transfer end choice that is actually set */
 function transferEndValueLabel(
-  choice: TransferEndChoice | null,
+  choice: TransferEndChoice,
   accountLabelById: (accountId: string) => string,
-): string | undefined {
-  if (choice === null) return undefined
+): string {
   return choice.scope === 'outside' ? OUTSIDE_ACCOUNT_LABEL : accountLabelById(choice.accountId)
 }
 
@@ -241,10 +237,18 @@ export function describeBulkEdit(
     })
   }
   if (fields.account_id !== undefined) {
+    const moveAccountLabel = labels.accountLabelById(fields.account_id)
+    const moveCount = rows.filter((row) => row.accountId !== fields.account_id).length
+
     summaryRows.push({
       label: 'Move to account',
-      value: labels.accountLabelById(fields.account_id),
-      detail: `${rows.length} move`,
+      value: moveAccountLabel,
+
+      // Hidden once every row moves or none does, the same rule the end details use below, since
+      // only a partial move needs to say how many of the selection actually goes
+      detail: moveCount > 0 && moveCount < rows.length
+        ? `${moveCount} of the ${rows.length} ${moveCount === 1 ? 'moves' : 'move'} into ${moveAccountLabel}`
+        : undefined,
     })
   }
   if (fields.merchant_id !== undefined) {
@@ -257,27 +261,33 @@ export function describeBulkEdit(
     summaryRows.push({ label: 'Tags added', value: labels.tagLabels.join(', ') })
   }
   if (fields.transfer_from !== undefined) {
+    // buildBulkEditFields only sends transfer_from when choice.transferFrom is set, so it is never
+    // null here
+    const transferFrom = choice.transferFrom as TransferEndChoice
     summaryRows.push({
       label: 'From',
-      value: transferEndValueLabel(choice.transferFrom, labels.accountLabelById) ?? OUTSIDE_ACCOUNT_LABEL,
+      value: transferEndValueLabel(transferFrom, labels.accountLabelById),
       detail: transferEndDetail(
         'from',
         effects.from,
-        choice.transferFrom,
-        choice.transferFrom?.scope === 'tracked' ? labels.accountLabelById(choice.transferFrom.accountId) : '',
+        transferFrom,
+        transferFrom.scope === 'tracked' ? labels.accountLabelById(transferFrom.accountId) : '',
         rows.length,
       ),
     })
   }
   if (fields.transfer_to !== undefined) {
+    // buildBulkEditFields only sends transfer_to when choice.transferTo is set, so it is never null
+    // here
+    const transferTo = choice.transferTo as TransferEndChoice
     summaryRows.push({
       label: 'To',
-      value: transferEndValueLabel(choice.transferTo, labels.accountLabelById) ?? OUTSIDE_ACCOUNT_LABEL,
+      value: transferEndValueLabel(transferTo, labels.accountLabelById),
       detail: transferEndDetail(
         'to',
         effects.to,
-        choice.transferTo,
-        choice.transferTo?.scope === 'tracked' ? labels.accountLabelById(choice.transferTo.accountId) : '',
+        transferTo,
+        transferTo.scope === 'tracked' ? labels.accountLabelById(transferTo.accountId) : '',
         rows.length,
       ),
     })

--- a/frontend/src/pages/transactions/components/bulk-edit/summary.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/summary.ts
@@ -90,17 +90,26 @@ export interface BulkEditSummaryLabels {
   tagLabels: string[]
 }
 
+/**
+ * One note or warning line, keyed by what it is about rather than by its current text, so a count
+ * changing rewrites the text in place instead of the animated list treating it as a new line
+ */
+export interface BulkEditSummaryMessage {
+  key: string
+  text: string
+}
+
 /** What the summary panel shows for one edit: the rows it sends, notes, and warnings to settle */
 export interface BulkEditSummary {
   rows: BulkEditSummaryRow[]
-  notes: string[]
-  warnings: string[]
+  notes: BulkEditSummaryMessage[]
+  warnings: BulkEditSummaryMessage[]
 }
 
 const DIRECTION_ROW_VALUES: Record<BulkDirectionChange, string> = {
   debit: 'Money out',
   credit: 'Money in',
-  reverse: 'Turned around',
+  reverse: 'Reversed',
 }
 
 /**
@@ -238,51 +247,59 @@ export function describeBulkEdit(
     summaryRows.push({ label: 'Note', value: fields.notes === null ? 'Removed' : fields.notes })
   }
 
-  const notes: string[] = []
+  const notes: BulkEditSummaryMessage[] = []
   if (choice.endsAreOffered) {
-    notes.push("A transfer's other half is a separate row. This changes only the rows selected.")
+    notes.push({
+      key: 'other-half',
+      text: "A transfer's other half is a separate row. This changes only the rows selected.",
+    })
   }
   const sendsAnEnd = choice.endsAreOffered && (choice.transferFrom !== null || choice.transferTo !== null)
   if (sendsAnEnd && effects.leftAlone > 0) {
-    notes.push(
-      effects.leftAlone === 1
+    notes.push({
+      key: 'left-alone',
+      text: effects.leftAlone === 1
         ? '1 selected transaction is not a transfer and is left as it is.'
         : `${effects.leftAlone} selected transactions are not transfers and are left as they are.`,
-    )
+    })
   }
 
-  const warnings: string[] = []
+  const warnings: BulkEditSummaryMessage[] = []
   if (blockers.withoutMerchant.length > 0) {
     const count = blockers.withoutMerchant.length
-    warnings.push(
-      count === 1
+    warnings.push({
+      key: 'without-merchant',
+      text: count === 1
         ? '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.'
         : `${count} selected transactions have no merchant recorded. Set a merchant above, or close this and untick them.`,
-    )
+    })
   }
   if (blockers.unansweredFarSide.length > 0) {
     const count = blockers.unansweredFarSide.length
-    warnings.push(
-      count === 1
+    warnings.push({
+      key: 'unanswered',
+      text: count === 1
         ? '1 selected transfer does not record where the money went. Set From or To above, or close this and untick it.'
         : `${count} selected transfers do not record where the money went. Set From or To above, or close this and untick them.`,
-    )
+    })
   }
   if (blockers.ownAccountFarSide.length > 0) {
     const count = blockers.ownAccountFarSide.length
-    warnings.push(
-      count === 1
+    warnings.push({
+      key: 'own-account',
+      text: count === 1
         ? '1 selected transaction would end up recording the account it already sits in. Change From, To or Move to account, or close this and untick it.'
         : `${count} selected transactions would end up recording the account they already sit in. Change From, To or Move to account, or close this and untick them.`,
-    )
+    })
   }
   if (blockers.sitsOutside.length > 0) {
     const count = blockers.sitsOutside.length
-    warnings.push(
-      count === 1
+    warnings.push({
+      key: 'sits-outside',
+      text: count === 1
         ? '1 selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick it.'
         : `${count} selected transactions would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick them.`,
-    )
+    })
   }
   const currencyMismatches = groupCurrencyMismatches(
     rows,
@@ -291,14 +308,18 @@ export function describeBulkEdit(
     chosenCategoryRecordsTransferTarget,
   )
   for (const mismatch of currencyMismatches) {
-    warnings.push(
-      mismatch.count === 1
+    warnings.push({
+      key: `currency-${mismatch.rowCurrency}-${mismatch.targetCurrency}`,
+      text: mismatch.count === 1
         ? `1 selected transaction is in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick it.`
         : `${mismatch.count} selected transactions are in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick them.`,
-    )
+    })
   }
   if (rows.length > MAX_BULK_EDIT_TRANSACTIONS) {
-    warnings.push(`One edit covers at most ${MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.`)
+    warnings.push({
+      key: 'over-cap',
+      text: `One edit covers at most ${MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.`,
+    })
   }
 
   return { rows: summaryRows, notes, warnings }

--- a/frontend/src/pages/transactions/components/bulk-edit/summary.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/summary.ts
@@ -129,7 +129,8 @@ function formatBulkEditDate(ymd: string): string {
  *
  * A move clause only makes sense for a tracked account, since a row can never move into "outside
  * this app"; a row whose own end resolves to outside is refused instead, by the sitsOutside blocker,
- * so its detail carries only what it records
+ * so its detail carries only what it records. A row whose own end already sits in the account named
+ * carries no clause at all, since countTransferEndEffects counts it as neither a move nor a record
  *
  * @param effect What the end would move and record, from countTransferEndEffects
  * @param choice What the control holds

--- a/frontend/src/pages/transactions/components/bulk-edit/summary.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/summary.ts
@@ -1,0 +1,305 @@
+/**
+ * Turns a bulk edit's choice into what the modal's summary panel shows: a row per detail the edit
+ * sends, a note for anything it passes over, and a warning for anything the server would refuse.
+ *
+ * A pure function of its inputs, so the panel can be tested without rendering the modal that feeds
+ * it. blockers is the one exception: it is computed by the caller rather than here, so the panel
+ * and the Apply button can never disagree about what the server would refuse.
+ */
+import type { BulkDirectionChange } from '@/api/transactions'
+import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
+import {
+  buildBulkEditFields,
+  countTransferEndEffects,
+  resolveTransferEnds,
+  type BulkEditBlockers,
+  type BulkEditChoice,
+  type SelectedTransactionFacts,
+  type TransferEndChoice,
+  type TransferEndEffect,
+} from '@/pages/transactions/components/bulk-edit/selection'
+import { DATE_FORMATS, formatDate, parseYmd } from '@/utils/date'
+import { OUTSIDE_ACCOUNT_LABEL } from '@/utils/transfers'
+
+/** One currency an own end would move blocked rows into, and how many rows share the pairing */
+interface CurrencyMismatch {
+  rowCurrency: string
+  targetCurrency: string
+  count: number
+}
+
+/**
+ * Groups the rows blocked for sitting in another currency than the end they would move into, by the
+ * pair of currencies involved, so the warning can name the right ones rather than assuming the
+ * selection holds only one
+ *
+ * @param rows The selected transactions
+ * @param blockedIds The row ids getBulkEditBlockers listed as ownSideInAnotherCurrency
+ * @param choice What the edit holds
+ * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other
+ *     side, or undefined while the edit sets no category and each row keeps its own
+ */
+function groupCurrencyMismatches(
+  rows: SelectedTransactionFacts[],
+  blockedIds: string[],
+  choice: BulkEditChoice,
+  chosenCategoryRecordsTransferTarget: boolean | undefined,
+): CurrencyMismatch[] {
+  const blocked = new Set(blockedIds)
+  const groups = new Map<string, CurrencyMismatch>()
+
+  for (const row of rows) {
+    if (!blocked.has(row.id)) continue
+    const endsUpRecordingFarSide = chosenCategoryRecordsTransferTarget ?? row.recordsFarSide
+    const { ownEnd } = resolveTransferEnds(row, choice, endsUpRecordingFarSide)
+    if (ownEnd?.scope !== 'tracked') continue
+
+    const key = `${row.currency}-${ownEnd.currency}`
+    const existing = groups.get(key)
+    if (existing) existing.count += 1
+    else groups.set(key, { rowCurrency: row.currency, targetCurrency: ownEnd.currency, count: 1 })
+  }
+
+  return [...groups.values()]
+}
+
+/** One line of the summary panel's row list: a control the edit touches and what it does */
+export interface BulkEditSummaryRow {
+  label: string
+  value: string
+
+  /** A second line under the value, such as who else an end moves or records */
+  detail?: string
+}
+
+/**
+ * Display text the modal has already resolved for the ids the panel would otherwise have to look
+ * up itself, so the panel never disagrees with what the dropdowns show as chosen
+ */
+export interface BulkEditSummaryLabels {
+  /** Resolves an account id to its name, already falling back for one the accounts list has lost */
+  accountLabelById: (accountId: string) => string
+
+  /** The chosen category's name, meaningless while the edit sets no category */
+  categoryLabel: string
+
+  /** The chosen merchant's name, meaningless while the edit sets no merchant */
+  merchantLabel: string
+
+  /** The chosen tags' names, in the order they were added */
+  tagLabels: string[]
+}
+
+/** What the summary panel shows for one edit: the rows it sends, notes, and warnings to settle */
+export interface BulkEditSummary {
+  rows: BulkEditSummaryRow[]
+  notes: string[]
+  warnings: string[]
+}
+
+const DIRECTION_ROW_VALUES: Record<BulkDirectionChange, string> = {
+  debit: 'Money out',
+  credit: 'Money in',
+  reverse: 'Turned around',
+}
+
+/**
+ * Renders the date the day headings would show for a "YYYY-MM-DD" string, falling back to the raw
+ * string for one the calendar cannot parse, the same way a broken date still appears in the list
+ * rather than disappearing behind it
+ */
+function formatBulkEditDate(ymd: string): string {
+  const parsed = parseYmd(ymd)
+  return parsed ? formatDate(parsed, DATE_FORMATS.longDate) : ymd
+}
+
+/**
+ * Renders one transfer end's detail line: what it moves and what it only records, in the singular
+ * or plural the count calls for, mirroring the notice the modal showed under the control before it
+ * moved into the panel
+ *
+ * A move clause only makes sense for a tracked account, since a row can never move into "outside
+ * this app"; a row whose own end resolves to outside is refused instead, by the sitsOutside blocker,
+ * so its detail carries only what it records
+ *
+ * @param effect What the end would move and record, from countTransferEndEffects
+ * @param choice What the control holds
+ * @param accountLabel The tracked account's name, meaningless while the control is set to outside
+ */
+function transferEndDetail(
+  effect: TransferEndEffect,
+  choice: TransferEndChoice | null,
+  accountLabel: string,
+): string | undefined {
+  const clauses: string[] = []
+
+  if (choice?.scope === 'tracked' && effect.moves > 0) {
+    clauses.push(`${effect.moves} ${effect.moves === 1 ? 'moves' : 'move'} into ${accountLabel}`)
+  }
+  if (effect.recordsOnly > 0) {
+    const target = choice?.scope === 'outside' ? 'the other side as outside this app' : `${accountLabel} as the other side`
+    clauses.push(`${effect.recordsOnly} ${effect.recordsOnly === 1 ? 'records' : 'record'} ${target}`)
+  }
+
+  return clauses.length > 0 ? clauses.join(', ') : undefined
+}
+
+/**
+ * Returns the account's label or "Outside this app" for a transfer end choice, or undefined for one
+ * the edit leaves unset
+ */
+function transferEndValueLabel(
+  choice: TransferEndChoice | null,
+  accountLabelById: (accountId: string) => string,
+): string | undefined {
+  if (choice === null) return undefined
+  return choice.scope === 'outside' ? OUTSIDE_ACCOUNT_LABEL : accountLabelById(choice.accountId)
+}
+
+/**
+ * Returns what the summary panel shows for a bulk edit: one row per detail it sends, in the modal's
+ * control order, a note for anything the edit passes over, and a warning per blocker the server
+ * would refuse it over.
+ *
+ * Row presence matches buildBulkEditFields exactly, built by reading its result rather than
+ * re-deriving which controls are live, so a stale end held while endsAreOffered is false stays
+ * absent here the same way it stays absent from the request. A row's detail says what the edit
+ * would do; whether the row is then refused is the warnings' job instead.
+ *
+ * @param choice What the edit holds
+ * @param rows The selected transactions
+ * @param blockers What the server would refuse, from getBulkEditBlockers against this same choice
+ * @param labels Display text the modal has already resolved for the chosen ids
+ * @param chosenCategoryRecordsTransferTarget Whether the category the edit sets records the other
+ *     side, or undefined while the edit sets no category and each row keeps its own
+ */
+export function describeBulkEdit(
+  choice: BulkEditChoice,
+  rows: SelectedTransactionFacts[],
+  blockers: BulkEditBlockers,
+  labels: BulkEditSummaryLabels,
+  chosenCategoryRecordsTransferTarget: boolean | undefined,
+): BulkEditSummary {
+  // An empty selection has nothing for a row to describe and nothing for a warning to refuse, so
+  // this returns before reading choice at all rather than letting a control still holding a value
+  // from before the selection emptied produce a row for a transaction that is no longer there
+  if (rows.length === 0) return { rows: [], notes: [], warnings: [] }
+
+  const fields = buildBulkEditFields(choice)
+  const effects = countTransferEndEffects(rows, choice, chosenCategoryRecordsTransferTarget)
+
+  const summaryRows: BulkEditSummaryRow[] = []
+
+  if (fields.direction) {
+    summaryRows.push({ label: 'Direction', value: DIRECTION_ROW_VALUES[fields.direction] })
+  }
+  if (fields.account_id !== undefined) {
+    summaryRows.push({
+      label: 'Move to account',
+      value: labels.accountLabelById(fields.account_id),
+      detail: `${rows.length} move`,
+    })
+  }
+  if (fields.merchant_id !== undefined) {
+    summaryRows.push({ label: 'Merchant', value: labels.merchantLabel })
+  }
+  if (fields.category_id !== undefined) {
+    summaryRows.push({ label: 'Category', value: labels.categoryLabel })
+  }
+  if (fields.add_tag_ids !== undefined) {
+    summaryRows.push({ label: 'Tags added', value: labels.tagLabels.join(', ') })
+  }
+  if (fields.transfer_from !== undefined) {
+    summaryRows.push({
+      label: 'From',
+      value: transferEndValueLabel(choice.transferFrom, labels.accountLabelById) ?? OUTSIDE_ACCOUNT_LABEL,
+      detail: transferEndDetail(
+        effects.from,
+        choice.transferFrom,
+        choice.transferFrom?.scope === 'tracked' ? labels.accountLabelById(choice.transferFrom.accountId) : '',
+      ),
+    })
+  }
+  if (fields.transfer_to !== undefined) {
+    summaryRows.push({
+      label: 'To',
+      value: transferEndValueLabel(choice.transferTo, labels.accountLabelById) ?? OUTSIDE_ACCOUNT_LABEL,
+      detail: transferEndDetail(
+        effects.to,
+        choice.transferTo,
+        choice.transferTo?.scope === 'tracked' ? labels.accountLabelById(choice.transferTo.accountId) : '',
+      ),
+    })
+  }
+  if (fields.dt !== undefined) {
+    summaryRows.push({ label: 'Date', value: formatBulkEditDate(fields.dt) })
+  }
+  if (fields.notes !== undefined) {
+    summaryRows.push({ label: 'Note', value: fields.notes === null ? 'Removed' : fields.notes })
+  }
+
+  const notes: string[] = []
+  if (choice.endsAreOffered) {
+    notes.push("A transfer's other half is a separate row. This changes only the rows selected.")
+  }
+  const sendsAnEnd = choice.endsAreOffered && (choice.transferFrom !== null || choice.transferTo !== null)
+  if (sendsAnEnd && effects.leftAlone > 0) {
+    notes.push(
+      effects.leftAlone === 1
+        ? '1 selected transaction is not a transfer and is left as it is.'
+        : `${effects.leftAlone} selected transactions are not transfers and are left as they are.`,
+    )
+  }
+
+  const warnings: string[] = []
+  if (blockers.withoutMerchant.length > 0) {
+    const count = blockers.withoutMerchant.length
+    warnings.push(
+      count === 1
+        ? '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.'
+        : `${count} selected transactions have no merchant recorded. Set a merchant above, or close this and untick them.`,
+    )
+  }
+  if (blockers.unansweredFarSide.length > 0) {
+    const count = blockers.unansweredFarSide.length
+    warnings.push(
+      count === 1
+        ? '1 selected transfer does not record where the money went. Set From or To above, or close this and untick it.'
+        : `${count} selected transfers do not record where the money went. Set From or To above, or close this and untick them.`,
+    )
+  }
+  if (blockers.ownAccountFarSide.length > 0) {
+    const count = blockers.ownAccountFarSide.length
+    warnings.push(
+      count === 1
+        ? '1 selected transaction would end up recording the account it already sits in. Change From, To or Move to account, or close this and untick it.'
+        : `${count} selected transactions would end up recording the account they already sit in. Change From, To or Move to account, or close this and untick them.`,
+    )
+  }
+  if (blockers.sitsOutside.length > 0) {
+    const count = blockers.sitsOutside.length
+    warnings.push(
+      count === 1
+        ? '1 selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick it.'
+        : `${count} selected transactions would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick them.`,
+    )
+  }
+  const currencyMismatches = groupCurrencyMismatches(
+    rows,
+    blockers.ownSideInAnotherCurrency,
+    choice,
+    chosenCategoryRecordsTransferTarget,
+  )
+  for (const mismatch of currencyMismatches) {
+    warnings.push(
+      mismatch.count === 1
+        ? `1 selected transaction is in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick it.`
+        : `${mismatch.count} selected transactions are in ${mismatch.rowCurrency} and would move into an account in ${mismatch.targetCurrency}. Pick an account in ${mismatch.rowCurrency}, or close this and untick them.`,
+    )
+  }
+  if (rows.length > MAX_BULK_EDIT_TRANSACTIONS) {
+    warnings.push(`One edit covers at most ${MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.`)
+  }
+
+  return { rows: summaryRows, notes, warnings }
+}

--- a/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
@@ -113,8 +113,8 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
     dispatch({ type: withShift ? 'extend' : 'toggle', id, rows: rowsRef.current })
   }, [])
 
-  const toggleGroup = useCallback((ids: string[]) => {
-    dispatch({ type: 'toggleGroup', ids, rows: rowsRef.current })
+  const toggleGroup = useCallback((ids: string[], options?: { clearsHover?: boolean }) => {
+    dispatch({ type: 'toggleGroup', ids, rows: rowsRef.current, clearsHover: options?.clearsHover })
   }, [])
 
   const handlePointerEnter = useCallback((id: string) => {

--- a/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
@@ -2,14 +2,17 @@ import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import {
   bulkSelectionReducer,
   emptyBulkSelection,
+  groupSelectionMark,
   previewSelection,
   rowSelectionMark,
+  type GroupSelectionMark,
   type RowSelectionMark,
   type SelectableRow,
 } from '@/pages/transactions/components/bulk-edit/selection'
 
 /**
- * Holds which transactions a bulk edit covers, and lights the rows a pending shift-click would take.
+ * Holds which transactions a bulk edit covers, and lights the rows a pending shift-click or day tick
+ * would take.
  *
  * @param rows The rows on screen, in the order they appear, which is what a range runs along
  * @param requestKey Identifies the list being shown, so the selection empties when the list changes
@@ -43,9 +46,16 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
   }, [displayedIds, isSettled])
 
   useEffect(() => {
-    function clearPreview() {
+    function clearRangePreview() {
       shiftHeldRef.current = false
       dispatch({ type: 'hover', id: null })
+    }
+
+    // Leaving the page takes the pointer with it, so the day heading it was resting on stops being
+    // hovered as well. Releasing shift does not, since a day preview never depended on shift
+    function clearEveryPreview() {
+      clearRangePreview()
+      dispatch({ type: 'hoverGroup', ids: null })
     }
 
     // The search box sits directly above the list, so a capital letter typed there would otherwise
@@ -66,7 +76,7 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
 
     function handleKeyUp(event: KeyboardEvent) {
       if (event.key !== 'Shift') return
-      clearPreview()
+      clearRangePreview()
     }
 
     window.addEventListener('keydown', handleKeyDown)
@@ -74,14 +84,14 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
 
     // A shift released in another application never reaches this page, so the flag would otherwise
     // stay set and promise a range the click would not take
-    window.addEventListener('blur', clearPreview)
-    document.addEventListener('visibilitychange', clearPreview)
+    window.addEventListener('blur', clearEveryPreview)
+    document.addEventListener('visibilitychange', clearEveryPreview)
 
     return () => {
       window.removeEventListener('keydown', handleKeyDown)
       window.removeEventListener('keyup', handleKeyUp)
-      window.removeEventListener('blur', clearPreview)
-      document.removeEventListener('visibilitychange', clearPreview)
+      window.removeEventListener('blur', clearEveryPreview)
+      document.removeEventListener('visibilitychange', clearEveryPreview)
     }
   }, [])
 
@@ -92,8 +102,19 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
     [state.selectedIds, preview],
   )
 
+  // Read against the ticks as they stand rather than against the preview, so resting the pointer on
+  // a day heading does not show its tick already taken
+  const groupMarkFor = useCallback(
+    (ids: string[]): GroupSelectionMark => groupSelectionMark(ids, rows, state.selectedIds),
+    [rows, state.selectedIds],
+  )
+
   const toggle = useCallback((id: string, withShift: boolean) => {
     dispatch({ type: withShift ? 'extend' : 'toggle', id, rows: rowsRef.current })
+  }, [])
+
+  const toggleGroup = useCallback((ids: string[]) => {
+    dispatch({ type: 'toggleGroup', ids, rows: rowsRef.current })
   }, [])
 
   const handlePointerEnter = useCallback((id: string) => {
@@ -101,9 +122,21 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
     if (shiftHeldRef.current) dispatch({ type: 'hover', id })
   }, [])
 
+  // Taken on a move rather than on entry, because a sticky heading travels under a still pointer
+  // while the list scrolls, and every day it passed would otherwise light its rows in turn
+  const handleGroupPointerMove = useCallback((ids: string[]) => {
+    pointerRowRef.current = null
+    dispatch({ type: 'hoverGroup', ids })
+  }, [])
+
+  const handleGroupPointerLeave = useCallback(() => {
+    dispatch({ type: 'hoverGroup', ids: null })
+  }, [])
+
   const handlePointerLeaveList = useCallback(() => {
     pointerRowRef.current = null
     dispatch({ type: 'hover', id: null })
+    dispatch({ type: 'hoverGroup', ids: null })
   }, [])
 
   const clear = useCallback(() => {
@@ -114,5 +147,16 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
 
   const selectedIds = useMemo(() => [...state.selectedIds], [state.selectedIds])
 
-  return { selectedIds, markFor, toggle, handlePointerEnter, handlePointerLeaveList, clear }
+  return {
+    selectedIds,
+    markFor,
+    groupMarkFor,
+    toggle,
+    toggleGroup,
+    handlePointerEnter,
+    handleGroupPointerMove,
+    handleGroupPointerLeave,
+    handlePointerLeaveList,
+    clear,
+  }
 }

--- a/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
 import {
   bulkSelectionReducer,
   emptyBulkSelection,
+  eligibleSelectionIds,
   groupSelectionMark,
   previewSelection,
   rowSelectionMark,
@@ -50,12 +51,12 @@ export function useBulkSelection(
     dispatch({ type: 'clear' })
   }, [requestKey])
 
-  const displayedIds = useMemo(() => rows.map((row) => row.id), [rows])
+  const eligibleIds = useMemo(() => eligibleSelectionIds(rows), [rows])
 
   useEffect(() => {
     if (!isSettled) return
-    dispatch({ type: 'keepDisplayed', ids: displayedIds })
-  }, [displayedIds, isSettled])
+    dispatch({ type: 'keepDisplayed', ids: eligibleIds })
+  }, [eligibleIds, isSettled])
 
   useEffect(() => {
     function clearRangePreview() {

--- a/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
@@ -5,10 +5,13 @@ import {
   groupSelectionMark,
   previewSelection,
   rowSelectionMark,
+  type BulkSelectionAction,
+  type BulkSelectionState,
   type GroupSelectionMark,
   type RowSelectionMark,
   type SelectableRow,
 } from '@/pages/transactions/components/bulk-edit/selection'
+import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 
 /**
  * Holds which transactions a bulk edit covers, and lights the rows a pending shift-click or day tick
@@ -17,9 +20,18 @@ import {
  * @param rows The rows on screen, in the order they appear, which is what a range runs along
  * @param requestKey Identifies the list being shown, so the selection empties when the list changes
  * @param isSettled False while the list is mid-change and still showing its previous rows
+ * @param limit How many rows one bulk edit may cover, so a test can use a small one
  */
-export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSettled: boolean) {
-  const [state, dispatch] = useReducer(bulkSelectionReducer, emptyBulkSelection)
+export function useBulkSelection(
+  rows: SelectableRow[],
+  requestKey: string,
+  isSettled: boolean,
+  limit: number = MAX_BULK_EDIT_TRANSACTIONS,
+) {
+  const [state, dispatch] = useReducer(
+    (current: BulkSelectionState, action: BulkSelectionAction) => bulkSelectionReducer(current, action, limit),
+    emptyBulkSelection,
+  )
 
   // Read at dispatch time rather than closed over, so a range always runs along the rows on screen
   const rowsRef = useRef(rows)
@@ -95,7 +107,7 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
     }
   }, [])
 
-  const preview = useMemo(() => previewSelection(state, rows), [state, rows])
+  const preview = useMemo(() => previewSelection(state, rows, limit), [state, rows, limit])
 
   const markFor = useCallback(
     (id: string): RowSelectionMark => rowSelectionMark(id, state.selectedIds, preview),
@@ -105,8 +117,8 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
   // Read against the ticks as they stand rather than against the preview, so resting the pointer on
   // a day heading does not show its tick already taken
   const groupMarkFor = useCallback(
-    (ids: string[]): GroupSelectionMark => groupSelectionMark(ids, rows, state.selectedIds),
-    [rows, state.selectedIds],
+    (ids: string[]): GroupSelectionMark => groupSelectionMark(ids, rows, state.selectedIds, limit),
+    [rows, state.selectedIds, limit],
   )
 
   const toggle = useCallback((id: string, withShift: boolean) => {

--- a/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
@@ -93,7 +93,7 @@ export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSe
   )
 
   const toggle = useCallback((id: string, withShift: boolean) => {
-    dispatch(withShift ? { type: 'extend', id, rows: rowsRef.current } : { type: 'toggle', id })
+    dispatch({ type: withShift ? 'extend' : 'toggle', id, rows: rowsRef.current })
   }, [])
 
   const handlePointerEnter = useCallback((id: string) => {

--- a/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
+++ b/frontend/src/pages/transactions/components/bulk-edit/useBulkSelection.ts
@@ -1,0 +1,118 @@
+import { useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
+import {
+  bulkSelectionReducer,
+  emptyBulkSelection,
+  previewSelection,
+  rowSelectionMark,
+  type RowSelectionMark,
+  type SelectableRow,
+} from '@/pages/transactions/components/bulk-edit/selection'
+
+/**
+ * Holds which transactions a bulk edit covers, and lights the rows a pending shift-click would take.
+ *
+ * @param rows The rows on screen, in the order they appear, which is what a range runs along
+ * @param requestKey Identifies the list being shown, so the selection empties when the list changes
+ * @param isSettled False while the list is mid-change and still showing its previous rows
+ */
+export function useBulkSelection(rows: SelectableRow[], requestKey: string, isSettled: boolean) {
+  const [state, dispatch] = useReducer(bulkSelectionReducer, emptyBulkSelection)
+
+  // Read at dispatch time rather than closed over, so a range always runs along the rows on screen
+  const rowsRef = useRef(rows)
+  useEffect(() => {
+    rowsRef.current = rows
+  }, [rows])
+
+  // The row the pointer is over, held whether or not shift is down, so pressing shift without
+  // moving the pointer lights the range straight away
+  const pointerRowRef = useRef<string | null>(null)
+  const shiftHeldRef = useRef(false)
+
+  // A filter or a search empties the selection, since the rows it pointed at are no longer the rows
+  // on screen
+  useEffect(() => {
+    dispatch({ type: 'clear' })
+  }, [requestKey])
+
+  const displayedIds = useMemo(() => rows.map((row) => row.id), [rows])
+
+  useEffect(() => {
+    if (!isSettled) return
+    dispatch({ type: 'keepDisplayed', ids: displayedIds })
+  }, [displayedIds, isSettled])
+
+  useEffect(() => {
+    function clearPreview() {
+      shiftHeldRef.current = false
+      dispatch({ type: 'hover', id: null })
+    }
+
+    // The search box sits directly above the list, so a capital letter typed there would otherwise
+    // light the rows under the pointer
+    function isShiftMeantForSomethingElse() {
+      const active = document.activeElement as HTMLElement | null
+      if (active && (active.tagName === 'INPUT' || active.tagName === 'TEXTAREA' || active.isContentEditable)) {
+        return true
+      }
+      return document.querySelector('[role="dialog"]') !== null
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key !== 'Shift' || isShiftMeantForSomethingElse()) return
+      shiftHeldRef.current = true
+      if (pointerRowRef.current !== null) dispatch({ type: 'hover', id: pointerRowRef.current })
+    }
+
+    function handleKeyUp(event: KeyboardEvent) {
+      if (event.key !== 'Shift') return
+      clearPreview()
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    window.addEventListener('keyup', handleKeyUp)
+
+    // A shift released in another application never reaches this page, so the flag would otherwise
+    // stay set and promise a range the click would not take
+    window.addEventListener('blur', clearPreview)
+    document.addEventListener('visibilitychange', clearPreview)
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown)
+      window.removeEventListener('keyup', handleKeyUp)
+      window.removeEventListener('blur', clearPreview)
+      document.removeEventListener('visibilitychange', clearPreview)
+    }
+  }, [])
+
+  const preview = useMemo(() => previewSelection(state, rows), [state, rows])
+
+  const markFor = useCallback(
+    (id: string): RowSelectionMark => rowSelectionMark(id, state.selectedIds, preview),
+    [state.selectedIds, preview],
+  )
+
+  const toggle = useCallback((id: string, withShift: boolean) => {
+    dispatch(withShift ? { type: 'extend', id, rows: rowsRef.current } : { type: 'toggle', id })
+  }, [])
+
+  const handlePointerEnter = useCallback((id: string) => {
+    pointerRowRef.current = id
+    if (shiftHeldRef.current) dispatch({ type: 'hover', id })
+  }, [])
+
+  const handlePointerLeaveList = useCallback(() => {
+    pointerRowRef.current = null
+    dispatch({ type: 'hover', id: null })
+  }, [])
+
+  const clear = useCallback(() => {
+    pointerRowRef.current = null
+    shiftHeldRef.current = false
+    dispatch({ type: 'clear' })
+  }, [])
+
+  const selectedIds = useMemo(() => [...state.selectedIds], [state.selectedIds])
+
+  return { selectedIds, markFor, toggle, handlePointerEnter, handlePointerLeaveList, clear }
+}

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
-import { Check, ListChecks, PencilLine, Upload } from 'lucide-react'
+import { Check, ListChecks, PencilLine, SlidersHorizontal, Upload } from 'lucide-react'
 import { DesktopToolbarControls } from '@/components/list-controls/DesktopToolbarControls'
 import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { MobileToolbarActions } from '@/components/list-controls/MobileToolbarActions'
@@ -79,17 +79,17 @@ export default function TransactionListToolbar({
     </button>
   ) : undefined
 
-  // Follows the import button's shape: square on a phone, widening for its word on a desktop, at the
-  // same 44px height as everything else on the row.
+  // Follows the import button's shape while browsing. In the mobile selection row, Done gains its
+  // word once Edit has enough room; the named container leaves the desktop layout independent.
   //
   // The icon and the word rise out and the next pair rises in, so pressing it reads as one control
-  // changing state. The label reserves the width of the longer of the two words at both states, so
+  // changing state. On desktop, the label reserves the longer word's width at both states, so
   // the button itself never resizes: the desktop toolbar measures its children to decide when the
   // create button stacks, and a width easing under it could flip that decision mid-animation
   const selectAction = onToggleSelecting ? (
     <button
       type="button"
-      className="app-glass-button h-11 w-11 shrink-0 overflow-hidden px-0 min-[750px]:w-auto min-[750px]:px-4"
+      className="app-glass-button h-11 w-11 shrink-0 overflow-hidden px-0 @min-[16rem]/bulk-actions:w-auto @min-[16rem]/bulk-actions:px-4 min-[750px]:w-auto min-[750px]:px-4"
       onClick={onToggleSelecting}
       aria-pressed={isSelecting}
       aria-label={isSelecting ? 'Stop selecting transactions' : 'Select transactions'}
@@ -104,7 +104,7 @@ export default function TransactionListToolbar({
           transition={{ duration: prefersReducedMotion ? 0 : 0.16, ease: TRANSACTION_LIST_EASE }}
         >
           {isSelecting ? <Check size={18} aria-hidden /> : <ListChecks size={18} aria-hidden />}
-          <span className="hidden text-center min-[750px]:inline min-[750px]:w-10">
+          <span className="hidden text-center @min-[16rem]/bulk-actions:inline min-[750px]:inline min-[750px]:w-10">
             {isSelecting ? 'Done' : 'Select'}
           </span>
         </motion.span>
@@ -112,9 +112,8 @@ export default function TransactionListToolbar({
     </button>
   ) : undefined
 
-  // Built to the shape of the row it sits in: square beside the other actions, and stretched on a
-  // phone in selection mode, where it and Done are the only two controls on the row
-  function renderEditAction(className: string) {
+  // Edit takes the remaining mobile space, retaining its word longer than Done and Filters.
+  function renderEditAction(className: string, labelClassName = 'hidden min-[750px]:inline') {
     if (!onEditSelection) return undefined
     const reason = editDisabledReason ?? (selectedCount === 0 ? 'Tick a transaction first' : undefined)
     return (
@@ -127,7 +126,7 @@ export default function TransactionListToolbar({
         aria-label="Edit the selected transactions"
       >
         <PencilLine size={18} aria-hidden />
-        <span className="hidden min-[750px]:inline">Edit</span>
+        <span className={labelClassName}>Edit</span>
       </button>
     )
   }
@@ -183,12 +182,33 @@ export default function TransactionListToolbar({
           wrapperClassName={getSearchFieldWrapperClassName(shell.mobileSearchStuck, shell.desktopInlineLayout)}
         />
 
-        {/* Selection mode takes the phone row down to the two controls it is for. Filtering or adding
-            a transaction mid-selection empties the selection anyway, so neither is worth the width */}
+        {/* Query this row's available width, including on an account page. Each threshold reserves
+            room for the higher-priority labels and all three 44px controls before adding a word. */}
         {isSelecting ? (
-          <div className="flex w-full items-center gap-3 min-[750px]:hidden">
-            {renderEditAction('app-glass-button h-11 min-w-0 flex-1 gap-2')}
+          <div className="@container/bulk-actions flex w-full items-center gap-3 min-[750px]:hidden">
+            {renderEditAction(
+              'app-glass-button h-11 min-w-11 flex-1 gap-2 px-0 @min-[12.5rem]/bulk-actions:px-4',
+              'hidden @min-[12.5rem]/bulk-actions:inline',
+            )}
             {selectAction}
+            <button
+              type="button"
+              className="app-glass-button relative h-11 w-11 shrink-0 px-0 @min-[20rem]/bulk-actions:w-auto @min-[20rem]/bulk-actions:px-4"
+              onClick={shell.openMobileSheet}
+              aria-label={activeFilterCount > 0 ? `Filters, ${activeFilterCount} active` : 'Filters'}
+            >
+              <SlidersHorizontal size={17} aria-hidden />
+              <span className="hidden @min-[20rem]/bulk-actions:inline">Filters</span>
+              {activeFilterCount > 0 && (
+                <span
+                  aria-hidden
+                  className="absolute right-0 -top-1 flex h-5 min-w-5 items-center justify-center rounded-full px-1.5 text-xs font-semibold"
+                  style={{ background: 'var(--app-accent-soft)', color: 'var(--app-accent)' }}
+                >
+                  {activeFilterCount}
+                </span>
+              )}
+            </button>
           </div>
         ) : (
           <MobileToolbarActions

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -1,11 +1,13 @@
 import { useMemo } from 'react'
-import { ListChecks, Upload } from 'lucide-react'
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
+import { Check, ListChecks, Upload } from 'lucide-react'
 import { DesktopToolbarControls } from '@/components/list-controls/DesktopToolbarControls'
 import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { MobileToolbarActions } from '@/components/list-controls/MobileToolbarActions'
 import { ToolbarStickyShell } from '@/components/list-controls/ToolbarStickyShell'
 import { getSearchFieldWrapperClassName } from '@/components/list-controls/toolbarStyles'
 import { useToolbarShellState } from '@/components/list-controls/useToolbarShellState'
+import { TRANSACTION_LIST_EASE } from '@/pages/transactions/constants/transactionList'
 import type { TransactionListToolbarProps } from '@/pages/transactions/components/toolbar/types'
 import { TransactionFilterPanel } from '@/pages/transactions/components/toolbar/FilterPanel'
 import { MobileFilterPanel } from '@/pages/transactions/components/toolbar/MobileFilterPanel'
@@ -39,6 +41,7 @@ export default function TransactionListToolbar({
   isSelecting = false,
   onToggleSelecting,
 }: TransactionListToolbarProps) {
+  const prefersReducedMotion = useReducedMotion()
   const shell = useToolbarShellState()
   useToolbarStickyOffset(shell.toolbarRef, onStickyOffsetChange)
 
@@ -67,17 +70,35 @@ export default function TransactionListToolbar({
   ) : undefined
 
   // Follows the import button's shape: square on a phone, widening for its word on a desktop, at the
-  // same 44px height as everything else on the row
+  // same 44px height as everything else on the row.
+  //
+  // The icon and the word rise out and the next pair rises in, so pressing it reads as one control
+  // changing state. The label reserves the width of the longer of the two words at both states, so
+  // the button itself never resizes: the desktop toolbar measures its children to decide when the
+  // create button stacks, and a width easing under it could flip that decision mid-animation
   const selectAction = onToggleSelecting ? (
     <button
       type="button"
-      className="app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:w-auto min-[750px]:px-4"
+      className="app-glass-button h-11 w-11 shrink-0 overflow-hidden px-0 min-[750px]:w-auto min-[750px]:px-4"
       onClick={onToggleSelecting}
       aria-pressed={isSelecting}
       aria-label={isSelecting ? 'Stop selecting transactions' : 'Select transactions'}
     >
-      <ListChecks size={18} aria-hidden />
-      <span className="hidden min-[750px]:inline">{isSelecting ? 'Done' : 'Select'}</span>
+      <AnimatePresence mode="wait" initial={false}>
+        <motion.span
+          key={isSelecting ? 'done' : 'select'}
+          className="flex items-center gap-2"
+          initial={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: 7 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, y: -7 }}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.16, ease: TRANSACTION_LIST_EASE }}
+        >
+          {isSelecting ? <Check size={18} aria-hidden /> : <ListChecks size={18} aria-hidden />}
+          <span className="hidden text-center min-[750px]:inline min-[750px]:w-10">
+            {isSelecting ? 'Done' : 'Select'}
+          </span>
+        </motion.span>
+      </AnimatePresence>
     </button>
   ) : undefined
 

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { Upload } from 'lucide-react'
+import { ListChecks, Upload } from 'lucide-react'
 import { DesktopToolbarControls } from '@/components/list-controls/DesktopToolbarControls'
 import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { MobileToolbarActions } from '@/components/list-controls/MobileToolbarActions'
@@ -36,6 +36,8 @@ export default function TransactionListToolbar({
   importDisabled = false,
   importDisabledReason,
   onStickyOffsetChange,
+  isSelecting = false,
+  onToggleSelecting,
 }: TransactionListToolbarProps) {
   const shell = useToolbarShellState()
   useToolbarStickyOffset(shell.toolbarRef, onStickyOffsetChange)
@@ -61,6 +63,21 @@ export default function TransactionListToolbar({
       {/* The word is dropped on a phone, where the row is three controls wide and the filters button
           needs the space it would take. The accessible name carries it at both widths */}
       <span className="hidden min-[750px]:inline">Import</span>
+    </button>
+  ) : undefined
+
+  // Follows the import button's shape: square on a phone, widening for its word on a desktop, at the
+  // same 44px height as everything else on the row
+  const selectAction = onToggleSelecting ? (
+    <button
+      type="button"
+      className="app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:w-auto min-[750px]:px-4"
+      onClick={onToggleSelecting}
+      aria-pressed={isSelecting}
+      aria-label={isSelecting ? 'Stop selecting transactions' : 'Select transactions'}
+    >
+      <ListChecks size={18} aria-hidden />
+      <span className="hidden min-[750px]:inline">{isSelecting ? 'Done' : 'Select'}</span>
     </button>
   ) : undefined
 
@@ -98,7 +115,12 @@ export default function TransactionListToolbar({
           primaryLabel="Add transaction"
           primaryDisabled={createDisabled}
           primaryDisabledReason={createDisabledReason}
-          secondaryAction={importAction}
+          secondaryAction={
+            <>
+              {selectAction}
+              {importAction}
+            </>
+          }
         />
 
         <DesktopToolbarControls
@@ -114,6 +136,7 @@ export default function TransactionListToolbar({
             // narrower than it draws and stay on one line where it no longer fits. Wrapped as one
             // child, since the group spreads its children apart once the create button stacks
             <div className="flex min-w-0 items-center gap-3">
+              {selectAction}
               {importAction}
               <TransactionFilterPanel
                 accountOptions={accountOptions}

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -186,11 +186,6 @@ export default function TransactionListToolbar({
             room for the higher-priority labels and all three 44px controls before adding a word. */}
         {isSelecting ? (
           <div className="@container/bulk-actions flex w-full items-center gap-3 min-[750px]:hidden">
-            {renderEditAction(
-              'app-glass-button h-11 min-w-11 flex-1 gap-2 px-0 @min-[12.5rem]/bulk-actions:px-4',
-              'hidden @min-[12.5rem]/bulk-actions:inline',
-            )}
-            {selectAction}
             <button
               type="button"
               className="app-glass-button relative h-11 w-11 shrink-0 px-0 @min-[20rem]/bulk-actions:w-auto @min-[20rem]/bulk-actions:px-4"
@@ -209,6 +204,11 @@ export default function TransactionListToolbar({
                 </span>
               )}
             </button>
+            {renderEditAction(
+              'app-glass-button h-11 min-w-11 flex-1 gap-2 px-0 @min-[12.5rem]/bulk-actions:px-4',
+              'hidden @min-[12.5rem]/bulk-actions:inline',
+            )}
+            {selectAction}
           </div>
         ) : (
           <MobileToolbarActions

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
 import { Check, ListChecks, PencilLine, Upload } from 'lucide-react'
 import { DesktopToolbarControls } from '@/components/list-controls/DesktopToolbarControls'
@@ -46,9 +46,13 @@ export default function TransactionListToolbar({
 }: TransactionListToolbarProps) {
   const prefersReducedMotion = useReducedMotion()
 
+  // Set from the desktop edit button's own onAnimationStart and onAnimationComplete, so the wrap
+  // layout hook holds its measurement still for exactly the span its width is changing
+  const [isEditActionAnimating, setIsEditActionAnimating] = useState(false)
+
   // Selection mode swaps the row's own controls, and the wrap layout measures boxes rather than
   // contents, so it is told rather than left to notice
-  const shell = useToolbarShellState(isSelecting ? 'selecting' : 'browsing')
+  const shell = useToolbarShellState(isSelecting ? 'selecting' : 'browsing', isEditActionAnimating)
   useToolbarStickyOffset(shell.toolbarRef, onStickyOffsetChange)
 
   // One node for both widths, at the 44px control height the row is built on, which the search field
@@ -128,9 +132,29 @@ export default function TransactionListToolbar({
     )
   }
 
-  const editAction = isSelecting
-    ? renderEditAction('app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:w-auto min-[750px]:px-4')
-    : undefined
+  // Animates in beside Done rather than appearing in one frame. The always-present actions keep the
+  // row's own gap-3 among themselves in a group of their own; this button's trailing space instead
+  // lives inside the animated box, as a margin on the button that the width animation carries along
+  // with it, so the space closes with the button instead of sitting at a fixed width until the box
+  // unmounts and the row's gap snaps shut behind it
+  const desktopEditAction = (
+    <AnimatePresence initial={false}>
+      {isSelecting && onEditSelection && (
+        <motion.div
+          key="edit-action"
+          className="overflow-hidden"
+          initial={{ width: 0, opacity: 0 }}
+          animate={{ width: 'auto', opacity: 1 }}
+          exit={{ width: 0, opacity: 0 }}
+          transition={{ duration: prefersReducedMotion ? 0 : 0.16, ease: TRANSACTION_LIST_EASE }}
+          onAnimationStart={() => setIsEditActionAnimating(true)}
+          onAnimationComplete={() => setIsEditActionAnimating(false)}
+        >
+          {renderEditAction('app-glass-button h-11 w-11 shrink-0 px-0 mr-3 min-[750px]:w-auto min-[750px]:px-4')}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  )
 
   const accountOptions = useMemo(
     () => getAccountOptions(accounts),
@@ -195,18 +219,20 @@ export default function TransactionListToolbar({
             // group instead would need its own measured twin, or the row would report itself
             // narrower than it draws and stay on one line where it no longer fits. Wrapped as one
             // child, since the group spreads its children apart once the create button stacks
-            <div className="flex min-w-0 items-center gap-3">
-              {editAction}
-              {selectAction}
-              {importAction}
-              <TransactionFilterPanel
-                accountOptions={accountOptions}
-                categoryOptions={categoryOptions}
-                filters={filters}
-                setFilter={setFilter}
-                showAccountFilter={showAccountFilter}
-                lockedCurrency={lockedCurrency}
-              />
+            <div className="flex min-w-0 items-center">
+              {desktopEditAction}
+              <div className="flex min-w-0 items-center gap-3">
+                {selectAction}
+                {importAction}
+                <TransactionFilterPanel
+                  accountOptions={accountOptions}
+                  categoryOptions={categoryOptions}
+                  filters={filters}
+                  setFilter={setFilter}
+                  showAccountFilter={showAccountFilter}
+                  lockedCurrency={lockedCurrency}
+                />
+              </div>
             </div>
           }
           createLabel="Add Transaction"

--- a/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
+++ b/frontend/src/pages/transactions/components/toolbar/ListToolbar.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react'
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react'
-import { Check, ListChecks, Upload } from 'lucide-react'
+import { Check, ListChecks, PencilLine, Upload } from 'lucide-react'
 import { DesktopToolbarControls } from '@/components/list-controls/DesktopToolbarControls'
 import { GlassSearchField } from '@/components/list-controls/GlassSearchField'
 import { MobileToolbarActions } from '@/components/list-controls/MobileToolbarActions'
@@ -39,10 +39,16 @@ export default function TransactionListToolbar({
   importDisabledReason,
   onStickyOffsetChange,
   isSelecting = false,
+  selectedCount = 0,
+  editDisabledReason,
+  onEditSelection,
   onToggleSelecting,
 }: TransactionListToolbarProps) {
   const prefersReducedMotion = useReducedMotion()
-  const shell = useToolbarShellState()
+
+  // Selection mode swaps the row's own controls, and the wrap layout measures boxes rather than
+  // contents, so it is told rather than left to notice
+  const shell = useToolbarShellState(isSelecting ? 'selecting' : 'browsing')
   useToolbarStickyOffset(shell.toolbarRef, onStickyOffsetChange)
 
   // One node for both widths, at the 44px control height the row is built on, which the search field
@@ -102,6 +108,30 @@ export default function TransactionListToolbar({
     </button>
   ) : undefined
 
+  // Built to the shape of the row it sits in: square beside the other actions, and stretched on a
+  // phone in selection mode, where it and Done are the only two controls on the row
+  function renderEditAction(className: string) {
+    if (!onEditSelection) return undefined
+    const reason = editDisabledReason ?? (selectedCount === 0 ? 'Tick a transaction first' : undefined)
+    return (
+      <button
+        type="button"
+        className={className}
+        onClick={onEditSelection}
+        disabled={Boolean(reason)}
+        title={reason}
+        aria-label="Edit the selected transactions"
+      >
+        <PencilLine size={18} aria-hidden />
+        <span className="hidden min-[750px]:inline">Edit</span>
+      </button>
+    )
+  }
+
+  const editAction = isSelecting
+    ? renderEditAction('app-glass-button h-11 w-11 shrink-0 px-0 min-[750px]:w-auto min-[750px]:px-4')
+    : undefined
+
   const accountOptions = useMemo(
     () => getAccountOptions(accounts),
     [accounts],
@@ -129,20 +159,29 @@ export default function TransactionListToolbar({
           wrapperClassName={getSearchFieldWrapperClassName(shell.mobileSearchStuck, shell.desktopInlineLayout)}
         />
 
-        <MobileToolbarActions
-          activeFilterCount={activeFilterCount}
-          onOpenFilters={shell.openMobileSheet}
-          onPrimaryAction={onCreateTransaction}
-          primaryLabel="Add transaction"
-          primaryDisabled={createDisabled}
-          primaryDisabledReason={createDisabledReason}
-          secondaryAction={
-            <>
-              {selectAction}
-              {importAction}
-            </>
-          }
-        />
+        {/* Selection mode takes the phone row down to the two controls it is for. Filtering or adding
+            a transaction mid-selection empties the selection anyway, so neither is worth the width */}
+        {isSelecting ? (
+          <div className="flex w-full items-center gap-3 min-[750px]:hidden">
+            {renderEditAction('app-glass-button h-11 min-w-0 flex-1 gap-2')}
+            {selectAction}
+          </div>
+        ) : (
+          <MobileToolbarActions
+            activeFilterCount={activeFilterCount}
+            onOpenFilters={shell.openMobileSheet}
+            onPrimaryAction={onCreateTransaction}
+            primaryLabel="Add transaction"
+            primaryDisabled={createDisabled}
+            primaryDisabledReason={createDisabledReason}
+            secondaryAction={
+              <>
+                {selectAction}
+                {importAction}
+              </>
+            }
+          />
+        )}
 
         <DesktopToolbarControls
           controlsRef={shell.controlsRef}
@@ -157,6 +196,7 @@ export default function TransactionListToolbar({
             // narrower than it draws and stay on one line where it no longer fits. Wrapped as one
             // child, since the group spreads its children apart once the create button stacks
             <div className="flex min-w-0 items-center gap-3">
+              {editAction}
               {selectAction}
               {importAction}
               <TransactionFilterPanel

--- a/frontend/src/pages/transactions/components/toolbar/types.ts
+++ b/frontend/src/pages/transactions/components/toolbar/types.ts
@@ -27,5 +27,14 @@ export type TransactionListToolbarProps = {
 
   // Whether the list is showing a checkbox on every row, so a bulk edit can pick rows out
   isSelecting?: boolean
+
+  // How many rows are ticked, which is what decides whether the edit button can be pressed
+  selectedCount?: number
+
+  // Shown as the edit button's title while it is off for a reason other than nothing being ticked
+  editDisabledReason?: string
+
+  // Opens the bulk edit modal. Absent on a list that offers no selection at all
+  onEditSelection?: () => void
   onToggleSelecting?: () => void
 }

--- a/frontend/src/pages/transactions/components/toolbar/types.ts
+++ b/frontend/src/pages/transactions/components/toolbar/types.ts
@@ -24,4 +24,8 @@ export type TransactionListToolbarProps = {
   importDisabled?: boolean
   importDisabledReason?: string
   onStickyOffsetChange?: (offset: number) => void
+
+  // Whether the list is showing a checkbox on every row, so a bulk edit can pick rows out
+  isSelecting?: boolean
+  onToggleSelecting?: () => void
 }

--- a/frontend/src/pages/transactions/components/transaction-modal/types.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/types.ts
@@ -1,8 +1,8 @@
-import type { Transaction } from '@/api/transactions'
+import type { Transaction, TransactionDirection } from '@/api/transactions'
 
 export type TransactionModalKind = 'expense' | 'income' | 'transfer'
 
-export type TransactionDirection = 'debit' | 'credit'
+export type { TransactionDirection }
 
 export interface TransactionFormValues {
   kind: TransactionModalKind

--- a/frontend/src/pages/transactions/components/transaction-modal/utils/categories.ts
+++ b/frontend/src/pages/transactions/components/transaction-modal/utils/categories.ts
@@ -13,12 +13,14 @@ const CATEGORY_KIND_ORDER: TransactionModalKind[] = ['expense', 'income', 'trans
 
 /**
  * Builds category dropdown options with the selected transaction kind shown first
+ *
+ * @param selectedKind Kind to put first, omitted where the caller edits several transactions at
+ *   once and so has no one kind to lead with
  */
-export function buildCategoryOptions(categories: Category[], selectedKind: TransactionModalKind) {
-  const sortedKinds = [
-    selectedKind,
-    ...CATEGORY_KIND_ORDER.filter((kind) => kind !== selectedKind),
-  ]
+export function buildCategoryOptions(categories: Category[], selectedKind?: TransactionModalKind) {
+  const sortedKinds = selectedKind
+    ? [selectedKind, ...CATEGORY_KIND_ORDER.filter((kind) => kind !== selectedKind)]
+    : CATEGORY_KIND_ORDER
 
   return sortedKinds.flatMap((kind) => buildOptionsForKind(categories, kind))
 }

--- a/frontend/src/pages/transactions/constants/transactionList.ts
+++ b/frontend/src/pages/transactions/constants/transactionList.ts
@@ -18,3 +18,26 @@ export const TRANSACTION_FILTER_KEYS: Array<keyof TransactionListFilters> = [
 
 export const FILTER_LIST_LOADING_MIN_MS = 1000
 export const TRANSACTION_LIST_EASE = [0.25, 0.1, 0.25, 1] as const
+
+// The room the checkbox sits in while the list is in selection mode. Held as padding on the list
+// rather than as a column, because a column the list declares in both states still takes a column
+// gap at zero width, and every row outside selection mode would lose that much space and start
+// truncating text it fits today
+export const TRANSACTION_CHECKBOX_RAIL_WIDTH = '2.5rem'
+
+// Set on the list while selection mode opens and closes, and read by the rows and date headings
+export const TRANSACTION_CHECKBOX_RAIL_VARIABLE = '--transaction-checkbox-rail' as const
+
+// Falls back to zero for the import preview, which renders the same row outside this list
+export const TRANSACTION_CHECKBOX_RAIL = `var(${TRANSACTION_CHECKBOX_RAIL_VARIABLE}, 0rem)`
+
+// How long the rail takes to open and close, matched by the checkbox fading in and out inside it
+export const TRANSACTION_CHECKBOX_RAIL_DURATION_S = 0.22
+
+// Given to every row and date heading, so their backgrounds and separators still run the full width
+// of the list while their cells stay on the tracks it declares. The negative margin reaches the box
+// back across the rail and the width puts back what the margin took
+export const REACHES_ACROSS_TRANSACTION_CHECKBOX_RAIL = {
+  marginLeft: `calc(-1 * ${TRANSACTION_CHECKBOX_RAIL})`,
+  width: `calc(100% + ${TRANSACTION_CHECKBOX_RAIL})`,
+}

--- a/frontend/src/pages/transactions/types/transactionList.ts
+++ b/frontend/src/pages/transactions/types/transactionList.ts
@@ -24,6 +24,7 @@ export interface TransactionListAccount {
   name?: string
   currency?: string
   institution?: AccountsOverview['institution']
+  can_write: boolean
   is_archived?: boolean
 
   /** When the account was closed, which is a second state that takes no new transactions */
@@ -42,6 +43,7 @@ export function toTransactionListAccount(account: AccountsOverview): Transaction
     name: account.name,
     currency: account.currency,
     institution: account.institution,
+    can_write: account.can_write,
     is_archived: account.is_archived,
     closed_at: account.closed_at,
   }

--- a/frontend/src/pages/transactions/utils/rowEditability.ts
+++ b/frontend/src/pages/transactions/utils/rowEditability.ts
@@ -1,3 +1,4 @@
+import type { Category } from '@/api/categories'
 import type { Transaction } from '@/api/transactions'
 import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
 
@@ -5,13 +6,18 @@ import type { TransactionListAccount } from '@/pages/transactions/types/transact
  * Returns why a transaction cannot be edited, or undefined when it can be.
  *
  * One rule decides both the mark the row shows and whether a bulk selection may tick it, so the
- * two cannot disagree about which rows are editable.
+ * two cannot disagree about which rows are editable. A category missing from the map is one the
+ * current user cannot open, since the list only ever loads the categories open to them, and a
+ * bulk edit sent over such a row is refused whole regardless of what else it touches.
  */
 export function getTransactionReadOnlyReason(
   transaction: Transaction,
   accountMap: Map<string, TransactionListAccount>,
+  categoryMap: Map<string, Category>,
   fixedAccount?: TransactionListAccount,
 ): string | undefined {
   const rowAccount = fixedAccount ?? accountMap.get(transaction.account_id)
-  return rowAccount?.is_archived ? 'Archived · Read-only' : undefined
+  if (rowAccount?.is_archived) return 'Archived · Read-only'
+  if (!categoryMap.has(transaction.category_id)) return 'Uses a category you cannot open'
+  return undefined
 }

--- a/frontend/src/pages/transactions/utils/rowEditability.ts
+++ b/frontend/src/pages/transactions/utils/rowEditability.ts
@@ -1,0 +1,17 @@
+import type { Transaction } from '@/api/transactions'
+import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
+
+/**
+ * Returns why a transaction cannot be edited, or undefined when it can be.
+ *
+ * One rule decides both the mark the row shows and whether a bulk selection may tick it, so the
+ * two cannot disagree about which rows are editable.
+ */
+export function getTransactionReadOnlyReason(
+  transaction: Transaction,
+  accountMap: Map<string, TransactionListAccount>,
+  fixedAccount?: TransactionListAccount,
+): string | undefined {
+  const rowAccount = fixedAccount ?? accountMap.get(transaction.account_id)
+  return rowAccount?.is_archived ? 'Archived · Read-only' : undefined
+}

--- a/frontend/src/pages/transactions/utils/rowEditability.ts
+++ b/frontend/src/pages/transactions/utils/rowEditability.ts
@@ -18,6 +18,7 @@ export function getTransactionReadOnlyReason(
 ): string | undefined {
   const rowAccount = fixedAccount ?? accountMap.get(transaction.account_id)
   if (rowAccount?.is_archived) return 'Archived · Read-only'
+  if (rowAccount?.can_write !== true) return 'Read-only access'
   if (!categoryMap.has(transaction.category_id)) return 'Uses a category you cannot open'
   return undefined
 }

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -6,6 +6,11 @@
     /* Light — warm parchment */
     --app-bg: #F2EDE4;
     --app-surface-soft: #FBF8F0;
+    /* A row's own hover, pending mark and focus background. Kept apart from
+       .app-dropdown-row-highlighted, which mixes the same proportion in both themes rather than
+       taking this token, since pointing that rule at this token would carry the flat light value
+       below into the dropdown and lose the mix it depends on there */
+    --app-hover-soft: #FBF8F0;
 
     --app-border: #4b37231c;
     --app-border-strong: #4b372333;
@@ -92,6 +97,7 @@
     /* Dark — warm charcoal */
     --app-bg: #0F0E0C;
     --app-surface-soft: #13100E;
+    --app-hover-soft: color-mix(in srgb, var(--app-text) 6%, transparent);
 
     --app-border: #d2b47817;
     --app-border-strong: #d2b4782b;

--- a/frontend/tests/api/cache/updates/transactions.bulk.test.ts
+++ b/frontend/tests/api/cache/updates/transactions.bulk.test.ts
@@ -17,6 +17,7 @@ function seedCache() {
   queryClient.setQueryData(transactionKeys.list({}), []);
   queryClient.setQueryData(budgetKeys.latestUtilizations(), []);
   queryClient.setQueryData(accountKeys.list(), []);
+  queryClient.setQueryData(accountKeys.cashFlowAll('acc_1'), []);
   return queryClient;
 }
 
@@ -121,5 +122,18 @@ describe('invalidateBulkUpdatedTransactionData', () => {
     );
 
     expect(isStale(queryClient, accountKeys.list())).toBe(true);
+  });
+
+  it('refreshes the account balances and activity after a transfer-only direction change', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], transfer_direction: 'reverse' },
+      ['acc_1'],
+    );
+
+    expect(isStale(queryClient, accountKeys.list())).toBe(true);
+    expect(isStale(queryClient, accountKeys.cashFlowAll('acc_1'))).toBe(true);
   });
 });

--- a/frontend/tests/api/cache/updates/transactions.bulk.test.ts
+++ b/frontend/tests/api/cache/updates/transactions.bulk.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { QueryClient } from '@tanstack/react-query';
-import { budgetKeys, transactionKeys } from '@/api/cache/queryKeys';
+import { accountKeys, budgetKeys, transactionKeys } from '@/api/cache/queryKeys';
 import { invalidateBulkUpdatedTransactionData } from '@/api/cache/updates/transactions';
 
 /**
@@ -16,6 +16,7 @@ function seedCache() {
   const queryClient = new QueryClient();
   queryClient.setQueryData(transactionKeys.list({}), []);
   queryClient.setQueryData(budgetKeys.latestUtilizations(), []);
+  queryClient.setQueryData(accountKeys.list(), []);
   return queryClient;
 }
 
@@ -58,6 +59,43 @@ describe('invalidateBulkUpdatedTransactionData', () => {
     );
 
     expect(isStale(queryClient, budgetKeys.latestUtilizations())).toBe(true);
+    expect(isStale(queryClient, transactionKeys.list({}))).toBe(true);
+  });
+
+  it('refreshes the account balances after a move', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], account_id: 'acc_2' },
+      ['acc_1', 'acc_2'],
+    );
+
+    expect(isStale(queryClient, accountKeys.list())).toBe(true);
+  });
+
+  it('refreshes the account balances after a date change', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], dt: '2026-08-14' },
+      ['acc_1'],
+    );
+
+    expect(isStale(queryClient, accountKeys.list())).toBe(true);
+  });
+
+  it('leaves the account balances alone after a note edit', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], notes: 'Corrected' },
+      ['acc_1'],
+    );
+
+    expect(isStale(queryClient, accountKeys.list())).toBe(false);
     expect(isStale(queryClient, transactionKeys.list({}))).toBe(true);
   });
 });

--- a/frontend/tests/api/cache/updates/transactions.bulk.test.ts
+++ b/frontend/tests/api/cache/updates/transactions.bulk.test.ts
@@ -98,4 +98,28 @@ describe('invalidateBulkUpdatedTransactionData', () => {
     expect(isStale(queryClient, accountKeys.list())).toBe(false);
     expect(isStale(queryClient, transactionKeys.list({}))).toBe(true);
   });
+
+  it('refreshes the account balances after a direction change', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], direction: 'reverse' },
+      ['acc_1'],
+    );
+
+    expect(isStale(queryClient, accountKeys.list())).toBe(true);
+  });
+
+  it('refreshes the account balances after a transfer end is set', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], transfer_from: { scope: 'tracked', account_id: 'acc_2' } },
+      ['acc_1', 'acc_2'],
+    );
+
+    expect(isStale(queryClient, accountKeys.list())).toBe(true);
+  });
 });

--- a/frontend/tests/api/cache/updates/transactions.bulk.test.ts
+++ b/frontend/tests/api/cache/updates/transactions.bulk.test.ts
@@ -7,10 +7,11 @@
 import { describe, expect, it } from 'vitest';
 import { QueryClient } from '@tanstack/react-query';
 import { accountKeys, budgetKeys, transactionKeys } from '@/api/cache/queryKeys';
+import type { BulkUpdateTransactionsPayload } from '@/api/transactions';
 import { invalidateBulkUpdatedTransactionData } from '@/api/cache/updates/transactions';
 
 /**
- * Seeds the two query families these tests read back, so each one exists to be marked stale
+ * Seeds the shared queries these tests read back, so each one exists to be marked stale
  */
 function seedCache() {
   const queryClient = new QueryClient();
@@ -26,6 +27,47 @@ function isStale(queryClient: QueryClient, queryKey: readonly unknown[]) {
 }
 
 describe('invalidateBulkUpdatedTransactionData', () => {
+  it.each([
+    { name: 'moving transactions', fields: { account_id: 'destination' } },
+    { name: 'changing From', fields: { transfer_from: { scope: 'tracked', account_id: 'destination' } } },
+    { name: 'changing To', fields: { transfer_to: { scope: 'tracked', account_id: 'replacement_counterparty' } } },
+    {
+      name: 'changing both transfer ends',
+      fields: {
+        transfer_from: { scope: 'tracked', account_id: 'destination' },
+        transfer_to: { scope: 'tracked', account_id: 'replacement_counterparty' },
+      },
+    },
+  ] satisfies { name: string; fields: Omit<BulkUpdateTransactionsPayload, 'transaction_ids'> }[])(
+    'refreshes every affected account after $name, leaving unrelated accounts fresh',
+    ({ fields }) => {
+      const queryClient = seedCache();
+      // A mixed selection can reach accounts absent from the request, including old counterparties.
+      const affectedAccountIds = ['source', 'destination', 'previous_counterparty', 'replacement_counterparty'];
+      const accountViews = [...affectedAccountIds, 'unrelated'].flatMap((accountId) => [
+        { accountId, key: accountKeys.detail(accountId) },
+        { accountId, key: accountKeys.snapshots(accountId, { fromDate: '2026-08-01', granularity: 'day' }) },
+        { accountId, key: accountKeys.snapshots(accountId, { fromDate: '2026-01-01', granularity: 'month' }) },
+        { accountId, key: accountKeys.spendingBreakdown(accountId, 'month') },
+        { accountId, key: accountKeys.spendingBreakdown(accountId, 'year') },
+        { accountId, key: accountKeys.cashFlow(accountId, 3) },
+        { accountId, key: accountKeys.cashFlow(accountId, 12) },
+      ]);
+      for (const { key } of accountViews) queryClient.setQueryData(key, {});
+
+      invalidateBulkUpdatedTransactionData(
+        queryClient,
+        { transaction_ids: ['txn_1', 'txn_2'], ...fields },
+        affectedAccountIds,
+      );
+
+      expect(isStale(queryClient, accountKeys.list())).toBe(true);
+      for (const { accountId, key } of accountViews) {
+        expect(queryClient.getQueryState(key)?.isInvalidated, JSON.stringify(key)).toBe(accountId !== 'unrelated');
+      }
+    },
+  );
+
   it('refreshes the transaction lists after a tags-only edit', () => {
     const queryClient = seedCache();
 

--- a/frontend/tests/api/cache/updates/transactions.bulk.test.ts
+++ b/frontend/tests/api/cache/updates/transactions.bulk.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests which cached views a bulk transaction edit refreshes
+ *
+ * useBulkUpdateTransactions calls useMutation and useQueryClient, which need a live React tree to
+ * invoke, so this covers invalidateBulkUpdatedTransactionData directly against a real QueryClient
+ */
+import { describe, expect, it } from 'vitest';
+import { QueryClient } from '@tanstack/react-query';
+import { budgetKeys, transactionKeys } from '@/api/cache/queryKeys';
+import { invalidateBulkUpdatedTransactionData } from '@/api/cache/updates/transactions';
+
+/**
+ * Seeds the two query families these tests read back, so each one exists to be marked stale
+ */
+function seedCache() {
+  const queryClient = new QueryClient();
+  queryClient.setQueryData(transactionKeys.list({}), []);
+  queryClient.setQueryData(budgetKeys.latestUtilizations(), []);
+  return queryClient;
+}
+
+function isStale(queryClient: QueryClient, queryKey: readonly unknown[]) {
+  return queryClient.getQueryCache().find({ queryKey })?.state.isInvalidated === true;
+}
+
+describe('invalidateBulkUpdatedTransactionData', () => {
+  it('refreshes the transaction lists after a tags-only edit', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], add_tag_ids: ['tag_1'] },
+      ['acc_1'],
+    );
+
+    expect(isStale(queryClient, transactionKeys.list({}))).toBe(true);
+  });
+
+  it('leaves the budget totals alone after a tags-only edit', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], add_tag_ids: ['tag_1'] },
+      ['acc_1'],
+    );
+
+    expect(isStale(queryClient, budgetKeys.latestUtilizations())).toBe(false);
+  });
+
+  it('refreshes the budget totals after a category edit', () => {
+    const queryClient = seedCache();
+
+    invalidateBulkUpdatedTransactionData(
+      queryClient,
+      { transaction_ids: ['txn_1'], category_id: 'cat_1' },
+      ['acc_1'],
+    );
+
+    expect(isStale(queryClient, budgetKeys.latestUtilizations())).toBe(true);
+    expect(isStale(queryClient, transactionKeys.list({}))).toBe(true);
+  });
+});

--- a/frontend/tests/api/transactions.bulkUpdate.test.ts
+++ b/frontend/tests/api/transactions.bulkUpdate.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Covers the request a bulk transaction edit sends, since the endpoint applies all of it or none
+ * and a field left out of the body is a change the user asked for and did not get
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { authenticatedFetchMock } = vi.hoisted(() => ({
+  authenticatedFetchMock: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  authenticatedFetch: authenticatedFetchMock,
+}));
+
+import { bulkUpdateTransactions } from '@/api/transactions';
+
+beforeEach(() => {
+  authenticatedFetchMock.mockReset();
+  authenticatedFetchMock.mockResolvedValue({ transactions_updated: 0, affected_account_ids: [] });
+});
+
+describe('bulkUpdateTransactions', () => {
+  it('sends the ticked transactions and the chosen category', async () => {
+    await bulkUpdateTransactions({
+      transaction_ids: ['txn_1', 'txn_2'],
+      category_id: 'cat_1',
+    });
+
+    expect(authenticatedFetchMock).toHaveBeenCalledWith('/transactions/bulk', {
+      method: 'PATCH',
+      body: JSON.stringify({ transaction_ids: ['txn_1', 'txn_2'], category_id: 'cat_1' }),
+    });
+  });
+
+  it('sends a merchant and added tags together', async () => {
+    await bulkUpdateTransactions({
+      transaction_ids: ['txn_1'],
+      merchant_id: 'mer_1',
+      add_tag_ids: ['tag_1', 'tag_2'],
+    });
+
+    expect(authenticatedFetchMock).toHaveBeenCalledWith('/transactions/bulk', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        transaction_ids: ['txn_1'],
+        merchant_id: 'mer_1',
+        add_tag_ids: ['tag_1', 'tag_2'],
+      }),
+    });
+  });
+});

--- a/frontend/tests/components/dropdown/options.test.ts
+++ b/frontend/tests/components/dropdown/options.test.ts
@@ -9,6 +9,7 @@ import {
   getGroupedDropdownOptions,
   getSelectedDropdownOption,
   getVisibleDropdownOptions,
+  isDropdownOptionSelected,
 } from '@/components/dropdown/options'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
 
@@ -85,6 +86,19 @@ describe('dropdown option helpers', () => {
     expect(canEditDropdownOption({ value: '', label: 'None' }, true)).toBe(false)
     expect(canEditDropdownOption({ value: 'inst-1', label: 'Alpha Bank', disabled: true }, true)).toBe(false)
     expect(canEditDropdownOption({ value: 'inst-1', label: 'Alpha Bank' }, false)).toBe(false)
+  })
+
+  it('ticks the single selected value while no selected values list is given', () => {
+    expect(isDropdownOptionSelected(options[0], 'chequing', undefined)).toBe(true)
+    expect(isDropdownOptionSelected(options[1], 'chequing', undefined)).toBe(false)
+  })
+
+  it('ticks every option in the selected values list instead, ignoring the single value', () => {
+    // The single value names savings, which would tick it under the fallback rule, but the list
+    // does not carry it and wins instead
+    expect(isDropdownOptionSelected(options[0], 'savings', ['chequing', 'visa'])).toBe(true)
+    expect(isDropdownOptionSelected(options[2], 'savings', ['chequing', 'visa'])).toBe(true)
+    expect(isDropdownOptionSelected(options[1], 'savings', ['chequing', 'visa'])).toBe(false)
   })
 })
 

--- a/frontend/tests/pages/accounts/detail/utils/identityForm.test.ts
+++ b/frontend/tests/pages/accounts/detail/utils/identityForm.test.ts
@@ -30,6 +30,7 @@ function createAccount(overrides: Partial<Account> = {}): Account {
     base_currency_current_balance: overrides.base_currency_current_balance ?? null,
     current_balance_fx_status: overrides.current_balance_fx_status ?? { state: 'none', missing_pairs: [] },
     credit_limit: overrides.credit_limit ?? null,
+    can_write: overrides.can_write ?? true,
     is_archived: overrides.is_archived ?? false,
     closed_at: null,
     created_at: '2026-01-01T00:00:00Z',

--- a/frontend/tests/pages/accounts/utils/fixtures.ts
+++ b/frontend/tests/pages/accounts/utils/fixtures.ts
@@ -29,6 +29,7 @@ export function createAccount(overrides: Partial<AccountsOverview>): AccountsOve
     base_currency_current_balance: overrides.base_currency_current_balance ?? null,
     current_balance_fx_status: overrides.current_balance_fx_status ?? { state: 'none', missing_pairs: [] },
     credit_limit: overrides.credit_limit ?? null,
+    can_write: overrides.can_write ?? true,
     is_archived: overrides.is_archived ?? false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/dashboard/utils/fixtures.ts
+++ b/frontend/tests/pages/dashboard/utils/fixtures.ts
@@ -36,6 +36,7 @@ export function createAccount(overrides: Partial<AccountsOverview>): AccountsOve
     base_currency_current_balance: null,
     current_balance_fx_status: fxStatus,
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/imports/firefly/utils/preview.test.ts
+++ b/frontend/tests/pages/imports/firefly/utils/preview.test.ts
@@ -49,6 +49,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/imports/firefly/utils/skippedRows.test.ts
+++ b/frontend/tests/pages/imports/firefly/utils/skippedRows.test.ts
@@ -47,6 +47,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/imports/utils/accountMapping.createDefault.test.ts
+++ b/frontend/tests/pages/imports/utils/accountMapping.createDefault.test.ts
@@ -59,6 +59,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/imports/utils/accountMapping.fixedAccount.test.ts
+++ b/frontend/tests/pages/imports/utils/accountMapping.fixedAccount.test.ts
@@ -39,6 +39,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/imports/utils/accountMapping.nameMatching.test.ts
+++ b/frontend/tests/pages/imports/utils/accountMapping.nameMatching.test.ts
@@ -34,6 +34,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/imports/utils/importAccountScope.test.ts
+++ b/frontend/tests/pages/imports/utils/importAccountScope.test.ts
@@ -24,6 +24,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/imports/utils/payload.amountPrecision.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.amountPrecision.test.ts
@@ -72,6 +72,7 @@ function createAccount(currency: string): AccountsOverview {
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
   }

--- a/frontend/tests/pages/imports/utils/payload.counterpartyAccount.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.counterpartyAccount.test.ts
@@ -63,6 +63,7 @@ function createAccount(id: string, name: string): AccountsOverview {
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
   }

--- a/frontend/tests/pages/imports/utils/payload.mappingGaps.test.ts
+++ b/frontend/tests/pages/imports/utils/payload.mappingGaps.test.ts
@@ -48,6 +48,7 @@ const ACCOUNT: AccountsOverview = {
   base_currency_current_balance: 0,
   current_balance_fx_status: { state: 'complete', missing_pairs: [] },
   credit_limit: null,
+  can_write: true,
   is_archived: false,
   closed_at: null,
 }

--- a/frontend/tests/pages/imports/utils/preview.test.ts
+++ b/frontend/tests/pages/imports/utils/preview.test.ts
@@ -42,6 +42,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/imports/utils/workflowOptions.test.ts
+++ b/frontend/tests/pages/imports/utils/workflowOptions.test.ts
@@ -57,6 +57,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/transactions/components/bulkConfirmation.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkConfirmation.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests which stored transaction changes invalidate a pending bulk-edit confirmation
+ */
+import { describe, expect, it } from 'vitest'
+import type { Transaction } from '@/api/transactions'
+import { selectedTransactionsSignature } from '@/pages/transactions/components/bulk-edit/confirmation'
+
+const selected: Transaction = {
+  id: 'txn-1',
+  created_by_user_id: 'user-1',
+  account_id: 'chequing',
+  dt: '2026-08-01',
+  merchant_id: 'merchant-1',
+  merchant_name: 'Corner Market',
+  category_id: 'groceries',
+  amount: -4400,
+  account_amount: -4400,
+  base_currency_amount: -4400,
+  currency: 'CAD',
+  fx_rate: null,
+  notes: 'Weekly shop',
+  counterparty_account_id: null,
+  counterparty_account_scope: null,
+  created_at: '2026-08-01T12:00:00Z',
+  updated_at: '2026-08-01T12:00:00Z',
+  tag_ids: ['tag-b', 'tag-a'],
+  tags: [
+    { id: 'tag-b', group_id: null, name: 'Household' },
+    { id: 'tag-a', group_id: null, name: 'Essential' },
+  ],
+}
+
+const unselected: Transaction = {
+  ...selected,
+  id: 'txn-2',
+  amount: -1200,
+  notes: 'Coffee',
+  tag_ids: [],
+  tags: [],
+}
+
+/** Returns the signature for one selected transaction unless a test specifies the full list */
+function signature(
+  transaction: Transaction,
+  selectedIds: string[] = ['txn-1'],
+  transactions: Transaction[] = [transaction],
+) {
+  return selectedTransactionsSignature(transactions, selectedIds)
+}
+
+const storedValueChanges = [
+  ['direction', { amount: 4400 }],
+  ['magnitude', { amount: -4500 }],
+  ['update timestamp', { updated_at: '2026-08-01T12:01:00Z' }],
+  ['account', { account_id: 'savings' }],
+  ['date', { dt: '2026-08-02' }],
+  ['merchant', { merchant_id: 'merchant-2' }],
+  ['category', { category_id: 'dining' }],
+  ['currency', { currency: 'USD' }],
+  ['exchange rate', { fx_rate: 1.37 }],
+  ['note', { notes: 'Changed note' }],
+  ['counterparty account', { counterparty_account_id: 'savings' }],
+  ['counterparty scope', { counterparty_account_scope: 'outside' }],
+] satisfies [string, Partial<Transaction>][]
+
+describe('the values bound to bulk-edit confirmation', () => {
+  it.each(storedValueChanges)(
+    'changes when the selected transaction changes its %s',
+    (_field, patch) => {
+      expect(signature({ ...selected, ...patch })).not.toBe(signature(selected))
+    },
+  )
+
+  it('changes when tag membership changes without an update timestamp change', () => {
+    expect(signature({ ...selected, tag_ids: ['tag-a', 'tag-c'] })).not.toBe(signature(selected))
+  })
+
+  it('matches fresh objects with the same stored values', () => {
+    expect(signature({ ...selected, tag_ids: [...selected.tag_ids] })).toBe(signature(selected))
+  })
+
+  it('matches when selected rows and their tags arrive in another order', () => {
+    const first = selectedTransactionsSignature([selected, unselected], ['txn-1', 'txn-2'])
+    const second = selectedTransactionsSignature(
+      [
+        { ...unselected },
+        { ...selected, tag_ids: ['tag-a', 'tag-b'] },
+      ],
+      ['txn-2', 'txn-1'],
+    )
+
+    expect(second).toBe(first)
+  })
+
+  it('matches when only calculated amounts and display labels change', () => {
+    expect(
+      signature({
+        ...selected,
+        account_amount: -4500,
+        base_currency_amount: -4300,
+        merchant_name: 'Renamed merchant',
+        tags: selected.tags.map((tag) => ({ ...tag, name: `Renamed ${tag.name}` })),
+      }),
+    ).toBe(signature(selected))
+  })
+
+  it('changes when a selected transaction is removed', () => {
+    expect(selectedTransactionsSignature([unselected], ['txn-2'])).not.toBe(
+      selectedTransactionsSignature([selected, unselected], ['txn-1', 'txn-2']),
+    )
+  })
+
+  it('changes when a selected transaction is replaced', () => {
+    const replacement = { ...selected, id: 'txn-replacement' }
+
+    expect(selectedTransactionsSignature([replacement], [replacement.id])).not.toBe(signature(selected))
+  })
+
+  it('ignores changes to an unselected transaction', () => {
+    const first = selectedTransactionsSignature([selected, unselected], ['txn-1'])
+    const second = selectedTransactionsSignature(
+      [selected, { ...unselected, amount: -9900, notes: 'Changed outside the selection' }],
+      ['txn-1'],
+    )
+
+    expect(second).toBe(first)
+  })
+})

--- a/frontend/tests/pages/transactions/components/bulkEditFixtures.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditFixtures.ts
@@ -61,6 +61,14 @@ export const eurExpense: SelectedTransactionFacts = {
   recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null, currency: 'EUR', direction: 'debit',
 }
 
+// A transfer in USD recorded in Chequing, a CAD account, the way an exchange-rate transfer sits
+// once it is imported. Its own end already answers to Chequing, so setting From back to Chequing
+// moves nothing and should trip no currency blocker, unlike setting it to another CAD account
+export const usdTransferInChequing: SelectedTransactionFacts = {
+  id: 'usd_in_chequing', accountId: 'chequing', hasMerchant: true,
+  recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'USD', direction: 'debit',
+}
+
 /** A panel with every control untouched, so each test states only the one it fills in */
 export function untouched(overrides: Partial<BulkEditChoice> = {}): BulkEditChoice {
   return {

--- a/frontend/tests/pages/transactions/components/bulkEditFixtures.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditFixtures.ts
@@ -4,6 +4,15 @@
  */
 import type { Category } from '@/api/categories'
 import type { BulkEditChoice, SelectedTransactionFacts } from '@/pages/transactions/components/bulk-edit/selection'
+import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
+
+export const writableAccounts: TransactionListAccount[] = [
+  { id: 'chequing', name: 'Chequing', currency: 'CAD', can_write: true },
+  { id: 'savings', name: 'Savings', currency: 'CAD', can_write: true },
+  { id: 'cash', name: 'Cash', currency: 'CAD', can_write: true },
+  { id: 'us_savings', name: 'US Savings', currency: 'USD', can_write: true },
+  { id: 'eur_account', name: 'Euro account', currency: 'EUR', can_write: true },
+]
 
 export const transferCategory = {
   id: 'cat_t', name: 'Transfer', kind: 'transfer', icon: null,
@@ -18,22 +27,27 @@ export const groceriesCategory = {
 export const groceries: SelectedTransactionFacts = {
   id: 'a', accountId: 'chequing', hasMerchant: true,
   recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
+  isZeroAmount: false,
 }
 export const oldImport: SelectedTransactionFacts = {
   id: 'b', accountId: 'chequing', hasMerchant: false,
   recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
+  isZeroAmount: false,
 }
 export const toSavings: SelectedTransactionFacts = {
   id: 'c', accountId: 'chequing', hasMerchant: true,
   recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'CAD', direction: 'debit',
+  isZeroAmount: false,
 }
 export const toOutside: SelectedTransactionFacts = {
   id: 'd', accountId: 'chequing', hasMerchant: true,
   recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null, currency: 'CAD', direction: 'debit',
+  isZeroAmount: false,
 }
 export const unanswered: SelectedTransactionFacts = {
   id: 'e', accountId: 'chequing', hasMerchant: true,
   recordsFarSide: true, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
+  isZeroAmount: false,
 }
 
 // The two halves a transfer pair makes: the money-out half sitting in Chequing and recording
@@ -41,10 +55,12 @@ export const unanswered: SelectedTransactionFacts = {
 export const chequingHalf: SelectedTransactionFacts = {
   id: 'chequing_half', accountId: 'chequing', hasMerchant: true,
   recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'CAD', direction: 'debit',
+  isZeroAmount: false,
 }
 export const savingsHalf: SelectedTransactionFacts = {
   id: 'savings_half', accountId: 'savings', hasMerchant: true,
   recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'chequing', currency: 'CAD', direction: 'credit',
+  isZeroAmount: false,
 }
 export const pair = [chequingHalf, savingsHalf]
 
@@ -59,6 +75,7 @@ export const chequingHalf2: SelectedTransactionFacts = { ...chequingHalf, id: 'c
 export const eurExpense: SelectedTransactionFacts = {
   id: 'eur_expense', accountId: 'eur_account', hasMerchant: true,
   recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null, currency: 'EUR', direction: 'debit',
+  isZeroAmount: false,
 }
 
 // A transfer in USD recorded in Chequing, a CAD account, the way an exchange-rate transfer sits
@@ -67,6 +84,14 @@ export const eurExpense: SelectedTransactionFacts = {
 export const usdTransferInChequing: SelectedTransactionFacts = {
   id: 'usd_in_chequing', accountId: 'chequing', hasMerchant: true,
   recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'USD', direction: 'debit',
+  isZeroAmount: false,
+}
+
+export const zeroTransfer: SelectedTransactionFacts = {
+  ...chequingHalf,
+  id: 'zero_transfer',
+  direction: 'credit',
+  isZeroAmount: true,
 }
 
 /** A panel with every control untouched, so each test states only the one it fills in */

--- a/frontend/tests/pages/transactions/components/bulkEditFixtures.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditFixtures.ts
@@ -1,0 +1,76 @@
+/**
+ * Selected-transaction fixtures shared by the bulk edit selection and summary tests, so both cover
+ * the same rows rather than each drifting its own copies
+ */
+import type { Category } from '@/api/categories'
+import type { BulkEditChoice, SelectedTransactionFacts } from '@/pages/transactions/components/bulk-edit/selection'
+
+export const transferCategory = {
+  id: 'cat_t', name: 'Transfer', kind: 'transfer', icon: null,
+  is_system: true, owner_id: null, group_id: null,
+} as Category
+
+export const groceriesCategory = {
+  id: 'cat_g', name: 'Groceries', kind: 'expense', icon: null,
+  is_system: true, owner_id: null, group_id: null,
+} as Category
+
+export const groceries: SelectedTransactionFacts = {
+  id: 'a', accountId: 'chequing', hasMerchant: true,
+  recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
+}
+export const oldImport: SelectedTransactionFacts = {
+  id: 'b', accountId: 'chequing', hasMerchant: false,
+  recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
+}
+export const toSavings: SelectedTransactionFacts = {
+  id: 'c', accountId: 'chequing', hasMerchant: true,
+  recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'CAD', direction: 'debit',
+}
+export const toOutside: SelectedTransactionFacts = {
+  id: 'd', accountId: 'chequing', hasMerchant: true,
+  recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null, currency: 'CAD', direction: 'debit',
+}
+export const unanswered: SelectedTransactionFacts = {
+  id: 'e', accountId: 'chequing', hasMerchant: true,
+  recordsFarSide: true, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
+}
+
+// The two halves a transfer pair makes: the money-out half sitting in Chequing and recording
+// Savings, and the money-in half sitting in Savings and recording Chequing back
+export const chequingHalf: SelectedTransactionFacts = {
+  id: 'chequing_half', accountId: 'chequing', hasMerchant: true,
+  recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'CAD', direction: 'debit',
+}
+export const savingsHalf: SelectedTransactionFacts = {
+  id: 'savings_half', accountId: 'savings', hasMerchant: true,
+  recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'chequing', currency: 'CAD', direction: 'credit',
+}
+export const pair = [chequingHalf, savingsHalf]
+
+// A transfer recording outside in EUR, its far side already answered so the only blocker it can
+// trip is the own-currency check. Sits alongside the Chequing half so a From set to a tracked USD
+// account produces two distinct currency-mismatch warnings rather than the one pair either row
+// would trip alone
+export const eurExpense: SelectedTransactionFacts = {
+  id: 'eur_expense', accountId: 'eur_account', hasMerchant: true,
+  recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null, currency: 'EUR', direction: 'debit',
+}
+
+/** A panel with every control untouched, so each test states only the one it fills in */
+export function untouched(overrides: Partial<BulkEditChoice> = {}): BulkEditChoice {
+  return {
+    categoryId: '',
+    merchantId: '',
+    tagIds: [],
+    accountId: '',
+    date: '',
+    note: '',
+    clearsNote: false,
+    transferFrom: null,
+    transferTo: null,
+    direction: null,
+    endsAreOffered: false,
+    ...overrides,
+  }
+}

--- a/frontend/tests/pages/transactions/components/bulkEditFixtures.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditFixtures.ts
@@ -48,6 +48,10 @@ export const savingsHalf: SelectedTransactionFacts = {
 }
 export const pair = [chequingHalf, savingsHalf]
 
+// A second money-out transfer in Chequing recording Savings, alongside chequingHalf, for the
+// direction-implying cases, which need more than one row already sitting in the same account
+export const chequingHalf2: SelectedTransactionFacts = { ...chequingHalf, id: 'chequing_half_2' }
+
 // A transfer recording outside in EUR, its far side already answered so the only blocker it can
 // trip is the own-currency check. Sits alongside the Chequing half so a From set to a tracked USD
 // account produces two distinct currency-mismatch warnings rather than the one pair either row
@@ -70,6 +74,7 @@ export function untouched(overrides: Partial<BulkEditChoice> = {}): BulkEditChoi
     transferFrom: null,
     transferTo: null,
     direction: null,
+    directionIsImplied: false,
     endsAreOffered: false,
     ...overrides,
   }

--- a/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
@@ -3,10 +3,9 @@
  * beside them, and the warnings that hold Apply disabled
  */
 import { describe, expect, it } from 'vitest'
-import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import { getBulkEditBlockers, type BulkEditChoice, type SelectedTransactionFacts } from '@/pages/transactions/components/bulk-edit/selection'
-import { describeBulkEdit, type BulkEditSummary, type BulkEditSummaryLabels } from '@/pages/transactions/components/bulk-edit/summary'
-import { chequingHalf, eurExpense, groceries, oldImport, pair, savingsHalf, unanswered, untouched } from './bulkEditFixtures'
+import { describeBulkEdit, shareOpening, type BulkEditSummary, type BulkEditSummaryLabels } from '@/pages/transactions/components/bulk-edit/summary'
+import { chequingHalf, chequingHalf2, eurExpense, groceries, oldImport, pair, savingsHalf, unanswered, untouched } from './bulkEditFixtures'
 
 const ACCOUNT_NAMES: Record<string, string> = {
   chequing: 'Chequing',
@@ -41,6 +40,21 @@ function summarize(
   return describeBulkEdit(choice, rows, blockers, { ...labels, ...labelOverrides }, chosenCategoryRecordsTransferTarget)
 }
 
+describe('the opening clause of a warning sentence', () => {
+  it('reads as the whole selection once the count fills it', () => {
+    expect(shareOpening(5, 5)).toBe('All 5 selected')
+  })
+
+  it('states both numbers otherwise', () => {
+    expect(shareOpening(1, 5)).toBe('1 out of 5 selected')
+    expect(shareOpening(3, 5)).toBe('3 out of 5 selected')
+  })
+
+  it('drops the count entirely once only one row is selected', () => {
+    expect(shareOpening(1, 1)).toBe('The selected')
+  })
+})
+
 describe('the rows, notes and warnings a bulk edit choice produces', () => {
   it('shows nothing while nothing is chosen over a clean pair', () => {
     expect(summarize(pair, untouched())).toEqual({ rows: [], notes: [], warnings: [] })
@@ -52,7 +66,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([])
     expect(result.warnings).toEqual([{
       key: 'without-merchant',
-      text: '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.',
+      text: 'The selected transaction is missing merchant information.',
     }])
   })
 
@@ -60,13 +74,13 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const one = summarize([oldImport], untouched())
     expect(one.warnings).toEqual([{
       key: 'without-merchant',
-      text: '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.',
+      text: 'The selected transaction is missing merchant information.',
     }])
 
     const two = summarize([oldImport, { ...oldImport, id: 'old_import_2' }], untouched())
     expect(two.warnings).toEqual([{
       key: 'without-merchant',
-      text: '2 selected transactions have no merchant recorded. Set a merchant above, or close this and untick them.',
+      text: 'All 2 selected transactions are missing merchant information.',
     }])
   })
 
@@ -77,7 +91,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([{ label: 'Direction', value: 'Money out' }])
     expect(result.notes).toEqual([{
       key: 'other-half',
-      text: "A transfer's other half is a separate row. This changes only the rows selected.",
+      text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
     }])
   })
 
@@ -107,37 +121,30 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([{
       label: 'From',
       value: 'Cash',
-      detail: '1 moves into Cash, 1 records Cash as the other side',
+      detail: '1 out of 2 moves into Cash, 1 out of 2 now comes from Cash',
     }])
     // Both rows are transfers whose own account it moves or records, so leftAlone stays at zero and
     // only the other-half note, not the not-a-transfer note, is left standing
     expect(result.notes).toEqual([{
       key: 'other-half',
-      text: "A transfer's other half is a separate row. This changes only the rows selected.",
+      text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
     }])
   })
 
-  it('shows only a records clause once the From end is outside this app', () => {
+  it('hides the records clause once it is true of the one row selected', () => {
     const choice = untouched({ transferFrom: { scope: 'outside' }, endsAreOffered: true })
     const result = summarize([savingsHalf], choice)
 
-    expect(result.rows).toEqual([{
-      label: 'From',
-      value: 'Outside this app',
-      detail: '1 records the other side as outside this app',
-    }])
+    expect(result.rows).toEqual([{ label: 'From', value: 'Outside this app' }])
     expect(result.warnings).toEqual([])
   })
 
-  it('drops the detail and warns once the own end resolves outside instead', () => {
+  it('drops the detail and no longer warns once the own end resolves outside instead', () => {
     const choice = untouched({ transferFrom: { scope: 'outside' }, endsAreOffered: true })
     const result = summarize([chequingHalf], choice)
 
     expect(result.rows).toEqual([{ label: 'From', value: 'Outside this app' }])
-    expect(result.warnings).toEqual([{
-      key: 'sits-outside',
-      text: '1 selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick it.',
-    }])
+    expect(result.warnings).toEqual([])
   })
 
   it('answers a To end across a transfer pair and leaves a plain expense to its own note', () => {
@@ -153,15 +160,18 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([{
       label: 'To',
       value: 'Savings',
-      detail: '1 records Savings as the other side',
+      detail: '1 out of 3 now goes to Savings',
     }])
     expect(result.notes).toEqual([
-      { key: 'other-half', text: "A transfer's other half is a separate row. This changes only the rows selected." },
-      { key: 'left-alone', text: '1 selected transaction is not a transfer and is left as it is.' },
+      {
+        key: 'other-half',
+        text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
+      },
+      { key: 'left-alone', text: 'Changes to From and To apply only to 2 out of 3 selected transactions.' },
     ])
   })
 
-  it('keeps the records clause plural while warning about the far side matching the own account', () => {
+  it('hides the records clause once it is true of every selected row, while still warning about the far side matching the own account', () => {
     const choice = untouched({
       direction: 'credit',
       transferFrom: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
@@ -171,11 +181,11 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
 
     expect(result.rows).toEqual([
       { label: 'Direction', value: 'Money in' },
-      { label: 'From', value: 'Chequing', detail: '2 record Chequing as the other side' },
+      { label: 'From', value: 'Chequing' },
     ])
     expect(result.warnings).toEqual([{
       key: 'own-account',
-      text: '1 selected transaction would end up recording the account it already sits in. Change From, To or Move to account, or close this and untick it.',
+      text: '1 out of 2 selected transfers can\'t have the same account on both sides.',
     }])
   })
 
@@ -209,20 +219,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
 
     expect(result.warnings).toEqual([{
       key: 'unanswered',
-      text: '1 selected transfer does not record where the money went. Set From or To above, or close this and untick it.',
-    }])
-  })
-
-  it('warns once the selection is over the cap', () => {
-    const overCap = Array.from({ length: MAX_BULK_EDIT_TRANSACTIONS + 1 }, (_, index) => ({
-      ...groceries,
-      id: `row_${index}`,
-    }))
-    const result = summarize(overCap, untouched())
-
-    expect(result.warnings).toEqual([{
-      key: 'over-cap',
-      text: `One edit covers at most ${MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.`,
+      text: 'The selected transfer is missing the To or From account.',
     }])
   })
 
@@ -253,11 +250,11 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.warnings).toEqual([
       {
         key: 'currency-CAD-USD',
-        text: '1 selected transaction is in CAD and would move into an account in USD. Pick an account in CAD, or close this and untick it.',
+        text: "1 out of 2 selected transactions in CAD can't move to a USD account.",
       },
       {
         key: 'currency-EUR-USD',
-        text: '1 selected transaction is in EUR and would move into an account in USD. Pick an account in EUR, or close this and untick it.',
+        text: "1 out of 2 selected transactions in EUR can't move to a USD account.",
       },
     ])
   })
@@ -266,5 +263,100 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const choice = untouched({ date: '2026-08-23', accountId: 'cash' })
 
     expect(summarize([], choice)).toEqual({ rows: [], notes: [], warnings: [] })
+  })
+
+  it('warns proportionally when only one of two selected rows is missing a merchant', () => {
+    const result = summarize([oldImport, groceries], untouched())
+
+    expect(result.warnings).toEqual([{
+      key: 'without-merchant',
+      text: '1 out of 2 selected transactions is missing merchant information.',
+    }])
+  })
+
+  it('scales the unanswered-far-side warning to the transfer rows in a larger mixed selection', () => {
+    const rows = [
+      { ...unanswered, id: 'unanswered_1' },
+      { ...unanswered, id: 'unanswered_2' },
+      { ...unanswered, id: 'unanswered_3' },
+      groceries,
+      { ...groceries, id: 'expense_2' },
+    ]
+    const result = summarize(rows, untouched())
+
+    expect(result.warnings).toEqual([{
+      key: 'unanswered',
+      text: '3 out of 5 selected transfers are missing the To or From account.',
+    }])
+  })
+
+  it('notes the transfer share and details a tracked To end alongside a plain expense', () => {
+    const rows = [chequingHalf, savingsHalf, groceries]
+    const choice = untouched({
+      transferTo: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+      endsAreOffered: true,
+    })
+    const result = summarize(rows, choice)
+
+    expect(result.rows).toEqual([{
+      label: 'To',
+      value: 'Cash',
+      detail: '1 out of 3 moves into Cash, 1 out of 3 now goes to Cash',
+    }])
+    expect(result.notes).toEqual([
+      {
+        key: 'other-half',
+        text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
+      },
+      { key: 'left-alone', text: 'Changes to From and To apply only to 2 out of 3 selected transactions.' },
+    ])
+  })
+
+  it('hides the From detail once its move count reaches every selected row', () => {
+    const rows = [chequingHalf, chequingHalf2]
+    const choice = untouched({
+      transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+      endsAreOffered: true,
+    })
+    const result = summarize(rows, choice)
+
+    expect(result.rows).toEqual([{ label: 'From', value: 'Cash' }])
+  })
+
+  it('details a tracked To end moving and recording across a transfer pair', () => {
+    const choice = untouched({
+      transferTo: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+      endsAreOffered: true,
+    })
+    const result = summarize(pair, choice)
+
+    expect(result.rows).toEqual([{
+      label: 'To',
+      value: 'Cash',
+      detail: '1 out of 2 moves into Cash, 1 out of 2 now goes to Cash',
+    }])
+  })
+
+  it('shows the other-half note only once a direction reaches the transfer row', () => {
+    const withoutDirection = summarize([chequingHalf], untouched({ clearsNote: true }))
+    expect(withoutDirection.notes).toEqual([])
+
+    const withReverse = summarize([chequingHalf], untouched({ clearsNote: true, direction: 'reverse' }))
+    expect(withReverse.notes).toEqual([{
+      key: 'other-half',
+      text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
+    }])
+  })
+
+  it('lists an implied direction over rows that are not all transfers with which rows it reaches, unlike one the user picked', () => {
+    const rows = [chequingHalf, savingsHalf, groceries]
+
+    const implied = summarize(rows, untouched({ direction: 'credit', directionIsImplied: true, endsAreOffered: true }))
+    expect(implied.rows).toEqual([
+      { label: 'Direction', value: 'Money in', detail: 'applies to 2 out of 3 selected transactions' },
+    ])
+
+    const picked = summarize(rows, untouched({ direction: 'credit', directionIsImplied: false, endsAreOffered: true }))
+    expect(picked.rows).toEqual([{ label: 'Direction', value: 'Money in' }])
   })
 })

--- a/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
@@ -104,11 +104,29 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.notes).toEqual([])
   })
 
-  it('shows the account a move sends every selected row to', () => {
+  it('hides the move detail once every selected row moves, since none of them stay behind', () => {
     const rows = [groceries, { ...groceries, id: 'expense_2' }, { ...groceries, id: 'expense_3' }]
     const result = summarize(rows, untouched({ accountId: 'cash' }))
 
-    expect(result.rows).toEqual([{ label: 'Move to account', value: 'Cash', detail: '3 move' }])
+    expect(result.rows).toEqual([{ label: 'Move to account', value: 'Cash' }])
+  })
+
+  it('hides the move detail when every selected row already sits in the target account', () => {
+    const rows = [groceries, { ...groceries, id: 'expense_2' }, { ...groceries, id: 'expense_3' }]
+    const result = summarize(rows, untouched({ accountId: 'chequing' }))
+
+    expect(result.rows).toEqual([{ label: 'Move to account', value: 'Chequing' }])
+  })
+
+  it('shows how many of the selected rows actually move when only some of them sit elsewhere', () => {
+    const rows = [
+      { ...groceries, id: 'chequing_1' },
+      { ...groceries, id: 'chequing_2' },
+      { ...groceries, id: 'cash_1', accountId: 'cash' },
+    ]
+    const result = summarize(rows, untouched({ accountId: 'cash' }))
+
+    expect(result.rows).toEqual([{ label: 'Move to account', value: 'Cash', detail: '2 of the 3 move into Cash' }])
   })
 
   it('shows what a tracked From end moves and records across a transfer pair', () => {
@@ -237,7 +255,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
   it('falls back to Account for an id the label lookup does not know', () => {
     const result = summarize([groceries], untouched({ accountId: 'unknown_account' }))
 
-    expect(result.rows).toEqual([{ label: 'Move to account', value: 'Account', detail: '1 move' }])
+    expect(result.rows).toEqual([{ label: 'Move to account', value: 'Account' }])
   })
 
   it('warns once per currency pair, each keyed by its own pair, when a tracked end mismatches more than one row currency', () => {

--- a/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests what the bulk edit summary panel shows for a given choice: the rows it sends, the notes
+ * beside them, and the warnings that hold Apply disabled
+ */
+import { describe, expect, it } from 'vitest'
+import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
+import { getBulkEditBlockers, type BulkEditChoice, type SelectedTransactionFacts } from '@/pages/transactions/components/bulk-edit/selection'
+import { describeBulkEdit, type BulkEditSummary, type BulkEditSummaryLabels } from '@/pages/transactions/components/bulk-edit/summary'
+import { chequingHalf, eurExpense, groceries, oldImport, pair, savingsHalf, unanswered, untouched } from './bulkEditFixtures'
+
+const ACCOUNT_NAMES: Record<string, string> = {
+  chequing: 'Chequing',
+  savings: 'Savings',
+  cash: 'Cash',
+  us_savings: 'US Savings',
+}
+
+/** Resolves an account id the way the modal's own accountName lookup does */
+function accountLabelById(accountId: string): string {
+  return ACCOUNT_NAMES[accountId] ?? 'Account'
+}
+
+const labels: BulkEditSummaryLabels = {
+  accountLabelById,
+  categoryLabel: '',
+  merchantLabel: '',
+  tagLabels: [],
+}
+
+/**
+ * Computes blockers the way the modal does, then asks describeBulkEdit for the same choice, so each
+ * test states only the rows, choice, and label overrides it needs
+ */
+function summarize(
+  rows: SelectedTransactionFacts[],
+  choice: BulkEditChoice,
+  labelOverrides: Partial<BulkEditSummaryLabels> = {},
+  chosenCategoryRecordsTransferTarget: boolean | undefined = undefined,
+): BulkEditSummary {
+  const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget)
+  return describeBulkEdit(choice, rows, blockers, { ...labels, ...labelOverrides }, chosenCategoryRecordsTransferTarget)
+}
+
+describe('the rows, notes and warnings a bulk edit choice produces', () => {
+  it('shows nothing while nothing is chosen over a clean pair', () => {
+    expect(summarize(pair, untouched())).toEqual({ rows: [], notes: [], warnings: [] })
+  })
+
+  it('warns about a merchant-less row even while nothing else is chosen', () => {
+    const result = summarize([oldImport], untouched())
+
+    expect(result.rows).toEqual([])
+    expect(result.warnings).toEqual([
+      '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.',
+    ])
+  })
+
+  it('shows the direction row and the other-half note over a transfer selection', () => {
+    const choice = untouched({ direction: 'debit', endsAreOffered: true })
+    const result = summarize(pair, choice)
+
+    expect(result.rows).toEqual([{ label: 'Direction', value: 'Money out' }])
+    expect(result.notes).toEqual([
+      "A transfer's other half is a separate row. This changes only the rows selected.",
+    ])
+  })
+
+  it('shows the direction row with no note over a plain expense selection', () => {
+    const expenses = [groceries, { ...groceries, id: 'expense_2' }, { ...groceries, id: 'expense_3' }]
+    const choice = untouched({ direction: 'reverse', endsAreOffered: false })
+    const result = summarize(expenses, choice)
+
+    expect(result.rows).toEqual([{ label: 'Direction', value: 'Turned around' }])
+    expect(result.notes).toEqual([])
+  })
+
+  it('shows the account a move sends every selected row to', () => {
+    const rows = [groceries, { ...groceries, id: 'expense_2' }, { ...groceries, id: 'expense_3' }]
+    const result = summarize(rows, untouched({ accountId: 'cash' }))
+
+    expect(result.rows).toEqual([{ label: 'Move to account', value: 'Cash', detail: '3 move' }])
+  })
+
+  it('shows what a tracked From end moves and records across a transfer pair', () => {
+    const choice = untouched({
+      transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+      endsAreOffered: true,
+    })
+    const result = summarize(pair, choice)
+
+    expect(result.rows).toEqual([{
+      label: 'From',
+      value: 'Cash',
+      detail: '1 moves into Cash, 1 records Cash as the other side',
+    }])
+    // Both rows are transfers whose own account it moves or records, so leftAlone stays at zero and
+    // only the other-half note, not the not-a-transfer note, is left standing
+    expect(result.notes).toEqual([
+      "A transfer's other half is a separate row. This changes only the rows selected.",
+    ])
+  })
+
+  it('shows only a records clause once the From end is outside this app', () => {
+    const choice = untouched({ transferFrom: { scope: 'outside' }, endsAreOffered: true })
+    const result = summarize([savingsHalf], choice)
+
+    expect(result.rows).toEqual([{
+      label: 'From',
+      value: 'Outside this app',
+      detail: '1 records the other side as outside this app',
+    }])
+    expect(result.warnings).toEqual([])
+  })
+
+  it('drops the detail and warns once the own end resolves outside instead', () => {
+    const choice = untouched({ transferFrom: { scope: 'outside' }, endsAreOffered: true })
+    const result = summarize([chequingHalf], choice)
+
+    expect(result.rows).toEqual([{ label: 'From', value: 'Outside this app' }])
+    expect(result.warnings).toEqual([
+      '1 selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick it.',
+    ])
+  })
+
+  it('answers a To end across a transfer pair and leaves a plain expense to its own note', () => {
+    const rows = [chequingHalf, savingsHalf, groceries]
+    const choice = untouched({
+      transferTo: { scope: 'tracked', accountId: 'savings', currency: 'CAD' },
+      endsAreOffered: true,
+    })
+    const result = summarize(rows, choice)
+
+    expect(result.rows).toEqual([{
+      label: 'To',
+      value: 'Savings',
+      detail: '1 moves into Savings, 1 records Savings as the other side',
+    }])
+    expect(result.notes).toEqual([
+      "A transfer's other half is a separate row. This changes only the rows selected.",
+      '1 selected transaction is not a transfer and is left as it is.',
+    ])
+  })
+
+  it('keeps the records clause plural while warning about the far side matching the own account', () => {
+    const choice = untouched({
+      direction: 'credit',
+      transferFrom: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
+      endsAreOffered: true,
+    })
+    const result = summarize(pair, choice)
+
+    expect(result.rows).toEqual([
+      { label: 'Direction', value: 'Money in' },
+      { label: 'From', value: 'Chequing', detail: '2 record Chequing as the other side' },
+    ])
+    expect(result.warnings).toEqual([
+      '1 selected transaction would end up recording the account it already sits in. Change From, To or Move to account, or close this and untick it.',
+    ])
+  })
+
+  it('joins chosen tag names with commas', () => {
+    const choice = untouched({ tagIds: ['tag_1', 'tag_2'] })
+    const result = summarize([groceries], choice, { tagLabels: ['Holiday', 'Cash'] })
+
+    expect(result.rows).toEqual([{ label: 'Tags added', value: 'Holiday, Cash' }])
+  })
+
+  it('shows Removed for a cleared note and the typed text for one that was set', () => {
+    const cleared = summarize([groceries], untouched({ clearsNote: true }))
+    expect(cleared.rows).toEqual([{ label: 'Note', value: 'Removed' }])
+
+    const written = summarize([groceries], untouched({ note: 'paid back' }))
+    expect(written.rows).toEqual([{ label: 'Note', value: 'paid back' }])
+  })
+
+  it('renders the date the way the day headings do, falling back to the raw string', () => {
+    const parseable = summarize([groceries], untouched({ date: '2026-08-23' }))
+    expect(parseable.rows).toEqual([{ label: 'Date', value: 'August 23, 2026' }])
+
+    // The year rolls to 1900 under the Date constructor's two-digit-year rule and fails the
+    // round-trip check parseYmd uses to reject it, the same as it does for the day headings
+    const unparseable = summarize([groceries], untouched({ date: '0000-01-01' }))
+    expect(unparseable.rows).toEqual([{ label: 'Date', value: '0000-01-01' }])
+  })
+
+  it('warns about an unanswered far side even with no end chosen', () => {
+    const result = summarize([unanswered], untouched())
+
+    expect(result.warnings).toEqual([
+      '1 selected transfer does not record where the money went. Set From or To above, or close this and untick it.',
+    ])
+  })
+
+  it('warns once the selection is over the cap', () => {
+    const overCap = Array.from({ length: MAX_BULK_EDIT_TRANSACTIONS + 1 }, (_, index) => ({
+      ...groceries,
+      id: `row_${index}`,
+    }))
+    const result = summarize(overCap, untouched())
+
+    expect(result.warnings).toEqual([
+      `One edit covers at most ${MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.`,
+    ])
+  })
+
+  it('drops a stale From end once endsAreOffered goes false', () => {
+    const choice = untouched({
+      transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+      endsAreOffered: false,
+    })
+    const result = summarize(pair, choice)
+
+    expect(result.rows).toEqual([])
+    expect(result.notes).toEqual([])
+  })
+
+  it('falls back to Account for an id the label lookup does not know', () => {
+    const result = summarize([groceries], untouched({ accountId: 'unknown_account' }))
+
+    expect(result.rows).toEqual([{ label: 'Move to account', value: 'Account', detail: '1 move' }])
+  })
+
+  it('warns once per currency pair when a tracked end mismatches more than one row currency', () => {
+    const choice = untouched({
+      transferFrom: { scope: 'tracked', accountId: 'us_savings', currency: 'USD' },
+      endsAreOffered: true,
+    })
+    const result = summarize([chequingHalf, eurExpense], choice)
+
+    expect(result.warnings).toEqual([
+      '1 selected transaction is in CAD and would move into an account in USD. Pick an account in CAD, or close this and untick it.',
+      '1 selected transaction is in EUR and would move into an account in USD. Pick an account in EUR, or close this and untick it.',
+    ])
+  })
+
+  it('shows nothing for an empty selection, whatever the controls still hold', () => {
+    const choice = untouched({ date: '2026-08-23', accountId: 'cash' })
+
+    expect(summarize([], choice)).toEqual({ rows: [], notes: [], warnings: [] })
+  })
+})

--- a/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
@@ -46,8 +46,8 @@ describe('the opening clause of a warning sentence', () => {
   })
 
   it('states both numbers otherwise', () => {
-    expect(shareOpening(1, 5)).toBe('1 out of 5 selected')
-    expect(shareOpening(3, 5)).toBe('3 out of 5 selected')
+    expect(shareOpening(1, 5)).toBe('1 of the 5 selected')
+    expect(shareOpening(3, 5)).toBe('3 of the 5 selected')
   })
 
   it('drops the count entirely once only one row is selected', () => {
@@ -121,7 +121,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([{
       label: 'From',
       value: 'Cash',
-      detail: '1 out of 2 moves into Cash, 1 out of 2 now comes from Cash',
+      detail: '1 of the 2 moves into Cash, 1 of the 2 now comes from Cash',
     }])
     // Both rows are transfers whose own account it moves or records, so leftAlone stays at zero and
     // only the other-half note, not the not-a-transfer note, is left standing
@@ -160,14 +160,14 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([{
       label: 'To',
       value: 'Savings',
-      detail: '1 out of 3 now goes to Savings',
+      detail: '1 of the 3 now goes to Savings',
     }])
     expect(result.notes).toEqual([
       {
         key: 'other-half',
         text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
       },
-      { key: 'left-alone', text: 'Changes to From and To apply only to 2 out of 3 selected transactions.' },
+      { key: 'left-alone', text: 'Changes to From and To apply only to 2 of the 3 selected transactions.' },
     ])
   })
 
@@ -185,7 +185,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     ])
     expect(result.warnings).toEqual([{
       key: 'own-account',
-      text: '1 out of 2 selected transfers can\'t have the same account on both sides.',
+      text: '1 of the 2 selected transfers can\'t have the same account on both sides.',
     }])
   })
 
@@ -250,11 +250,11 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.warnings).toEqual([
       {
         key: 'currency-CAD-USD',
-        text: "1 out of 2 selected transactions in CAD can't move to a USD account.",
+        text: "1 of the 2 selected transactions in CAD can't move to a USD account.",
       },
       {
         key: 'currency-EUR-USD',
-        text: "1 out of 2 selected transactions in EUR can't move to a USD account.",
+        text: "1 of the 2 selected transactions in EUR can't move to a USD account.",
       },
     ])
   })
@@ -270,7 +270,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
 
     expect(result.warnings).toEqual([{
       key: 'without-merchant',
-      text: '1 out of 2 selected transactions is missing merchant information.',
+      text: '1 of the 2 selected transactions is missing merchant information.',
     }])
   })
 
@@ -286,7 +286,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
 
     expect(result.warnings).toEqual([{
       key: 'unanswered',
-      text: '3 out of 5 selected transfers are missing the To or From account.',
+      text: '3 of the 5 selected transfers are missing the To or From account.',
     }])
   })
 
@@ -301,14 +301,14 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([{
       label: 'To',
       value: 'Cash',
-      detail: '1 out of 3 moves into Cash, 1 out of 3 now goes to Cash',
+      detail: '1 of the 3 moves into Cash, 1 of the 3 now goes to Cash',
     }])
     expect(result.notes).toEqual([
       {
         key: 'other-half',
         text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
       },
-      { key: 'left-alone', text: 'Changes to From and To apply only to 2 out of 3 selected transactions.' },
+      { key: 'left-alone', text: 'Changes to From and To apply only to 2 of the 3 selected transactions.' },
     ])
   })
 
@@ -333,7 +333,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([{
       label: 'To',
       value: 'Cash',
-      detail: '1 out of 2 moves into Cash, 1 out of 2 now goes to Cash',
+      detail: '1 of the 2 moves into Cash, 1 of the 2 now goes to Cash',
     }])
   })
 
@@ -353,7 +353,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
 
     const implied = summarize(rows, untouched({ direction: 'credit', directionIsImplied: true, endsAreOffered: true }))
     expect(implied.rows).toEqual([
-      { label: 'Direction', value: 'Credit', detail: 'applies to 2 out of 3 selected transactions' },
+      { label: 'Direction', value: 'Credit', detail: 'applies to 2 of the 3 selected transactions' },
     ])
 
     const picked = summarize(rows, untouched({ direction: 'credit', directionIsImplied: false, endsAreOffered: true }))

--- a/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
@@ -3,9 +3,10 @@
  * beside them, and the warnings that hold Apply disabled
  */
 import { describe, expect, it } from 'vitest'
-import { getBulkEditBlockers, type BulkEditChoice, type SelectedTransactionFacts } from '@/pages/transactions/components/bulk-edit/selection'
+import { canApplyBulkEdit, getBulkEditBlockers, type BulkEditChoice, type SelectedTransactionFacts } from '@/pages/transactions/components/bulk-edit/selection'
 import { describeBulkEdit, shareOpening, type BulkEditSummary, type BulkEditSummaryLabels } from '@/pages/transactions/components/bulk-edit/summary'
-import { chequingHalf, chequingHalf2, eurExpense, groceries, oldImport, pair, savingsHalf, unanswered, untouched } from './bulkEditFixtures'
+import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
+import { chequingHalf, chequingHalf2, eurExpense, groceries, oldImport, pair, savingsHalf, unanswered, untouched, writableAccounts, zeroTransfer } from './bulkEditFixtures'
 
 const ACCOUNT_NAMES: Record<string, string> = {
   chequing: 'Chequing',
@@ -35,8 +36,9 @@ function summarize(
   choice: BulkEditChoice,
   labelOverrides: Partial<BulkEditSummaryLabels> = {},
   chosenCategoryRecordsTransferTarget: boolean | undefined = undefined,
+  currentAccounts?: TransactionListAccount[],
 ): BulkEditSummary {
-  const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget)
+  const blockers = getBulkEditBlockers(rows, choice, chosenCategoryRecordsTransferTarget, currentAccounts)
   return describeBulkEdit(choice, rows, blockers, { ...labels, ...labelOverrides }, chosenCategoryRecordsTransferTarget)
 }
 
@@ -102,6 +104,31 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
 
     expect(result.rows).toEqual([{ label: 'Direction', value: 'Reversed' }])
     expect(result.notes).toEqual([])
+  })
+
+  it('states that zero directions remain Credit and applies Reverse only to a nonzero row', () => {
+    const result = summarize(
+      [zeroTransfer, { ...savingsHalf, id: 'income_4000' }],
+      untouched({ direction: 'reverse', endsAreOffered: true }),
+    )
+
+    expect(result.rows[0]).toEqual({
+      label: 'Direction',
+      value: 'Reversed',
+      detail: 'applies to 1 of the 2 selected transactions',
+    })
+    expect(result.notes).toContainEqual({ key: 'zero-direction', text: 'The zero amount remains Credit.' })
+  })
+
+  it('does not promise Debit when every selected amount is zero', () => {
+    const result = summarize([zeroTransfer], untouched({ direction: 'debit', endsAreOffered: true }))
+
+    expect(result.rows[0]).toEqual({
+      label: 'Direction',
+      value: 'Unchanged',
+      detail: 'applies to 0 of the 1 selected transactions',
+    })
+    expect(result.notes).toContainEqual({ key: 'zero-direction', text: 'The zero amount remains Credit.' })
   })
 
   it('hides the move detail once every selected row moves, since none of them stay behind', () => {
@@ -256,6 +283,21 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const result = summarize([groceries], untouched({ accountId: 'unknown_account' }))
 
     expect(result.rows).toEqual([{ label: 'Move to account', value: 'Account' }])
+  })
+
+  it('warns and disables Apply when a chosen Move account becomes unavailable', () => {
+    const choice = untouched({ accountId: 'cash' })
+    const currentAccounts = writableAccounts.map((account) =>
+      account.id === 'cash' ? { ...account, can_write: false } : account,
+    )
+    const blockers = getBulkEditBlockers([groceries], choice, undefined, currentAccounts)
+    const result = describeBulkEdit(choice, [groceries], blockers, labels, undefined)
+
+    expect(result.warnings).toContainEqual({
+      key: 'unavailable-account',
+      text: "The selected transaction can't be edited because its account isn't available for editing.",
+    })
+    expect(canApplyBulkEdit([groceries], choice, blockers)).toBe(false)
   })
 
   it('warns once per currency pair, each keyed by its own pair, when a tracked end mismatches more than one row currency', () => {

--- a/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
@@ -50,9 +50,24 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const result = summarize([oldImport], untouched())
 
     expect(result.rows).toEqual([])
-    expect(result.warnings).toEqual([
-      '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.',
-    ])
+    expect(result.warnings).toEqual([{
+      key: 'without-merchant',
+      text: '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.',
+    }])
+  })
+
+  it('keeps the without-merchant key stable while its text moves from singular to plural', () => {
+    const one = summarize([oldImport], untouched())
+    expect(one.warnings).toEqual([{
+      key: 'without-merchant',
+      text: '1 selected transaction has no merchant recorded. Set a merchant above, or close this and untick it.',
+    }])
+
+    const two = summarize([oldImport, { ...oldImport, id: 'old_import_2' }], untouched())
+    expect(two.warnings).toEqual([{
+      key: 'without-merchant',
+      text: '2 selected transactions have no merchant recorded. Set a merchant above, or close this and untick them.',
+    }])
   })
 
   it('shows the direction row and the other-half note over a transfer selection', () => {
@@ -60,17 +75,18 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const result = summarize(pair, choice)
 
     expect(result.rows).toEqual([{ label: 'Direction', value: 'Money out' }])
-    expect(result.notes).toEqual([
-      "A transfer's other half is a separate row. This changes only the rows selected.",
-    ])
+    expect(result.notes).toEqual([{
+      key: 'other-half',
+      text: "A transfer's other half is a separate row. This changes only the rows selected.",
+    }])
   })
 
-  it('shows the direction row with no note over a plain expense selection', () => {
+  it('shows the direction row reversed with no note over a plain expense selection', () => {
     const expenses = [groceries, { ...groceries, id: 'expense_2' }, { ...groceries, id: 'expense_3' }]
     const choice = untouched({ direction: 'reverse', endsAreOffered: false })
     const result = summarize(expenses, choice)
 
-    expect(result.rows).toEqual([{ label: 'Direction', value: 'Turned around' }])
+    expect(result.rows).toEqual([{ label: 'Direction', value: 'Reversed' }])
     expect(result.notes).toEqual([])
   })
 
@@ -95,9 +111,10 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     }])
     // Both rows are transfers whose own account it moves or records, so leftAlone stays at zero and
     // only the other-half note, not the not-a-transfer note, is left standing
-    expect(result.notes).toEqual([
-      "A transfer's other half is a separate row. This changes only the rows selected.",
-    ])
+    expect(result.notes).toEqual([{
+      key: 'other-half',
+      text: "A transfer's other half is a separate row. This changes only the rows selected.",
+    }])
   })
 
   it('shows only a records clause once the From end is outside this app', () => {
@@ -117,9 +134,10 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const result = summarize([chequingHalf], choice)
 
     expect(result.rows).toEqual([{ label: 'From', value: 'Outside this app' }])
-    expect(result.warnings).toEqual([
-      '1 selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick it.',
-    ])
+    expect(result.warnings).toEqual([{
+      key: 'sits-outside',
+      text: '1 selected transaction would sit outside this app. Money leaves from or arrives in one of your accounts, so pick one for From or To, or close this and untick it.',
+    }])
   })
 
   it('answers a To end across a transfer pair and leaves a plain expense to its own note', () => {
@@ -136,8 +154,8 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
       detail: '1 moves into Savings, 1 records Savings as the other side',
     }])
     expect(result.notes).toEqual([
-      "A transfer's other half is a separate row. This changes only the rows selected.",
-      '1 selected transaction is not a transfer and is left as it is.',
+      { key: 'other-half', text: "A transfer's other half is a separate row. This changes only the rows selected." },
+      { key: 'left-alone', text: '1 selected transaction is not a transfer and is left as it is.' },
     ])
   })
 
@@ -153,9 +171,10 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
       { label: 'Direction', value: 'Money in' },
       { label: 'From', value: 'Chequing', detail: '2 record Chequing as the other side' },
     ])
-    expect(result.warnings).toEqual([
-      '1 selected transaction would end up recording the account it already sits in. Change From, To or Move to account, or close this and untick it.',
-    ])
+    expect(result.warnings).toEqual([{
+      key: 'own-account',
+      text: '1 selected transaction would end up recording the account it already sits in. Change From, To or Move to account, or close this and untick it.',
+    }])
   })
 
   it('joins chosen tag names with commas', () => {
@@ -186,9 +205,10 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
   it('warns about an unanswered far side even with no end chosen', () => {
     const result = summarize([unanswered], untouched())
 
-    expect(result.warnings).toEqual([
-      '1 selected transfer does not record where the money went. Set From or To above, or close this and untick it.',
-    ])
+    expect(result.warnings).toEqual([{
+      key: 'unanswered',
+      text: '1 selected transfer does not record where the money went. Set From or To above, or close this and untick it.',
+    }])
   })
 
   it('warns once the selection is over the cap', () => {
@@ -198,9 +218,10 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     }))
     const result = summarize(overCap, untouched())
 
-    expect(result.warnings).toEqual([
-      `One edit covers at most ${MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.`,
-    ])
+    expect(result.warnings).toEqual([{
+      key: 'over-cap',
+      text: `One edit covers at most ${MAX_BULK_EDIT_TRANSACTIONS} transactions. Untick some to continue.`,
+    }])
   })
 
   it('drops a stale From end once endsAreOffered goes false', () => {
@@ -220,7 +241,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     expect(result.rows).toEqual([{ label: 'Move to account', value: 'Account', detail: '1 move' }])
   })
 
-  it('warns once per currency pair when a tracked end mismatches more than one row currency', () => {
+  it('warns once per currency pair, each keyed by its own pair, when a tracked end mismatches more than one row currency', () => {
     const choice = untouched({
       transferFrom: { scope: 'tracked', accountId: 'us_savings', currency: 'USD' },
       endsAreOffered: true,
@@ -228,8 +249,14 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const result = summarize([chequingHalf, eurExpense], choice)
 
     expect(result.warnings).toEqual([
-      '1 selected transaction is in CAD and would move into an account in USD. Pick an account in CAD, or close this and untick it.',
-      '1 selected transaction is in EUR and would move into an account in USD. Pick an account in EUR, or close this and untick it.',
+      {
+        key: 'currency-CAD-USD',
+        text: '1 selected transaction is in CAD and would move into an account in USD. Pick an account in CAD, or close this and untick it.',
+      },
+      {
+        key: 'currency-EUR-USD',
+        text: '1 selected transaction is in EUR and would move into an account in USD. Pick an account in EUR, or close this and untick it.',
+      },
     ])
   })
 

--- a/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
@@ -148,10 +148,12 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     })
     const result = summarize(rows, choice)
 
+    // The Savings half's own end already sits in Savings, so it neither moves nor records and the
+    // detail carries only the Chequing half's records clause
     expect(result.rows).toEqual([{
       label: 'To',
       value: 'Savings',
-      detail: '1 moves into Savings, 1 records Savings as the other side',
+      detail: '1 records Savings as the other side',
     }])
     expect(result.notes).toEqual([
       { key: 'other-half', text: "A transfer's other half is a separate row. This changes only the rows selected." },

--- a/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkEditSummary.test.ts
@@ -88,7 +88,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const choice = untouched({ direction: 'debit', endsAreOffered: true })
     const result = summarize(pair, choice)
 
-    expect(result.rows).toEqual([{ label: 'Direction', value: 'Money out' }])
+    expect(result.rows).toEqual([{ label: 'Direction', value: 'Debit' }])
     expect(result.notes).toEqual([{
       key: 'other-half',
       text: 'Adjustments to a transfer affect the selected transaction only and do not update its counterpart.',
@@ -180,7 +180,7 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
     const result = summarize(pair, choice)
 
     expect(result.rows).toEqual([
-      { label: 'Direction', value: 'Money in' },
+      { label: 'Direction', value: 'Credit' },
       { label: 'From', value: 'Chequing' },
     ])
     expect(result.warnings).toEqual([{
@@ -353,10 +353,10 @@ describe('the rows, notes and warnings a bulk edit choice produces', () => {
 
     const implied = summarize(rows, untouched({ direction: 'credit', directionIsImplied: true, endsAreOffered: true }))
     expect(implied.rows).toEqual([
-      { label: 'Direction', value: 'Money in', detail: 'applies to 2 out of 3 selected transactions' },
+      { label: 'Direction', value: 'Credit', detail: 'applies to 2 out of 3 selected transactions' },
     ])
 
     const picked = summarize(rows, untouched({ direction: 'credit', directionIsImplied: false, endsAreOffered: true }))
-    expect(picked.rows).toEqual([{ label: 'Direction', value: 'Money in' }])
+    expect(picked.rows).toEqual([{ label: 'Direction', value: 'Credit' }])
   })
 })

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -4,8 +4,10 @@
  */
 import { describe, expect, it } from 'vitest'
 import {
+  buildBulkEditFields,
   bulkSelectionReducer,
   emptyBulkSelection,
+  hasBulkEditChoice,
   previewSelection,
   rowSelectionMark,
   type BulkSelectionState,
@@ -108,6 +110,31 @@ describe('the preview shown while shift is held', () => {
     const state = click(emptyBulkSelection, 'b')
 
     expect(previewSelection(state, rows)).toBeNull()
+  })
+})
+
+describe('the fields the bar sends', () => {
+  it('leaves out a control the user did not touch', () => {
+    const fields = buildBulkEditFields({ categoryId: 'cat_1', merchantId: '', tagIds: [] })
+
+    expect(fields).toEqual({ category_id: 'cat_1' })
+  })
+
+  it('sends every control the user did fill in', () => {
+    const fields = buildBulkEditFields({ categoryId: 'cat_1', merchantId: 'mer_1', tagIds: ['tag_1'] })
+
+    expect(fields).toEqual({ category_id: 'cat_1', merchant_id: 'mer_1', add_tag_ids: ['tag_1'] })
+  })
+
+  it('sends nothing at all when every control is untouched', () => {
+    const choice = { categoryId: '', merchantId: '', tagIds: [] }
+
+    expect(buildBulkEditFields(choice)).toEqual({})
+    expect(hasBulkEditChoice(choice)).toBe(false)
+  })
+
+  it('counts one filled control as something to apply', () => {
+    expect(hasBulkEditChoice({ categoryId: '', merchantId: '', tagIds: ['tag_1'] })).toBe(true)
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -21,6 +21,7 @@ import {
   groupSelectionMark,
   hasBulkEditChoice,
   impliedDirection,
+  isMixedSelection,
   isRowSelectable,
   nextDirectionAfterEndChange,
   previewSelection,
@@ -1101,6 +1102,24 @@ describe("the accounts a transfer's ends can be set to", () => {
     const ids = getTransferEndTargets(accounts).map((account) => account.id)
     expect(ids).not.toContain('acc_2')
     expect(ids).not.toContain('acc_3')
+  })
+})
+
+describe('whether a selection mixes transfers with other transactions', () => {
+  it('reads false for a pair of transfer halves alone', () => {
+    expect(isMixedSelection(pair)).toBe(false)
+  })
+
+  it('reads false for an ordinary transaction alone', () => {
+    expect(isMixedSelection([groceries])).toBe(false)
+  })
+
+  it('reads true once a transfer and an ordinary transaction sit in the same selection', () => {
+    expect(isMixedSelection([chequingHalf, groceries])).toBe(true)
+  })
+
+  it('reads false for an empty selection', () => {
+    expect(isMixedSelection([])).toBe(false)
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -18,10 +18,13 @@ import {
   getBulkEditBlockers,
   groupSelectionMark,
   hasBulkEditChoice,
+  impliedDirection,
+  nextDirectionAfterEndChange,
   previewSelection,
   resolveTransferEnds,
   rowSelectionMark,
   toggleChosenTag,
+  type BulkDirectionChoice,
   type BulkSelectionState,
   type ChosenTagOption,
   type SelectableRow,
@@ -39,6 +42,10 @@ import {
   unanswered,
   untouched,
 } from './bulkEditFixtures'
+
+// A second money-out transfer in Chequing recording Savings, alongside chequingHalf, for the
+// direction-implying cases below, which need more than one row already sitting in the same account
+const chequingHalf2 = { ...chequingHalf, id: 'chequing_half_2' }
 
 const rows: SelectableRow[] = [
   { id: 'a', isReadOnly: false },
@@ -683,6 +690,16 @@ describe('what a bulk edit may do to the rows it covers', () => {
         unansweredFarSide: ['e'],
       })
     })
+
+    it('refuses nothing over two Chequing rows given the direction and To their own implication would set', () => {
+      const choice = untouched({
+        direction: 'credit',
+        transferTo: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      expect(getBulkEditBlockers([chequingHalf, chequingHalf2], choice, undefined)).toEqual(noBlockers)
+    })
   })
 
   describe("resolving a transfer's ends", () => {
@@ -748,6 +765,88 @@ describe('what a bulk edit may do to the rows it covers', () => {
       const effects = countTransferEndEffects([groceries, toSavings], choice, undefined)
       expect(effects.leftAlone).toBe(1)
       expect(effects.from.moves).toBe(1)
+    })
+
+    it('counts no move and no record for an own end that already sits in the account it points to', () => {
+      const choice = untouched({
+        direction: 'credit',
+        transferTo: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      expect(countTransferEndEffects([chequingHalf, chequingHalf2], choice, undefined).to).toEqual({
+        moves: 0, recordsOnly: 0,
+      })
+    })
+
+    it('still counts a far end normally alongside an own end that stays put', () => {
+      const choice = untouched({
+        direction: 'credit',
+        transferTo: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
+        transferFrom: { scope: 'tracked', accountId: 'savings', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      expect(countTransferEndEffects([chequingHalf, chequingHalf2], choice, undefined).from.recordsOnly).toBe(2)
+    })
+  })
+
+  describe('the direction the ends imply', () => {
+    // The tracked Chequing account, as an end value, passed as From or To depending on the case
+    const chequing = { scope: 'tracked' as const, accountId: 'chequing', currency: 'CAD' }
+    const outside = { scope: 'outside' as const }
+
+    it('implies money in once every selected row already sits in the account To is set to', () => {
+      expect(impliedDirection([chequingHalf, chequingHalf2], null, chequing, undefined)).toBe('credit')
+    })
+
+    it('implies money out once every selected row already sits in the account From is set to', () => {
+      expect(impliedDirection([chequingHalf, chequingHalf2], chequing, null, undefined)).toBe('debit')
+    })
+
+    it('implies nothing once the selected rows sit in more than one account', () => {
+      expect(impliedDirection(pair, null, chequing, undefined)).toBeNull()
+    })
+
+    it('implies nothing once both ends resolve to the same home account', () => {
+      expect(impliedDirection([chequingHalf, chequingHalf2], chequing, chequing, undefined)).toBeNull()
+    })
+
+    it('implies nothing from an outside end, and nothing at all with no rows selected', () => {
+      expect(impliedDirection([chequingHalf, chequingHalf2], null, outside, undefined)).toBeNull()
+      expect(impliedDirection([], null, chequing, undefined)).toBeNull()
+    })
+
+    it('implies nothing while a selected row would not end up recording a far side, and money in once a chosen transfer category makes every row record one', () => {
+      expect(impliedDirection([chequingHalf, groceries], null, chequing, undefined)).toBeNull()
+      expect(impliedDirection([chequingHalf, groceries], null, chequing, true)).toBe('credit')
+    })
+  })
+
+  describe('what the direction pills hold after an end changes', () => {
+    const nothingSet: BulkDirectionChoice = { value: null, source: 'implied' }
+    const moneyInFromRule: BulkDirectionChoice = { value: 'credit', source: 'implied' }
+    const moneyOutByUser: BulkDirectionChoice = { value: 'debit', source: 'user' }
+    const reverseByUser: BulkDirectionChoice = { value: 'reverse', source: 'user' }
+
+    it('takes an implication over nothing set', () => {
+      expect(nextDirectionAfterEndChange(nothingSet, 'credit')).toEqual(moneyInFromRule)
+    })
+
+    it('clears an implied direction back to nothing set once nothing is implied', () => {
+      expect(nextDirectionAfterEndChange(moneyInFromRule, null)).toEqual(nothingSet)
+    })
+
+    it('leaves a user choice alone once nothing is implied', () => {
+      expect(nextDirectionAfterEndChange(moneyOutByUser, null)).toEqual(moneyOutByUser)
+    })
+
+    it('replaces a user choice once an implication lands', () => {
+      expect(nextDirectionAfterEndChange(moneyOutByUser, 'credit')).toEqual(moneyInFromRule)
+    })
+
+    it('replaces Reverse by the user the same way', () => {
+      expect(nextDirectionAfterEndChange(reverseByUser, 'credit')).toEqual(moneyInFromRule)
     })
   })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -7,16 +7,19 @@ import type { Category } from '@/api/categories'
 import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   buildBulkEditFields,
+  doesAnyResultingCategoryRecordTransferTarget,
   doesChosenCategoryRecordTransferTarget,
   getBulkMoveTargets,
+  getTransferEndTargets,
   bulkSelectionReducer,
   canApplyBulkEdit,
-  doEveryResultingCategoryRecordTransferTarget,
+  countTransferEndEffects,
   emptyBulkSelection,
   getBulkEditBlockers,
   groupSelectionMark,
   hasBulkEditChoice,
   previewSelection,
+  resolveTransferEnds,
   rowSelectionMark,
   type BulkEditChoice,
   type BulkSelectionState,
@@ -157,8 +160,10 @@ function untouched(overrides: Partial<BulkEditChoice> = {}): BulkEditChoice {
     date: '',
     note: '',
     clearsNote: false,
-    transferTarget: null,
-    resultingCategoriesRecordTransferTarget: false,
+    transferFrom: null,
+    transferTo: null,
+    direction: null,
+    endsAreOffered: false,
     ...overrides,
   }
 }
@@ -349,54 +354,67 @@ describe('the details the panel sends', () => {
     expect(buildBulkEditFields(untouched({ note: '', clearsNote: true }))).toEqual({ notes: null })
   })
 
-  it('sends a tracked transfer target as an account and a scope', () => {
+  it('sends a tracked end as an account, dropping the currency it carries', () => {
     const fields = buildBulkEditFields(untouched({
-      resultingCategoriesRecordTransferTarget: true,
-      transferTarget: { scope: 'tracked', accountId: 'acc_2' },
+      endsAreOffered: true,
+      transferFrom: { scope: 'tracked', accountId: 'acc_2', currency: 'CAD' },
     }))
 
-    expect(fields).toEqual({
-      counterparty_account_scope: 'tracked',
-      counterparty_account_id: 'acc_2',
-    })
+    expect(fields).toEqual({ transfer_from: { scope: 'tracked', account_id: 'acc_2' } })
   })
 
-  it('sends money that left the tracked accounts with no account', () => {
+  it('sends the other end the same way', () => {
     const fields = buildBulkEditFields(untouched({
-      resultingCategoriesRecordTransferTarget: true,
-      transferTarget: { scope: 'outside' },
+      endsAreOffered: true,
+      transferTo: { scope: 'tracked', accountId: 'acc_3', currency: 'USD' },
     }))
 
-    expect(fields).toEqual({
-      counterparty_account_scope: 'outside',
-      counterparty_account_id: null,
+    expect(fields).toEqual({ transfer_to: { scope: 'tracked', account_id: 'acc_3' } })
+  })
+
+  it('sends an end set to outside this app with no account', () => {
+    const fields = buildBulkEditFields(untouched({
+      endsAreOffered: true,
+      transferTo: { scope: 'outside' },
+    }))
+
+    expect(fields).toEqual({ transfer_to: { scope: 'outside' } })
+  })
+
+  it('drops the move once an end is answered', () => {
+    const choice = untouched({
+      accountId: 'acc_1',
+      endsAreOffered: true,
+      transferFrom: { scope: 'tracked', accountId: 'acc_2', currency: 'CAD' },
     })
+
+    expect(buildBulkEditFields(choice)).toEqual({ transfer_from: { scope: 'tracked', account_id: 'acc_2' } })
   })
 
   it('counts a category on its own as something to apply, whatever it is', () => {
-    const choice = untouched({ categoryId: 'cat_1', resultingCategoriesRecordTransferTarget: true })
+    const choice = untouched({ categoryId: 'cat_1', endsAreOffered: true })
 
     expect(buildBulkEditFields(choice)).toEqual({ category_id: 'cat_1' })
     expect(hasBulkEditChoice(choice)).toBe(true)
   })
 
-  it('drops a transfer target left behind by a category the user changed away from', () => {
+  it('drops an end left behind by a category the user changed away from', () => {
     const choice = untouched({
       categoryId: 'cat_1',
-      resultingCategoriesRecordTransferTarget: false,
-      transferTarget: { scope: 'tracked', accountId: 'acc_2' },
+      endsAreOffered: false,
+      transferFrom: { scope: 'tracked', accountId: 'acc_2', currency: 'CAD' },
     })
 
-    // The control is off screen under this category, so sending it would refuse the whole batch
-    // over something the user cannot see to undo
+    // The controls are off screen under this category, so sending the end would refuse the whole
+    // batch over something the user cannot see to undo
     expect(buildBulkEditFields(choice)).toEqual({ category_id: 'cat_1' })
   })
 
-  it('has something to apply once the transfer target is answered', () => {
+  it('has something to apply once an end is answered', () => {
     const choice = untouched({
       categoryId: 'cat_1',
-      resultingCategoriesRecordTransferTarget: true,
-      transferTarget: { scope: 'outside' },
+      endsAreOffered: true,
+      transferTo: { scope: 'outside' },
     })
 
     expect(hasBulkEditChoice(choice)).toBe(true)
@@ -409,59 +427,80 @@ describe('what a bulk edit may do to the rows it covers', () => {
     is_system: true, owner_id: null, group_id: null,
   } as Category
 
+  const groceriesCategory = {
+    id: 'cat_g', name: 'Groceries', kind: 'expense', icon: null,
+    is_system: true, owner_id: null, group_id: null,
+  } as Category
+
   const groceries: SelectedTransactionFacts = {
     id: 'a', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null,
+    recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
   }
   const oldImport: SelectedTransactionFacts = {
     id: 'b', accountId: 'chequing', hasMerchant: false,
-    recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null,
+    recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
   }
   const toSavings: SelectedTransactionFacts = {
     id: 'c', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings',
+    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'CAD', direction: 'debit',
   }
   const toOutside: SelectedTransactionFacts = {
     id: 'd', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null,
+    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null, currency: 'CAD', direction: 'debit',
   }
   const unanswered: SelectedTransactionFacts = {
     id: 'e', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: true, hasFarSideRecorded: false, farSideAccountId: null,
+    recordsFarSide: true, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
   }
+
+  // The two halves a transfer pair makes: the money-out half sitting in Chequing and recording
+  // Savings, and the money-in half sitting in Savings and recording Chequing back
+  const chequingHalf: SelectedTransactionFacts = {
+    id: 'chequing_half', accountId: 'chequing', hasMerchant: true,
+    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'CAD', direction: 'debit',
+  }
+  const savingsHalf: SelectedTransactionFacts = {
+    id: 'savings_half', accountId: 'savings', hasMerchant: true,
+    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'chequing', currency: 'CAD', direction: 'credit',
+  }
+  const pair = [chequingHalf, savingsHalf]
 
   /** An edit that sets a note and nothing else, which is the smallest thing a user can ask for */
   const noteOnly = untouched({ note: 'Corrected' })
-  const noBlockers = { withoutMerchant: [], unansweredFarSide: [], ownAccountFarSide: [] }
+  const noBlockers = {
+    withoutMerchant: [], unansweredFarSide: [], ownAccountFarSide: [], sitsOutside: [], ownSideInAnotherCurrency: [],
+  }
 
-  describe('whether the far account can be set', () => {
+  describe('whether the ends can be set', () => {
     it('sends it for a selection of transfers under no new category', () => {
       const choice = untouched({
-        transferTarget: { scope: 'tracked', accountId: 'savings2' },
-        resultingCategoriesRecordTransferTarget:
-          doEveryResultingCategoryRecordTransferTarget(undefined, [toSavings]),
+        transferTo: { scope: 'tracked', accountId: 'savings2', currency: 'CAD' },
+        endsAreOffered: doesAnyResultingCategoryRecordTransferTarget(undefined, [toSavings]),
       })
 
       expect(buildBulkEditFields(choice)).toEqual({
-        counterparty_account_scope: 'tracked',
-        counterparty_account_id: 'savings2',
+        transfer_to: { scope: 'tracked', account_id: 'savings2' },
       })
     })
 
     it('does not offer it where no selected row records one', () => {
-      expect(doEveryResultingCategoryRecordTransferTarget(undefined, [groceries])).toBe(false)
+      expect(doesAnyResultingCategoryRecordTransferTarget(undefined, [groceries])).toBe(false)
     })
 
-    it('does not offer it where only some selected rows record one', () => {
-      expect(doEveryResultingCategoryRecordTransferTarget(undefined, [groceries, toSavings])).toBe(false)
+    it('offers it where only some selected rows record one', () => {
+      expect(doesAnyResultingCategoryRecordTransferTarget(undefined, [groceries, toSavings])).toBe(true)
     })
 
     it('offers it once the chosen category records one, whatever the rows were', () => {
-      expect(doEveryResultingCategoryRecordTransferTarget(transferCategory, [groceries, toSavings])).toBe(true)
+      expect(doesAnyResultingCategoryRecordTransferTarget(transferCategory, [groceries, toSavings])).toBe(true)
+    })
+
+    it('does not offer it once the chosen category is changed away from a transfer, whatever the rows were', () => {
+      expect(doesAnyResultingCategoryRecordTransferTarget(groceriesCategory, pair)).toBe(false)
     })
 
     it('does not offer it against an empty selection', () => {
-      expect(doEveryResultingCategoryRecordTransferTarget(undefined, [])).toBe(false)
+      expect(doesAnyResultingCategoryRecordTransferTarget(undefined, [])).toBe(false)
     })
   })
 
@@ -489,10 +528,24 @@ describe('what a bulk edit may do to the rows it covers', () => {
       expect(getBulkEditBlockers([toOutside], noteOnly, undefined)).toEqual(noBlockers)
     })
 
-    it('counts a row whose chosen far account is the one it sits in', () => {
+    it('answers an unanswered money-out row once To is set, but not while only From is set', () => {
+      const withTo = untouched({
+        transferTo: { scope: 'tracked', accountId: 'savings', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([unanswered], withTo, undefined).unansweredFarSide).toEqual([])
+
+      const withFrom = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([unanswered], withFrom, undefined).unansweredFarSide).toEqual(['e'])
+    })
+
+    it('counts a row whose chosen far end is the one it sits in', () => {
       const choice = untouched({
-        transferTarget: { scope: 'tracked', accountId: 'chequing' },
-        resultingCategoriesRecordTransferTarget: true,
+        transferTo: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
+        endsAreOffered: true,
       })
 
       expect(getBulkEditBlockers([toSavings], choice, undefined)).toEqual({
@@ -509,11 +562,85 @@ describe('what a bulk edit may do to the rows it covers', () => {
       })
     })
 
+    it('counts both rows of a pair once the chosen own end matches what each already records', () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'savings', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      expect(getBulkEditBlockers(pair, choice, undefined).ownAccountFarSide.sort()).toEqual([
+        'chequing_half', 'savings_half',
+      ])
+    })
+
+    it('counts a row whose own end would sit outside the tracked accounts', () => {
+      const choice = untouched({ transferFrom: { scope: 'outside' }, endsAreOffered: true })
+      expect(getBulkEditBlockers([toSavings], choice, undefined)).toEqual({
+        ...noBlockers,
+        sitsOutside: ['c'],
+      })
+    })
+
+    it('counts a money-in row whose own end would sit outside the tracked accounts the same way', () => {
+      const choice = untouched({ transferTo: { scope: 'outside' }, endsAreOffered: true })
+      expect(getBulkEditBlockers([savingsHalf], choice, undefined)).toEqual({
+        ...noBlockers,
+        sitsOutside: ['savings_half'],
+      })
+    })
+
+    it('counts a row with no far side recorded as sitting outside rather than as unanswered, once its own end is set to outside', () => {
+      // The server checks the own end before it ever asks whether the far side was answered, so a
+      // row missing both is refused for the one reason the user can act on without touching To
+      const choice = untouched({ transferFrom: { scope: 'outside' }, endsAreOffered: true })
+      expect(getBulkEditBlockers([unanswered], choice, undefined)).toEqual({
+        ...noBlockers,
+        sitsOutside: ['e'],
+      })
+    })
+
+    it('counts a row with no far side recorded as another currency rather than as unanswered, once its own end is set that way', () => {
+      // The currency check reads the same resolved own end the unanswered check would otherwise
+      // fall through to, and comes first, so a row missing both is refused for the currency alone
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'us_savings', currency: 'USD' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([unanswered], choice, undefined)).toEqual({
+        ...noBlockers,
+        ownSideInAnotherCurrency: ['e'],
+      })
+    })
+
+    it('counts a row whose own end would land in another currency, whatever its exchange rate', () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'us_savings', currency: 'USD' },
+        endsAreOffered: true,
+      })
+
+      expect(getBulkEditBlockers([toSavings], choice, undefined)).toEqual({
+        ...noBlockers,
+        ownSideInAnotherCurrency: ['c'],
+      })
+    })
+
     it('counts a row recategorized into a transfer with no far side to fall back on', () => {
       expect(getBulkEditBlockers([groceries], untouched({ categoryId: 'cat_t' }), true)).toEqual({
         ...noBlockers,
         unansweredFarSide: ['a'],
       })
+    })
+
+    it('answers an expense recategorized into a transfer once To is set, but not without it', () => {
+      const withTo = untouched({
+        categoryId: 'cat_t',
+        transferTo: { scope: 'tracked', accountId: 'savings', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([groceries], withTo, true).unansweredFarSide).toEqual([])
+
+      const withoutTo = untouched({ categoryId: 'cat_t', endsAreOffered: true })
+      expect(getBulkEditBlockers([groceries], withoutTo, true).unansweredFarSide).toEqual(['a'])
     })
 
     it('stops asking for a far side once the row is recategorized away from a transfer', () => {
@@ -523,10 +650,92 @@ describe('what a bulk edit may do to the rows it covers', () => {
 
     it('counts each kind of blocking row separately', () => {
       expect(getBulkEditBlockers([oldImport, unanswered], noteOnly, undefined)).toEqual({
+        ...noBlockers,
         withoutMerchant: ['b'],
         unansweredFarSide: ['e'],
-        ownAccountFarSide: [],
       })
+    })
+  })
+
+  describe("resolving a transfer's ends", () => {
+    it('resolves both ends of a pair the way the service would', () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        transferTo: { scope: 'tracked', accountId: 'savings', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      expect(resolveTransferEnds(chequingHalf, choice, true)).toEqual({
+        ownEnd: choice.transferFrom,
+        farEnd: choice.transferTo,
+      })
+      expect(resolveTransferEnds(savingsHalf, choice, true)).toEqual({
+        ownEnd: choice.transferTo,
+        farEnd: choice.transferFrom,
+      })
+    })
+
+    it("resolves the own end under reverse by flipping the row's own direction", () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        transferTo: { scope: 'tracked', accountId: 'savings', currency: 'CAD' },
+        direction: 'reverse',
+        endsAreOffered: true,
+      })
+
+      // The Chequing half is money out on its own, so reverse makes it money in, which turns the
+      // own and far ends around from the non-reversed case above
+      expect(resolveTransferEnds(chequingHalf, choice, true)).toEqual({
+        ownEnd: choice.transferTo,
+        farEnd: choice.transferFrom,
+      })
+    })
+
+    it('ignores both ends on a row whose resulting category records no far side', () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      expect(resolveTransferEnds(groceries, choice, false)).toEqual({ ownEnd: null, farEnd: null })
+    })
+  })
+
+  describe('counting what an end edit would do', () => {
+    it('reports one end moving the money-out half of a pair and recording on the money-in half', () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      expect(countTransferEndEffects(pair, choice, undefined).from).toEqual({ moves: 1, recordsOnly: 1 })
+    })
+
+    it('reports a non-transfer row as left alone alongside a moved transfer', () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      const effects = countTransferEndEffects([groceries, toSavings], choice, undefined)
+      expect(effects.leftAlone).toBe(1)
+      expect(effects.from.moves).toBe(1)
+    })
+  })
+
+  describe('which way the money moves', () => {
+    it('sends the direction the edit picked', () => {
+      expect(buildBulkEditFields(untouched({ direction: 'debit' }))).toEqual({ direction: 'debit' })
+      expect(buildBulkEditFields(untouched({ direction: 'credit' }))).toEqual({ direction: 'credit' })
+      expect(buildBulkEditFields(untouched({ direction: 'reverse' }))).toEqual({ direction: 'reverse' })
+    })
+
+    it('sends nothing while the edit leaves it alone', () => {
+      expect(buildBulkEditFields(untouched({ direction: null }))).toEqual({})
+    })
+
+    it('counts a direction on its own as something to apply', () => {
+      expect(hasBulkEditChoice(untouched({ direction: 'debit' }))).toBe(true)
     })
   })
 
@@ -564,19 +773,35 @@ describe('what a bulk edit may do to the rows it covers', () => {
 
     it('refuses while a row would end up recording the account it sits in', () => {
       const choice = untouched({
-        transferTarget: { scope: 'tracked', accountId: 'chequing' },
-        resultingCategoriesRecordTransferTarget: true,
+        transferTo: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
+        endsAreOffered: true,
       })
       const blockers = getBulkEditBlockers([toSavings], choice, undefined)
 
       expect(canApplyBulkEdit([toSavings], choice, blockers)).toBe(false)
     })
 
-    it('writes a note across a selection of transfers without touching their far side', () => {
+    it('refuses while an own end would sit outside the tracked accounts', () => {
+      const choice = untouched({ transferFrom: { scope: 'outside' }, endsAreOffered: true })
+      const blockers = getBulkEditBlockers([toSavings], choice, undefined)
+
+      expect(canApplyBulkEdit([toSavings], choice, blockers)).toBe(false)
+    })
+
+    it('refuses while an own end would land in another currency', () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'us_savings', currency: 'USD' },
+        endsAreOffered: true,
+      })
+      const blockers = getBulkEditBlockers([toSavings], choice, undefined)
+
+      expect(canApplyBulkEdit([toSavings], choice, blockers)).toBe(false)
+    })
+
+    it('writes a note across a selection of transfers without touching their ends', () => {
       const choice = untouched({
         note: 'Reconciled',
-        resultingCategoriesRecordTransferTarget:
-          doEveryResultingCategoryRecordTransferTarget(undefined, [toSavings]),
+        endsAreOffered: doesAnyResultingCategoryRecordTransferTarget(undefined, [toSavings]),
       })
       const blockers = getBulkEditBlockers([toSavings], choice, undefined)
 
@@ -585,7 +810,7 @@ describe('what a bulk edit may do to the rows it covers', () => {
     })
 
     it('refuses a recategorization into a transfer that leaves the far side unanswered', () => {
-      const choice = untouched({ categoryId: 'cat_t', resultingCategoriesRecordTransferTarget: true })
+      const choice = untouched({ categoryId: 'cat_t', endsAreOffered: true })
       const blockers = getBulkEditBlockers([groceries], choice, true)
 
       // The category on its own is something to apply, so the refusal is the unanswered far side
@@ -663,6 +888,25 @@ describe('the accounts a selection can move to', () => {
 
   it('offers nothing before anything is selected', () => {
     expect(getBulkMoveTargets(accounts, [])).toEqual([])
+  })
+})
+
+describe("the accounts a transfer's ends can be set to", () => {
+  const accounts = [
+    { id: 'acc_1', currency: 'CAD' },
+    { id: 'acc_2', currency: 'CAD', is_archived: true },
+    { id: 'acc_3', currency: 'CAD', closed_at: '2026-03-01' },
+    { id: 'acc_4', currency: 'USD' },
+  ]
+
+  it('offers every open account, whatever its currency', () => {
+    expect(getTransferEndTargets(accounts).map((account) => account.id)).toEqual(['acc_1', 'acc_4'])
+  })
+
+  it('leaves out an archived or a closed account', () => {
+    const ids = getTransferEndTargets(accounts).map((account) => account.id)
+    expect(ids).not.toContain('acc_2')
+    expect(ids).not.toContain('acc_3')
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -21,7 +21,9 @@ import {
   previewSelection,
   resolveTransferEnds,
   rowSelectionMark,
+  toggleChosenTag,
   type BulkSelectionState,
+  type ChosenTagOption,
   type SelectableRow,
 } from '@/pages/transactions/components/bulk-edit/selection'
 import {
@@ -136,13 +138,13 @@ describe('the preview shown while shift is held', () => {
     expect(preview && [...preview].sort()).toEqual(['b', 'c'])
   })
 
-  it('marks a ticked row the click would drop as no longer selected', () => {
+  it('keeps a ticked row selected even while a re-aimed range would drop it', () => {
     let state = click(emptyBulkSelection, 'b')
     state = click(state, 'e', true)
     state = bulkSelectionReducer(state, { type: 'hover', id: 'c' })
     const preview = previewSelection(state, rows)
 
-    expect(rowSelectionMark('e', state.selectedIds, preview)).toBe('none')
+    expect(rowSelectionMark('e', state.selectedIds, preview)).toBe('selected')
     expect(rowSelectionMark('b', state.selectedIds, preview)).toBe('selected')
   })
 
@@ -243,11 +245,11 @@ describe('the preview shown while the pointer rests on a day heading', () => {
     expect(markOf(state, 'd')).toBe('selected')
   })
 
-  it('shows a fully ticked day dropped, keeping the ticks made in other days', () => {
+  it('keeps a fully ticked day selected while the tick previews dropping it, keeping the ticks made in other days', () => {
     const ticked = click(clickDay(emptyBulkSelection, dayOne), 'd', false, withReadOnlyC)
     const state = hoverDay(ticked, dayOne)
-    expect(markOf(state, 'a')).toBe('none')
-    expect(markOf(state, 'b')).toBe('none')
+    expect(markOf(state, 'a')).toBe('selected')
+    expect(markOf(state, 'b')).toBe('selected')
     expect(markOf(state, 'd')).toBe('selected')
   })
 
@@ -289,9 +291,9 @@ describe('the preview shown while the pointer rests on a day heading', () => {
   })
 
 
-  it('goes once the day is ticked, so its rows read as ticked rather than as about to be dropped', () => {
+  it('stays up once the day is ticked, refreshed to the ids just toggled, so its rows read as ticked rather than as about to be dropped', () => {
     const state = clickDay(hoverDay(emptyBulkSelection, dayOne), dayOne)
-    expect(previewSelection(state, withReadOnlyC)).toBeNull()
+    expect(state.hoveredGroupIds).toEqual(dayOne)
     expect(markOf(state, 'a')).toBe('selected')
     expect(markOf(state, 'b')).toBe('selected')
   })
@@ -301,6 +303,82 @@ describe('the preview shown while the pointer rests on a day heading', () => {
     const state = clickDay(pendingRange, dayTwo)
     expect(state.hoveredId).toBeNull()
     expect(markOf(state, 'c')).toBe('none')
+  })
+})
+
+describe('toggling a day heading keeps its hover refreshed to the ids it just toggled', () => {
+  it('selects a fully unticked day and keeps both rows reading selected under the still-hovered tick', () => {
+    const hovering: BulkSelectionState = { ...emptyBulkSelection, hoveredGroupIds: ['a', 'b'] }
+    const state = bulkSelectionReducer(hovering, { type: 'toggleGroup', ids: ['a', 'b'], rows })
+
+    expect([...state.selectedIds].sort()).toEqual(['a', 'b'])
+    expect(state.hoveredGroupIds).toEqual(['a', 'b'])
+    expect(state.hoveredId).toBeNull()
+    expect(rowSelectionMark('a', state.selectedIds, previewSelection(state, rows))).toBe('selected')
+    expect(rowSelectionMark('b', state.selectedIds, previewSelection(state, rows))).toBe('selected')
+  })
+
+  it('drops a fully ticked day and marks both rows pending under the still-hovered tick', () => {
+    const hovering: BulkSelectionState = {
+      ...emptyBulkSelection,
+      selectedIds: new Set(['a', 'b']),
+      hoveredGroupIds: ['a', 'b'],
+    }
+    const state = bulkSelectionReducer(hovering, { type: 'toggleGroup', ids: ['a', 'b'], rows })
+
+    expect(state.selectedIds.size).toBe(0)
+    expect(state.hoveredGroupIds).toEqual(['a', 'b'])
+    expect(rowSelectionMark('a', state.selectedIds, previewSelection(state, rows))).toBe('pending')
+    expect(rowSelectionMark('b', state.selectedIds, previewSelection(state, rows))).toBe('pending')
+  })
+
+  it('reads a fully ticked day as still selected while the tick merely previews dropping it, with no click yet', () => {
+    const state: BulkSelectionState = {
+      ...emptyBulkSelection,
+      selectedIds: new Set(['a', 'b']),
+      hoveredGroupIds: ['a', 'b'],
+    }
+
+    expect(rowSelectionMark('a', state.selectedIds, previewSelection(state, rows))).toBe('selected')
+    expect(rowSelectionMark('b', state.selectedIds, previewSelection(state, rows))).toBe('selected')
+  })
+
+  it('refreshes the hovered ids to the ones just toggled rather than the ones hovered before', () => {
+    const threeRows: SelectableRow[] = [
+      { id: 'r1', isReadOnly: false },
+      { id: 'r2', isReadOnly: false },
+      { id: 'r3', isReadOnly: false },
+    ]
+    const hovering: BulkSelectionState = { ...emptyBulkSelection, hoveredGroupIds: ['r1', 'r2'] }
+    const state = bulkSelectionReducer(hovering, { type: 'toggleGroup', ids: ['r1', 'r2', 'r3'], rows: threeRows })
+
+    expect([...state.selectedIds].sort()).toEqual(['r1', 'r2', 'r3'])
+    expect(state.hoveredGroupIds).toEqual(['r1', 'r2', 'r3'])
+  })
+
+  it('nulls the hover only when the toggle is told to clear it, and always nulls the single-row hover', () => {
+    const state = bulkSelectionReducer(emptyBulkSelection, {
+      type: 'toggleGroup',
+      ids: ['a', 'b'],
+      rows,
+      clearsHover: true,
+    })
+
+    expect(state.hoveredGroupIds).toBeNull()
+    expect(state.hoveredId).toBeNull()
+  })
+})
+
+describe('choosing a tag in the bulk edit panel', () => {
+  const holiday: ChosenTagOption = { value: 'tag_holiday', label: 'Holiday' }
+  const cash: ChosenTagOption = { value: 'tag_cash', label: 'Cash' }
+
+  it('adds a tag that was not chosen yet', () => {
+    expect(toggleChosenTag([], holiday)).toEqual([holiday])
+  })
+
+  it('removes a chosen tag, leaving the order of the rest as it stood', () => {
+    expect(toggleChosenTag([holiday, cash], holiday)).toEqual([cash])
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -26,6 +26,7 @@ import {
   nextDirectionAfterEndChange,
   previewSelection,
   resolveTransferEnds,
+  rowFactsKey,
   rowSelectionMark,
   toggleChosenTag,
   type BulkDirectionChoice,
@@ -46,6 +47,7 @@ import {
   transferCategory,
   unanswered,
   untouched,
+  usdTransferInChequing,
 } from './bulkEditFixtures'
 
 const rows: SelectableRow[] = [
@@ -433,6 +435,14 @@ describe('the details the panel sends', () => {
     expect(buildBulkEditFields(untouched({ note: '', clearsNote: true }))).toEqual({ notes: null })
   })
 
+  it('trims the note, so a note of only spaces sends nothing', () => {
+    expect(buildBulkEditFields(untouched({ note: '  ' }))).toEqual({})
+  })
+
+  it('trims surrounding space off a note that has one', () => {
+    expect(buildBulkEditFields(untouched({ note: '  paid back  ' }))).toEqual({ notes: 'paid back' })
+  })
+
   it('sends a tracked end as an account, dropping the currency it carries', () => {
     const fields = buildBulkEditFields(untouched({
       endsAreOffered: true,
@@ -590,6 +600,22 @@ describe('what a bulk edit may do to the rows it covers', () => {
       })
     })
 
+    it('reads the account an end actually sends rather than a stray Move to account choice, once both are set', () => {
+      // Move to account is disabled in the panel whenever an end is set, but the choice this
+      // function reads can still carry both, and only the end reaches the request then. The own
+      // side this row resolves to is left as its own account, not the accountId, since sendsAnEnd
+      // is what actually decides whether account_id is ever sent
+      const choice = untouched({
+        accountId: 'unrelated',
+        transferTo: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([toSavings], choice, undefined)).toEqual({
+        ...noBlockers,
+        ownAccountFarSide: ['c'],
+      })
+    })
+
     it('counts a move into the account a row already records as its far side', () => {
       const choice = untouched({ accountId: 'savings' })
       expect(getBulkEditBlockers([toSavings], choice, undefined)).toEqual({
@@ -657,6 +683,27 @@ describe('what a bulk edit may do to the rows it covers', () => {
       expect(getBulkEditBlockers([toSavings], choice, undefined)).toEqual({
         ...noBlockers,
         ownSideInAnotherCurrency: ['c'],
+      })
+    })
+
+    it('skips the currency check once the own end resolves to the account the row already sits in', () => {
+      // The row already sits in Chequing, so setting From back to Chequing moves nothing and the
+      // server never touches the exchange rate for it, whatever currency the row is denominated in
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'chequing', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([usdTransferInChequing], choice, undefined)).toEqual(noBlockers)
+    })
+
+    it('still counts the currency mismatch once the own end resolves to a different CAD account', () => {
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'savings', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([usdTransferInChequing], choice, undefined)).toEqual({
+        ...noBlockers,
+        ownSideInAnotherCurrency: ['usd_in_chequing'],
       })
     })
 
@@ -908,6 +955,40 @@ describe('what a bulk edit may do to the rows it covers', () => {
 
     it('replaces Reverse by the user the same way', () => {
       expect(nextDirectionAfterEndChange(reverseByUser, 'credit')).toEqual(moneyInFromRule)
+    })
+  })
+
+  describe('the key that changes only when a fact the direction and end rules read changes', () => {
+    it('matches across two fresh arrays holding the same facts', () => {
+      expect(rowFactsKey([{ ...toSavings }, { ...groceries }])).toBe(rowFactsKey([{ ...toSavings }, { ...groceries }]))
+    })
+
+    it('differs once a row drops out of the selection', () => {
+      expect(rowFactsKey([toSavings, groceries])).not.toBe(rowFactsKey([toSavings]))
+    })
+
+    it("differs once a row's account changes", () => {
+      expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, accountId: 'savings' }]))
+    })
+
+    it("differs once a row's direction changes", () => {
+      expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, direction: 'credit' }]))
+    })
+
+    it("differs once a row's currency changes", () => {
+      expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, currency: 'USD' }]))
+    })
+
+    it("differs once whether a row records a far side changes", () => {
+      expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, recordsFarSide: false }]))
+    })
+
+    it("differs once whether a row's far side is recorded changes", () => {
+      expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, hasFarSideRecorded: false }]))
+    })
+
+    it("differs once a row's far side account changes", () => {
+      expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, farSideAccountId: 'chequing' }]))
     })
   })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -25,8 +25,12 @@ const rows: SelectableRow[] = [
 
 /** Applies a run of clicks, so each test reads as the sequence a user would perform */
 function click(state: BulkSelectionState, id: string, withShift = false, over = rows) {
-  return bulkSelectionReducer(state, withShift ? { type: 'extend', id, rows: over } : { type: 'toggle', id })
+  return bulkSelectionReducer(state, { type: withShift ? 'extend' : 'toggle', id, rows: over })
 }
+
+const withReadOnlyC: SelectableRow[] = rows.map((row) =>
+  row.id === 'c' ? { ...row, isReadOnly: true } : row,
+)
 
 describe('the range a shift-click takes', () => {
   it('takes every row between the two, both ends included', () => {
@@ -67,13 +71,33 @@ describe('the range a shift-click takes', () => {
   })
 
   it('steps over a row the app does not allow editing', () => {
-    const withReadOnly: SelectableRow[] = rows.map((row) =>
-      row.id === 'c' ? { ...row, isReadOnly: true } : row,
-    )
-    let state = click(emptyBulkSelection, 'b', false, withReadOnly)
-    state = click(state, 'e', true, withReadOnly)
+    let state = click(emptyBulkSelection, 'b', false, withReadOnlyC)
+    state = click(state, 'e', true, withReadOnlyC)
 
     expect([...state.selectedIds].sort()).toEqual(['b', 'd', 'e'])
+  })
+})
+
+describe('a row the app does not allow editing', () => {
+  it('cannot be ticked by a plain click', () => {
+    const state = click(emptyBulkSelection, 'c', false, withReadOnlyC)
+
+    expect(state.selectedIds.size).toBe(0)
+    expect(state.anchorId).toBeNull()
+  })
+
+  it('cannot be ticked by a shift-click made before any anchor is set', () => {
+    const state = click(emptyBulkSelection, 'c', true, withReadOnlyC)
+
+    expect(state.selectedIds.size).toBe(0)
+    expect(state.anchorId).toBeNull()
+  })
+
+  it('still ends a range that runs through it', () => {
+    let state = click(emptyBulkSelection, 'a', false, withReadOnlyC)
+    state = click(state, 'c', true, withReadOnlyC)
+
+    expect([...state.selectedIds].sort()).toEqual(['a', 'b'])
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests which transactions a bulk edit covers: the range a shift-click takes, the anchor it runs
+ * from, and the preview shown while the pointer moves with shift held
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  bulkSelectionReducer,
+  emptyBulkSelection,
+  previewSelection,
+  rowSelectionMark,
+  type BulkSelectionState,
+  type SelectableRow,
+} from '@/pages/transactions/components/bulk-edit/selection'
+
+const rows: SelectableRow[] = [
+  { id: 'a', isReadOnly: false },
+  { id: 'b', isReadOnly: false },
+  { id: 'c', isReadOnly: false },
+  { id: 'd', isReadOnly: false },
+  { id: 'e', isReadOnly: false },
+  { id: 'f', isReadOnly: false },
+]
+
+/** Applies a run of clicks, so each test reads as the sequence a user would perform */
+function click(state: BulkSelectionState, id: string, withShift = false, over = rows) {
+  return bulkSelectionReducer(state, withShift ? { type: 'extend', id, rows: over } : { type: 'toggle', id })
+}
+
+describe('the range a shift-click takes', () => {
+  it('takes every row between the two, both ends included', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = click(state, 'e', true)
+
+    expect([...state.selectedIds].sort()).toEqual(['b', 'c', 'd', 'e'])
+  })
+
+  it('takes the same rows when aimed upward', () => {
+    let state = click(emptyBulkSelection, 'e')
+    state = click(state, 'b', true)
+
+    expect([...state.selectedIds].sort()).toEqual(['b', 'c', 'd', 'e'])
+  })
+
+  it('leaves a tick made before the anchor in place', () => {
+    let state = click(emptyBulkSelection, 'a')
+    state = click(state, 'f')
+    state = click(state, 'b')
+    state = click(state, 'd', true)
+
+    expect([...state.selectedIds].sort()).toEqual(['a', 'b', 'c', 'd', 'f'])
+  })
+
+  it('drops what the previous range took when re-aimed from the same anchor', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = click(state, 'e', true)
+    state = click(state, 'c', true)
+
+    expect([...state.selectedIds].sort()).toEqual(['b', 'c'])
+  })
+
+  it('ticks one row when no anchor has been set', () => {
+    const state = click(emptyBulkSelection, 'd', true)
+
+    expect([...state.selectedIds]).toEqual(['d'])
+  })
+
+  it('steps over a row the app does not allow editing', () => {
+    const withReadOnly: SelectableRow[] = rows.map((row) =>
+      row.id === 'c' ? { ...row, isReadOnly: true } : row,
+    )
+    let state = click(emptyBulkSelection, 'b', false, withReadOnly)
+    state = click(state, 'e', true, withReadOnly)
+
+    expect([...state.selectedIds].sort()).toEqual(['b', 'd', 'e'])
+  })
+})
+
+describe('the preview shown while shift is held', () => {
+  it('is the whole set the click would produce, not only what it would add', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = click(state, 'e', true)
+    state = bulkSelectionReducer(state, { type: 'hover', id: 'c' })
+
+    const preview = previewSelection(state, rows)
+
+    expect(preview && [...preview].sort()).toEqual(['b', 'c'])
+  })
+
+  it('marks a ticked row the click would drop as no longer selected', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = click(state, 'e', true)
+    state = bulkSelectionReducer(state, { type: 'hover', id: 'c' })
+    const preview = previewSelection(state, rows)
+
+    expect(rowSelectionMark('e', state.selectedIds, preview)).toBe('none')
+    expect(rowSelectionMark('b', state.selectedIds, preview)).toBe('selected')
+  })
+
+  it('marks a row the click would add as pending', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = bulkSelectionReducer(state, { type: 'hover', id: 'd' })
+    const preview = previewSelection(state, rows)
+
+    expect(rowSelectionMark('d', state.selectedIds, preview)).toBe('pending')
+  })
+
+  it('is absent when the pointer is over nothing', () => {
+    const state = click(emptyBulkSelection, 'b')
+
+    expect(previewSelection(state, rows)).toBeNull()
+  })
+})
+
+describe('what empties the selection', () => {
+  it('clears the ticks, the anchor and the baseline', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = click(state, 'e', true)
+    state = bulkSelectionReducer(state, { type: 'clear' })
+
+    expect(state.selectedIds.size).toBe(0)
+    expect(state.anchorId).toBeNull()
+    expect(state.baselineIds.size).toBe(0)
+  })
+
+  it('drops a tick whose row has left the list', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = click(state, 'd')
+    state = bulkSelectionReducer(state, { type: 'keepDisplayed', ids: ['a', 'b', 'c'] })
+
+    expect([...state.selectedIds]).toEqual(['b'])
+  })
+
+  it('leaves the state untouched when every ticked row is still displayed', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = click(state, 'd')
+    const settled = bulkSelectionReducer(state, {
+      type: 'keepDisplayed',
+      ids: rows.map((row) => row.id),
+    })
+
+    expect(settled).toBe(state)
+  })
+})

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -15,6 +15,7 @@ import {
   canApplyBulkEdit,
   countTransferEndEffects,
   emptyBulkSelection,
+  eligibleSelectionIds,
   endsAfterDirectionClick,
   endsAfterEndPick,
   getBulkEditBlockers,
@@ -48,6 +49,8 @@ import {
   unanswered,
   untouched,
   usdTransferInChequing,
+  writableAccounts,
+  zeroTransfer,
 } from './bulkEditFixtures'
 
 const rows: SelectableRow[] = [
@@ -515,6 +518,7 @@ describe('what a bulk edit may do to the rows it covers', () => {
   const noteOnly = untouched({ note: 'Corrected' })
   const noBlockers = {
     withoutMerchant: [], unansweredFarSide: [], ownAccountFarSide: [], sitsOutside: [], ownSideInAnotherCurrency: [],
+    unavailableOwnAccount: [],
   }
 
   describe('whether the ends can be set', () => {
@@ -748,6 +752,70 @@ describe('what a bulk edit may do to the rows it covers', () => {
 
       expect(getBulkEditBlockers([chequingHalf, chequingHalf2], choice, undefined)).toEqual(noBlockers)
     })
+
+    it('blocks a stale Move destination after it becomes read-only or disappears', () => {
+      const choice = untouched({ accountId: 'cash' })
+      const readOnlyCash = writableAccounts.map((account) =>
+        account.id === 'cash' ? { ...account, can_write: false } : account,
+      )
+
+      expect(getBulkEditBlockers([groceries], choice, undefined, readOnlyCash).unavailableOwnAccount).toEqual(['a'])
+      expect(getBulkEditBlockers(
+        [groceries],
+        choice,
+        undefined,
+        writableAccounts.filter((account) => account.id !== 'cash'),
+      ).unavailableOwnAccount).toEqual(['a'])
+    })
+
+    it('allows a read-only account only while From resolves to the far side', () => {
+      const readOnlyCash = writableAccounts.map((account) =>
+        account.id === 'cash' ? { ...account, can_write: false } : account,
+      )
+      const choice = untouched({
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+
+      const farSideOnly = getBulkEditBlockers([savingsHalf], choice, undefined, readOnlyCash)
+      expect(farSideOnly.unavailableOwnAccount).toEqual([])
+      expect(canApplyBulkEdit([savingsHalf], choice, farSideOnly)).toBe(true)
+      expect(getBulkEditBlockers([chequingHalf], choice, undefined, readOnlyCash).unavailableOwnAccount)
+        .toEqual(['chequing_half'])
+      expect(getBulkEditBlockers(pair, choice, undefined, readOnlyCash).unavailableOwnAccount)
+        .toEqual(['chequing_half'])
+    })
+
+    it('recomputes a read-only transfer end after Reverse and category conversion', () => {
+      const readOnlyCash = writableAccounts.map((account) =>
+        account.id === 'cash' ? { ...account, can_write: false } : account,
+      )
+      const reversed = untouched({
+        direction: 'reverse',
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([savingsHalf], reversed, undefined, readOnlyCash).unavailableOwnAccount)
+        .toEqual(['savings_half'])
+
+      const converted = untouched({
+        categoryId: transferCategory.id,
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        transferTo: { scope: 'outside' },
+        endsAreOffered: true,
+      })
+      expect(getBulkEditBlockers([groceries], converted, true, readOnlyCash).unavailableOwnAccount).toEqual(['a'])
+    })
+
+    it('blocks a selected source after its current capability is downgraded', () => {
+      const downgraded = writableAccounts.map((account) =>
+        account.id === 'chequing' ? { ...account, can_write: false } : account,
+      )
+      const blockers = getBulkEditBlockers([groceries], noteOnly, undefined, downgraded)
+
+      expect(blockers.unavailableOwnAccount).toEqual(['a'])
+      expect(canApplyBulkEdit([groceries], noteOnly, blockers)).toBe(false)
+    })
   })
 
   describe("resolving a transfer's ends", () => {
@@ -765,6 +833,31 @@ describe('what a bulk edit may do to the rows it covers', () => {
       expect(resolveTransferEnds(savingsHalf, choice, true)).toEqual({
         ownEnd: choice.transferTo,
         farEnd: choice.transferFrom,
+      })
+    })
+
+    it('keeps zero credit-facing for Debit and Reverse when resolving From and To', () => {
+      const fromCash = untouched({
+        direction: 'debit',
+        transferFrom: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(resolveTransferEnds(zeroTransfer, fromCash, true)).toEqual({ ownEnd: null, farEnd: fromCash.transferFrom })
+
+      const toCash = untouched({
+        direction: 'reverse',
+        transferTo: { scope: 'tracked', accountId: 'cash', currency: 'CAD' },
+        endsAreOffered: true,
+      })
+      expect(resolveTransferEnds(zeroTransfer, toCash, true)).toEqual({ ownEnd: toCash.transferTo, farEnd: null })
+
+      expect(countTransferEndEffects([zeroTransfer], fromCash, undefined).from).toEqual({
+        moves: 0,
+        recordsOnly: 1,
+      })
+      expect(countTransferEndEffects([zeroTransfer], toCash, undefined).to).toEqual({
+        moves: 1,
+        recordsOnly: 0,
       })
     })
 
@@ -975,6 +1068,10 @@ describe('what a bulk edit may do to the rows it covers', () => {
       expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, direction: 'credit' }]))
     })
 
+    it("differs once a row's zero state changes", () => {
+      expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, isZeroAmount: true }]))
+    })
+
     it("differs once a row's currency changes", () => {
       expect(rowFactsKey([toSavings])).not.toBe(rowFactsKey([{ ...toSavings, currency: 'USD' }]))
     })
@@ -1148,10 +1245,12 @@ describe('whether a chosen category records the other side of a transfer', () =>
 
 describe('the accounts a selection can move to', () => {
   const accounts = [
-    { id: 'acc_1', currency: 'CAD' },
-    { id: 'acc_2', currency: 'CAD', is_archived: true },
-    { id: 'acc_3', currency: 'CAD', closed_at: '2026-03-01' },
-    { id: 'acc_4', currency: 'USD' },
+    { id: 'acc_1', currency: 'CAD', can_write: true },
+    { id: 'acc_2', currency: 'CAD', can_write: true, is_archived: true },
+    { id: 'acc_3', currency: 'CAD', can_write: true, closed_at: '2026-03-01' },
+    { id: 'acc_4', currency: 'USD', can_write: true },
+    { id: 'acc_5', currency: 'CAD', can_write: false },
+    { id: 'acc_6', currency: 'CAD' },
   ]
 
   it('offers the open accounts in the currency the selection uses', () => {
@@ -1169,10 +1268,10 @@ describe('the accounts a selection can move to', () => {
 
 describe("the accounts a transfer's ends can be set to", () => {
   const accounts = [
-    { id: 'acc_1', currency: 'CAD' },
-    { id: 'acc_2', currency: 'CAD', is_archived: true },
-    { id: 'acc_3', currency: 'CAD', closed_at: '2026-03-01' },
-    { id: 'acc_4', currency: 'USD' },
+    { id: 'acc_1', currency: 'CAD', can_write: true },
+    { id: 'acc_2', currency: 'CAD', can_write: true, is_archived: true },
+    { id: 'acc_3', currency: 'CAD', can_write: true, closed_at: '2026-03-01' },
+    { id: 'acc_4', currency: 'USD', can_write: false },
   ]
 
   it('offers every open account, whatever its currency', () => {
@@ -1183,6 +1282,10 @@ describe("the accounts a transfer's ends can be set to", () => {
     const ids = getTransferEndTargets(accounts).map((account) => account.id)
     expect(ids).not.toContain('acc_2')
     expect(ids).not.toContain('acc_3')
+  })
+
+  it('keeps a read-only account because it can be recorded as the far side', () => {
+    expect(getTransferEndTargets(accounts).map((account) => account.id)).toContain('acc_4')
   })
 })
 
@@ -1232,6 +1335,20 @@ describe('what empties the selection', () => {
     })
 
     expect(settled).toBe(state)
+  })
+
+  it('prunes selected ids, the baseline and the anchor after capability changes', () => {
+    let state = click(emptyBulkSelection, 'b')
+    state = click(state, 'd')
+    const refreshedRows = rows.map((row) => row.id === 'd' ? { ...row, isReadOnly: true } : row)
+
+    expect(eligibleSelectionIds(rows)).toContain('d')
+    expect(eligibleSelectionIds(refreshedRows)).not.toContain('d')
+    state = bulkSelectionReducer(state, { type: 'keepDisplayed', ids: eligibleSelectionIds(refreshedRows) })
+
+    expect([...state.selectedIds]).toEqual(['b'])
+    expect([...state.baselineIds]).toEqual(['b'])
+    expect(state.anchorId).toBeNull()
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -1,6 +1,6 @@
 /**
  * Tests which transactions a bulk edit covers: the range a shift-click takes, the anchor it runs
- * from, and the preview shown while the pointer moves with shift held
+ * from, the rows a day heading's tick takes, and the preview shown before either one is clicked
  */
 import { describe, expect, it } from 'vitest'
 import type { Category } from '@/api/categories'
@@ -10,6 +10,7 @@ import {
   getBulkMoveTargets,
   bulkSelectionReducer,
   emptyBulkSelection,
+  groupSelectionMark,
   hasBulkEditChoice,
   previewSelection,
   rowSelectionMark,
@@ -156,6 +157,149 @@ function untouched(overrides: Partial<BulkEditChoice> = {}): BulkEditChoice {
     ...overrides,
   }
 }
+
+// The two days a heading tick works over. Day one holds a read-only row, so a tick that took every
+// row rather than every editable one shows up in the result
+const dayOne = ['a', 'b', 'c']
+const dayTwo = ['d', 'e']
+
+/** Ticks a whole day heading, the way clicking its tick does */
+function clickDay(state: BulkSelectionState, ids: string[], over = withReadOnlyC) {
+  return bulkSelectionReducer(state, { type: 'toggleGroup', ids, rows: over })
+}
+
+/** Rests the pointer on a day heading's tick */
+function hoverDay(state: BulkSelectionState, ids: string[] | null) {
+  return bulkSelectionReducer(state, { type: 'hoverGroup', ids })
+}
+
+/** Rests the pointer on a row with shift held */
+function hoverRow(state: BulkSelectionState, id: string | null) {
+  return bulkSelectionReducer(state, { type: 'hover', id })
+}
+
+/** Marks one row against whatever preview the state is showing */
+function markOf(state: BulkSelectionState, id: string, over = withReadOnlyC) {
+  return rowSelectionMark(id, state.selectedIds, previewSelection(state, over))
+}
+
+describe("the rows a day heading's tick takes", () => {
+  it('takes only the rows the app allows editing', () => {
+    expect([...clickDay(emptyBulkSelection, dayOne).selectedIds]).toEqual(['a', 'b'])
+  })
+
+  it('keeps the ticks made in other days', () => {
+    const withD = click(emptyBulkSelection, 'd', false, withReadOnlyC)
+    expect([...clickDay(withD, dayOne).selectedIds].sort()).toEqual(['a', 'b', 'd'])
+  })
+
+  it('drops the day again once all of it is ticked, leaving the other days alone', () => {
+    const both = clickDay(clickDay(emptyBulkSelection, dayOne), dayTwo)
+    expect([...both.selectedIds].sort()).toEqual(['a', 'b', 'd', 'e'])
+    expect([...clickDay(both, dayOne).selectedIds].sort()).toEqual(['d', 'e'])
+  })
+
+  it('offers nothing on a day with no row the app allows editing', () => {
+    const readOnlyDay = ['c']
+    expect(groupSelectionMark(readOnlyDay, withReadOnlyC, new Set())).toBe('unselectable')
+    expect(clickDay(emptyBulkSelection, readOnlyDay)).toBe(emptyBulkSelection)
+  })
+
+  it('sets no anchor, so a shift-click straight after it ticks the one row it lands on', () => {
+    const afterDay = clickDay(emptyBulkSelection, dayOne)
+    expect([...click(afterDay, 'e', true, withReadOnlyC).selectedIds].sort()).toEqual(['a', 'b', 'e'])
+  })
+})
+
+describe('how a day heading is marked', () => {
+  it('reads mixed while only some of its rows are ticked', () => {
+    expect(groupSelectionMark(dayOne, withReadOnlyC, new Set(['a']))).toBe('some')
+  })
+
+  it('reads ticked once every row the app allows editing is ticked', () => {
+    expect(groupSelectionMark(dayOne, withReadOnlyC, new Set(['a', 'b']))).toBe('all')
+  })
+
+  it('reads mixed again once a later page adds more of that day', () => {
+    expect(groupSelectionMark(['a', 'b'], withReadOnlyC, new Set(['a', 'b']))).toBe('all')
+    expect(groupSelectionMark(['a', 'b', 'f'], withReadOnlyC, new Set(['a', 'b']))).toBe('some')
+  })
+
+  it('reads unticked while none of its rows are ticked', () => {
+    expect(groupSelectionMark(dayOne, withReadOnlyC, new Set(['d']))).toBe('none')
+  })
+})
+
+describe('the preview shown while the pointer rests on a day heading', () => {
+  it('shows the whole day taken, keeping the ticks made in other days', () => {
+    const ticked = click(click(emptyBulkSelection, 'a', false, withReadOnlyC), 'd', false, withReadOnlyC)
+    const state = hoverDay(ticked, dayOne)
+    expect(markOf(state, 'a')).toBe('selected')
+    expect(markOf(state, 'b')).toBe('pending')
+    expect(markOf(state, 'c')).toBe('none')
+    expect(markOf(state, 'd')).toBe('selected')
+  })
+
+  it('shows a fully ticked day dropped, keeping the ticks made in other days', () => {
+    const ticked = click(clickDay(emptyBulkSelection, dayOne), 'd', false, withReadOnlyC)
+    const state = hoverDay(ticked, dayOne)
+    expect(markOf(state, 'a')).toBe('none')
+    expect(markOf(state, 'b')).toBe('none')
+    expect(markOf(state, 'd')).toBe('selected')
+  })
+
+  it('replaces a range the pointer left pending', () => {
+    const pendingRange = hoverRow(click(emptyBulkSelection, 'b', false, withReadOnlyC), 'e')
+    expect(markOf(pendingRange, 'd')).toBe('pending')
+
+    const state = hoverDay(pendingRange, dayTwo)
+    expect(markOf(state, 'b')).toBe('selected')
+    expect(markOf(state, 'c')).toBe('none')
+    expect(markOf(state, 'd')).toBe('pending')
+    expect(markOf(state, 'e')).toBe('pending')
+  })
+  it('drops the pending range outright, so moving off the heading leaves nothing lit', () => {
+    const pendingRange = hoverRow(click(emptyBulkSelection, 'b', false, withReadOnlyC), 'e')
+    const onHeading = hoverDay(pendingRange, dayTwo)
+    expect(onHeading.hoveredId).toBeNull()
+
+    // Leaving the tick for the heading's own label, which is still neither a row nor outside the list
+    const offHeading = hoverDay(onHeading, null)
+    expect(previewSelection(offHeading, withReadOnlyC)).toBeNull()
+    expect(markOf(offHeading, 'e')).toBe('none')
+  })
+
+  it('moves to the day the pointer moved to, even where both days show the same number of rows', () => {
+    const state = hoverDay(hoverDay(emptyBulkSelection, ['a', 'b']), ['d', 'e'])
+    expect(state.hoveredGroupIds).toEqual(['d', 'e'])
+  })
+
+  it('goes when the pointer moves onto a row, letting a pending range show instead', () => {
+    const onARow = hoverRow(hoverDay(click(emptyBulkSelection, 'b', false, withReadOnlyC), dayOne), 'e')
+    expect(onARow.hoveredGroupIds).toBeNull()
+    expect(markOf(onARow, 'e')).toBe('pending')
+  })
+
+  it('stays up when shift is released, which only takes the row preview', () => {
+    const afterShiftRelease = hoverRow(hoverDay(emptyBulkSelection, dayOne), null)
+    expect(afterShiftRelease.hoveredGroupIds).toEqual(dayOne)
+  })
+
+
+  it('goes once the day is ticked, so its rows read as ticked rather than as about to be dropped', () => {
+    const state = clickDay(hoverDay(emptyBulkSelection, dayOne), dayOne)
+    expect(previewSelection(state, withReadOnlyC)).toBeNull()
+    expect(markOf(state, 'a')).toBe('selected')
+    expect(markOf(state, 'b')).toBe('selected')
+  })
+
+  it('takes a pending range with it when a day is ticked', () => {
+    const pendingRange = hoverRow(click(emptyBulkSelection, 'b', false, withReadOnlyC), 'e')
+    const state = clickDay(pendingRange, dayTwo)
+    expect(state.hoveredId).toBeNull()
+    expect(markOf(state, 'c')).toBe('none')
+  })
+})
 
 describe('the details the panel sends', () => {
   it('leaves out a control the user did not touch', () => {

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -3,8 +3,11 @@
  * from, and the preview shown while the pointer moves with shift held
  */
 import { describe, expect, it } from 'vitest'
+import type { Category } from '@/api/categories'
 import {
   buildBulkEditFields,
+  doesChosenCategoryRecordTransferTarget,
+  getBulkMoveTargets,
   bulkSelectionReducer,
   emptyBulkSelection,
   hasBulkEditChoice,
@@ -192,12 +195,14 @@ describe('the details the panel sends', () => {
     expect(buildBulkEditFields(untouched({ clearsNote: true }))).toEqual({ notes: null })
   })
 
-  it('leaves the note alone when the box is empty and nothing asked to clear it', () => {
+  it('needs the clear box to take a note off, since an empty note box sends nothing', () => {
     expect(buildBulkEditFields(untouched({ note: '' }))).toEqual({})
+    expect(buildBulkEditFields(untouched({ note: '', clearsNote: true }))).toEqual({ notes: null })
   })
 
   it('sends a tracked transfer target as an account and a scope', () => {
     const fields = buildBulkEditFields(untouched({
+      categoryRecordsTransferTarget: true,
       transferTarget: { scope: 'tracked', accountId: 'acc_2' },
     }))
 
@@ -208,7 +213,10 @@ describe('the details the panel sends', () => {
   })
 
   it('sends money that left the tracked accounts with no account', () => {
-    const fields = buildBulkEditFields(untouched({ transferTarget: { scope: 'outside' } }))
+    const fields = buildBulkEditFields(untouched({
+      categoryRecordsTransferTarget: true,
+      transferTarget: { scope: 'outside' },
+    }))
 
     expect(fields).toEqual({
       counterparty_account_scope: 'outside',
@@ -223,6 +231,18 @@ describe('the details the panel sends', () => {
     expect(hasBulkEditChoice(choice)).toBe(false)
   })
 
+  it('drops a transfer target left behind by a category the user changed away from', () => {
+    const choice = untouched({
+      categoryId: 'cat_1',
+      categoryRecordsTransferTarget: false,
+      transferTarget: { scope: 'tracked', accountId: 'acc_2' },
+    })
+
+    // The control is off screen under this category, so sending it would refuse the whole batch
+    // over something the user cannot see to undo
+    expect(buildBulkEditFields(choice)).toEqual({ category_id: 'cat_1' })
+  })
+
   it('has something to apply once the transfer target is answered', () => {
     const choice = untouched({
       categoryId: 'cat_1',
@@ -231,6 +251,66 @@ describe('the details the panel sends', () => {
     })
 
     expect(hasBulkEditChoice(choice)).toBe(true)
+  })
+})
+
+describe('whether a chosen category records the other side of a transfer', () => {
+  const category = (overrides: Partial<Category>): Category => ({
+    id: 'cat_1',
+    name: 'Groceries',
+    kind: 'expense',
+    icon: null,
+    is_system: true,
+    owner_id: null,
+    group_id: null,
+    ...overrides,
+  } as Category)
+
+  it('says no while nothing is chosen', () => {
+    expect(doesChosenCategoryRecordTransferTarget(undefined)).toBe(false)
+  })
+
+  it('says no for an expense', () => {
+    expect(doesChosenCategoryRecordTransferTarget(category({}))).toBe(false)
+  })
+
+  it('says yes for a transfer', () => {
+    expect(doesChosenCategoryRecordTransferTarget(category({ kind: 'transfer', name: 'Transfer' }))).toBe(true)
+  })
+
+  it('says no for a balance adjustment, which corrects a balance rather than moving money', () => {
+    expect(
+      doesChosenCategoryRecordTransferTarget(category({ kind: 'transfer', name: 'Balance Adjustment' })),
+    ).toBe(false)
+  })
+
+  it('reads the name alone, so one the user made themselves counts the same', () => {
+    expect(
+      doesChosenCategoryRecordTransferTarget(
+        category({ kind: 'transfer', name: 'Balance Adjustment', is_system: false }),
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('the accounts a selection can move to', () => {
+  const accounts = [
+    { id: 'acc_1', currency: 'CAD' },
+    { id: 'acc_2', currency: 'CAD', is_archived: true },
+    { id: 'acc_3', currency: 'CAD', closed_at: '2026-03-01' },
+    { id: 'acc_4', currency: 'USD' },
+  ]
+
+  it('offers the open accounts in the currency the selection uses', () => {
+    expect(getBulkMoveTargets(accounts, ['CAD']).map((account) => account.id)).toEqual(['acc_1'])
+  })
+
+  it('offers nothing when the selection spans currencies', () => {
+    expect(getBulkMoveTargets(accounts, ['CAD', 'USD'])).toEqual([])
+  })
+
+  it('offers nothing before anything is selected', () => {
+    expect(getBulkMoveTargets(accounts, [])).toEqual([])
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -15,10 +15,13 @@ import {
   canApplyBulkEdit,
   countTransferEndEffects,
   emptyBulkSelection,
+  endsAfterDirectionClick,
+  endsAfterEndPick,
   getBulkEditBlockers,
   groupSelectionMark,
   hasBulkEditChoice,
   impliedDirection,
+  isRowSelectable,
   nextDirectionAfterEndChange,
   previewSelection,
   resolveTransferEnds,
@@ -31,6 +34,7 @@ import {
 } from '@/pages/transactions/components/bulk-edit/selection'
 import {
   chequingHalf,
+  chequingHalf2,
   groceries,
   groceriesCategory,
   oldImport,
@@ -42,10 +46,6 @@ import {
   unanswered,
   untouched,
 } from './bulkEditFixtures'
-
-// A second money-out transfer in Chequing recording Savings, alongside chequingHalf, for the
-// direction-implying cases below, which need more than one row already sitting in the same account
-const chequingHalf2 = { ...chequingHalf, id: 'chequing_half_2' }
 
 const rows: SelectableRow[] = [
   { id: 'a', isReadOnly: false },
@@ -796,15 +796,15 @@ describe('what a bulk edit may do to the rows it covers', () => {
     const chequing = { scope: 'tracked' as const, accountId: 'chequing', currency: 'CAD' }
     const outside = { scope: 'outside' as const }
 
-    it('implies money in once every selected row already sits in the account To is set to', () => {
+    it('implies money in once every transfer row already sits in the account To is set to', () => {
       expect(impliedDirection([chequingHalf, chequingHalf2], null, chequing, undefined)).toBe('credit')
     })
 
-    it('implies money out once every selected row already sits in the account From is set to', () => {
+    it('implies money out once every transfer row already sits in the account From is set to', () => {
       expect(impliedDirection([chequingHalf, chequingHalf2], chequing, null, undefined)).toBe('debit')
     })
 
-    it('implies nothing once the selected rows sit in more than one account', () => {
+    it('implies nothing once the transfer rows sit in more than one account', () => {
       expect(impliedDirection(pair, null, chequing, undefined)).toBeNull()
     })
 
@@ -812,14 +812,74 @@ describe('what a bulk edit may do to the rows it covers', () => {
       expect(impliedDirection([chequingHalf, chequingHalf2], chequing, chequing, undefined)).toBeNull()
     })
 
-    it('implies nothing from an outside end, and nothing at all with no rows selected', () => {
-      expect(impliedDirection([chequingHalf, chequingHalf2], null, outside, undefined)).toBeNull()
+    it('implies nothing while no row is selected, since there is no transfer row to read', () => {
       expect(impliedDirection([], null, chequing, undefined)).toBeNull()
     })
 
-    it('implies nothing while a selected row would not end up recording a far side, and money in once a chosen transfer category makes every row record one', () => {
-      expect(impliedDirection([chequingHalf, groceries], null, chequing, undefined)).toBeNull()
+    it('reads the transfer rows alone, ignoring a selected row that is not one of them', () => {
+      expect(impliedDirection([chequingHalf, groceries], null, chequing, undefined)).toBe('credit')
       expect(impliedDirection([chequingHalf, groceries], null, chequing, true)).toBe('credit')
+    })
+
+    it('implies money in once From is set to outside, whichever accounts the transfer rows sit in', () => {
+      expect(impliedDirection(pair, outside, null, undefined)).toBe('credit')
+    })
+
+    it('implies money out once To is set to outside the same way', () => {
+      expect(impliedDirection(pair, null, outside, undefined)).toBe('debit')
+    })
+
+    it('implies nothing once both ends are set to outside', () => {
+      expect(impliedDirection(pair, outside, outside, undefined)).toBeNull()
+    })
+
+    it('reads To = outside over a mixed selection with no category chosen, ignoring the row that is not a transfer', () => {
+      expect(impliedDirection([...pair, groceries], null, outside, undefined)).toBe('debit')
+    })
+  })
+
+  describe('keeping the ends legal after an end pick or a direction click', () => {
+    it('reverts the other end to null once the just-picked end and the other are both outside', () => {
+      const outside = { scope: 'outside' as const }
+      expect(endsAfterEndPick(outside, outside, 'to')).toEqual({ from: null, to: outside })
+    })
+
+    it('leaves the other end alone once it is not outside', () => {
+      const outside = { scope: 'outside' as const }
+      const cash = { scope: 'tracked' as const, accountId: 'cash', currency: 'CAD' }
+      expect(endsAfterEndPick(outside, cash, 'to')).toEqual({ from: outside, to: cash })
+    })
+
+    it('reverts whichever end the clicked direction would make an outside own side', () => {
+      const outside = { scope: 'outside' as const }
+      const cash = { scope: 'tracked' as const, accountId: 'cash', currency: 'CAD' }
+
+      expect(endsAfterDirectionClick('debit', outside, cash, [chequingHalf, chequingHalf2], undefined))
+        .toEqual({ from: null, to: cash })
+      expect(endsAfterDirectionClick('credit', cash, outside, [chequingHalf, chequingHalf2], undefined))
+        .toEqual({ from: cash, to: null })
+    })
+
+    it('keeps an outside end through Reverse while every transfer row reverses onto the other side', () => {
+      const outside = { scope: 'outside' as const }
+      expect(endsAfterDirectionClick('reverse', outside, null, [chequingHalf, chequingHalf2], undefined))
+        .toEqual({ from: outside, to: null })
+    })
+
+    it('reverts an outside end once a mixed-direction selection puts it on some row\'s own side', () => {
+      const outside = { scope: 'outside' as const }
+      expect(endsAfterDirectionClick('reverse', outside, null, pair, undefined)).toEqual({ from: null, to: null })
+      expect(endsAfterDirectionClick(null, outside, null, pair, undefined)).toEqual({ from: null, to: null })
+    })
+
+    it('keeps an outside end while leaving it as is over a selection that resolves it to the far side alone', () => {
+      const outside = { scope: 'outside' as const }
+      expect(endsAfterDirectionClick(null, outside, null, [savingsHalf], undefined)).toEqual({ from: outside, to: null })
+    })
+
+    it('reverts an outside end once the chosen category turns another row into a transfer resolving money out', () => {
+      const outside = { scope: 'outside' as const }
+      expect(endsAfterDirectionClick(null, outside, null, [savingsHalf, groceries], true)).toEqual({ from: null, to: null })
     })
   })
 
@@ -863,6 +923,13 @@ describe('what a bulk edit may do to the rows it covers', () => {
 
     it('counts a direction on its own as something to apply', () => {
       expect(hasBulkEditChoice(untouched({ direction: 'debit' }))).toBe(true)
+    })
+
+    it('sends transfer_direction rather than direction once the source is implied', () => {
+      expect(buildBulkEditFields(untouched({ direction: 'credit', directionIsImplied: true })))
+        .toEqual({ transfer_direction: 'credit' })
+      expect(buildBulkEditFields(untouched({ direction: 'credit', directionIsImplied: false })))
+        .toEqual({ direction: 'credit' })
     })
   })
 
@@ -1065,5 +1132,94 @@ describe('what empties the selection', () => {
     })
 
     expect(settled).toBe(state)
+  })
+})
+
+describe("a row's tick at the selection limit", () => {
+  it('is false for an unselected row once the limit is reached, true for one already selected', () => {
+    const selected = new Set(['x', 'y', 'z'])
+    expect(isRowSelectable('w', selected, false, 3)).toBe(false)
+    expect(isRowSelectable('x', selected, false, 3)).toBe(true)
+  })
+
+  it('is false for a read-only row whether or not the limit is reached', () => {
+    expect(isRowSelectable('w', new Set(['x', 'y', 'z']), true, 3)).toBe(false)
+    expect(isRowSelectable('w', new Set(['x', 'y']), true, 3)).toBe(false)
+  })
+
+  it('is true for an unselected row while the limit still has room', () => {
+    expect(isRowSelectable('w', new Set(['x', 'y']), false, 3)).toBe(true)
+  })
+})
+
+describe('the selection limit', () => {
+  const limitedRows: SelectableRow[] = [
+    { id: 'a', isReadOnly: false },
+    { id: 'b', isReadOnly: false },
+    { id: 'c', isReadOnly: false },
+    { id: 'd', isReadOnly: false },
+    { id: 'e', isReadOnly: false },
+  ]
+
+  /** Ticks a row through the reducer at a given limit, the way a plain click does */
+  function toggleAt(state: BulkSelectionState, id: string, limit: number, over = limitedRows) {
+    return bulkSelectionReducer(state, { type: 'toggle', id, rows: over }, limit)
+  }
+
+  it('selects rows up to the limit and refuses to add past it, freeing a slot once one is unticked', () => {
+    let state = toggleAt(emptyBulkSelection, 'a', 3)
+    state = toggleAt(state, 'b', 3)
+    state = toggleAt(state, 'c', 3)
+    state = toggleAt(state, 'd', 3)
+
+    expect([...state.selectedIds].sort()).toEqual(['a', 'b', 'c'])
+
+    state = toggleAt(state, 'b', 3)
+    state = toggleAt(state, 'd', 3)
+    expect([...state.selectedIds].sort()).toEqual(['a', 'c', 'd'])
+  })
+
+  it('joins a day up to the limit, reads it as part-filled, and drops just the part that joined', () => {
+    const withOneElsewhere: BulkSelectionState = { ...emptyBulkSelection, selectedIds: new Set(['elsewhere']) }
+    const day = ['a', 'b', 'c', 'd']
+
+    const joined = bulkSelectionReducer(
+      withOneElsewhere,
+      { type: 'toggleGroup', ids: day, rows: limitedRows },
+      3,
+    )
+    expect([...joined.selectedIds].sort()).toEqual(['a', 'b', 'elsewhere'])
+    expect(groupSelectionMark(day, limitedRows, joined.selectedIds, 3)).toBe('some')
+
+    const dropped = bulkSelectionReducer(joined, { type: 'toggleGroup', ids: day, rows: limitedRows }, 3)
+    expect([...dropped.selectedIds]).toEqual(['elsewhere'])
+  })
+
+  it('reads a day whose rows are all selected as all, whatever the limit', () => {
+    const allTicked = new Set(['a', 'b', 'c'])
+    expect(groupSelectionMark(['a', 'b', 'c'], limitedRows, allTicked, 3)).toBe('all')
+  })
+
+  it('reads a day with none of its rows selected as unselectable once the limit is reached', () => {
+    const atLimit = new Set(['x', 'y', 'z'])
+    expect(groupSelectionMark(['a', 'b'], limitedRows, atLimit, 3)).toBe('unselectable')
+  })
+
+  it('takes a shift-click range in list order up to the limit', () => {
+    let state = toggleAt(emptyBulkSelection, 'a', 3)
+    state = bulkSelectionReducer(state, { type: 'extend', id: 'e', rows: limitedRows }, 3)
+
+    expect([...state.selectedIds].sort()).toEqual(['a', 'b', 'c'])
+  })
+
+  it('previews pending only on the rows a hovered day has room for', () => {
+    const state: BulkSelectionState = {
+      ...emptyBulkSelection,
+      selectedIds: new Set(['elsewhere']),
+      hoveredGroupIds: ['a', 'b', 'c', 'd'],
+    }
+    const preview = previewSelection(state, limitedRows, 3)
+
+    expect(preview && [...preview].sort()).toEqual(['a', 'b', 'elsewhere'])
   })
 })

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -10,6 +10,7 @@ import {
   hasBulkEditChoice,
   previewSelection,
   rowSelectionMark,
+  type BulkEditChoice,
   type BulkSelectionState,
   type SelectableRow,
 } from '@/pages/transactions/components/bulk-edit/selection'
@@ -137,28 +138,99 @@ describe('the preview shown while shift is held', () => {
   })
 })
 
-describe('the fields the bar sends', () => {
-  it('leaves out a control the user did not touch', () => {
-    const fields = buildBulkEditFields({ categoryId: 'cat_1', merchantId: '', tagIds: [] })
+/** A panel with every control untouched, so each test states only the one it fills in */
+function untouched(overrides: Partial<BulkEditChoice> = {}): BulkEditChoice {
+  return {
+    categoryId: '',
+    merchantId: '',
+    tagIds: [],
+    accountId: '',
+    date: '',
+    note: '',
+    clearsNote: false,
+    transferTarget: null,
+    categoryRecordsTransferTarget: false,
+    ...overrides,
+  }
+}
 
-    expect(fields).toEqual({ category_id: 'cat_1' })
+describe('the details the panel sends', () => {
+  it('leaves out a control the user did not touch', () => {
+    expect(buildBulkEditFields(untouched({ categoryId: 'cat_1' }))).toEqual({ category_id: 'cat_1' })
   })
 
   it('sends every control the user did fill in', () => {
-    const fields = buildBulkEditFields({ categoryId: 'cat_1', merchantId: 'mer_1', tagIds: ['tag_1'] })
+    const fields = buildBulkEditFields(untouched({
+      categoryId: 'cat_1',
+      merchantId: 'mer_1',
+      tagIds: ['tag_1'],
+      accountId: 'acc_1',
+      date: '2026-08-14',
+      note: 'Corrected',
+    }))
 
-    expect(fields).toEqual({ category_id: 'cat_1', merchant_id: 'mer_1', add_tag_ids: ['tag_1'] })
+    expect(fields).toEqual({
+      category_id: 'cat_1',
+      merchant_id: 'mer_1',
+      add_tag_ids: ['tag_1'],
+      account_id: 'acc_1',
+      dt: '2026-08-14',
+      notes: 'Corrected',
+    })
   })
 
   it('sends nothing at all when every control is untouched', () => {
-    const choice = { categoryId: '', merchantId: '', tagIds: [] }
-
-    expect(buildBulkEditFields(choice)).toEqual({})
-    expect(hasBulkEditChoice(choice)).toBe(false)
+    expect(buildBulkEditFields(untouched())).toEqual({})
+    expect(hasBulkEditChoice(untouched())).toBe(false)
   })
 
   it('counts one filled control as something to apply', () => {
-    expect(hasBulkEditChoice({ categoryId: '', merchantId: '', tagIds: ['tag_1'] })).toBe(true)
+    expect(hasBulkEditChoice(untouched({ tagIds: ['tag_1'] }))).toBe(true)
+  })
+
+  it('clears a note with null rather than an empty string', () => {
+    expect(buildBulkEditFields(untouched({ clearsNote: true }))).toEqual({ notes: null })
+  })
+
+  it('leaves the note alone when the box is empty and nothing asked to clear it', () => {
+    expect(buildBulkEditFields(untouched({ note: '' }))).toEqual({})
+  })
+
+  it('sends a tracked transfer target as an account and a scope', () => {
+    const fields = buildBulkEditFields(untouched({
+      transferTarget: { scope: 'tracked', accountId: 'acc_2' },
+    }))
+
+    expect(fields).toEqual({
+      counterparty_account_scope: 'tracked',
+      counterparty_account_id: 'acc_2',
+    })
+  })
+
+  it('sends money that left the tracked accounts with no account', () => {
+    const fields = buildBulkEditFields(untouched({ transferTarget: { scope: 'outside' } }))
+
+    expect(fields).toEqual({
+      counterparty_account_scope: 'outside',
+      counterparty_account_id: null,
+    })
+  })
+
+  it('has nothing to apply while a transfer category has no transfer target', () => {
+    const choice = untouched({ categoryId: 'cat_1', categoryRecordsTransferTarget: true })
+
+    expect(buildBulkEditFields(choice)).toEqual({ category_id: 'cat_1' })
+    expect(hasBulkEditChoice(choice)).toBe(false)
+  })
+
+  it('has something to apply once the transfer target is answered', () => {
+    const choice = untouched({
+      categoryId: 'cat_1',
+      categoryRecordsTransferTarget: true,
+      transferTarget: { scope: 'outside' },
+    })
+
+    expect(hasBulkEditChoice(choice)).toBe(true)
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -4,12 +4,16 @@
  */
 import { describe, expect, it } from 'vitest'
 import type { Category } from '@/api/categories'
+import { MAX_BULK_EDIT_TRANSACTIONS } from '@/pages/transactions/components/bulk-edit/constants'
 import {
   buildBulkEditFields,
   doesChosenCategoryRecordTransferTarget,
   getBulkMoveTargets,
   bulkSelectionReducer,
+  canApplyBulkEdit,
+  doEveryResultingCategoryRecordTransferTarget,
   emptyBulkSelection,
+  getBulkEditBlockers,
   groupSelectionMark,
   hasBulkEditChoice,
   previewSelection,
@@ -17,6 +21,7 @@ import {
   type BulkEditChoice,
   type BulkSelectionState,
   type SelectableRow,
+  type SelectedTransactionFacts,
 } from '@/pages/transactions/components/bulk-edit/selection'
 
 const rows: SelectableRow[] = [
@@ -153,7 +158,7 @@ function untouched(overrides: Partial<BulkEditChoice> = {}): BulkEditChoice {
     note: '',
     clearsNote: false,
     transferTarget: null,
-    categoryRecordsTransferTarget: false,
+    resultingCategoriesRecordTransferTarget: false,
     ...overrides,
   }
 }
@@ -346,7 +351,7 @@ describe('the details the panel sends', () => {
 
   it('sends a tracked transfer target as an account and a scope', () => {
     const fields = buildBulkEditFields(untouched({
-      categoryRecordsTransferTarget: true,
+      resultingCategoriesRecordTransferTarget: true,
       transferTarget: { scope: 'tracked', accountId: 'acc_2' },
     }))
 
@@ -358,7 +363,7 @@ describe('the details the panel sends', () => {
 
   it('sends money that left the tracked accounts with no account', () => {
     const fields = buildBulkEditFields(untouched({
-      categoryRecordsTransferTarget: true,
+      resultingCategoriesRecordTransferTarget: true,
       transferTarget: { scope: 'outside' },
     }))
 
@@ -368,17 +373,17 @@ describe('the details the panel sends', () => {
     })
   })
 
-  it('has nothing to apply while a transfer category has no transfer target', () => {
-    const choice = untouched({ categoryId: 'cat_1', categoryRecordsTransferTarget: true })
+  it('counts a category on its own as something to apply, whatever it is', () => {
+    const choice = untouched({ categoryId: 'cat_1', resultingCategoriesRecordTransferTarget: true })
 
     expect(buildBulkEditFields(choice)).toEqual({ category_id: 'cat_1' })
-    expect(hasBulkEditChoice(choice)).toBe(false)
+    expect(hasBulkEditChoice(choice)).toBe(true)
   })
 
   it('drops a transfer target left behind by a category the user changed away from', () => {
     const choice = untouched({
       categoryId: 'cat_1',
-      categoryRecordsTransferTarget: false,
+      resultingCategoriesRecordTransferTarget: false,
       transferTarget: { scope: 'tracked', accountId: 'acc_2' },
     })
 
@@ -390,11 +395,214 @@ describe('the details the panel sends', () => {
   it('has something to apply once the transfer target is answered', () => {
     const choice = untouched({
       categoryId: 'cat_1',
-      categoryRecordsTransferTarget: true,
+      resultingCategoriesRecordTransferTarget: true,
       transferTarget: { scope: 'outside' },
     })
 
     expect(hasBulkEditChoice(choice)).toBe(true)
+  })
+})
+
+describe('what a bulk edit may do to the rows it covers', () => {
+  const transferCategory = {
+    id: 'cat_t', name: 'Transfer', kind: 'transfer', icon: null,
+    is_system: true, owner_id: null, group_id: null,
+  } as Category
+
+  const groceries: SelectedTransactionFacts = {
+    id: 'a', accountId: 'chequing', hasMerchant: true,
+    recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null,
+  }
+  const oldImport: SelectedTransactionFacts = {
+    id: 'b', accountId: 'chequing', hasMerchant: false,
+    recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null,
+  }
+  const toSavings: SelectedTransactionFacts = {
+    id: 'c', accountId: 'chequing', hasMerchant: true,
+    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings',
+  }
+  const toOutside: SelectedTransactionFacts = {
+    id: 'd', accountId: 'chequing', hasMerchant: true,
+    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null,
+  }
+  const unanswered: SelectedTransactionFacts = {
+    id: 'e', accountId: 'chequing', hasMerchant: true,
+    recordsFarSide: true, hasFarSideRecorded: false, farSideAccountId: null,
+  }
+
+  /** An edit that sets a note and nothing else, which is the smallest thing a user can ask for */
+  const noteOnly = untouched({ note: 'Corrected' })
+  const noBlockers = { withoutMerchant: [], unansweredFarSide: [], ownAccountFarSide: [] }
+
+  describe('whether the far account can be set', () => {
+    it('sends it for a selection of transfers under no new category', () => {
+      const choice = untouched({
+        transferTarget: { scope: 'tracked', accountId: 'savings2' },
+        resultingCategoriesRecordTransferTarget:
+          doEveryResultingCategoryRecordTransferTarget(undefined, [toSavings]),
+      })
+
+      expect(buildBulkEditFields(choice)).toEqual({
+        counterparty_account_scope: 'tracked',
+        counterparty_account_id: 'savings2',
+      })
+    })
+
+    it('does not offer it where no selected row records one', () => {
+      expect(doEveryResultingCategoryRecordTransferTarget(undefined, [groceries])).toBe(false)
+    })
+
+    it('does not offer it where only some selected rows record one', () => {
+      expect(doEveryResultingCategoryRecordTransferTarget(undefined, [groceries, toSavings])).toBe(false)
+    })
+
+    it('offers it once the chosen category records one, whatever the rows were', () => {
+      expect(doEveryResultingCategoryRecordTransferTarget(transferCategory, [groceries, toSavings])).toBe(true)
+    })
+
+    it('does not offer it against an empty selection', () => {
+      expect(doEveryResultingCategoryRecordTransferTarget(undefined, [])).toBe(false)
+    })
+  })
+
+  describe('the rows the server would refuse', () => {
+    it('counts a row with no merchant', () => {
+      expect(getBulkEditBlockers([groceries, oldImport], noteOnly, undefined)).toEqual({
+        ...noBlockers,
+        withoutMerchant: ['b'],
+      })
+    })
+
+    it('stops counting a row with no merchant once the edit sets one', () => {
+      const choice = untouched({ merchantId: 'mer_1' })
+      expect(getBulkEditBlockers([groceries, oldImport], choice, undefined)).toEqual(noBlockers)
+    })
+
+    it('counts a transfer with no far side recorded', () => {
+      expect(getBulkEditBlockers([unanswered], noteOnly, undefined)).toEqual({
+        ...noBlockers,
+        unansweredFarSide: ['e'],
+      })
+    })
+
+    it('treats a transfer recorded as going outside the tracked accounts as answered', () => {
+      expect(getBulkEditBlockers([toOutside], noteOnly, undefined)).toEqual(noBlockers)
+    })
+
+    it('counts a row whose chosen far account is the one it sits in', () => {
+      const choice = untouched({
+        transferTarget: { scope: 'tracked', accountId: 'chequing' },
+        resultingCategoriesRecordTransferTarget: true,
+      })
+
+      expect(getBulkEditBlockers([toSavings], choice, undefined)).toEqual({
+        ...noBlockers,
+        ownAccountFarSide: ['c'],
+      })
+    })
+
+    it('counts a move into the account a row already records as its far side', () => {
+      const choice = untouched({ accountId: 'savings' })
+      expect(getBulkEditBlockers([toSavings], choice, undefined)).toEqual({
+        ...noBlockers,
+        ownAccountFarSide: ['c'],
+      })
+    })
+
+    it('counts a row recategorized into a transfer with no far side to fall back on', () => {
+      expect(getBulkEditBlockers([groceries], untouched({ categoryId: 'cat_t' }), true)).toEqual({
+        ...noBlockers,
+        unansweredFarSide: ['a'],
+      })
+    })
+
+    it('stops asking for a far side once the row is recategorized away from a transfer', () => {
+      const choice = untouched({ categoryId: 'cat_expense' })
+      expect(getBulkEditBlockers([unanswered], choice, false)).toEqual(noBlockers)
+    })
+
+    it('counts each kind of blocking row separately', () => {
+      expect(getBulkEditBlockers([oldImport, unanswered], noteOnly, undefined)).toEqual({
+        withoutMerchant: ['b'],
+        unansweredFarSide: ['e'],
+        ownAccountFarSide: [],
+      })
+    })
+  })
+
+  describe('whether the edit can be written', () => {
+    it('refuses while no control has been filled in', () => {
+      expect(canApplyBulkEdit([groceries], untouched({}), noBlockers)).toBe(false)
+    })
+
+    it('refuses against an empty selection', () => {
+      expect(canApplyBulkEdit([], noteOnly, noBlockers)).toBe(false)
+    })
+
+    it('refuses while the selection is over the cap', () => {
+      const overCap = Array.from({ length: MAX_BULK_EDIT_TRANSACTIONS + 1 }, (_, index) => ({
+        ...groceries,
+        id: `row_${index}`,
+      }))
+
+      expect(canApplyBulkEdit(overCap, noteOnly, noBlockers)).toBe(false)
+    })
+
+    it('allows a selection sitting exactly on the cap', () => {
+      const atCap = Array.from({ length: MAX_BULK_EDIT_TRANSACTIONS }, (_, index) => ({
+        ...groceries,
+        id: `row_${index}`,
+      }))
+
+      expect(canApplyBulkEdit(atCap, noteOnly, noBlockers)).toBe(true)
+    })
+
+    it('refuses while a transfer still has no far side recorded', () => {
+      const blockers = getBulkEditBlockers([unanswered], noteOnly, undefined)
+      expect(canApplyBulkEdit([unanswered], noteOnly, blockers)).toBe(false)
+    })
+
+    it('refuses while a row would end up recording the account it sits in', () => {
+      const choice = untouched({
+        transferTarget: { scope: 'tracked', accountId: 'chequing' },
+        resultingCategoriesRecordTransferTarget: true,
+      })
+      const blockers = getBulkEditBlockers([toSavings], choice, undefined)
+
+      expect(canApplyBulkEdit([toSavings], choice, blockers)).toBe(false)
+    })
+
+    it('writes a note across a selection of transfers without touching their far side', () => {
+      const choice = untouched({
+        note: 'Reconciled',
+        resultingCategoriesRecordTransferTarget:
+          doEveryResultingCategoryRecordTransferTarget(undefined, [toSavings]),
+      })
+      const blockers = getBulkEditBlockers([toSavings], choice, undefined)
+
+      expect(buildBulkEditFields(choice)).toEqual({ notes: 'Reconciled' })
+      expect(canApplyBulkEdit([toSavings], choice, blockers)).toBe(true)
+    })
+
+    it('refuses a recategorization into a transfer that leaves the far side unanswered', () => {
+      const choice = untouched({ categoryId: 'cat_t', resultingCategoriesRecordTransferTarget: true })
+      const blockers = getBulkEditBlockers([groceries], choice, true)
+
+      // The category on its own is something to apply, so the refusal is the unanswered far side
+      // rather than an edit that fills in nothing
+      expect(hasBulkEditChoice(choice)).toBe(true)
+      expect(blockers.unansweredFarSide).toEqual(['a'])
+      expect(canApplyBulkEdit([groceries], choice, blockers)).toBe(false)
+    })
+
+    it('refuses while a blocking row stands, and allows it once a control settles that row', () => {
+      const blocked = getBulkEditBlockers([oldImport], noteOnly, undefined)
+      expect(canApplyBulkEdit([oldImport], noteOnly, blocked)).toBe(false)
+
+      const withMerchant = untouched({ merchantId: 'mer_1' })
+      const settled = getBulkEditBlockers([oldImport], withMerchant, undefined)
+      expect(canApplyBulkEdit([oldImport], withMerchant, settled)).toBe(true)
+    })
   })
 })
 

--- a/frontend/tests/pages/transactions/components/bulkSelection.test.ts
+++ b/frontend/tests/pages/transactions/components/bulkSelection.test.ts
@@ -21,11 +21,22 @@ import {
   previewSelection,
   resolveTransferEnds,
   rowSelectionMark,
-  type BulkEditChoice,
   type BulkSelectionState,
   type SelectableRow,
-  type SelectedTransactionFacts,
 } from '@/pages/transactions/components/bulk-edit/selection'
+import {
+  chequingHalf,
+  groceries,
+  groceriesCategory,
+  oldImport,
+  pair,
+  savingsHalf,
+  toOutside,
+  toSavings,
+  transferCategory,
+  unanswered,
+  untouched,
+} from './bulkEditFixtures'
 
 const rows: SelectableRow[] = [
   { id: 'a', isReadOnly: false },
@@ -149,24 +160,6 @@ describe('the preview shown while shift is held', () => {
     expect(previewSelection(state, rows)).toBeNull()
   })
 })
-
-/** A panel with every control untouched, so each test states only the one it fills in */
-function untouched(overrides: Partial<BulkEditChoice> = {}): BulkEditChoice {
-  return {
-    categoryId: '',
-    merchantId: '',
-    tagIds: [],
-    accountId: '',
-    date: '',
-    note: '',
-    clearsNote: false,
-    transferFrom: null,
-    transferTo: null,
-    direction: null,
-    endsAreOffered: false,
-    ...overrides,
-  }
-}
 
 // The two days a heading tick works over. Day one holds a read-only row, so a tick that took every
 // row rather than every editable one shows up in the result
@@ -422,49 +415,6 @@ describe('the details the panel sends', () => {
 })
 
 describe('what a bulk edit may do to the rows it covers', () => {
-  const transferCategory = {
-    id: 'cat_t', name: 'Transfer', kind: 'transfer', icon: null,
-    is_system: true, owner_id: null, group_id: null,
-  } as Category
-
-  const groceriesCategory = {
-    id: 'cat_g', name: 'Groceries', kind: 'expense', icon: null,
-    is_system: true, owner_id: null, group_id: null,
-  } as Category
-
-  const groceries: SelectedTransactionFacts = {
-    id: 'a', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
-  }
-  const oldImport: SelectedTransactionFacts = {
-    id: 'b', accountId: 'chequing', hasMerchant: false,
-    recordsFarSide: false, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
-  }
-  const toSavings: SelectedTransactionFacts = {
-    id: 'c', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'CAD', direction: 'debit',
-  }
-  const toOutside: SelectedTransactionFacts = {
-    id: 'd', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: null, currency: 'CAD', direction: 'debit',
-  }
-  const unanswered: SelectedTransactionFacts = {
-    id: 'e', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: true, hasFarSideRecorded: false, farSideAccountId: null, currency: 'CAD', direction: 'debit',
-  }
-
-  // The two halves a transfer pair makes: the money-out half sitting in Chequing and recording
-  // Savings, and the money-in half sitting in Savings and recording Chequing back
-  const chequingHalf: SelectedTransactionFacts = {
-    id: 'chequing_half', accountId: 'chequing', hasMerchant: true,
-    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'savings', currency: 'CAD', direction: 'debit',
-  }
-  const savingsHalf: SelectedTransactionFacts = {
-    id: 'savings_half', accountId: 'savings', hasMerchant: true,
-    recordsFarSide: true, hasFarSideRecorded: true, farSideAccountId: 'chequing', currency: 'CAD', direction: 'credit',
-  }
-  const pair = [chequingHalf, savingsHalf]
-
   /** An edit that sets a note and nothing else, which is the smallest thing a user can ask for */
   const noteOnly = untouched({ note: 'Corrected' })
   const noBlockers = {

--- a/frontend/tests/pages/transactions/components/transaction-modal/utils/fixtures.ts
+++ b/frontend/tests/pages/transactions/components/transaction-modal/utils/fixtures.ts
@@ -49,6 +49,7 @@ export function createAccount(overrides: Partial<AccountsOverview>): AccountsOve
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,

--- a/frontend/tests/pages/transactions/types/transactionList.test.ts
+++ b/frontend/tests/pages/transactions/types/transactionList.test.ts
@@ -24,6 +24,7 @@ function createAccount(overrides: Partial<AccountsOverview> = {}): AccountsOverv
     base_currency_current_balance: 0,
     current_balance_fx_status: { state: 'complete', missing_pairs: [] },
     credit_limit: null,
+    can_write: true,
     is_archived: false,
     closed_at: null,
     ...overrides,
@@ -37,6 +38,7 @@ describe('the account the transaction list is handed', () => {
       name: 'Everyday Chequing',
       currency: 'CAD',
       institution: null,
+      can_write: true,
       is_archived: false,
       closed_at: null,
     })
@@ -52,5 +54,10 @@ describe('the account the transaction list is handed', () => {
 
   it('carries the archived state through', () => {
     expect(toTransactionListAccount(createAccount({ is_archived: true })).is_archived).toBe(true)
+  })
+
+  it('preserves both write capability values', () => {
+    expect(toTransactionListAccount(createAccount({ can_write: true })).can_write).toBe(true)
+    expect(toTransactionListAccount(createAccount({ can_write: false })).can_write).toBe(false)
   })
 })

--- a/frontend/tests/pages/transactions/utils/filterOptions.test.ts
+++ b/frontend/tests/pages/transactions/utils/filterOptions.test.ts
@@ -30,6 +30,7 @@ function createAccount(overrides: Partial<TransactionListAccount>): TransactionL
     name: 'name' in overrides ? overrides.name : 'Account',
     currency: 'USD',
     institution: null,
+    can_write: true,
     is_archived: false,
     ...overrides,
   }

--- a/frontend/tests/pages/transactions/utils/rowEditability.test.ts
+++ b/frontend/tests/pages/transactions/utils/rowEditability.test.ts
@@ -9,8 +9,8 @@ import type { Transaction } from '@/api/transactions'
 import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
 import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEditability'
 
-const openAccount: TransactionListAccount = { id: 'chequing', is_archived: false }
-const archivedAccount: TransactionListAccount = { id: 'old_account', is_archived: true }
+const openAccount: TransactionListAccount = { id: 'chequing', is_archived: false, can_write: true }
+const archivedAccount: TransactionListAccount = { id: 'old_account', is_archived: true, can_write: true }
 const accountMap = new Map([[openAccount.id, openAccount], [archivedAccount.id, archivedAccount]])
 
 const groceriesCategory: Category = {
@@ -57,6 +57,36 @@ describe('getTransactionReadOnlyReason', () => {
   it('still marks an archived account row read-only for its own reason', () => {
     expect(getTransactionReadOnlyReason(transaction({ account_id: archivedAccount.id }), accountMap, categoryMap))
       .toBe('Archived · Read-only')
+  })
+
+  it('marks a read-only account row and an account with unknown capability as read-only', () => {
+    const readOnly = { ...openAccount, id: 'shared', can_write: false }
+    const unknown = { id: 'unknown' } as TransactionListAccount
+    const accounts = new Map([...accountMap, [readOnly.id, readOnly], [unknown.id, unknown]])
+
+    expect(getTransactionReadOnlyReason(transaction({ account_id: readOnly.id }), accounts, categoryMap))
+      .toBe('Read-only access')
+    expect(getTransactionReadOnlyReason(transaction({ account_id: unknown.id }), accounts, categoryMap))
+      .toBe('Read-only access')
+  })
+
+  it('keeps writable closed history editable', () => {
+    const closed = { ...openAccount, id: 'closed', closed_at: '2026-03-01T14:00:00Z' }
+    expect(getTransactionReadOnlyReason(
+      transaction({ account_id: closed.id }),
+      new Map([[closed.id, closed]]),
+      categoryMap,
+    )).toBeUndefined()
+  })
+
+  it('uses the fixed account capability over a duplicate general account entry', () => {
+    const fixed = { ...openAccount, can_write: false }
+    expect(getTransactionReadOnlyReason(transaction(), accountMap, categoryMap, fixed)).toBe('Read-only access')
+  })
+
+  it('fails closed when the fixed account omits capability despite a writable general entry', () => {
+    const fixed = { id: 'chequing' } as TransactionListAccount
+    expect(getTransactionReadOnlyReason(transaction(), accountMap, categoryMap, fixed)).toBe('Read-only access')
   })
 
   it('gives the archived reason over the category reason when a row trips both', () => {

--- a/frontend/tests/pages/transactions/utils/rowEditability.test.ts
+++ b/frontend/tests/pages/transactions/utils/rowEditability.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests why a transaction row is marked read-only: an archived account's row, and now a row whose
+ * category the current user cannot open, which the bulk edit rules and the row's own tick have to
+ * agree on
+ */
+import { describe, expect, it } from 'vitest'
+import type { Category } from '@/api/categories'
+import type { Transaction } from '@/api/transactions'
+import type { TransactionListAccount } from '@/pages/transactions/types/transactionList'
+import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEditability'
+
+const openAccount: TransactionListAccount = { id: 'chequing', is_archived: false }
+const archivedAccount: TransactionListAccount = { id: 'old_account', is_archived: true }
+const accountMap = new Map([[openAccount.id, openAccount], [archivedAccount.id, archivedAccount]])
+
+const groceriesCategory: Category = {
+  id: 'cat_g', name: 'Groceries', kind: 'expense', icon: null,
+  is_system: true, owner_id: null, group_id: null,
+} as Category
+const categoryMap = new Map([[groceriesCategory.id, groceriesCategory]])
+
+function transaction(overrides: Partial<Transaction> = {}): Transaction {
+  return {
+    id: 'txn_1',
+    created_by_user_id: 'user_1',
+    account_id: openAccount.id,
+    dt: '2026-08-23',
+    merchant_id: 'mer_1',
+    merchant_name: 'Merchant',
+    category_id: groceriesCategory.id,
+    amount: -1000,
+    account_amount: null,
+    base_currency_amount: null,
+    currency: 'CAD',
+    fx_rate: null,
+    notes: null,
+    counterparty_account_id: null,
+    counterparty_account_scope: null,
+    created_at: '2026-08-23T00:00:00Z',
+    updated_at: '2026-08-23T00:00:00Z',
+    tag_ids: [],
+    tags: [],
+    ...overrides,
+  }
+}
+
+describe('getTransactionReadOnlyReason', () => {
+  it('allows a row whose category is in the map', () => {
+    expect(getTransactionReadOnlyReason(transaction(), accountMap, categoryMap)).toBeUndefined()
+  })
+
+  it('marks a row read-only whose category id is not in the map', () => {
+    expect(getTransactionReadOnlyReason(transaction({ category_id: 'cat_gone' }), accountMap, categoryMap))
+      .toBe('Uses a category you cannot open')
+  })
+
+  it('still marks an archived account row read-only for its own reason', () => {
+    expect(getTransactionReadOnlyReason(transaction({ account_id: archivedAccount.id }), accountMap, categoryMap))
+      .toBe('Archived · Read-only')
+  })
+
+  it('gives the archived reason over the category reason when a row trips both', () => {
+    expect(getTransactionReadOnlyReason(
+      transaction({ category_id: 'cat_gone' }),
+      accountMap,
+      categoryMap,
+      archivedAccount,
+    )).toBe('Archived · Read-only')
+  })
+})

--- a/frontend/tests/pages/transactions/utils/transactionDateGroups.test.ts
+++ b/frontend/tests/pages/transactions/utils/transactionDateGroups.test.ts
@@ -72,7 +72,7 @@ describe('transaction date-group helpers', () => {
       createTransaction({ base_currency_amount: 1200, account_amount: 1000 }),
       createTransaction({ base_currency_amount: -450, account_amount: -400 }),
     ]
-    const fixedAccount: TransactionListAccount = { id: 'account', name: 'Checking' }
+    const fixedAccount: TransactionListAccount = { id: 'account', name: 'Checking', can_write: true }
 
     expect(getTransactionDateGroupTotal(transactions)).toBe(750)
     expect(getTransactionDateGroupTotal(transactions, fixedAccount)).toBe(600)


### PR DESCRIPTION
Added bulk editing for transactions selected individually, by range, or by day. The edit modal previews and confirms shared transaction details, including transfer ends and direction. The server also checks access and transfer compatibility, applies the selection as one change, and locks balance updates when edits overlap.

As requested in #93
