### PR TITLE
Improve frontend contrast and control feedback

### DIFF
--- a/frontend/src/components/passkeys/OverflowMenu.tsx
+++ b/frontend/src/components/passkeys/OverflowMenu.tsx
@@ -123,7 +123,7 @@ export function OverflowMenu({ label, items, disabled = false }: OverflowMenuPro
                     closeMenu();
                     item.onSelect();
                   }}
-                  className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors duration-150 hover:bg-[color:var(--app-surface-soft)]"
+                  className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm transition-colors duration-150 hover:bg-[color:var(--app-hover-soft)]"
                   style={{ color: item.danger ? 'var(--app-negative)' : 'var(--app-text)' }}
                 >
                   {item.icon}

--- a/frontend/src/components/time-range/Selector.tsx
+++ b/frontend/src/components/time-range/Selector.tsx
@@ -252,9 +252,9 @@ function MobileTimeRangeSelector<T extends string>({
                     type="button"
                     role="option"
                     aria-selected={active}
-                    className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition-colors duration-150 hover:bg-[var(--app-surface-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-accent-soft)] motion-reduce:transition-none"
+                    className="flex w-full items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition-colors duration-150 hover:bg-[var(--app-hover-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-accent-soft)] motion-reduce:transition-none"
                     style={{
-                      background: active ? 'var(--app-accent-soft)' : 'transparent',
+                      background: active ? 'var(--app-accent-soft)' : undefined,
                       color: active ? 'var(--app-accent)' : 'var(--app-text)',
                     }}
                     onClick={() => handleSelect(option.value)}

--- a/frontend/src/components/transactions/Row.tsx
+++ b/frontend/src/components/transactions/Row.tsx
@@ -390,7 +390,7 @@ export default function TransactionRow({
         {formattedAmount}
       </span>
 
-      <span className="grid grid-cols-[2rem_minmax(0,1fr)_max-content] items-start gap-x-2.5 gap-y-1 min-[750px]:hidden">
+      <span className="grid grid-cols-[2.125rem_minmax(0,1fr)_max-content] items-start gap-x-2.5 gap-y-1 min-[750px]:hidden">
         <span className="row-span-3 pt-0.5 text-[1.35rem] leading-none" aria-hidden>
           {categoryIcon}
         </span>
@@ -454,7 +454,7 @@ export default function TransactionRow({
         )}
       </span>
 
-      <span className="hidden grid-cols-[2.5rem_minmax(0,1fr)_max-content] items-start gap-x-3 gap-y-1.5 min-[750px]:grid min-[1300px]:hidden">
+      <span className="hidden grid-cols-[2.75rem_minmax(0,1fr)_max-content] items-start gap-x-3 gap-y-1.5 min-[750px]:grid min-[1300px]:hidden">
         <span className="row-span-3 text-2xl leading-none" aria-hidden>
           {categoryIcon}
         </span>

--- a/frontend/src/components/two-factor/TotpEnrollment.tsx
+++ b/frontend/src/components/two-factor/TotpEnrollment.tsx
@@ -250,7 +250,7 @@ export function TotpEnrollment({ onComplete, onSkip, onSwitchToPasskey, initialS
                 type="button"
                 onClick={copyKey}
                 aria-label={keyCopied ? 'Key copied' : 'Copy key'}
-                className="mx-auto flex items-center gap-2 rounded-md px-2 py-1 font-mono text-xs transition-colors duration-200 hover:bg-[color:var(--app-surface-soft)]"
+                className="mx-auto flex items-center gap-2 rounded-md px-2 py-1 font-mono text-xs transition-colors duration-200 hover:bg-[color:var(--app-hover-soft)]"
                 style={{ color: 'var(--app-text-muted)' }}
               >
                 <span>{setupData.secret}</span>

--- a/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/CreateModal.tsx
@@ -273,7 +273,6 @@ export default function BudgetCreateModal({
             namePlaceholder="e.g. Groceries"
             currencyReadOnly={false}
             currencyState="ready"
-            currencyTooltip
             limitDisabled={false}
             fieldsLocked={false}
             showError={showError}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/EditModal.tsx
@@ -365,7 +365,6 @@ export default function BudgetEditModal({
             limitPlaceholder={latestPeriod ? undefined : 'No period yet'}
             currencyReadOnly
             currencyState={currencyState}
-            currencyTooltip={false}
             limitDisabled={!latestPeriod}
             fieldsLocked={fieldsLocked}
             showError={showError}

--- a/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
+++ b/frontend/src/pages/budgets/components/budget-editor-modal/sections/ScopeSection.tsx
@@ -22,7 +22,6 @@ interface BudgetEditorModalScopeSectionProps {
   // with no period yet
   limitPlaceholder?: string
   currencyReadOnly: boolean
-  currencyTooltip: boolean
   limitDisabled: boolean
 
   // Stands the limit down unless the currency table is in hand, since its decimal places are the only way
@@ -46,7 +45,6 @@ export default function BudgetEditorModalScopeSection({
   namePlaceholder,
   limitPlaceholder,
   currencyReadOnly,
-  currencyTooltip,
   limitDisabled,
   currencyState,
   fieldsLocked,
@@ -98,14 +96,12 @@ export default function BudgetEditorModalScopeSection({
           <div>
             <BudgetEditorFieldLabelRow
               htmlFor={ids.currency}
-              label={currencyTooltip || isLimitLocked ? (
+              label={(
                 <span className="inline-flex items-center gap-2">
                   Currency
-                  {currencyTooltip && (
-                    <IconTooltip label="Budget currency limitation" level="important">
-                      Budgets currently track only accounts in the same currency
-                    </IconTooltip>
-                  )}
+                  <IconTooltip label="Budget display currency" modalFieldTabStop>
+                    This is the budget’s display currency.
+                  </IconTooltip>
                   {currencyState === 'loading' && (
                     <IconTooltip label="Loading currencies" modalFieldTabStop>
                       {CURRENCY_LIST_LOADING}
@@ -117,7 +113,7 @@ export default function BudgetEditorModalScopeSection({
                     </IconTooltip>
                   )}
                 </span>
-              ) : 'Currency'}
+              )}
               error={showError('currency')}
             />
             {currencyReadOnly ? (

--- a/frontend/src/pages/imports/components/FileUpload.tsx
+++ b/frontend/src/pages/imports/components/FileUpload.tsx
@@ -64,7 +64,7 @@ export function ImportUploadCard({
   // `aria-disabled:` ones, whose hover rule would land at the same specificity as the plain hover
   // above it and be settled by the order Tailwind happens to emit them in
   const unavailableClasses = blockReason?.isFailure ? 'cursor-not-allowed' : 'cursor-wait'
-  const availableClasses = 'hover:bg-[var(--app-surface-soft)]'
+  const availableClasses = 'hover:bg-[var(--app-hover-soft)]'
 
   return (
     <>

--- a/frontend/src/pages/imports/components/PreviewList.tsx
+++ b/frontend/src/pages/imports/components/PreviewList.tsx
@@ -18,7 +18,7 @@ export function ImportPreviewList({
   // clipping vertically cuts off the tag stack that opens above a row
   return (
     <div className="overflow-x-auto min-[1300px]:overflow-visible">
-      <div className="min-w-[58rem] min-[1300px]:grid min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content] min-[1300px]:gap-x-3">
+      <div className="min-w-[58rem] min-[1300px]:grid min-[1300px]:grid-cols-[2.75rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content] min-[1300px]:gap-x-3">
         {groups.map((group, groupIndex) => (
           <div
             key={`${group.dateLabel}-${groupIndex}`}

--- a/frontend/src/pages/insights/components/fund-flow-card/CategoryList.tsx
+++ b/frontend/src/pages/insights/components/fund-flow-card/CategoryList.tsx
@@ -54,7 +54,7 @@ export function FundFlowCategoryList({
       <div className="relative flex min-h-14 w-full items-center justify-between gap-4 px-3 py-2">
         <button
           type="button"
-          className="absolute inset-0 rounded-xl text-left transition-colors duration-150 hover:bg-[var(--app-surface-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-accent-soft)] motion-reduce:transition-none"
+          className="absolute inset-0 rounded-xl text-left transition-colors duration-150 hover:bg-[var(--app-hover-soft)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--app-accent-soft)] motion-reduce:transition-none"
           aria-expanded={open}
           aria-controls={listId}
           onClick={onToggle}
@@ -97,7 +97,7 @@ export function FundFlowCategoryList({
               {rows.length > 0 ? rows.map(({ entry: [name, amount], label, flipped }) => (
                 <div
                   key={`${label}-${name}-${amount}`}
-                  className="flex h-14 items-center justify-between gap-4 px-3 text-sm transition-colors duration-150 hover:bg-[var(--app-surface-soft)] motion-reduce:transition-none"
+                  className="flex h-14 items-center justify-between gap-4 px-3 text-sm transition-colors duration-150 hover:bg-[var(--app-hover-soft)] motion-reduce:transition-none"
                 >
                   <span className="min-w-0">
                     <span className="block truncate font-semibold">{name}</span>

--- a/frontend/src/pages/transactions/components/DateGroupList.tsx
+++ b/frontend/src/pages/transactions/components/DateGroupList.tsx
@@ -23,7 +23,7 @@ import { getTransactionReadOnlyReason } from '@/pages/transactions/utils/rowEdit
 // and disappear with the checkbox, and a row still animating one out against a list that has
 // already dropped the column has nowhere to put its content but a second line
 const LIST_COLUMNS =
-  'min-[1300px]:grid-cols-[2.5rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
+  'min-[1300px]:grid-cols-[2.75rem_fit-content(24rem)_fit-content(18rem)_minmax(0,1fr)_max-content_max-content]'
 
 /**
  * What a day heading needs while the list is in selection mode

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -780,6 +780,7 @@
   @media (prefers-reduced-motion: reduce) {
     .app-dropdown-glass,
     .app-dropdown-row,
+    .app-dropdown-glass-open .app-dropdown-bodywrap,
     .app-dropdown-bodywrap {
       transition-duration: 0s;
     }

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -32,6 +32,8 @@
     --app-negative: #9A3C34;
     --app-negative-soft: #9a3c341a;
     --app-negative-border: #9a3c344d;
+    /* Filled destructive buttons need a darker red than negative text to keep white labels readable */
+    --app-danger-fill: #9A3C34;
     --app-button-primary-bg: #7F541C;
     --app-button-primary-bg-hover: #8F6124;
     --app-button-primary-text: #FFF8EC;
@@ -116,9 +118,10 @@
     --app-warning: #F5D547;
     --app-warning-soft: #f5d5472e;
     --app-warning-text: #F8E28A;
-    --app-negative: #B8584E;
+    --app-negative: #D8776A;
     --app-negative-soft: #b8584e1f;
     --app-negative-border: #b8584e59;
+    --app-danger-fill: #B8584E;
     --app-button-primary-bg: #C9A96A;
     --app-button-primary-bg-hover: #D5B978;
     --app-button-primary-text: #100F0E;
@@ -1408,13 +1411,13 @@
     border-radius: 20px;
     font-size: 0.9375rem;
     color: white;
-    border: 1px solid color-mix(in srgb, var(--app-negative) 65%, var(--app-border-strong));
-    background: color-mix(in srgb, var(--app-negative) 82%, transparent);
+    border: 1px solid color-mix(in srgb, var(--app-danger-fill) 65%, var(--app-border-strong));
+    background: color-mix(in srgb, var(--app-danger-fill) 82%, transparent);
   }
 
   .app-danger-button:hover {
-    background: color-mix(in srgb, var(--app-negative) 90%, transparent);
-    border-color: color-mix(in srgb, var(--app-negative) 72%, var(--app-border-strong));
+    background: color-mix(in srgb, var(--app-danger-fill) 90%, transparent);
+    border-color: color-mix(in srgb, var(--app-danger-fill) 72%, var(--app-border-strong));
   }
 
   .app-danger-button:active {

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -6,7 +6,8 @@
     /* Light — warm parchment */
     --app-bg: #F2EDE4;
     --app-surface-soft: #FBF8F0;
-    /* A row's own hover, pending mark and focus background. Kept apart from
+    /* Shared hover feedback for rows and controls, plus transaction pending and focus backgrounds.
+       Kept apart from
        .app-dropdown-row-highlighted, which mixes the same proportion in both themes rather than
        taking this token, since pointing that rule at this token would carry the flat light value
        below into the dropdown and lose the mix it depends on there */
@@ -583,7 +584,7 @@
   }
 
   .app-calendar-day:hover {
-    background: var(--app-surface-soft);
+    background: var(--app-hover-soft);
   }
 
   .app-calendar-day[data-outside] {
@@ -1568,7 +1569,7 @@
 
   .app-segmented-option:hover {
     color: var(--app-text);
-    background: var(--app-surface-soft);
+    background: var(--app-hover-soft);
   }
 
   .app-segmented-option:focus-visible {
@@ -1758,7 +1759,7 @@
 
   .app-icon-button:hover {
     color: var(--app-text);
-    background: var(--app-surface-soft);
+    background: var(--app-hover-soft);
     border-color: var(--app-border);
   }
 

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -629,6 +629,9 @@
      box underneath. Its own clipping is what hides the list while closed, so the list can grow out of
      the head instead of appearing beside it */
   .app-dropdown-glass {
+    /* Sticky group headings share the box's opaque background in every validation state */
+    --app-dropdown-bg: var(--app-input-bg);
+
     display: flex;
     flex-direction: column;
 
@@ -640,7 +643,7 @@
     min-width: 0;
     border: 1px solid var(--app-input-border);
     border-radius: var(--app-dropdown-radius);
-    background: var(--app-input-bg);
+    background: var(--app-dropdown-bg);
     color: var(--app-text);
 
     transition: border-color 0.2s, background 0.2s, box-shadow 0.2s;
@@ -680,7 +683,7 @@
      instead, which cost nothing to draw and nothing to redraw while the box opens */
   .app-dropdown-glass.app-dropdown-glass-floating {
     border-color: var(--app-border-strong);
-    background: var(--app-input-bg);
+    background: var(--app-dropdown-bg);
     box-shadow: var(--app-shadow-soft);
   }
 
@@ -688,7 +691,7 @@
      The message above it points at this field, and a plain one is the wrong thing to point at */
   .app-dropdown-glass.app-dropdown-glass-disabled {
     border-color: var(--app-input-border);
-    background: var(--app-input-bg);
+    background: var(--app-dropdown-bg);
     box-shadow: none;
     opacity: var(--app-dropdown-disabled-opacity-control);
   }
@@ -696,8 +699,9 @@
   /* Mixed from the opaque negative rather than its soft variant, which carries alpha of its own. The
      two land on nearly the same colour over a form, and this one stays solid over anything */
   .app-dropdown-glass.app-dropdown-glass-error {
+    --app-dropdown-bg: color-mix(in srgb, var(--app-negative) 10%, var(--app-input-bg));
+
     border-color: var(--app-negative-border);
-    background: color-mix(in srgb, var(--app-negative) 10%, var(--app-input-bg));
   }
 
   .app-dropdown-glass.app-dropdown-glass-error:focus-within {
@@ -867,7 +871,7 @@
     top: 0;
     z-index: 1;
     padding: 6px var(--app-dropdown-row-padding-x);
-    background: var(--app-input-bg);
+    background: var(--app-dropdown-bg);
     border-bottom: 1px solid var(--app-border);
     color: var(--app-text-subtle);
     font-size: 0.75rem;


### PR DESCRIPTION
Improved dark-theme hover feedback and negative text contrast, and increased the spacing between transaction icons and text. Dropdowns now honour reduced-motion preferences and keep group headings consistent with their error background. The legacy currency warning on the create budget modal is now removed as well.
