### PR TITLE
chore: check frontend test types in CI

### DIFF
--- a/.github/workflows/_frontend-build.yml
+++ b/.github/workflows/_frontend-build.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Type-check application, build configuration and tests
+        run: npx tsc -b
+
       # Mirror the production bundle the Docker image builds so the test build catches the same failures
       - name: Build production bundle
         run: npm run build:app


### PR DESCRIPTION
Added a full TypeScript check to the frontend CI build. Type errors in test files now fail the build before the production bundle is generated.
