### PR TITLE
Improve field labels and hover feedback

### DIFF
--- a/frontend/src/pages/accounts/components/create-account-modal/utils/options.ts
+++ b/frontend/src/pages/accounts/components/create-account-modal/utils/options.ts
@@ -2,6 +2,7 @@ import type { Institution } from '@/api/institutions'
 import type { Currency } from '@/api/currency'
 import type { TaxAdvantagedCategory } from '@/api/tax-advantaged-categories'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
+import { formatCurrencyLabel } from '@/utils/formatCurrency'
 
 /**
  * Builds the currency selector labels without leaking formatting details into the modal component
@@ -9,7 +10,7 @@ import type { DropdownOption } from '@/components/dropdown/Dropdown'
 export function buildCreateAccountCurrencyOptions(currencies: Currency[]): DropdownOption[] {
   return currencies.map((currency) => ({
     value: currency.id,
-    label: `${currency.id} — ${currency.name} (${currency.symbol})`,
+    label: formatCurrencyLabel(currency),
   }))
 }
 

--- a/frontend/src/pages/accounts/detail/components/identity/Card.tsx
+++ b/frontend/src/pages/accounts/detail/components/identity/Card.tsx
@@ -39,7 +39,7 @@ export default function AccountIdentityCard({
     { label: 'Currency', value: account.currency },
     {
       label: 'Credit limit',
-      value: account.credit_limit === null ? '—' : formatCurrency(account.credit_limit, account.currency),
+      value: account.credit_limit === null ? 'Not set' : formatCurrency(account.credit_limit, account.currency),
     },
   ]
 

--- a/frontend/src/pages/auth/utils/authForm.ts
+++ b/frontend/src/pages/auth/utils/authForm.ts
@@ -1,6 +1,7 @@
 import { ApiError, type LoginPayload, type SignupPayload } from '@/api/auth'
 import type { Currency } from '@/api/currency'
 import type { DropdownOption } from '@/components/dropdown/Dropdown'
+import { formatCurrencyLabel } from '@/utils/formatCurrency'
 import { isNewPasswordValid } from '@/utils/passwordPolicy'
 
 export type AuthMode = 'login' | 'signup' | 'forgot'
@@ -154,7 +155,7 @@ export function buildSignupPayload(form: AuthFormValues): SignupPayload {
 export function buildCurrencyOptions(currencies: Currency[]): DropdownOption[] {
   return currencies.map((currency) => ({
     value: currency.id,
-    label: `${currency.id} — ${currency.name} (${currency.symbol})`,
+    label: formatCurrencyLabel(currency),
   }))
 }
 

--- a/frontend/src/pages/settings/components/ProfileSection.tsx
+++ b/frontend/src/pages/settings/components/ProfileSection.tsx
@@ -5,6 +5,7 @@ import SettingsField from '@/pages/settings/components/Field'
 import SettingsSectionHeader from '@/pages/settings/components/SectionHeader'
 import SettingsCard from '@/pages/settings/components/Card'
 import type { ProfileFormState } from '@/pages/settings/profileForm'
+import { formatCurrencyLabel } from '@/utils/formatCurrency'
 
 const TIMEZONES = Intl.supportedValuesOf('timeZone').map((tz) => ({
   value: tz,
@@ -50,7 +51,7 @@ export default function ProfileSection({
   // same code/name/symbol label format used by account creation
   const baseCurrency = currencies?.find((c) => c.id === user?.base_currency)
   const baseCurrencyLabel = baseCurrency
-    ? `${baseCurrency.id} — ${baseCurrency.name} (${baseCurrency.symbol})`
+    ? formatCurrencyLabel(baseCurrency)
     : user?.base_currency ?? ''
 
   return (

--- a/frontend/src/pages/settings/components/runway-section/Section.tsx
+++ b/frontend/src/pages/settings/components/runway-section/Section.tsx
@@ -37,7 +37,7 @@ export default function RunwaySection({
         description={
           <>
             <p>
-              Pick which accounts should count toward calculating your runway — how long the total balance in the selected accounts will last if your average monthly net expenses don't change. The average uses up to the last 12 completed months with recorded expenses; the current partial month and months with no net expense data are excluded. Only open asset accounts are eligible; liabilities like credit cards or loans can't be counted.
+              Pick which accounts should count toward calculating your runway, which is how long the total balance in the selected accounts will last if your average monthly net expenses don't change. The average uses up to the last 12 completed months with recorded expenses; the current partial month and months with no net expense data are excluded. Only open asset accounts are eligible; liabilities like credit cards or loans can't be counted.
             </p>
             <p>
               For example, if your selected accounts hold $30,000 and you've averaged $5,000 a month in net expenses, that's a 6-month runway.

--- a/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/utils/categoryUtils.ts
+++ b/frontend/src/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/utils/categoryUtils.ts
@@ -1,6 +1,7 @@
 import type { Currency } from '@/api/currency'
 import type { TaxAdvantagedCategoryLimit, TaxTreatment } from '@/api/tax-advantaged-categories'
 import { TAX_TREATMENT_OPTIONS } from '@/pages/settings/components/tax-advantaged/tax-advantaged-categories-section/constants'
+import { formatCurrencyLabel } from '@/utils/formatCurrency'
 import {
   fromMinorUnits as fromMinorUnitsCanonical,
   getCurrencyExponent,
@@ -27,7 +28,10 @@ export function nextAvailableLimitYear(limits: TaxAdvantagedCategoryLimit[], cur
  * Builds the currency dropdown options, labelling each with its code, name and symbol
  */
 export function currencyOptions(currencies: Currency[]) {
-  return currencies.map((c) => ({ value: c.id, label: `${c.id} — ${c.name} (${c.symbol})` }))
+  return currencies.map((currency) => ({
+    value: currency.id,
+    label: formatCurrencyLabel(currency),
+  }))
 }
 
 /**

--- a/frontend/src/styles/tailwind.css
+++ b/frontend/src/styles/tailwind.css
@@ -23,6 +23,9 @@
     --app-accent-border: #9b6c2c38;
     --app-input-bg: #FFFFFF;
     --app-input-border: #4b372338;
+
+    /* Fields strengthen their own hover edge without changing borders used by panels */
+    --app-input-border-hover: #4b372359;
     --app-positive: #3A7850;
     --app-positive-soft: #3a78501a;
     --app-chart-positive: #5D8F6D;
@@ -112,6 +115,7 @@
     --app-accent-border: #c9a96a38;
     --app-input-bg: #241F19;
     --app-input-border: #d2b47833;
+    --app-input-border-hover: #d2b47859;
     --app-positive: #6CA07B;
     --app-positive-soft: #6ca07b24;
     --app-chart-positive: #5D8F6D;
@@ -519,7 +523,7 @@
   }
 
   .app-input:hover {
-    border-color: var(--app-border-strong);
+    border-color: var(--app-input-border-hover);
     background: var(--app-input-bg);
   }
 
@@ -552,7 +556,7 @@
   }
 
   .app-date-field:hover {
-    border-color: var(--app-border-strong);
+    border-color: var(--app-input-border-hover);
   }
 
   .app-date-field:focus-within {
@@ -667,7 +671,7 @@
      less than a hover and lose to it. A new state goes in this order rather than out-weighing what
      came before */
   .app-dropdown-glass:hover {
-    border-color: var(--app-border-strong);
+    border-color: var(--app-input-border-hover);
   }
 
   .app-dropdown-glass:focus-within {

--- a/frontend/src/utils/formatCurrency.ts
+++ b/frontend/src/utils/formatCurrency.ts
@@ -2,6 +2,13 @@ import type { Currency } from '@/api/currency'
 import { DEFAULT_MINOR_UNIT_EXPONENT, findCurrencyExponent } from '@/utils/moneyInput'
 
 /**
+ * Formats a currency's code, name, and symbol for selection and reference fields
+ */
+export function formatCurrencyLabel(currency: Currency): string {
+  return `${currency.id}: ${currency.name} (${currency.symbol})`
+}
+
+/**
  * Builds the money formatter for a currency, fixed at the decimal places given
  *
  * The locale is left to the reader's own, which is what decides how a currency's symbol is written.

--- a/frontend/tests/pages/accounts/components/create-account-modal/utils/options.test.ts
+++ b/frontend/tests/pages/accounts/components/create-account-modal/utils/options.test.ts
@@ -73,7 +73,7 @@ describe('create account option helpers', () => {
   it('builds dropdown options and filters tax-advantaged categories by ownership scope and currency', () => {
     expect(buildCreateAccountCurrencyOptions(currencies)[0]).toEqual({
       value: 'CAD',
-      label: 'CAD — Canadian Dollar ($)',
+      label: 'CAD: Canadian Dollar ($)',
     })
     expect(buildCreateAccountInstitutionOptions(institutions)).toEqual([
       { value: '', label: 'None' },

--- a/frontend/tests/pages/auth/utils/authForm.test.ts
+++ b/frontend/tests/pages/auth/utils/authForm.test.ts
@@ -90,8 +90,8 @@ describe('auth form helpers', () => {
 
   it('guards signup when currencies are loading or failed', () => {
     expect(buildCurrencyOptions(currencies)).toEqual([
-      { value: 'CAD', label: 'CAD — Canadian Dollar ($)' },
-      { value: 'USD', label: 'USD — US Dollar (US$)' },
+      { value: 'CAD', label: 'CAD: Canadian Dollar ($)' },
+      { value: 'USD', label: 'USD: US Dollar (US$)' },
     ])
     expect(getCurrencyPlaceholder(false, 0)).toBe('Loading currencies…')
     expect(getCurrencyPlaceholder(true, 0)).toBe('Failed to load currencies')


### PR DESCRIPTION
Improved field labels and hover feedback across forms. Text inputs, date fields and dropdowns now show stronger borders on hover in both themes. Currency labels use consistent formatting, the runway explanation reads more naturally, and missing credit limits display “Not set”.
